### PR TITLE
Add doc formatters.

### DIFF
--- a/src/components/collection-detail/render-plugin-doc.scss
+++ b/src/components/collection-detail/render-plugin-doc.scss
@@ -38,3 +38,11 @@
 .plugin-raw {
     white-space: pre-wrap;
 }
+
+.inline-code {
+    background-color: #e6e9e9;
+    font-family: var(--pf-global--FontFamily--monospace);
+    display: inline-block;
+    border-radius: 2px;
+    padding: 0px 2px 0px 2px;
+}

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 
 import { DocsBlobType } from '../../api';
 import { Paths, formatPath } from '../../paths';
-import { ParamHelper } from '../../utilities/param-helper';
+import { ParamHelper, sanitizeDocsUrls } from '../../utilities';
 
 interface IProps {
     docs_blob: DocsBlobType;
@@ -55,7 +55,7 @@ export class TableOfContents extends React.Component<IProps> {
 
         if (docs_blob.documentation_files) {
             for (const file of docs_blob.documentation_files) {
-                const url = file.name.replace('.', '-');
+                const url = sanitizeDocsUrls(file.name);
                 table.documentation.push({
                     display: this.capitalize(
                         file.name
@@ -65,7 +65,6 @@ export class TableOfContents extends React.Component<IProps> {
                     ),
                     url: formatPath(Paths.collectionDocsPage, {
                         ...baseUrlParams,
-                        // TODO: Find a better way to handle file extensions in urls
                         page: url,
                     }),
                     selected: selectedType === 'docs' && selectedName === url,

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -21,7 +21,7 @@ import {
     LoadingPageWithHeader,
 } from '../../components';
 import { loadCollection, IBaseCollectionState } from './base';
-import { ParamHelper } from '../../utilities/param-helper';
+import { ParamHelper, sanitizeDocsUrls } from '../../utilities';
 import { formatPath, Paths } from '../../paths';
 
 // renders markdown files in collection docs/ directory
@@ -66,9 +66,7 @@ class CollectionDocs extends React.Component<
         if (contentType === 'docs' && contentName) {
             if (collection.latest_version.docs_blob.documentation_files) {
                 const file = collection.latest_version.docs_blob.documentation_files.find(
-                    // TODO: insights crashes when you give it a .md page. Need to find
-                    // a more elegant solution to this problem
-                    x => x.name.replace('.', '-') === urlFields['page'],
+                    x => sanitizeDocsUrls(x.name) === urlFields['page'],
                 );
 
                 if (file) {
@@ -158,7 +156,17 @@ class CollectionDocs extends React.Component<
                                     ></div>
                                 ) : (
                                     // if plugin data is set render it
-                                    <RenderPluginDoc plugin={pluginData} />
+                                    <RenderPluginDoc
+                                        plugin={pluginData}
+                                        collectionName={collection.name}
+                                        namespaceName={
+                                            collection.namespace.name
+                                        }
+                                        allContent={
+                                            collection.latest_version.contents
+                                        }
+                                        params={params}
+                                    />
                                 )
                             ) : (
                                 this.renderNotFound(collection.name)

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,2 +1,3 @@
 export { convertContentSummaryCounts } from './content-summary';
 export { ParamHelper } from './param-helper';
+export { sanitizeDocsUrls } from './sanitize-docs-urls';

--- a/src/utilities/sanitize-docs-urls.ts
+++ b/src/utilities/sanitize-docs-urls.ts
@@ -1,0 +1,6 @@
+// TODO: insights crashes when you give it a .md page. Need to find
+// a more elegant solution to this problem
+
+export function sanitizeDocsUrls(url) {
+    return url.replace('.md', '');
+}


### PR DESCRIPTION
Adds the following formatters to plugin docs:
- `L(name,url)` if `url` starts with `http`, creates a link to the given url. Otherwise, try to link to documentation in the collection's `docs` directory
- `U(url)` hyperlinks the given url
- `I(text)` italicizes the text
- `C(text)` applies inline code formatting to the text
- `M(module_name)` looks up the given module name in the collection. if it exists, link to it, otherwise just display the module name
- `B(text)` makes the text bold