### PR TITLE
Cherry pick new general components and refactored components from pr #16

### DIFF
--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -3,30 +3,51 @@ import './header.scss';
 
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import { BaseHeader } from '../../components';
+import { BaseHeader, Tabs, Breadcrumbs } from '../../components';
 import { NamespaceType } from '../../api';
 
 interface IProps {
     namespace: NamespaceType;
-    tabs: React.ReactNode;
-    breadcrumbs: React.ReactNode;
+    tabs: string[];
+    breadcrumbs: {
+        url?: string;
+        name: string;
+    }[];
+    params: { tab?: string };
+    updateParams: (p) => void;
+
+    pageControls?: React.ReactNode;
 }
 
 export class PartnerHeader extends React.Component<IProps, {}> {
     render() {
-        const { namespace, breadcrumbs, tabs } = this.props;
+        const {
+            namespace,
+            breadcrumbs,
+            tabs,
+            pageControls,
+            params,
+            updateParams,
+        } = this.props;
         return (
             <BaseHeader
                 title={namespace.company}
                 imageURL={namespace.avatar_url}
-                breadcrumbs={breadcrumbs}
+                breadcrumbs={<Breadcrumbs links={breadcrumbs} />}
+                pageControls={pageControls}
             >
                 {namespace.description ? (
                     <div>{namespace.description}</div>
                 ) : null}
 
                 <div className='tab-link-container'>
-                    <div className='tabs'>{tabs}</div>
+                    <div className='tabs'>
+                        <Tabs
+                            tabs={tabs}
+                            params={params}
+                            updateParams={p => updateParams(p)}
+                        />
+                    </div>
                     {namespace.useful_links.length > 0 ? (
                         <div className='links'>
                             <div>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,4 @@
 export { Tag } from './tags/tag';
-export { Sort } from './patternfly-wrappers/sort';
 export { NumericLabel } from './numeric-label/numeric-label';
 export { NotImplemented } from './not-implemented/not-implemented';
 export { NamespaceForm } from './namespace-form/namespace-form';
@@ -9,6 +8,10 @@ export { PartnerHeader } from './headers/partner-header';
 export { CollectionList } from './collection-list/collection-list';
 export { CollectionListItem } from './collection-list/collection-list-item';
 export { NamespaceCard } from './cards/namespace-card';
+export { Breadcrumbs } from './patternfly-wrappers/breadcrumbs';
+export { Sort } from './patternfly-wrappers/sort';
+export { Tabs } from './patternfly-wrappers/tabs';
+export { StatefulDropdown } from './patternfly-wrappers/stateful-dropdown';
 export { Toolbar } from './patternfly-wrappers/toolbar';
 export { ImportConsole } from './my-imports/import-console';
 export { ImportList } from './my-imports/import-list';

--- a/src/components/patternfly-wrappers/breadcrumbs.tsx
+++ b/src/components/patternfly-wrappers/breadcrumbs.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
+import { Link } from 'react-router-dom';
+
+interface IProps {
+    links: {
+        name: string;
+        url?: string;
+    }[];
+}
+
+export class Breadcrumbs extends React.Component<IProps> {
+    render() {
+        return (
+            <Breadcrumb>
+                {this.props.links.map((link, i) => this.renderLink(link, i))}
+            </Breadcrumb>
+        );
+    }
+
+    renderLink(link, index) {
+        return (
+            <BreadcrumbItem
+                key={index}
+                isActive={index + 1 === this.props.links.length}
+            >
+                {link.url ? <Link to={link.url}>{link.name}</Link> : link.name}
+            </BreadcrumbItem>
+        );
+    }
+}

--- a/src/components/patternfly-wrappers/stateful-dropdown.tsx
+++ b/src/components/patternfly-wrappers/stateful-dropdown.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+
+import {
+    Dropdown,
+    DropdownPosition,
+    KebabToggle,
+} from '@patternfly/react-core';
+
+interface IProps {
+    items: React.ReactNodeArray;
+    onSelect?: (event) => void;
+}
+
+interface IState {
+    isOpen: boolean;
+}
+
+export class StatefulDropdown extends React.Component<IProps, IState> {
+    constructor(props) {
+        super(props);
+        this.state = {
+            isOpen: false,
+        };
+    }
+
+    render() {
+        const { isOpen } = this.state;
+        const { items } = this.props;
+
+        return (
+            <Dropdown
+                onSelect={e => this.onSelect(e)}
+                toggle={<KebabToggle onToggle={e => this.onToggle(e)} />}
+                isOpen={isOpen}
+                isPlain
+                dropdownItems={items}
+                position={DropdownPosition.right}
+            />
+        );
+    }
+
+    private onToggle(isOpen) {
+        this.setState({
+            isOpen,
+        });
+    }
+    private onSelect(event) {
+        this.setState(
+            {
+                isOpen: !this.state.isOpen,
+            },
+            () => {
+                if (this.props.onSelect) {
+                    this.props.onSelect(event);
+                }
+            },
+        );
+    }
+}

--- a/src/components/patternfly-wrappers/tabs.tsx
+++ b/src/components/patternfly-wrappers/tabs.tsx
@@ -1,0 +1,53 @@
+import * as React from 'react';
+
+import { Tab, Tabs as PFTabs } from '@patternfly/react-core';
+
+import { ParamHelper } from '../../utilities/param-helper';
+
+interface IProps {
+    tabs: string[];
+    params: { tab?: string };
+    updateParams: (params) => void;
+}
+
+export class Tabs extends React.Component<IProps> {
+    render() {
+        const { tabs, params, updateParams } = this.props;
+        return (
+            <PFTabs
+                activeKey={this.getActiveTab()}
+                onSelect={(_, key) =>
+                    updateParams(
+                        ParamHelper.setParam(
+                            params,
+                            'tab',
+                            tabs[key].toLowerCase(),
+                        ),
+                    )
+                }
+            >
+                {tabs.map((tab, i) => (
+                    <Tab key={i} eventKey={i} title={tab} />
+                ))}
+            </PFTabs>
+        );
+    }
+
+    private getActiveTab() {
+        const { params, tabs } = this.props;
+        if (params.tab) {
+            const i = tabs.findIndex(
+                x => x.toLowerCase() === params.tab.toLowerCase(),
+            );
+
+            // If tab is not found, default to the first tab.
+            if (i === -1) {
+                return 0;
+            } else {
+                return i;
+            }
+        } else {
+            return 0;
+        }
+    }
+}

--- a/src/containers/partners/partner-detail.tsx
+++ b/src/containers/partners/partner-detail.tsx
@@ -29,7 +29,7 @@ interface IState {
         sort?: string;
         page?: number;
         page_size?: number;
-        tab?: number;
+        tab?: string;
         keywords?: string;
     };
     redirect: string;
@@ -48,7 +48,7 @@ class PartnerDetail extends React.Component<RouteComponentProps, IState> {
         ]);
 
         if (!params['tab']) {
-            params['tab'] = 1;
+            params['tab'] = 'collections';
         }
 
         this.state = {
@@ -99,44 +99,19 @@ class PartnerDetail extends React.Component<RouteComponentProps, IState> {
             <React.Fragment>
                 <PartnerHeader
                     namespace={namespace}
-                    breadcrumbs={
-                        <Breadcrumb>
-                            <BreadcrumbItem>
-                                <Link to={Paths.partners}>Partners</Link>
-                            </BreadcrumbItem>
-                            <BreadcrumbItem isActive>
-                                {namespace.name}
-                            </BreadcrumbItem>
-                        </Breadcrumb>
-                    }
-                    tabs={
-                        <Tabs
-                            activeKey={params.tab}
-                            onSelect={(_, key) =>
-                                this.updateParams(
-                                    ParamHelper.setParam(
-                                        params,
-                                        'tab',
-                                        parseInt(key.toString()),
-                                    ),
-                                    true,
-                                )
-                            }
-                        >
-                            <Tab
-                                eventKey={TabKeys.collections}
-                                title='Collections'
-                            ></Tab>
-                            <Tab
-                                eventKey={TabKeys.resources}
-                                title='Resources'
-                            ></Tab>
-                        </Tabs>
-                    }
+                    breadcrumbs={[
+                        { name: 'Partners', url: Paths.partners },
+                        {
+                            name: namespace.name,
+                        },
+                    ]}
+                    tabs={['Collections', 'Resources']}
+                    params={params}
+                    updateParams={p => this.updateParams(p)}
                 ></PartnerHeader>
                 <Main>
                     <Section className='body'>
-                        {params.tab === TabKeys.collections ? (
+                        {params.tab.toLowerCase() === 'collections' ? (
                             <CollectionList
                                 updateParams={params =>
                                     this.updateParams(params)


### PR DESCRIPTION
This PR contains a subset of the changes made in #16, specifically
- New wrapped patternfly components (tabs, breadcrumbs, dropdowns)
- Refactors to the partner header
- Refactors to the edit partner page

These missing components have been blocking me from adding the collection detail header for https://github.com/ansible/galaxy-dev/issues/28 as well as some other piece that require a dropdown menu.