### PR TITLE
Ensure the UI is authenticated before every API call.

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -12,6 +12,10 @@ export class BaseAPI {
             baseURL: this.apiBaseURL,
             paramsSerializer: params => ParamHelper.getQueryString(params),
         });
+
+        this.http.interceptors.request.use(request =>
+            this.authHandler(request),
+        );
     }
 
     list(params?: object, apiPath?: string) {
@@ -37,6 +41,14 @@ export class BaseAPI {
     create(data: any, apiPath?: string) {
         const path = apiPath || this.apiPath;
         return this.http.post(path, data);
+    }
+
+    private async authHandler(request) {
+        // This runs before every API request and ensures that the user is
+        // authenticated before the request is executed. On most calls it appears
+        // to only add ~10ms of latency.
+        await (window as any).insights.chrome.auth.getUser();
+        return request;
     }
 
     private mapPageToOffset(p) {


### PR DESCRIPTION
This fixes issues where the user's JWT would time out and then cause the next API call to return a 401 or 403. Adding a call to `insights.chrome.auth.getUser()` on every API call ensures the user is always authenticated.