### PR TITLE
Organize and clean up imports

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,4 @@
+export { CollectionAPI } from './collection';
+export { NamespaceAPI } from './namespace';
+export { NamespaceType } from './response-types/namespace';
+export { CollectionListType } from './response-types/collection';

--- a/src/api/mocked-responses/collection.ts
+++ b/src/api/mocked-responses/collection.ts
@@ -1,5 +1,5 @@
 import * as MockAdapter from 'axios-mock-adapter';
-import { CollectionList } from '../response-types/collection';
+import { CollectionListType } from '../../api';
 import { redHat } from './namespace';
 
 export class MockCollection {
@@ -53,7 +53,7 @@ export class MockCollection {
     }
 
     getCollectionList() {
-        const collections = [] as CollectionList[];
+        const collections = [] as CollectionListType[];
 
         for (let i = 0; i < this.collectionNames.length; i++) {
             collections.push(
@@ -114,7 +114,7 @@ class CollectionGenerator {
         return w;
     }
 
-    static generate(id, name, namespace): CollectionList {
+    static generate(id, name, namespace): CollectionListType {
         const collection = {
             id: id,
             name: name,
@@ -146,7 +146,7 @@ class CollectionGenerator {
                     },
                 },
             },
-        } as CollectionList;
+        } as CollectionListType;
 
         return collection;
     }

--- a/src/api/mocked-responses/namespace.ts
+++ b/src/api/mocked-responses/namespace.ts
@@ -1,5 +1,5 @@
 import * as MockAdapter from 'axios-mock-adapter';
-import { Namespace } from '../response-types/namespace';
+import { NamespaceType } from '../../api';
 
 export const redHat = {
     name: 'red_hat',
@@ -64,7 +64,7 @@ Ansible Galaxy is an [Ansible by Red Hat](https://ansible.com) sponsored project
     ],
     owners: [{ name: 'newswangerd' }],
     num_collections: 10,
-} as Namespace;
+} as NamespaceType;
 
 export class MockNamespace {
     mock: any;

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -61,6 +61,6 @@ export class CollectionListType {
     };
 }
 
-export class CollectionDetail extends CollectionList {
+export class CollectionDetailType extends CollectionListType {
     all_versions: CollectionVersion[];
 }

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -35,7 +35,7 @@ export class CollectionVersion {
     // readme_html: string;
 }
 
-export class CollectionList {
+export class CollectionListType {
     id: number;
     name: string;
     description: string;

--- a/src/api/response-types/namespace.ts
+++ b/src/api/response-types/namespace.ts
@@ -1,4 +1,4 @@
-export class Namespace {
+export class NamespaceType {
     name: string;
     company: string;
     email: string;

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
+import './cards.scss';
 
 import { Card } from '@patternfly/react-core';
-
-import './cards.scss';
 
 // Use snake case to match field types provided py python API so that the
 // spread operator can be used.

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-
 import './list-item.scss';
 
 import {
@@ -9,12 +8,12 @@ import {
     DataListCell,
 } from '@patternfly/react-core';
 
-import { Paths, formatPath } from '../../paths';
 import { Link } from 'react-router-dom';
-import { NumericLabel } from '../numeric-label/numeric-label';
-import { CollectionListType } from '../../api';
 import * as moment from 'moment';
-import { Tag } from '../tags/tag';
+
+import { Paths, formatPath } from '../../paths';
+import { NumericLabel, Tag } from '../../components';
+import { CollectionListType } from '../../api';
 
 export class CollectionListItem extends React.Component<
     CollectionListType,

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -12,11 +12,14 @@ import {
 import { Paths, formatPath } from '../../paths';
 import { Link } from 'react-router-dom';
 import { NumericLabel } from '../numeric-label/numeric-label';
-import { CollectionList } from '../../api/response-types/collection';
+import { CollectionListType } from '../../api';
 import * as moment from 'moment';
 import { Tag } from '../tags/tag';
 
-export class CollectionListItem extends React.Component<CollectionList, {}> {
+export class CollectionListItem extends React.Component<
+    CollectionListType,
+    {}
+> {
     render() {
         const { name, download_count, latest_version, namespace } = this.props;
 

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -5,7 +5,7 @@ import { DataList } from '@patternfly/react-core';
 
 import { CollectionListType } from '../../api';
 
-import { CollectionListItem } from '../../components/collection-list/collection-list-item';
+import { CollectionListItem } from '../../components';
 import { Sort } from '../patternfly-wrappers/sort';
 
 import { Constants } from '../../constants';

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -3,7 +3,7 @@ import './list.scss';
 
 import { DataList } from '@patternfly/react-core';
 
-import { CollectionList as CollectionListType } from '../../api/response-types/collection';
+import { CollectionListType } from '../../api';
 
 import { CollectionListItem } from '../../components/collection-list/collection-list-item';
 import { Sort } from '../patternfly-wrappers/sort';

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -4,12 +4,8 @@ import './list.scss';
 import { DataList } from '@patternfly/react-core';
 
 import { CollectionListType } from '../../api';
-
-import { CollectionListItem } from '../../components';
-import { Sort } from '../patternfly-wrappers/sort';
-
+import { CollectionListItem, Sort } from '../../components';
 import { Constants } from '../../constants';
-
 import { ParamHelper } from '../../utilities/param-helper';
 
 import {

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { BaseHeader } from './base-header';
-import { Namespace } from '../../api/response-types/namespace';
+import { NamespaceType } from '../../api';
 import './header.scss';
 
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 interface IProps {
-    namespace: Namespace;
+    namespace: NamespaceType;
     tabs: React.ReactNode;
     breadcrumbs: React.ReactNode;
 }

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { BaseHeader } from './base-header';
-import { NamespaceType } from '../../api';
 import './header.scss';
 
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+import { BaseHeader } from '../../components';
+import { NamespaceType } from '../../api';
 
 interface IProps {
     namespace: NamespaceType;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,11 @@
+export { Tag } from './tags/tag';
+export { Sort } from './patternfly-wrappers/sort';
+export { NumericLabel } from './numeric-label/numeric-label';
+export { NotImplemented } from './not-implemented/not-implemented';
+export { NamespaceForm } from './namespace-form/namespace-form';
+export { ResourcesForm } from './namespace-form/resources-form';
+export { BaseHeader } from './headers/base-header';
+export { PartnerHeader } from './headers/partner-header';
+export { CollectionList } from './collection-list/collection-list';
+export { CollectionListItem } from './collection-list/collection-list-item';
+export { NamespaceCard } from './cards/namespace-card';

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -7,10 +7,10 @@ import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import { NamespaceCard } from '../cards/namespace-card';
 
-import { Namespace } from '../../api/response-types/namespace';
+import { NamespaceType } from '../../api';
 
 interface IProps {
-    namespace: Namespace;
+    namespace: NamespaceType;
     errorMessages: any;
 
     updateNamespace: (namespace) => void;

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -2,11 +2,9 @@ import * as React from 'react';
 import './namespace-form.scss';
 
 import { Form, FormGroup, TextInput, TextArea } from '@patternfly/react-core';
-
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
-import { NamespaceCard } from '../cards/namespace-card';
-
+import { NamespaceCard } from '../../components';
 import { NamespaceType } from '../../api';
 
 interface IProps {

--- a/src/components/namespace-form/resources-form.tsx
+++ b/src/components/namespace-form/resources-form.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { NamespaceType } from '../../api';
 import './namespace-form.scss';
-import * as ReactMarkdown from 'react-markdown';
 
 import { Form, FormGroup, TextArea } from '@patternfly/react-core';
+import * as ReactMarkdown from 'react-markdown';
+
+import { NamespaceType } from '../../api';
 
 interface IProps {
     namespace: NamespaceType;

--- a/src/components/namespace-form/resources-form.tsx
+++ b/src/components/namespace-form/resources-form.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { Namespace } from '../../api/response-types/namespace';
+import { NamespaceType } from '../../api';
 import './namespace-form.scss';
 import * as ReactMarkdown from 'react-markdown';
 
 import { Form, FormGroup, TextArea } from '@patternfly/react-core';
 
 interface IProps {
-    namespace: Namespace;
+    namespace: NamespaceType;
 
     updateNamespace: (data) => void;
 }

--- a/src/components/not-implemented/not-implemented.tsx
+++ b/src/components/not-implemented/not-implemented.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import { Link } from 'react-router-dom';
 
 export class NotImplemented extends React.Component<{}, {}> {

--- a/src/containers/collection-detail/collection-content-docs.tsx
+++ b/src/containers/collection-detail/collection-content-docs.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
-import { BaseHeader } from '../../components/headers/base-header';
-import { NotImplemented } from '../../components/not-implemented/not-implemented';
+import { BaseHeader, NotImplemented } from '../../components';
 
 import { Main, Section } from '@redhat-cloud-services/frontend-components';
 

--- a/src/containers/collection-detail/collection-content-docs.tsx
+++ b/src/containers/collection-detail/collection-content-docs.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 import { BaseHeader, NotImplemented } from '../../components';
-
-import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 class CollectionContentDocs extends React.Component<RouteComponentProps, {}> {
     render() {

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
-import { BaseHeader } from '../../components/headers/base-header';
-import { NotImplemented } from '../../components/not-implemented/not-implemented';
+import { BaseHeader, NotImplemented } from '../../components';
 
 import { Main, Section } from '@redhat-cloud-services/frontend-components';
 

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 import { BaseHeader, NotImplemented } from '../../components';
-
-import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 class CollectionContent extends React.Component<RouteComponentProps, {}> {
     render() {

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
-import { BaseHeader } from '../../components/headers/base-header';
-import { NotImplemented } from '../../components/not-implemented/not-implemented';
+import { BaseHeader, NotImplemented } from '../../components';
 
 import { Main, Section } from '@redhat-cloud-services/frontend-components';
 

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 import { BaseHeader, NotImplemented } from '../../components';
-
-import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 class CollectionDetail extends React.Component<RouteComponentProps, {}> {
     render() {

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
-import { BaseHeader } from '../../components/headers/base-header';
-import { NotImplemented } from '../../components/not-implemented/not-implemented';
+import { BaseHeader, NotImplemented } from '../../components';
 
 import { Main, Section } from '@redhat-cloud-services/frontend-components';
 

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 import { BaseHeader, NotImplemented } from '../../components';
-
-import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 class CollectionDocs extends React.Component<RouteComponentProps, {}> {
     render() {

--- a/src/containers/edit-namespace/namespace-form.tsx
+++ b/src/containers/edit-namespace/namespace-form.tsx
@@ -11,8 +11,7 @@ import { PartnerHeader } from '../../components/headers/partner-header';
 import { NamespaceForm } from '../../components/namespace-form/namespace-form';
 import { ResourcesForm } from '../../components/namespace-form/resources-form';
 
-import { NamespaceAPI } from '../../api/namespace';
-import { Namespace } from '../../api/response-types/namespace';
+import { NamespaceAPI, NamespaceType } from '../../api';
 
 interface IProps extends RouteComponentProps {}
 
@@ -31,7 +30,7 @@ import { Paths, formatPath } from '../../paths';
 import { Link } from 'react-router-dom';
 
 interface IState {
-    namespace: Namespace;
+    namespace: NamespaceType;
     newLinkName: string;
     newLinkURL: string;
     errorMessages: any;

--- a/src/containers/edit-namespace/namespace-form.tsx
+++ b/src/containers/edit-namespace/namespace-form.tsx
@@ -7,10 +7,7 @@ import {
     Spinner,
 } from '@redhat-cloud-services/frontend-components';
 
-import { PartnerHeader } from '../../components/headers/partner-header';
-import { NamespaceForm } from '../../components/namespace-form/namespace-form';
-import { ResourcesForm } from '../../components/namespace-form/resources-form';
-
+import { PartnerHeader, NamespaceForm, ResourcesForm } from '../../components';
 import { NamespaceAPI, NamespaceType } from '../../api';
 
 interface IProps extends RouteComponentProps {}

--- a/src/containers/edit-namespace/namespace-form.tsx
+++ b/src/containers/edit-namespace/namespace-form.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
 import {
     Main,
     Section,
     Spinner,
 } from '@redhat-cloud-services/frontend-components';
+import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
 import { PartnerHeader, NamespaceForm, ResourcesForm } from '../../components';
 import { NamespaceAPI, NamespaceType } from '../../api';

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 import { BaseHeader, NotImplemented } from '../../components';
-
-import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 class MyImports extends React.Component<RouteComponentProps, {}> {
     render() {

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
-import { BaseHeader } from '../../components/headers/base-header';
-import { NotImplemented } from '../../components/not-implemented/not-implemented';
+import { BaseHeader, NotImplemented } from '../../components';
 
 import { Main, Section } from '@redhat-cloud-services/frontend-components';
 

--- a/src/containers/my-namespaces/my-collections.tsx
+++ b/src/containers/my-namespaces/my-collections.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 import { BaseHeader, NotImplemented } from '../../components';
-
-import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 class MyCollections extends React.Component<RouteComponentProps, {}> {
     render() {

--- a/src/containers/my-namespaces/my-collections.tsx
+++ b/src/containers/my-namespaces/my-collections.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
-import { BaseHeader } from '../../components/headers/base-header';
-import { NotImplemented } from '../../components/not-implemented/not-implemented';
+import { BaseHeader, NotImplemented } from '../../components';
 
 import { Main, Section } from '@redhat-cloud-services/frontend-components';
 

--- a/src/containers/my-namespaces/my-namespaces.tsx
+++ b/src/containers/my-namespaces/my-namespaces.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
-import { BaseHeader } from '../../components/headers/base-header';
-import { NotImplemented } from '../../components/not-implemented/not-implemented';
+import { BaseHeader, NotImplemented } from '../../components';
 
 import { Main, Section } from '@redhat-cloud-services/frontend-components';
 

--- a/src/containers/my-namespaces/my-namespaces.tsx
+++ b/src/containers/my-namespaces/my-namespaces.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 import { BaseHeader, NotImplemented } from '../../components';
-
-import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 class MyNamespaces extends React.Component<RouteComponentProps, {}> {
     render() {

--- a/src/containers/not-found/not-found.tsx
+++ b/src/containers/not-found/not-found.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
-import { BaseHeader } from '../../components/headers/base-header';
-import { NotImplemented } from '../../components/not-implemented/not-implemented';
+import { BaseHeader, NotImplemented } from '../../components';
 
 import { Main, Section } from '@redhat-cloud-services/frontend-components';
 

--- a/src/containers/not-found/not-found.tsx
+++ b/src/containers/not-found/not-found.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 import { BaseHeader, NotImplemented } from '../../components';
-
-import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 class NotFound extends React.Component<RouteComponentProps, {}> {
     render() {

--- a/src/containers/partners/partner-detail.tsx
+++ b/src/containers/partners/partner-detail.tsx
@@ -1,7 +1,10 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
+import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 import { Main, Section } from '@redhat-cloud-services/frontend-components';
+import { Breadcrumb, BreadcrumbItem, Tab, Tabs } from '@patternfly/react-core';
+import * as ReactMarkdown from 'react-markdown';
+import { Link } from 'react-router-dom';
 
 import {
     CollectionListType,
@@ -11,16 +14,8 @@ import {
 } from '../../api';
 
 import { CollectionList, PartnerHeader } from '../../components';
-
 import { ParamHelper } from '../../utilities/param-helper';
-
 import { Paths } from '../../paths';
-
-import { Breadcrumb, BreadcrumbItem, Tab, Tabs } from '@patternfly/react-core';
-
-import * as ReactMarkdown from 'react-markdown';
-
-import { Link } from 'react-router-dom';
 
 enum TabKeys {
     collections = 1,

--- a/src/containers/partners/partner-detail.tsx
+++ b/src/containers/partners/partner-detail.tsx
@@ -10,11 +10,10 @@ import {
     NamespaceAPI,
 } from '../../api';
 
-import { CollectionList } from '../../components/collection-list/collection-list';
+import { CollectionList, PartnerHeader } from '../../components';
 
 import { ParamHelper } from '../../utilities/param-helper';
 
-import { PartnerHeader } from '../../components/headers/partner-header';
 import { Paths } from '../../paths';
 
 import { Breadcrumb, BreadcrumbItem, Tab, Tabs } from '@patternfly/react-core';

--- a/src/containers/partners/partner-detail.tsx
+++ b/src/containers/partners/partner-detail.tsx
@@ -3,10 +3,13 @@ import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
 import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
-import { CollectionList as CollectionListType } from '../../api/response-types/collection';
-import { Namespace } from '../../api/response-types/namespace';
-import { CollectionAPI } from '../../api/collection';
-import { NamespaceAPI } from '../../api/namespace';
+import {
+    CollectionListType,
+    NamespaceType,
+    CollectionAPI,
+    NamespaceAPI,
+} from '../../api';
+
 import { CollectionList } from '../../components/collection-list/collection-list';
 
 import { ParamHelper } from '../../utilities/param-helper';
@@ -27,7 +30,7 @@ enum TabKeys {
 
 interface IState {
     collections: CollectionListType[];
-    namespace: Namespace;
+    namespace: NamespaceType;
     params: {
         sort?: string;
         page?: number;

--- a/src/containers/partners/partners.tsx
+++ b/src/containers/partners/partners.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 import { BaseHeader, NotImplemented } from '../../components';
-
-import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 class Partners extends React.Component<RouteComponentProps, {}> {
     render() {

--- a/src/containers/partners/partners.tsx
+++ b/src/containers/partners/partners.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
-import { BaseHeader } from '../../components/headers/base-header';
-import { NotImplemented } from '../../components/not-implemented/not-implemented';
+import { BaseHeader, NotImplemented } from '../../components';
 
 import { Main, Section } from '@redhat-cloud-services/frontend-components';
 

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
-import { BaseHeader } from '../../components/headers/base-header';
-import { NotImplemented } from '../../components/not-implemented/not-implemented';
+import { BaseHeader, NotImplemented } from '../../components';
 
 import { Main, Section } from '@redhat-cloud-services/frontend-components';
 

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 import { BaseHeader, NotImplemented } from '../../components';
-
-import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 class Search extends React.Component<RouteComponentProps, {}> {
     render() {


### PR DESCRIPTION
- Convert `api/` and `components/`into modules.
- Organize imports in the following order: React, CSS, external libraries, internal libraries