### PR TITLE
Adding a table of contents to plugin docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15482,6 +15482,14 @@
         "warning": "^4.0.1"
       }
     },
+    "react-router-hash-link": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/react-router-hash-link/-/react-router-hash-link-1.2.2.tgz",
+      "integrity": "sha512-LBthLVHdqPeKDVt3+cFRhy15Z7veikOvdKRZRfyBR2vjqIE7rxn+tKLjb6DOmLm6JpoQVemVDnxQ35RVnEHdQA==",
+      "requires": {
+        "prop-types": "^15.6.0"
+      }
+    },
     "react-test-renderer": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.6.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "react-markdown": "^4.2.2",
         "react-redux": "^5.1.1",
         "react-router-dom": "^4.2.2",
+        "react-router-hash-link": "^1.2.2",
         "redux": "^3.7.2",
         "redux-logger": "^3.0.6",
         "redux-promise-middleware": "^5.1.1"

--- a/src/components/collection-detail/render-plugin-doc.tsx
+++ b/src/components/collection-detail/render-plugin-doc.tsx
@@ -435,12 +435,14 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
     private renderSynopsis(doc: PluginDoc) {
         return (
             <React.Fragment>
-                <h2>Synopsis</h2>
-                <ul>
-                    {doc.description.map((d, i) => (
-                        <li key={i}>{this.applyDocFormatters(d)}</li>
-                    ))}
-                </ul>
+                <div id="synopsis">
+                    <h2>Synopsis</h2>
+                    <ul>
+                        {doc.description.map((d, i) => (
+                            <li key={i}>{this.applyDocFormatters(d)}</li>
+                        ))}
+                    </ul>
+                </div>
             </React.Fragment>
         );
     }
@@ -451,90 +453,92 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
         }
         return (
             <React.Fragment>
-                <h2>Parameters</h2>
-                <table className='options-table'>
-                    <tbody>
-                        <tr>
-                            <th>Parameter</th>
-                            <th>
-                                Choices/<span className='blue'>Defaults</span>
-                            </th>
-                            {content_type !== 'module' ? (
-                                <th>Configuration</th>
-                            ) : null}
-                            <th>Comments</th>
-                        </tr>
-                        {
-                            // TODO: add support for sub options. Example:
-                            //https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/network/fortios/fortios_dlp_fp_doc_source.py#L93}
-                            // TODO: do we need to display version added?
-                        }
-                        {parameters.map((option, i) => (
-                            <tr key={i}>
-                                {
-                                    // PARAMETER --------------------------------
-                                }
-                                <td>
-                                    <span className='option-name'>
-                                        {option.name}
-                                    </span>
-                                    <small>
-                                        {this.documentedType(option['type'])}
-                                        {option['elements'] ? (
-                                            <span>
-                                                {' '}
-                                                / elements =
-                                                {this.documentedType(
-                                                    option['elements'],
-                                                )}
-                                            </span>
-                                        ) : null}
-                                        {option['required'] ? (
-                                            <span>
-                                                {' '}
-                                                /{' '}
-                                                <span className='red'>
-                                                    required
-                                                </span>
-                                            </span>
-                                        ) : null}
-                                    </small>
-                                </td>
-                                {
-                                    // CHOICES -------------------------------
-                                }
-                                <td>{this.renderChoices(option)}</td>
-                                {
-                                    // CONFIGURATION (non module only) -------
-                                }
+                <div id="parameters">
+                    <h2>Parameters</h2>
+                    <table className='options-table'>
+                        <tbody>
+                            <tr>
+                                <th>Parameter</th>
+                                <th>
+                                    Choices/<span className='blue'>Defaults</span>
+                                </th>
                                 {content_type !== 'module' ? (
-                                    <td>
-                                        {this.renderPluginConfiguration(option)}
-                                    </td>
+                                    <th>Configuration</th>
                                 ) : null}
-                                {
-                                    // COMMENTS ------------------------------
-                                }
-                                <td>
-                                    {option.description.map((d, i) => (
-                                        <p key={i}>
-                                            {this.applyDocFormatters(d)}
-                                        </p>
-                                    ))}
-
-                                    {option['aliases'] ? (
-                                        <small>
-                                            <span className='green'>
-                                                aliases:{' '}
-                                                {option['aliases'].join(', ')}
-                                            </span>
-                                        </small>
-                                    ) : null}
-                                </td>
+                                <th>Comments</th>
                             </tr>
-                        ))}
-                    </tbody>
-                </table>
+                            {
+                                // TODO: add support for sub options. Example:
+                                //https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/network/fortios/fortios_dlp_fp_doc_source.py#L93}
+                                // TODO: do we need to display version added?
+                            }
+                            {parameters.map((option, i) => (
+                                <tr key={i}>
+                                    {
+                                        // PARAMETER --------------------------------
+                                    }
+                                    <td>
+                                        <span className='option-name'>
+                                            {option.name}
+                                        </span>
+                                        <small>
+                                            {this.documentedType(option['type'])}
+                                            {option['elements'] ? (
+                                                <span>
+                                                    {' '}
+                                                    / elements =
+                                                    {this.documentedType(
+                                                        option['elements'],
+                                                    )}
+                                                </span>
+                                            ) : null}
+                                            {option['required'] ? (
+                                                <span>
+                                                    {' '}
+                                                    /{' '}
+                                                    <span className='red'>
+                                                        required
+                                                    </span>
+                                                </span>
+                                            ) : null}
+                                        </small>
+                                    </td>
+                                    {
+                                        // CHOICES -------------------------------
+                                    }
+                                    <td>{this.renderChoices(option)}</td>
+                                    {
+                                        // CONFIGURATION (non module only) -------
+                                    }
+                                    {content_type !== 'module' ? (
+                                        <td>
+                                            {this.renderPluginConfiguration(option)}
+                                        </td>
+                                    ) : null}
+                                    {
+                                        // COMMENTS ------------------------------
+                                    }
+                                    <td>
+                                        {option.description.map((d, i) => (
+                                            <p key={i}>
+                                                {this.applyDocFormatters(d)}
+                                            </p>
+                                        ))}
+
+                                        {option['aliases'] ? (
+                                            <small>
+                                                <span className='green'>
+                                                    aliases:{' '}
+                                                    {option['aliases'].join(', ')}
+                                                </span>
+                                            </small>
+                                        ) : null}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
             </React.Fragment>
         );
     }
@@ -626,7 +630,7 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
         }
 
         return (
-            <div>
+            <div id="notes">
                 <h2>Notes</h2>
                 <ul>
                     {doc.notes.map((note, i) => (
@@ -660,8 +664,10 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
         }
         return (
             <React.Fragment>
-                <h2>Examples</h2>
-                <pre>{example}</pre>
+                <div id="examples">
+                    <h2>Examples</h2>
+                    <pre>{example}</pre>
+                </div>
             </React.Fragment>
         );
     }
@@ -672,47 +678,49 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
         }
         return (
             <React.Fragment>
-                <h2>Return Values</h2>
-                <table className='options-table'>
-                    <tbody>
-                        <tr>
-                            <th>Key</th>
-                            <th>Returned</th>
-                            <th>Description</th>
-                        </tr>
-                        {returnV.map((option, i) => (
-                            <tr key={i}>
-                                <td>
-                                    {option.name} <br /> ({option.type})
-                                </td>
-                                <td>{option.returned}</td>
-                                <td>
-                                    {this.applyDocFormatters(
-                                        option.description,
-                                    )}
-                                    {option.sample ? (
-                                        <div>
-                                            <br />
-                                            sample:
-                                            {typeof option.sample ===
-                                            'string' ? (
-                                                option.sample
-                                            ) : (
-                                                <pre>
-                                                    {JSON.stringify(
-                                                        option.sample,
-                                                        null,
-                                                        2,
-                                                    )}
-                                                </pre>
-                                            )}
-                                        </div>
-                                    ) : null}
-                                </td>
+                <div id="return-values">
+                    <h2>Return Values</h2>
+                    <table className='options-table'>
+                        <tbody>
+                            <tr>
+                                <th>Key</th>
+                                <th>Returned</th>
+                                <th>Description</th>
                             </tr>
-                        ))}
-                    </tbody>
-                </table>
+                            {returnV.map((option, i) => (
+                                <tr key={i}>
+                                    <td>
+                                        {option.name} <br /> ({option.type})
+                                    </td>
+                                    <td>{option.returned}</td>
+                                    <td>
+                                        {this.applyDocFormatters(
+                                            option.description,
+                                        )}
+                                        {option.sample ? (
+                                            <div>
+                                                <br />
+                                                sample:
+                                                {typeof option.sample ===
+                                                'string' ? (
+                                                    option.sample
+                                                ) : (
+                                                    <pre>
+                                                        {JSON.stringify(
+                                                            option.sample,
+                                                            null,
+                                                            2,
+                                                        )}
+                                                    </pre>
+                                                )}
+                                            </div>
+                                        ) : null}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
             </React.Fragment>
         );
     }

--- a/src/components/collection-detail/render-plugin-doc.tsx
+++ b/src/components/collection-detail/render-plugin-doc.tsx
@@ -4,6 +4,7 @@ import './render-plugin-doc.scss';
 import { cloneDeep } from 'lodash';
 import { Alert } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
+import { HashLink } from 'react-router-hash-link';
 
 import { PluginContentType, ContentSummaryType } from '../../api';
 import { Paths, formatPath } from '../../paths';
@@ -399,27 +400,27 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
             <ul>
                 {content["synopsis"] !== null &&
                     <li>
-                        <Link to="#synopsis">Synopsis</Link>
+                        <HashLink to="#synopsis">Synopsis</HashLink>
                     </li>
                 }
                 {content["parameters"] !== null &&
                     <li>
-                        <Link to="#parameters">Parameters</Link>
+                        <HashLink to="#parameters">Parameters</HashLink>
                     </li>
                 }
                 {content["notes"] !== null &&
                     <li>
-                        <Link to="#notes">Notes</Link>
+                        <HashLink to="#notes">Notes</HashLink>
                     </li>
                 }
                 {content["examples"] !== null &&
                     <li>
-                        <Link to="#examples">Examples</Link>
+                        <HashLink to="#examples">Examples</HashLink>
                     </li>
                 }
                 {content["return-values"] !== null &&
                     <li>
-                        <Link to="#return-values">Return Values</Link>
+                        <HashLink to="#return-values">Return Values</HashLink>
                     </li>
                 }
             </ul>

--- a/src/components/collection-detail/render-plugin-doc.tsx
+++ b/src/components/collection-detail/render-plugin-doc.tsx
@@ -88,10 +88,8 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
           "synopsis": this.renderSynopsis(doc),
           "parameters": this.renderParameters(doc.options, plugin.content_type),
           "notes": this.renderNotes(doc),
-          "see-also": null,
           "examples": this.renderExample(example),
           "return-values": this.renderReturnValues(returnVals),
-          "status": null
         }
 
         if (!this.state.renderError) {
@@ -101,9 +99,9 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
                         {plugin.content_type} > {plugin.content_name}
                     </h1>
                     <br />
-                    {this.renderTableOfContents(content)}
                     {this.renderShortDescription(doc)}
                     {this.renderDeprecated(doc, plugin.content_name)}
+                    {this.renderTableOfContents(content)}
                     {content["synopsis"]}
                     {this.renderRequirements(doc)}
                     {content["parameters"]}

--- a/src/components/collection-detail/render-plugin-doc.tsx
+++ b/src/components/collection-detail/render-plugin-doc.tsx
@@ -93,7 +93,7 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
                     <br />
                     {this.renderShortDescription(doc)}
                     {this.renderDeprecated(doc, plugin.content_name)}
-                    {this.renderDescription(doc)}
+                    {this.renderSynopsis(doc)}
                     {this.renderRequirements(doc)}
                     {this.renderParameters(doc.options, plugin.content_type)}
                     {this.renderNotes(doc)}
@@ -389,7 +389,7 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
         return <div>{doc['short_description']}</div>;
     }
 
-    private renderDescription(doc: PluginDoc) {
+    private renderSynopsis(doc: PluginDoc) {
         return (
             <React.Fragment>
                 <h2>Synopsis</h2>

--- a/src/components/collection-detail/render-plugin-doc.tsx
+++ b/src/components/collection-detail/render-plugin-doc.tsx
@@ -395,35 +395,35 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
     }
 
     private renderTableOfContents(content: any) {
-      return (
+        return (
             <ul>
-              {content["synopsis"] !== null &&
-                  <li>
-                      <Link to="#synopsis">Synopsis</Link>
-                  </li>
-              }
-              {content["parameters"] !== null &&
-                  <li>
-                      <Link to="#parameters">Parameters</Link>
-                  </li>
-              }
-              {content["notes"] !== null &&
-                  <li>
-                      <Link to="#notes">Notes</Link>
-                  </li>
-              }
-              {content["examples"] !== null &&
-                  <li>
-                      <Link to="#examples">Examples</Link>
-                  </li>
-              }
-              {content["return-values"] !== null &&
-                  <li>
-                      <Link to="#return-values">Return Values</Link>
-                  </li>
-              }
+                {content["synopsis"] !== null &&
+                    <li>
+                        <Link to="#synopsis">Synopsis</Link>
+                    </li>
+                }
+                {content["parameters"] !== null &&
+                    <li>
+                        <Link to="#parameters">Parameters</Link>
+                    </li>
+                }
+                {content["notes"] !== null &&
+                    <li>
+                        <Link to="#notes">Notes</Link>
+                    </li>
+                }
+                {content["examples"] !== null &&
+                    <li>
+                        <Link to="#examples">Examples</Link>
+                    </li>
+                }
+                {content["return-values"] !== null &&
+                    <li>
+                        <Link to="#return-values">Return Values</Link>
+                    </li>
+                }
             </ul>
-          );
+        );
     }
 
     private renderShortDescription(doc: PluginDoc) {
@@ -433,14 +433,12 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
     private renderSynopsis(doc: PluginDoc) {
         return (
             <React.Fragment>
-                <div id="synopsis">
-                    <h2>Synopsis</h2>
-                    <ul>
-                        {doc.description.map((d, i) => (
-                            <li key={i}>{this.applyDocFormatters(d)}</li>
-                        ))}
-                    </ul>
-                </div>
+                <h2 id="synopsis">Synopsis</h2>
+                <ul>
+                    {doc.description.map((d, i) => (
+                        <li key={i}>{this.applyDocFormatters(d)}</li>
+                    ))}
+                </ul>
             </React.Fragment>
         );
     }
@@ -451,92 +449,90 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
         }
         return (
             <React.Fragment>
-                <div id="parameters">
-                    <h2>Parameters</h2>
-                    <table className='options-table'>
-                        <tbody>
-                            <tr>
-                                <th>Parameter</th>
-                                <th>
-                                    Choices/<span className='blue'>Defaults</span>
-                                </th>
-                                {content_type !== 'module' ? (
-                                    <th>Configuration</th>
-                                ) : null}
-                                <th>Comments</th>
-                            </tr>
-                            {
-                                // TODO: add support for sub options. Example:
-                                //https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/network/fortios/fortios_dlp_fp_doc_source.py#L93}
-                                // TODO: do we need to display version added?
-                            }
-                            {parameters.map((option, i) => (
-                                <tr key={i}>
-                                    {
-                                        // PARAMETER --------------------------------
-                                    }
-                                    <td>
-                                        <span className='option-name'>
-                                            {option.name}
-                                        </span>
-                                        <small>
-                                            {this.documentedType(option['type'])}
-                                            {option['elements'] ? (
-                                                <span>
-                                                    {' '}
-                                                    / elements =
-                                                    {this.documentedType(
-                                                        option['elements'],
-                                                    )}
-                                                </span>
-                                            ) : null}
-                                            {option['required'] ? (
-                                                <span>
-                                                    {' '}
-                                                    /{' '}
-                                                    <span className='red'>
-                                                        required
-                                                    </span>
-                                                </span>
-                                            ) : null}
-                                        </small>
-                                    </td>
-                                    {
-                                        // CHOICES -------------------------------
-                                    }
-                                    <td>{this.renderChoices(option)}</td>
-                                    {
-                                        // CONFIGURATION (non module only) -------
-                                    }
-                                    {content_type !== 'module' ? (
-                                        <td>
-                                            {this.renderPluginConfiguration(option)}
-                                        </td>
-                                    ) : null}
-                                    {
-                                        // COMMENTS ------------------------------
-                                    }
-                                    <td>
-                                        {option.description.map((d, i) => (
-                                            <p key={i}>
-                                                {this.applyDocFormatters(d)}
-                                            </p>
-                                        ))}
-
-                                        {option['aliases'] ? (
-                                            <small>
-                                                <span className='green'>
-                                                    aliases:{' '}
-                                                    {option['aliases'].join(', ')}
-                                                </span>
-                                            </small>
+                <h2 id="parameters">Parameters</h2>
+                <table className='options-table'>
+                    <tbody>
+                        <tr>
+                            <th>Parameter</th>
+                            <th>
+                                Choices/<span className='blue'>Defaults</span>
+                            </th>
+                            {content_type !== 'module' ? (
+                                <th>Configuration</th>
+                            ) : null}
+                            <th>Comments</th>
+                        </tr>
+                        {
+                            // TODO: add support for sub options. Example:
+                            //https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/network/fortios/fortios_dlp_fp_doc_source.py#L93}
+                            // TODO: do we need to display version added?
+                        }
+                        {parameters.map((option, i) => (
+                            <tr key={i}>
+                                {
+                                    // PARAMETER --------------------------------
+                                }
+                                <td>
+                                    <span className='option-name'>
+                                        {option.name}
+                                    </span>
+                                    <small>
+                                        {this.documentedType(option['type'])}
+                                        {option['elements'] ? (
+                                            <span>
+                                                {' '}
+                                                / elements =
+                                                {this.documentedType(
+                                                    option['elements'],
+                                                )}
+                                            </span>
                                         ) : null}
+                                        {option['required'] ? (
+                                            <span>
+                                                {' '}
+                                                /{' '}
+                                                <span className='red'>
+                                                    required
+                                                </span>
+                                            </span>
+                                        ) : null}
+                                    </small>
+                                </td>
+                                {
+                                    // CHOICES -------------------------------
+                                }
+                                <td>{this.renderChoices(option)}</td>
+                                {
+                                    // CONFIGURATION (non module only) -------
+                                }
+                                {content_type !== 'module' ? (
+                                    <td>
+                                        {this.renderPluginConfiguration(option)}
                                     </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
+                                ) : null}
+                                {
+                                    // COMMENTS ------------------------------
+                                }
+                                <td>
+                                    {option.description.map((d, i) => (
+                                        <p key={i}>
+                                            {this.applyDocFormatters(d)}
+                                        </p>
+                                    ))}
+
+                                    {option['aliases'] ? (
+                                        <small>
+                                            <span className='green'>
+                                                aliases:{' '}
+                                                {option['aliases'].join(', ')}
+                                            </span>
+                                        </small>
+                                    ) : null}
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
             </React.Fragment>
         );
     }
@@ -628,14 +624,14 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
         }
 
         return (
-            <div id="notes">
-                <h2>Notes</h2>
+            <React.Fragment>
+                <h2 id="notes">Notes</h2>
                 <ul>
                     {doc.notes.map((note, i) => (
                         <li key={i}>{this.applyDocFormatters(note)}</li>
                     ))}
                 </ul>
-            </div>
+            </React.Fragment>
         );
     }
 
@@ -645,14 +641,14 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
         }
 
         return (
-            <div>
+            <React.Fragment>
                 <h2>Requirements</h2>
                 <ul>
                     {doc.requirements.map((req, i) => (
                         <li key={i}>{req}</li>
                     ))}
                 </ul>
-            </div>
+            </React.Fragment>
         );
     }
 
@@ -662,10 +658,8 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
         }
         return (
             <React.Fragment>
-                <div id="examples">
-                    <h2>Examples</h2>
-                    <pre>{example}</pre>
-                </div>
+                <h2 id="examples">Examples</h2>
+                <pre>{example}</pre>
             </React.Fragment>
         );
     }
@@ -676,49 +670,47 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
         }
         return (
             <React.Fragment>
-                <div id="return-values">
-                    <h2>Return Values</h2>
-                    <table className='options-table'>
-                        <tbody>
-                            <tr>
-                                <th>Key</th>
-                                <th>Returned</th>
-                                <th>Description</th>
+                <h2 id="return-values">Return Values</h2>
+                <table className='options-table'>
+                    <tbody>
+                        <tr>
+                            <th>Key</th>
+                            <th>Returned</th>
+                            <th>Description</th>
+                        </tr>
+                        {returnV.map((option, i) => (
+                            <tr key={i}>
+                                <td>
+                                    {option.name} <br /> ({option.type})
+                                </td>
+                                <td>{option.returned}</td>
+                                <td>
+                                    {this.applyDocFormatters(
+                                        option.description,
+                                    )}
+                                    {option.sample ? (
+                                        <div>
+                                            <br />
+                                            sample:
+                                            {typeof option.sample ===
+                                            'string' ? (
+                                                option.sample
+                                            ) : (
+                                                <pre>
+                                                    {JSON.stringify(
+                                                        option.sample,
+                                                        null,
+                                                        2,
+                                                    )}
+                                                </pre>
+                                            )}
+                                        </div>
+                                    ) : null}
+                                </td>
                             </tr>
-                            {returnV.map((option, i) => (
-                                <tr key={i}>
-                                    <td>
-                                        {option.name} <br /> ({option.type})
-                                    </td>
-                                    <td>{option.returned}</td>
-                                    <td>
-                                        {this.applyDocFormatters(
-                                            option.description,
-                                        )}
-                                        {option.sample ? (
-                                            <div>
-                                                <br />
-                                                sample:
-                                                {typeof option.sample ===
-                                                'string' ? (
-                                                    option.sample
-                                                ) : (
-                                                    <pre>
-                                                        {JSON.stringify(
-                                                            option.sample,
-                                                            null,
-                                                            2,
-                                                        )}
-                                                    </pre>
-                                                )}
-                                            </div>
-                                        ) : null}
-                                    </td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
+                        ))}
+                    </tbody>
+                </table>
             </React.Fragment>
         );
     }

--- a/src/components/collection-detail/render-plugin-doc.tsx
+++ b/src/components/collection-detail/render-plugin-doc.tsx
@@ -84,6 +84,16 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
         const example: string = this.parseExamples(plugin);
         const returnVals: ReturnedValue[] = this.parseReturn(plugin);
 
+        const content: any = {
+          "synopsis": this.renderSynopsis(doc),
+          "parameters": this.renderParameters(doc.options, plugin.content_type),
+          "notes": this.renderNotes(doc),
+          "see-also": null,
+          "examples": this.renderExample(example),
+          "return-values": this.renderReturnValues(returnVals),
+          "status": null
+        }
+
         if (!this.state.renderError) {
             return (
                 <div className='pf-c-content'>
@@ -91,14 +101,15 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
                         {plugin.content_type} > {plugin.content_name}
                     </h1>
                     <br />
+                    {this.renderTableOfContents(content)}
                     {this.renderShortDescription(doc)}
                     {this.renderDeprecated(doc, plugin.content_name)}
-                    {this.renderSynopsis(doc)}
+                    {content["synopsis"]}
                     {this.renderRequirements(doc)}
-                    {this.renderParameters(doc.options, plugin.content_type)}
-                    {this.renderNotes(doc)}
-                    {this.renderExample(example)}
-                    {this.renderReturnValues(returnVals)}
+                    {content["parameters"]}
+                    {content["notes"]}
+                    {content["examples"]}
+                    {content["return-values"]}
                 </div>
             );
         } else {
@@ -383,6 +394,38 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
                 </div>
             </React.Fragment>
         );
+    }
+
+    private renderTableOfContents(content: any) {
+      return (
+            <ul>
+              {content["synopsis"] !== null &&
+                  <li>
+                      <Link to="#synopsis">Synopsis</Link>
+                  </li>
+              }
+              {content["parameters"] !== null &&
+                  <li>
+                      <Link to="#parameters">Parameters</Link>
+                  </li>
+              }
+              {content["notes"] !== null &&
+                  <li>
+                      <Link to="#notes">Notes</Link>
+                  </li>
+              }
+              {content["examples"] !== null &&
+                  <li>
+                      <Link to="#examples">Examples</Link>
+                  </li>
+              }
+              {content["return-values"] !== null &&
+                  <li>
+                      <Link to="#return-values">Return Values</Link>
+                  </li>
+              }
+            </ul>
+          );
     }
 
     private renderShortDescription(doc: PluginDoc) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,5 +5,6 @@
 declare module '@redhat-cloud-services/frontend-components';
 declare module 'axios-mock-adapter';
 declare module 'react-markdown';
+declare module 'react-router-hash-link';
 declare module '*.gif';
 declare module '*.svg';


### PR DESCRIPTION
Fixes: https://github.com/ansible/galaxy-dev/issues/123

These changes introduce a table of content identical to [Ansible docs](https://docs.ansible.com/ansible/latest/modules/copy_module.html#see-also).

cc/ @newswangerd 