### PR TITLE
Do a better job of handling collection upload errors.

### DIFF
--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -142,6 +142,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                         this.toggleImportModal(isOpen, warn)
                     }
                     collection={updateCollection}
+                    namespace={namespace.name}
                 />
                 {warning ? (
                     <Alert


### PR DESCRIPTION
Fixes: https://github.com/ansible/galaxy-dev/issues/144

- If the UI can't parse the error response from the UI, default to `API error. Status code: <status>`
- On the UI validate that the file name:
    - Matches the collection file name spec
    - Matches the namespace that the user is on