### PR TITLE
Remove download counts from the UI.

### DIFF
--- a/src/api/mocked-responses/collection.ts
+++ b/src/api/mocked-responses/collection.ts
@@ -83,7 +83,7 @@ class CollectionGenerator extends RandomGenerator {
         const collection = {
             id: id,
             name: name,
-            download_count: this.randNum(10 ** (this.randNum(8) + 1)),
+            // download_count: this.randNum(10 ** (this.randNum(8) + 1)),
             namespace: namespace,
 
             latest_version: {

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -47,7 +47,7 @@ export class CollectionListType {
     id: string;
     name: string;
     description: string;
-    download_count: number;
+    // download_count: number;
     deprecated: boolean;
     latest_version: CollectionVersion;
 
@@ -110,7 +110,7 @@ export class CollectionDetailType {
     id: string;
     name: string;
     description: string;
-    download_count: number;
+    // download_count: number;
 
     namespace: {
         id: number;

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -28,7 +28,7 @@ export class CollectionListItem extends React.Component<IProps, {}> {
     render() {
         const {
             name,
-            download_count,
+            // download_count,
             latest_version,
             namespace,
             showNamespace,
@@ -100,10 +100,15 @@ export class CollectionListItem extends React.Component<IProps, {}> {
         cells.push(
             <DataListCell isFilled={false} alignRight key='stats'>
                 {controls ? <div className='entry'>{controls}</div> : null}
+                {
+                    // <div className='right-col entry'>
+                    //     <NumericLabel
+                    //         number={download_count}
+                    //         label='Download'
+                    //     />
+                    // </div>
+                }
                 <div className='right-col entry'>
-                    <NumericLabel number={download_count} label='Download' />
-                </div>
-                <div className='entry'>
                     Updated {moment(latest_version.created_at).fromNow()}
                 </div>
                 <div className='entry'>v{latest_version.version}</div>


### PR DESCRIPTION
The API doesn't support download count, so we're removing it from the UI.