### PR TITLE
Enable tags, remove sort

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { Constants } from '../constants';
+import { ParamHelper } from '../utilities';
 
 export class BaseAPI {
     apiBaseURL = '/api/automation-hub/';
@@ -9,6 +10,7 @@ export class BaseAPI {
     constructor() {
         this.http = axios.create({
             baseURL: this.apiBaseURL,
+            paramsSerializer: params => ParamHelper.getQueryString(params),
         });
     }
 

--- a/src/components/patternfly-wrappers/toolbar.tsx
+++ b/src/components/patternfly-wrappers/toolbar.tsx
@@ -21,7 +21,7 @@ interface IProps {
         keywords?: string;
     };
 
-    sortOptions: {
+    sortOptions?: {
         id: string;
         title: string;
     }[];
@@ -79,15 +79,17 @@ export class Toolbar extends React.Component<IProps, IState> {
                         </InputGroup>
                     </ToolbarItem>
                 </ToolbarGroup>
-                <ToolbarGroup>
-                    <ToolbarItem>
-                        <Sort
-                            options={sortOptions}
-                            params={params}
-                            updateParams={updateParams}
-                        />
-                    </ToolbarItem>
-                </ToolbarGroup>
+                {sortOptions && (
+                    <ToolbarGroup>
+                        <ToolbarItem>
+                            <Sort
+                                options={sortOptions}
+                                params={params}
+                                updateParams={updateParams}
+                            />
+                        </ToolbarItem>
+                    </ToolbarGroup>
+                )}
                 {extraInputs.map((v, i) => (
                     <ToolbarGroup key={i}>
                         <ToolbarItem>{v}</ToolbarItem>

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -105,14 +105,6 @@ class Search extends React.Component<RouteComponentProps, IState> {
                     <div className='toolbar'>
                         <Toolbar
                             params={params}
-                            sortOptions={[
-                                { id: 'name', title: 'Name' },
-                                {
-                                    id: 'download_count',
-                                    title: 'Downloads',
-                                },
-                                { id: 'best_match', title: 'Best match' },
-                            ]}
                             updateParams={p =>
                                 this.updateParams(p, () =>
                                     this.queryCollections(),
@@ -229,11 +221,8 @@ class Search extends React.Component<RouteComponentProps, IState> {
     private queryCollections() {
         this.setState({ loading: true }, () => {
             CollectionAPI.list(
-                // TODO: ignoring tags and sort since they aren't supported yet
                 ParamHelper.getReduced(this.state.params, [
                     'view_type',
-                    'tags',
-                    'sort',
                 ]),
             ).then(result => {
                 this.setState({


### PR DESCRIPTION
- Enabling tags to be passed to the API
- Removing sort from collections page because the API doesn't support it yet