### PR TITLE
Fix derpy dropdown links.

### DIFF
--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -83,11 +83,14 @@ export class CollectionHeader extends React.Component<IProps> {
                         </FormSelect>
                         <StatefulDropdown
                             items={[
-                                <DropdownItem key='1'>
-                                    <Link to={Paths.token} target='_blank'>
-                                        Get API token
-                                    </Link>
-                                </DropdownItem>,
+                                <DropdownItem
+                                    key='1'
+                                    component={
+                                        <Link to={Paths.token} target='_blank'>
+                                            Get API token
+                                        </Link>
+                                    }
+                                />,
                             ]}
                         />
                     </div>

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -260,31 +260,43 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                 </Button>
                 <StatefulDropdown
                     items={[
-                        <DropdownItem key='1'>
-                            <Link
-                                to={formatPath(Paths.editNamespace, {
-                                    namespace: this.state.namespace.name,
-                                })}
-                            >
-                                Edit namespace
-                            </Link>
-                        </DropdownItem>,
-                        <DropdownItem key='2'>
-                            <Link
-                                to={formatPath(
-                                    Paths.myImports,
-                                    {},
-                                    { namespace: this.state.namespace.name },
-                                )}
-                            >
-                                Imports
-                            </Link>
-                        </DropdownItem>,
-                        <DropdownItem key='3'>
-                            <Link to={Paths.token} target='_blank'>
-                                Get API token
-                            </Link>
-                        </DropdownItem>,
+                        <DropdownItem
+                            key='1'
+                            component={
+                                <Link
+                                    to={formatPath(Paths.editNamespace, {
+                                        namespace: this.state.namespace.name,
+                                    })}
+                                >
+                                    Edit namespace
+                                </Link>
+                            }
+                        />,
+                        <DropdownItem
+                            key='2'
+                            component={
+                                <Link
+                                    to={formatPath(
+                                        Paths.myImports,
+                                        {},
+                                        {
+                                            namespace: this.state.namespace
+                                                .name,
+                                        },
+                                    )}
+                                >
+                                    Imports
+                                </Link>
+                            }
+                        />,
+                        <DropdownItem
+                            key='3'
+                            component={
+                                <Link to={Paths.token} target='_blank'>
+                                    Get API token
+                                </Link>
+                            }
+                        />,
                     ]}
                 />
             </div>


### PR DESCRIPTION
This fixes a warning that react was throwing

```
Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
    in a (created by Link)
    in Link (created by NamespaceDetail)
    in a (created by Context.Consumer)
```

And fixes some styling issues that the dropdown menus were having.