### PR TITLE
2 spaces for a tab in prettier

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,6 +1,7 @@
 printWidth: 80
 singleQuote: true
 trailingComma: 'all'
-tabWidth: 4
+tabWidth: 2
 jsxSingleQuote: true
 jsxBracketSameLine: false
+bracketSpacing: true

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -3,71 +3,69 @@ import { Constants } from '../constants';
 import { ParamHelper } from '../utilities';
 
 export class BaseAPI {
-    apiBaseURL = API_HOST + API_BASE_PATH;
-    apiPath: string;
-    http: any;
+  apiBaseURL = API_HOST + API_BASE_PATH;
+  apiPath: string;
+  http: any;
 
-    constructor() {
-        this.http = axios.create({
-            baseURL: this.apiBaseURL,
-            paramsSerializer: params => ParamHelper.getQueryString(params),
-        });
+  constructor() {
+    this.http = axios.create({
+      baseURL: this.apiBaseURL,
+      paramsSerializer: params => ParamHelper.getQueryString(params),
+    });
 
-        this.http.interceptors.request.use(request =>
-            this.authHandler(request),
-        );
+    this.http.interceptors.request.use(request => this.authHandler(request));
+  }
+
+  list(params?: object, apiPath?: string) {
+    const path = apiPath || this.apiPath;
+
+    // The api uses offset/limit for pagination. I think this is confusing
+    // for params on the front end, so we're going to use page/page size
+    // for the URL params and just map it to whatever the api expects.
+
+    return this.http.get(path, { params: this.mapPageToOffset(params) });
+  }
+
+  get(id: string, apiPath?: string) {
+    const path = apiPath || this.apiPath;
+    return this.http.get(path + id + '/');
+  }
+
+  update(id: string, data: any, apiPath?: string) {
+    const path = apiPath || this.apiPath;
+    return this.http.put(path + id + '/', data);
+  }
+
+  create(data: any, apiPath?: string) {
+    const path = apiPath || this.apiPath;
+    return this.http.post(path, data);
+  }
+
+  private async authHandler(request) {
+    // This runs before every API request and ensures that the user is
+    // authenticated before the request is executed. On most calls it appears
+    // to only add ~10ms of latency.
+    if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
+      await (window as any).insights.chrome.auth.getUser();
     }
+    return request;
+  }
 
-    list(params?: object, apiPath?: string) {
-        const path = apiPath || this.apiPath;
+  private mapPageToOffset(p) {
+    // Need to copy the object to make sure we aren't accidentally
+    // setting page state
+    const params = { ...p };
 
-        // The api uses offset/limit for pagination. I think this is confusing
-        // for params on the front end, so we're going to use page/page size
-        // for the URL params and just map it to whatever the api expects.
+    const pageSize =
+      parseInt(params['page_size']) || Constants.DEFAULT_PAGE_SIZE;
+    const page = parseInt(params['page']) || 1;
 
-        return this.http.get(path, { params: this.mapPageToOffset(params) });
-    }
+    delete params['page'];
+    delete params['page_size'];
 
-    get(id: string, apiPath?: string) {
-        const path = apiPath || this.apiPath;
-        return this.http.get(path + id + '/');
-    }
+    params['offset'] = page * pageSize - pageSize;
+    params['limit'] = pageSize;
 
-    update(id: string, data: any, apiPath?: string) {
-        const path = apiPath || this.apiPath;
-        return this.http.put(path + id + '/', data);
-    }
-
-    create(data: any, apiPath?: string) {
-        const path = apiPath || this.apiPath;
-        return this.http.post(path, data);
-    }
-
-    private async authHandler(request) {
-        // This runs before every API request and ensures that the user is
-        // authenticated before the request is executed. On most calls it appears
-        // to only add ~10ms of latency.
-        if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
-            await (window as any).insights.chrome.auth.getUser();
-        }
-        return request;
-    }
-
-    private mapPageToOffset(p) {
-        // Need to copy the object to make sure we aren't accidentally
-        // setting page state
-        const params = { ...p };
-
-        const pageSize =
-            parseInt(params['page_size']) || Constants.DEFAULT_PAGE_SIZE;
-        const page = parseInt(params['page']) || 1;
-
-        delete params['page'];
-        delete params['page_size'];
-
-        params['offset'] = page * pageSize - pageSize;
-        params['limit'] = pageSize;
-
-        return params;
-    }
+    return params;
+  }
 }

--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -2,27 +2,27 @@ import { BaseAPI } from './base';
 import { CertificationStatus } from '../api';
 
 export class API extends BaseAPI {
-    apiPath = 'v3/_ui/collection-versions/';
+  apiPath = 'v3/_ui/collection-versions/';
 
-    constructor() {
-        super();
-    }
+  constructor() {
+    super();
+  }
 
-    setCertifiation(
-        namespace: string,
-        collection: string,
-        version: string,
-        certification: CertificationStatus,
-    ) {
-        const id = `${namespace}/${collection}/${version}/certified`;
+  setCertifiation(
+    namespace: string,
+    collection: string,
+    version: string,
+    certification: CertificationStatus,
+  ) {
+    const id = `${namespace}/${collection}/${version}/certified`;
 
-        return this.update(id, {
-            namespace: namespace,
-            name: collection,
-            version: version,
-            certification: certification,
-        });
-    }
+    return this.update(id, {
+      namespace: namespace,
+      name: collection,
+      version: version,
+      certification: certification,
+    });
+  }
 }
 
 export const CollectionVersionAPI = new API();

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -1,120 +1,120 @@
 import { BaseAPI } from './base';
 import { MockCollection } from './mocked-responses/collection';
 import {
-    CollectionDetailType,
-    CollectionListType,
-    CollectionUploadType,
+  CollectionDetailType,
+  CollectionListType,
+  CollectionUploadType,
 } from '../api';
 import axios from 'axios';
 
 export class API extends BaseAPI {
-    apiPath = 'v3/_ui/collections/';
-    cachedCollection: CollectionDetailType;
+  apiPath = 'v3/_ui/collections/';
+  cachedCollection: CollectionDetailType;
 
-    constructor() {
-        super();
+  constructor() {
+    super();
 
-        // Comment this out to make an actual API request
-        // mocked responses will be removed when a real API is available
-        // new MockCollection(this.http, this.apiPath);
+    // Comment this out to make an actual API request
+    // mocked responses will be removed when a real API is available
+    // new MockCollection(this.http, this.apiPath);
+  }
+
+  setDeprecation(collection: CollectionListType, isDeprecated: boolean) {
+    const path = 'v3/collections/';
+
+    return this.update(
+      `${collection.namespace.name}/${collection.name}`,
+      {
+        name: collection.name,
+        namespace: collection.namespace.name,
+        deprecated: isDeprecated,
+      },
+      path,
+    );
+  }
+
+  upload(
+    data: CollectionUploadType,
+    progressCallback: (e) => void,
+    cancelToken?: any,
+  ) {
+    const formData = new FormData();
+    formData.append('file', data.file);
+    // formData.append('sha256', artifact.sha256);
+
+    const config = {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+      onUploadProgress: progressCallback,
+    };
+
+    if (cancelToken) {
+      config['cancelToken'] = cancelToken.token;
     }
 
-    setDeprecation(collection: CollectionListType, isDeprecated: boolean) {
-        const path = 'v3/collections/';
+    return this.http.post('v3/artifacts/collections/', formData, config);
+  }
 
-        return this.update(
-            `${collection.namespace.name}/${collection.name}`,
-            {
-                name: collection.name,
-                namespace: collection.namespace.name,
-                deprecated: isDeprecated,
-            },
-            path,
-        );
-    }
+  getCancelToken() {
+    const CancelToken = axios.CancelToken;
+    const source = CancelToken.source();
 
-    upload(
-        data: CollectionUploadType,
-        progressCallback: (e) => void,
-        cancelToken?: any,
+    return source;
+  }
+
+  // Caches the last collection returned from the server. If the requested
+  // collection matches the cache, return it, if it doesn't query the API
+  // for the collection and replace the old cache with the new value.
+  // This allows the collection page to be broken into separate components
+  // and routed separately without fetching redundant data from the API
+  getCached(
+    namespace,
+    name,
+    params?,
+    forceReload?: boolean,
+  ): Promise<CollectionDetailType> {
+    if (
+      !forceReload &&
+      this.cachedCollection &&
+      this.cachedCollection.name === name &&
+      this.cachedCollection.namespace.name === namespace
     ) {
-        const formData = new FormData();
-        formData.append('file', data.file);
-        // formData.append('sha256', artifact.sha256);
-
-        const config = {
-            headers: {
-                'Content-Type': 'multipart/form-data',
-            },
-            onUploadProgress: progressCallback,
-        };
-
-        if (cancelToken) {
-            config['cancelToken'] = cancelToken.token;
-        }
-
-        return this.http.post('v3/artifacts/collections/', formData, config);
-    }
-
-    getCancelToken() {
-        const CancelToken = axios.CancelToken;
-        const source = CancelToken.source();
-
-        return source;
-    }
-
-    // Caches the last collection returned from the server. If the requested
-    // collection matches the cache, return it, if it doesn't query the API
-    // for the collection and replace the old cache with the new value.
-    // This allows the collection page to be broken into separate components
-    // and routed separately without fetching redundant data from the API
-    getCached(
-        namespace,
-        name,
-        params?,
-        forceReload?: boolean,
-    ): Promise<CollectionDetailType> {
-        if (
-            !forceReload &&
-            this.cachedCollection &&
-            this.cachedCollection.name === name &&
-            this.cachedCollection.namespace.name === namespace
-        ) {
-            return new Promise((resolve, reject) => {
-                if (this.cachedCollection) {
-                    resolve(this.cachedCollection);
-                } else {
-                    reject(this.cachedCollection);
-                }
-            });
+      return new Promise((resolve, reject) => {
+        if (this.cachedCollection) {
+          resolve(this.cachedCollection);
         } else {
-            return new Promise((resolve, reject) => {
-                this.http
-                    .get(`${this.apiPath}${namespace}/${name}/`, {
-                        params: params,
-                    })
-                    .then(result => {
-                        this.cachedCollection = result.data;
-                        resolve(result.data);
-                    })
-                    .catch(result => {
-                        reject(result);
-                    });
-            });
+          reject(this.cachedCollection);
         }
+      });
+    } else {
+      return new Promise((resolve, reject) => {
+        this.http
+          .get(`${this.apiPath}${namespace}/${name}/`, {
+            params: params,
+          })
+          .then(result => {
+            this.cachedCollection = result.data;
+            resolve(result.data);
+          })
+          .catch(result => {
+            reject(result);
+          });
+      });
     }
+  }
 
-    getDownloadURL(namespace, name, version) {
-        // UI API doesn't have tarball download link, so query it separately here
-        return new Promise((resolve, reject) => {
-            this.http
-                .get(`v3/collections/${namespace}/${name}/versions/${version}/`)
-                .then(result => {
-                    resolve(result.data['download_url']);
-                })
-                .catch(err => reject(err));
-        });
-    }
+  getDownloadURL(namespace, name, version) {
+    // UI API doesn't have tarball download link, so query it separately here
+    return new Promise((resolve, reject) => {
+      this.http
+        .get(`v3/collections/${namespace}/${name}/versions/${version}/`)
+        .then(result => {
+          resolve(result.data['download_url']);
+        })
+        .catch(err => reject(err));
+    });
+  }
 }
 
 export const CollectionAPI = new API();

--- a/src/api/import.ts
+++ b/src/api/import.ts
@@ -2,22 +2,22 @@ import { BaseAPI } from './base';
 import { MockImport } from './mocked-responses/import';
 
 export class API extends BaseAPI {
-    apiPath = 'v3/_ui/imports/collections/';
-    mock: any;
+  apiPath = 'v3/_ui/imports/collections/';
+  mock: any;
 
-    constructor() {
-        super();
+  constructor() {
+    super();
 
-        // Comment this out to make an actual API request
-        // mocked responses will be removed when a real API is available
-        // this.mock = new MockImport(this.http, this.apiPath);
-    }
+    // Comment this out to make an actual API request
+    // mocked responses will be removed when a real API is available
+    // this.mock = new MockImport(this.http, this.apiPath);
+  }
 
-    get(id, path?) {
-        // call this to generate more task messages
-        // this.mock.updateImportDetail();
-        return super.get(id, path);
-    }
+  get(id, path?) {
+    // call this to generate more task messages
+    // this.mock.updateImportDetail();
+    return super.get(id, path);
+  }
 }
 
 export const ImportAPI = new API();

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -2,20 +2,20 @@ export { CollectionAPI } from './collection';
 export { NamespaceAPI } from './namespace';
 export { NamespaceType, NamespaceListType } from './response-types/namespace';
 export {
-    CollectionListType,
-    CollectionDetailType,
-    DocsBlobType,
-    PluginContentType,
-    CollectionUploadType,
-    ContentSummaryType,
-    CollectionVersion,
-    CertificationStatus,
+  CollectionListType,
+  CollectionDetailType,
+  DocsBlobType,
+  PluginContentType,
+  CollectionUploadType,
+  ContentSummaryType,
+  CollectionVersion,
+  CertificationStatus,
 } from './response-types/collection';
 export {
-    ImportListType,
-    ImportDetailType,
-    PulpStatus,
-    ImportMessageCodes,
+  ImportListType,
+  ImportDetailType,
+  PulpStatus,
+  ImportMessageCodes,
 } from './response-types/import';
 export { ImportAPI } from './import';
 export { UserAPI } from './user';

--- a/src/api/mocked-responses/collection.ts
+++ b/src/api/mocked-responses/collection.ts
@@ -4,250 +4,235 @@ import { redHat, google } from './namespace';
 import { RandomGenerator } from './generator';
 
 export class MockCollection {
-    mock: any;
-    collectionNames = [
-        // 'epel',
-        // 'collection_demo',
-        // 'a_collection_with_a_really_annoying_long_name',
-        'community',
-        // 'kitchen_sink',
-        // 'bathroom_sink',
-        // 'outdoor_sink',
-        'network',
-        'os',
-        'cloud',
-        'crypto',
-        'monitoring',
-        'messaging',
-        'packaging',
-        'openshift',
-    ];
+  mock: any;
+  collectionNames = [
+    // 'epel',
+    // 'collection_demo',
+    // 'a_collection_with_a_really_annoying_long_name',
+    'community',
+    // 'kitchen_sink',
+    // 'bathroom_sink',
+    // 'outdoor_sink',
+    'network',
+    'os',
+    'cloud',
+    'crypto',
+    'monitoring',
+    'messaging',
+    'packaging',
+    'openshift',
+  ];
 
-    constructor(http: any, apiPath: string) {
-        const collectionList = this.getCollectionList();
+  constructor(http: any, apiPath: string) {
+    const collectionList = this.getCollectionList();
 
-        this.mock = new MockAdapter(http, { delayResponse: 200 });
+    this.mock = new MockAdapter(http, { delayResponse: 200 });
 
-        this.mock
-            .onGet(apiPath + 'red_hat/collection_demo/')
-            .reply(200, this.getCollectionDetail(collectionList[0]));
+    this.mock
+      .onGet(apiPath + 'red_hat/collection_demo/')
+      .reply(200, this.getCollectionDetail(collectionList[0]));
 
-        this.mock
-            .onGet(apiPath, {
-                params: { keywords: 'epel', offset: 0, limit: 10 },
-            })
-            .reply(200, {
-                meta: { count: 1 },
-                links: {},
-                data: [collectionList[0]],
-            });
+    this.mock
+      .onGet(apiPath, {
+        params: { keywords: 'epel', offset: 0, limit: 10 },
+      })
+      .reply(200, {
+        meta: { count: 1 },
+        links: {},
+        data: [collectionList[0]],
+      });
 
-        this.mock
-            .onGet(apiPath, { params: { offset: 10, limit: 10 } })
-            .reply(200, {
-                meta: { count: collectionList.length },
-                links: {},
-                data: collectionList.slice(10, 19),
-            });
+    this.mock.onGet(apiPath, { params: { offset: 10, limit: 10 } }).reply(200, {
+      meta: { count: collectionList.length },
+      links: {},
+      data: collectionList.slice(10, 19),
+    });
 
-        this.mock.onGet(apiPath, {}).reply(200, {
-            meta: { count: collectionList.length },
-            links: {},
-            data: collectionList.slice(0, 9),
-        });
+    this.mock.onGet(apiPath, {}).reply(200, {
+      meta: { count: collectionList.length },
+      links: {},
+      data: collectionList.slice(0, 9),
+    });
+  }
+
+  getCollectionList() {
+    const collections = [] as CollectionListType[];
+
+    for (let i = 0; i < this.collectionNames.length; i++) {
+      collections.push(
+        CollectionGenerator.generate(
+          String(i),
+          this.collectionNames[i],
+          redHat,
+        ),
+      );
     }
 
-    getCollectionList() {
-        const collections = [] as CollectionListType[];
+    return collections;
+  }
 
-        for (let i = 0; i < this.collectionNames.length; i++) {
-            collections.push(
-                CollectionGenerator.generate(
-                    String(i),
-                    this.collectionNames[i],
-                    redHat,
-                ),
-            );
-        }
-
-        return collections;
-    }
-
-    getCollectionDetail(collection: CollectionListType): CollectionDetailType {
-        return CollectionGenerator.generateDetail(collection);
-    }
+  getCollectionDetail(collection: CollectionListType): CollectionDetailType {
+    return CollectionGenerator.generateDetail(collection);
+  }
 }
 
 class CollectionGenerator extends RandomGenerator {
-    static generate(id, name, namespace): CollectionListType {
-        const collection = {
-            id: id,
-            name: name,
-            // download_count: this.randNum(10 ** (this.randNum(8) + 1)),
-            namespace: namespace,
+  static generate(id, name, namespace): CollectionListType {
+    const collection = {
+      id: id,
+      name: name,
+      // download_count: this.randNum(10 ** (this.randNum(8) + 1)),
+      namespace: namespace,
 
-            latest_version: {
-                id: id,
-                version: `${this.randNum(5)}.${this.randNum(10)}.${this.randNum(
-                    100,
-                )}`,
-                created_at: this.randDate(
-                    new Date(2016, 0, 1),
-                    new Date(),
-                ).toString(),
-                metadata: {
-                    tags: this.randWords(9),
-                    description: this.lipsum.substring(
-                        0,
-                        this.randNum(this.lipsum.length),
-                    ),
+      latest_version: {
+        id: id,
+        version: `${this.randNum(5)}.${this.randNum(10)}.${this.randNum(100)}`,
+        created_at: this.randDate(new Date(2016, 0, 1), new Date()).toString(),
+        metadata: {
+          tags: this.randWords(9),
+          description: this.lipsum.substring(
+            0,
+            this.randNum(this.lipsum.length),
+          ),
+        },
+
+        contents: [
+          {
+            name: 'factoid',
+            description: null,
+            content_type: 'role',
+          },
+          {
+            name: 'deltoid',
+            description: null,
+            content_type: 'role',
+          },
+          {
+            name: 'real_facts',
+            description: 'A module that dishes out the true facts.',
+            content_type: 'module',
+          },
+        ],
+      },
+    } as CollectionListType;
+
+    return collection;
+  }
+
+  static generateDetail(collection: CollectionListType): CollectionDetailType {
+    const latest_version = collection.latest_version as any;
+
+    latest_version.metadata = {
+      ...collection.latest_version.metadata,
+      authors: ['David Newswanger'],
+      license: 'MIT',
+      homepage: 'https://www.example.com',
+      documentation: 'https://www.example.com',
+      issues: 'https://www.example.com',
+      repository: 'https://www.example.com',
+    };
+
+    latest_version.docs_blob = {
+      contents: [
+        {
+          doc_strings: {},
+          readme_file: 'README.md',
+          readme_html:
+            '<h1>Factoid</h1>\n<p>A brief description of the role goes here.</p>\n<h2>Requirements</h2>\n<p>Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.</p>\n<h2>Role Variables</h2>\n<p>A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.</p>\n<h2>Dependencies</h2>\n<p>A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.</p>\n<h2>Example Playbook</h2>\n<p>Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:</p>\n<pre><code>- hosts: servers\n  roles:\n     - { role: username.rolename, x: 42 }\n</code></pre>\n<h2>License</h2>\n<p>BSD</p>\n<h2>Author Information</h2>\n<p>An optional section for the role authors to include contact information, or a website (HTML is not allowed).</p>',
+          content_name: 'factoid',
+          content_type: 'role',
+        },
+        {
+          doc_strings: {},
+          readme_file: 'README.md',
+          readme_html: '<p>Role</p>',
+          content_name: 'deltoid',
+          content_type: 'role',
+        },
+        {
+          doc_strings: {
+            doc: {
+              author: ['David Newswanger (@newswangerd)'],
+              module: 'real_facts',
+              options: [
+                {
+                  name: 'name',
+                  default: 'Richard Stallman',
                 },
-
-                contents: [
-                    {
-                        name: 'factoid',
-                        description: null,
-                        content_type: 'role',
-                    },
-                    {
-                        name: 'deltoid',
-                        description: null,
-                        content_type: 'role',
-                    },
-                    {
-                        name: 'real_facts',
-                        description: 'A module that dishes out the true facts.',
-                        content_type: 'module',
-                    },
-                ],
+              ],
+              filename: '/tmp/tmplx7uj71c/plugins/modules/real_facts.py',
+              description: [
+                'A module that dishes out the true facts.',
+                "This is an ansible implementation of the GNU Octave 'truth' script.",
+                'https://fossies.org/linux/octave/scripts/miscellaneous/fact.m',
+              ],
+              version_added: '2.8',
+              short_description: 'A module that dishes out the true facts.',
             },
-        } as CollectionListType;
-
-        return collection;
-    }
-
-    static generateDetail(
-        collection: CollectionListType,
-    ): CollectionDetailType {
-        const latest_version = collection.latest_version as any;
-
-        latest_version.metadata = {
-            ...collection.latest_version.metadata,
-            authors: ['David Newswanger'],
-            license: 'MIT',
-            homepage: 'https://www.example.com',
-            documentation: 'https://www.example.com',
-            issues: 'https://www.example.com',
-            repository: 'https://www.example.com',
-        };
-
-        latest_version.docs_blob = {
-            contents: [
-                {
-                    doc_strings: {},
-                    readme_file: 'README.md',
-                    readme_html:
-                        '<h1>Factoid</h1>\n<p>A brief description of the role goes here.</p>\n<h2>Requirements</h2>\n<p>Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.</p>\n<h2>Role Variables</h2>\n<p>A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.</p>\n<h2>Dependencies</h2>\n<p>A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.</p>\n<h2>Example Playbook</h2>\n<p>Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:</p>\n<pre><code>- hosts: servers\n  roles:\n     - { role: username.rolename, x: 42 }\n</code></pre>\n<h2>License</h2>\n<p>BSD</p>\n<h2>Author Information</h2>\n<p>An optional section for the role authors to include contact information, or a website (HTML is not allowed).</p>',
-                    content_name: 'factoid',
-                    content_type: 'role',
-                },
-                {
-                    doc_strings: {},
-                    readme_file: 'README.md',
-                    readme_html: '<p>Role</p>',
-                    content_name: 'deltoid',
-                    content_type: 'role',
-                },
-                {
-                    doc_strings: {
-                        doc: {
-                            author: ['David Newswanger (@newswangerd)'],
-                            module: 'real_facts',
-                            options: [
-                                {
-                                    name: 'name',
-                                    default: 'Richard Stallman',
-                                },
-                            ],
-                            filename:
-                                '/tmp/tmplx7uj71c/plugins/modules/real_facts.py',
-                            description: [
-                                'A module that dishes out the true facts.',
-                                "This is an ansible implementation of the GNU Octave 'truth' script.",
-                                'https://fossies.org/linux/octave/scripts/miscellaneous/fact.m',
-                            ],
-                            version_added: '2.8',
-                            short_description:
-                                'A module that dishes out the true facts.',
-                        },
-                        return: [
-                            {
-                                name: 'fact',
-                                type: 'str',
-                                sample:
-                                    'Richard Stallman takes notes in binary.',
-                                description: 'Actual facts',
-                            },
-                        ],
-                        examples:
-                            '\n# Pass in a message\n- name: Test with a message\n  real_facts:\n    name: David Newswanger\n',
-                        metadata: {
-                            status: ['preview'],
-                            supported_by: 'community',
-                        },
-                    },
-                    readme_file: null,
-                    readme_html: null,
-                    content_name: 'real_facts',
-                    content_type: 'module',
-                },
+            return: [
+              {
+                name: 'fact',
+                type: 'str',
+                sample: 'Richard Stallman takes notes in binary.',
+                description: 'Actual facts',
+              },
             ],
-            collection_readme: {
-                html:
-                    '<h1>How to use this Demo</h1>\n<ol>\n<li>Install the latest version of mazer: <code>pip install mazer</code>.</li>\n<li>Install or upgrade to Ansible 2.8+</li>\n<li>Download this collection from galaxy: <code>mazer install newswangerd.collection_demo</code></li>\n<li>Execute the <code>real_facts</code> module using <code>ansible localhost -m newswangerd.collection_demo.real_facts</code></li>\n</ol>\n<p>To see a recorded demo using this collection <a href="https://www.youtube.com/watch?v=d792W44I5KM">check out this video here</a>.</p>\n<h1>What is a collection?</h1>\n<p>A collection is a distribution format for delivering all types of Ansible Content.</p>\n<p>To learn more about using and creating collections, <a href="https://docs.ansible.com/ansible/devel/dev_guide/collections_tech_preview.html">check out the official documentation here</a></p>',
-                name: 'README.md',
+            examples:
+              '\n# Pass in a message\n- name: Test with a message\n  real_facts:\n    name: David Newswanger\n',
+            metadata: {
+              status: ['preview'],
+              supported_by: 'community',
             },
-            documentation_files: [
-                {
-                    html:
-                        '<h1>Hello world</h1>\n<p>This is a test <strong>markdown</strong> file!</p>\n<ul>\n<li>Now watch me list</li>\n</ul>\n<pre><code>now watch me code\n</code></pre>\n\n<p><code>now watch me code again</code></p>\n<h2>Now with new things in version 1.0.7</h2>',
-                    name: 'test_guide.md',
-                },
-            ],
-        };
+          },
+          readme_file: null,
+          readme_html: null,
+          content_name: 'real_facts',
+          content_type: 'module',
+        },
+      ],
+      collection_readme: {
+        html:
+          '<h1>How to use this Demo</h1>\n<ol>\n<li>Install the latest version of mazer: <code>pip install mazer</code>.</li>\n<li>Install or upgrade to Ansible 2.8+</li>\n<li>Download this collection from galaxy: <code>mazer install newswangerd.collection_demo</code></li>\n<li>Execute the <code>real_facts</code> module using <code>ansible localhost -m newswangerd.collection_demo.real_facts</code></li>\n</ol>\n<p>To see a recorded demo using this collection <a href="https://www.youtube.com/watch?v=d792W44I5KM">check out this video here</a>.</p>\n<h1>What is a collection?</h1>\n<p>A collection is a distribution format for delivering all types of Ansible Content.</p>\n<p>To learn more about using and creating collections, <a href="https://docs.ansible.com/ansible/devel/dev_guide/collections_tech_preview.html">check out the official documentation here</a></p>',
+        name: 'README.md',
+      },
+      documentation_files: [
+        {
+          html:
+            '<h1>Hello world</h1>\n<p>This is a test <strong>markdown</strong> file!</p>\n<ul>\n<li>Now watch me list</li>\n</ul>\n<pre><code>now watch me code\n</code></pre>\n\n<p><code>now watch me code again</code></p>\n<h2>Now with new things in version 1.0.7</h2>',
+          name: 'test_guide.md',
+        },
+      ],
+    };
 
-        latest_version.contents = [
-            {
-                name: 'factoid',
-                description: null,
-                content_type: 'role',
-            },
-            {
-                name: 'deltoid',
-                description: null,
-                content_type: 'role',
-            },
-            {
-                name: 'real_facts',
-                description: 'A module that dishes out the true facts.',
-                content_type: 'module',
-            },
-        ];
+    latest_version.contents = [
+      {
+        name: 'factoid',
+        description: null,
+        content_type: 'role',
+      },
+      {
+        name: 'deltoid',
+        description: null,
+        content_type: 'role',
+      },
+      {
+        name: 'real_facts',
+        description: 'A module that dishes out the true facts.',
+        content_type: 'module',
+      },
+    ];
 
-        return {
-            ...collection,
-            name: 'collection_demo',
-            latest_version: latest_version,
-            all_versions: [
-                {
-                    id: '9',
-                    version: '1.0.0',
-                    created: this.randDate(
-                        new Date(2019, 0, 1),
-                        new Date(),
-                    ).toString(),
-                },
-            ],
-        };
-    }
+    return {
+      ...collection,
+      name: 'collection_demo',
+      latest_version: latest_version,
+      all_versions: [
+        {
+          id: '9',
+          version: '1.0.0',
+          created: this.randDate(new Date(2019, 0, 1), new Date()).toString(),
+        },
+      ],
+    };
+  }
 }

--- a/src/api/mocked-responses/generator.ts
+++ b/src/api/mocked-responses/generator.ts
@@ -1,47 +1,47 @@
 export class RandomGenerator {
-    static lipsum = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc eget nisl quis diam lacinia pretium. Donec pharetra varius erat in condimentum. Maecenas sed tortor fringilla, congue lectus sit amet, ultricies urna. Nam sodales mi quis lacus condimentum, id semper nunc ultrices. In sem orci, condimentum eu magna quis, faucibus ultricies metus. Nullam justo dolor, convallis sed lacinia eget, semper ac massa. Curabitur turpis metus, auctor sed tellus et, dictum aliquam velit.`;
+  static lipsum = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc eget nisl quis diam lacinia pretium. Donec pharetra varius erat in condimentum. Maecenas sed tortor fringilla, congue lectus sit amet, ultricies urna. Nam sodales mi quis lacus condimentum, id semper nunc ultrices. In sem orci, condimentum eu magna quis, faucibus ultricies metus. Nullam justo dolor, convallis sed lacinia eget, semper ac massa. Curabitur turpis metus, auctor sed tellus et, dictum aliquam velit.`;
 
-    static words = [
-        'network',
-        'security',
-        'rhel',
-        'cloud',
-        'system',
-        'collection',
-        'ubuntu',
-        'kubernetes',
-        'container',
-        'package',
-        'system',
-        'compliance',
-        'plugins',
-        'modules',
-        'roles',
-    ];
+  static words = [
+    'network',
+    'security',
+    'rhel',
+    'cloud',
+    'system',
+    'collection',
+    'ubuntu',
+    'kubernetes',
+    'container',
+    'package',
+    'system',
+    'compliance',
+    'plugins',
+    'modules',
+    'roles',
+  ];
 
-    static randNum(max) {
-        return Math.floor(Math.random() * max);
+  static randNum(max) {
+    return Math.floor(Math.random() * max);
+  }
+
+  static randDate(start, end) {
+    return new Date(
+      start.getTime() + Math.random() * (end.getTime() - start.getTime()),
+    );
+  }
+
+  static randWords(length) {
+    const w: string[] = [];
+
+    const n = this.randNum(length);
+
+    for (let i = 0; i < n; i++) {
+      w.push(this.words[this.randNum(this.words.length)]);
     }
 
-    static randDate(start, end) {
-        return new Date(
-            start.getTime() + Math.random() * (end.getTime() - start.getTime()),
-        );
-    }
+    return w;
+  }
 
-    static randWords(length) {
-        const w: string[] = [];
-
-        const n = this.randNum(length);
-
-        for (let i = 0; i < n; i++) {
-            w.push(this.words[this.randNum(this.words.length)]);
-        }
-
-        return w;
-    }
-
-    static randString(length) {
-        return this.lipsum.substring(0, this.randNum(length));
-    }
+  static randString(length) {
+    return this.lipsum.substring(0, this.randNum(length));
+  }
 }

--- a/src/api/mocked-responses/import.ts
+++ b/src/api/mocked-responses/import.ts
@@ -1,132 +1,124 @@
 import * as MockAdapter from 'axios-mock-adapter';
 import {
-    ImportListType,
-    ImportDetailType,
-    PulpStatus,
-    ImportMessageCodes,
+  ImportListType,
+  ImportDetailType,
+  PulpStatus,
+  ImportMessageCodes,
 } from '../../api';
 import { RandomGenerator } from './generator';
 
 export class MockImport {
-    mock: any;
+  mock: any;
 
-    collectionNames = [
-        'epel',
-        'collection_demo',
-        'a_collection_with_a_really_annoying_long_name',
-        'community',
-        'kitchen_sink',
-        'bathroom_sink',
-        'outdoor_sink',
-        'network',
-        'os',
-        'cloud',
-        'crypto',
-        'monitoring',
-        'messaging',
-        'packaging',
-        'openshift',
-    ];
+  collectionNames = [
+    'epel',
+    'collection_demo',
+    'a_collection_with_a_really_annoying_long_name',
+    'community',
+    'kitchen_sink',
+    'bathroom_sink',
+    'outdoor_sink',
+    'network',
+    'os',
+    'cloud',
+    'crypto',
+    'monitoring',
+    'messaging',
+    'packaging',
+    'openshift',
+  ];
 
-    imports: ImportListType[];
-    importMesages: any[];
-    importDetail: any;
+  imports: ImportListType[];
+  importMesages: any[];
+  importDetail: any;
 
-    constructor(http: any, apiPath: string) {
-        this.imports = this.getImportList();
-        this.importMesages = [];
-        this.importDetail = this.getImportDetail();
+  constructor(http: any, apiPath: string) {
+    this.imports = this.getImportList();
+    this.importMesages = [];
+    this.importDetail = this.getImportDetail();
 
-        this.mock = new MockAdapter(http, { delayResponse: 200 });
-        this.mock.onGet(`${apiPath}0/`).reply(200, this.importDetail);
-        this.mock.onGet(apiPath).reply(200, {
-            data: this.imports,
-            links: {},
-            meta: { count: this.imports.length },
-        });
+    this.mock = new MockAdapter(http, { delayResponse: 200 });
+    this.mock.onGet(`${apiPath}0/`).reply(200, this.importDetail);
+    this.mock.onGet(apiPath).reply(200, {
+      data: this.imports,
+      links: {},
+      meta: { count: this.imports.length },
+    });
+  }
+
+  getImportList() {
+    const imports = [] as ImportListType[];
+
+    for (let i = 0; i < this.collectionNames.length; i++) {
+      imports.push(ImportGenerator.generate(i, this.collectionNames[i]));
     }
 
-    getImportList() {
-        const imports = [] as ImportListType[];
+    return imports;
+  }
 
-        for (let i = 0; i < this.collectionNames.length; i++) {
-            imports.push(ImportGenerator.generate(i, this.collectionNames[i]));
-        }
+  updateImportDetail() {
+    if (this.importMesages.length < 60) {
+      for (let m of TaskGenerator.generate()) {
+        this.importMesages.push(m);
+      }
+    } else {
+      this.importDetail.state = PulpStatus.completed;
+    }
+  }
 
-        return imports;
+  getImportDetail() {
+    // Mutate the list of messages so that new messages get added each
+    // time this is called
+    for (let m of TaskGenerator.generate()) {
+      this.importMesages.push(m);
     }
 
-    updateImportDetail() {
-        if (this.importMesages.length < 60) {
-            for (let m of TaskGenerator.generate()) {
-                this.importMesages.push(m);
-            }
-        } else {
-            this.importDetail.state = PulpStatus.completed;
-        }
-    }
-
-    getImportDetail() {
-        // Mutate the list of messages so that new messages get added each
-        // time this is called
-        for (let m of TaskGenerator.generate()) {
-            this.importMesages.push(m);
-        }
-
-        return {
-            ...this.imports[0],
-            job_id: '1',
-            error: {
-                code: 'dun-goofed',
-                description: 'ya dun goofed',
-                traceback: 'omg you reeally really dun goofed',
-            },
-            imported_version: this.imports[0].version,
-            messages: this.importMesages,
-        };
-    }
+    return {
+      ...this.imports[0],
+      job_id: '1',
+      error: {
+        code: 'dun-goofed',
+        description: 'ya dun goofed',
+        traceback: 'omg you reeally really dun goofed',
+      },
+      imported_version: this.imports[0].version,
+      messages: this.importMesages,
+    };
+  }
 }
 
 class TaskGenerator extends RandomGenerator {
-    static generate(): any[] {
-        const l = [];
+  static generate(): any[] {
+    const l = [];
 
-        for (let i = 0; i < this.randNum(20); i++) {
-            l.push({
-                level: this.randNum(2) < 1 ? '' : ImportMessageCodes.error,
-                message: this.randString(150),
-                time: new Date().toString(),
-            });
-        }
-
-        l.push({
-            level: ImportMessageCodes.success,
-            time: new Date().toString(),
-            message: '',
-        });
-
-        return l;
+    for (let i = 0; i < this.randNum(20); i++) {
+      l.push({
+        level: this.randNum(2) < 1 ? '' : ImportMessageCodes.error,
+        message: this.randString(150),
+        time: new Date().toString(),
+      });
     }
+
+    l.push({
+      level: ImportMessageCodes.success,
+      time: new Date().toString(),
+      message: '',
+    });
+
+    return l;
+  }
 }
 
 class ImportGenerator extends RandomGenerator {
-    static generate(id, name): ImportListType {
-        return {
-            id: id,
-            state: id === 0 ? PulpStatus.running : PulpStatus.completed,
-            started_at: this.randDate(
-                new Date(2019, 0, 1),
-                new Date(),
-            ).toString(),
-            finished_at: this.randDate(
-                new Date(2019, 0, 1),
-                new Date(),
-            ).toString(),
-            namespace: 'red_hat',
-            name: name,
-            version: `${this.randNum(5)}.${this.randNum(10)}.${this.randNum(
-                100,
-            )}`,
-        };
-    }
+  static generate(id, name): ImportListType {
+    return {
+      id: id,
+      state: id === 0 ? PulpStatus.running : PulpStatus.completed,
+      started_at: this.randDate(new Date(2019, 0, 1), new Date()).toString(),
+      finished_at: this.randDate(new Date(2019, 0, 1), new Date()).toString(),
+      namespace: 'red_hat',
+      name: name,
+      version: `${this.randNum(5)}.${this.randNum(10)}.${this.randNum(100)}`,
+    };
+  }
 }

--- a/src/api/mocked-responses/namespace.ts
+++ b/src/api/mocked-responses/namespace.ts
@@ -2,14 +2,14 @@ import * as MockAdapter from 'axios-mock-adapter';
 import { NamespaceType, NamespaceListType } from '../../api';
 
 export const redHat = {
-    id: 1,
-    name: 'red_hat',
-    company: 'Red Hat',
-    avatar_url:
-        'https://www.redhat.com/cms/managed-files/styles/wysiwyg_full_width/s3/Logo-RedHat-Hat-Color-CMYK%20%281%29.jpg?itok=Mf0Ff9jq',
-    description:
-        'We’re the world’s leading provider of enterprise open source solutions, using a community-powered approach to deliver high-performing Linux, cloud, container, and Kubernetes technologies. We help you standardize across environments, develop cloud-native applications, and integrate, automate, secure, and manage complex environments with award-winning support, training, and consulting services.',
-    resources: `[![Build Status](https://travis-ci.com/ansible/galaxy.svg?branch=devel)](https://travis-ci.com/ansible/galaxy)
+  id: 1,
+  name: 'red_hat',
+  company: 'Red Hat',
+  avatar_url:
+    'https://www.redhat.com/cms/managed-files/styles/wysiwyg_full_width/s3/Logo-RedHat-Hat-Color-CMYK%20%281%29.jpg?itok=Mf0Ff9jq',
+  description:
+    'We’re the world’s leading provider of enterprise open source solutions, using a community-powered approach to deliver high-performing Linux, cloud, container, and Kubernetes technologies. We help you standardize across environments, develop cloud-native applications, and integrate, automate, secure, and manage complex environments with award-winning support, training, and consulting services.',
+  resources: `[![Build Status](https://travis-ci.com/ansible/galaxy.svg?branch=devel)](https://travis-ci.com/ansible/galaxy)
 
 # Ansible Galaxy
 
@@ -55,68 +55,68 @@ View [AUTHORS](./AUTHORS) for a list contributors to Ansible Galaxy. Thanks ever
 
 Ansible Galaxy is an [Ansible by Red Hat](https://ansible.com) sponsored project.
 `,
-    links: [
-        { name: 'Red Hat', url: 'https://www.redhat.com' },
-        {
-            name: 'Cormier: "Ansible is a Platform"',
-            url: 'https://www.redhat.com',
-        },
-    ],
-    owners: [{ name: 'newswangerd' }],
-    num_collections: 10,
+  links: [
+    { name: 'Red Hat', url: 'https://www.redhat.com' },
+    {
+      name: 'Cormier: "Ansible is a Platform"',
+      url: 'https://www.redhat.com',
+    },
+  ],
+  owners: [{ name: 'newswangerd' }],
+  num_collections: 10,
 } as NamespaceType;
 
 export const google = {
-    id: 4,
-    name: 'google',
-    company: 'Google Cloud',
-    num_collections: 2,
-    description: 'Google Cloud Platform',
-    avatar_url:
-        'https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/apple-icon.png',
+  id: 4,
+  name: 'google',
+  company: 'Google Cloud',
+  num_collections: 2,
+  description: 'Google Cloud Platform',
+  avatar_url:
+    'https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/apple-icon.png',
 };
 
 export class MockNamespace {
-    mock: any;
+  mock: any;
 
-    constructor(http: any, apiPath: string) {
-        this.mock = new MockAdapter(http, { delayResponse: 200 });
-        this.mock.onGet(apiPath).reply(200, {
-            links: {},
-            meta: { count: 1 },
-            data: this.getNSList(),
-        });
-        this.mock.onGet(apiPath + 'red_hat/').reply(200, this.getNSDetail());
-        this.mock.onPut(apiPath + 'red_hat/').reply(204, this.ns1);
-    }
+  constructor(http: any, apiPath: string) {
+    this.mock = new MockAdapter(http, { delayResponse: 200 });
+    this.mock.onGet(apiPath).reply(200, {
+      links: {},
+      meta: { count: 1 },
+      data: this.getNSList(),
+    });
+    this.mock.onGet(apiPath + 'red_hat/').reply(200, this.getNSDetail());
+    this.mock.onPut(apiPath + 'red_hat/').reply(204, this.ns1);
+  }
 
-    ns1 = redHat;
+  ns1 = redHat;
 
-    ns2 = {
-        id: 2,
-        name: 'cisco',
-        company: 'Cisco',
-        num_collections: 1,
-        avatar_url:
-            'https://upload.wikimedia.org/wikipedia/commons/thumb/6/64/Cisco_logo.svg/320px-Cisco_logo.svg.png',
-    };
+  ns2 = {
+    id: 2,
+    name: 'cisco',
+    company: 'Cisco',
+    num_collections: 1,
+    avatar_url:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/6/64/Cisco_logo.svg/320px-Cisco_logo.svg.png',
+  };
 
-    ns3 = {
-        id: 3,
-        name: 'ansible',
-        company: 'Ansible',
-        num_collections: 90,
-        avatar_url:
-            'https://logos-download.com/wp-content/uploads/2016/10/Ansible_logo.png',
-    };
+  ns3 = {
+    id: 3,
+    name: 'ansible',
+    company: 'Ansible',
+    num_collections: 90,
+    avatar_url:
+      'https://logos-download.com/wp-content/uploads/2016/10/Ansible_logo.png',
+  };
 
-    ns4 = google;
+  ns4 = google;
 
-    getNSList() {
-        return [this.ns1, this.ns2, this.ns3, this.ns4];
-    }
+  getNSList() {
+    return [this.ns1, this.ns2, this.ns3, this.ns4];
+  }
 
-    getNSDetail() {
-        return this.ns1;
-    }
+  getNSDetail() {
+    return this.ns1;
+  }
 }

--- a/src/api/my-namespace.ts
+++ b/src/api/my-namespace.ts
@@ -1,11 +1,11 @@
 import { BaseAPI } from './base';
 
 class API extends BaseAPI {
-    apiPath = 'v3/_ui/my-namespaces/';
+  apiPath = 'v3/_ui/my-namespaces/';
 
-    constructor() {
-        super();
-    }
+  constructor() {
+    super();
+  }
 }
 
 export const MyNamespaceAPI = new API();

--- a/src/api/namespace.ts
+++ b/src/api/namespace.ts
@@ -2,15 +2,15 @@ import { BaseAPI } from './base';
 import { MockNamespace } from './mocked-responses/namespace';
 
 class API extends BaseAPI {
-    apiPath = 'v3/_ui/namespaces/';
+  apiPath = 'v3/_ui/namespaces/';
 
-    constructor() {
-        super();
+  constructor() {
+    super();
 
-        // Comment this out to make an actual API request
-        // mocked responses will be removed when a real API is available
-        // new MockNamespace(this.http, this.apiPath);
-    }
+    // Comment this out to make an actual API request
+    // mocked responses will be removed when a real API is available
+    // new MockNamespace(this.http, this.apiPath);
+  }
 }
 
 export const NamespaceAPI = new API();

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -1,122 +1,122 @@
 export class CollectionUploadType {
-    id: string;
-    file: File;
-    sha256: string;
+  id: string;
+  file: File;
+  sha256: string;
 }
 
 export class CollectionVersion {
-    id: string;
-    version: string;
-    metadata: {
-        tags: string[];
-        description: string;
-    };
-    created_at: string;
-    contents: ContentSummaryType[];
-    certification: CertificationStatus;
-    namespace: string;
-    name: string;
+  id: string;
+  version: string;
+  metadata: {
+    tags: string[];
+    description: string;
+  };
+  created_at: string;
+  contents: ContentSummaryType[];
+  certification: CertificationStatus;
+  namespace: string;
+  name: string;
 }
 
 export enum CertificationStatus {
-    certified = 'certified',
-    notCertified = 'not_certified',
-    needsReview = 'needs_review',
+  certified = 'certified',
+  notCertified = 'not_certified',
+  needsReview = 'needs_review',
 }
 
 class RenderedFile {
-    name: string;
-    html: string;
+  name: string;
+  html: string;
 }
 
 export class CollectionVersionDetail extends CollectionVersion {
-    metadata: {
-        description: string;
-        tags: string[];
-        authors: string[];
-        license: string;
-        homepage: string;
-        documentation: string;
-        issues: string;
-        repository: string;
-    };
-    docs_blob: DocsBlobType;
+  metadata: {
+    description: string;
+    tags: string[];
+    authors: string[];
+    license: string;
+    homepage: string;
+    documentation: string;
+    issues: string;
+    repository: string;
+  };
+  docs_blob: DocsBlobType;
 }
 
 export class CollectionListType {
-    id: string;
-    name: string;
-    description: string;
-    // download_count: number;
-    deprecated: boolean;
-    latest_version: CollectionVersion;
+  id: string;
+  name: string;
+  description: string;
+  // download_count: number;
+  deprecated: boolean;
+  latest_version: CollectionVersion;
 
-    namespace: {
-        id: number;
-        description: string;
-        name: string;
-        avatar_url: string;
-        company: string;
-    };
+  namespace: {
+    id: number;
+    description: string;
+    name: string;
+    avatar_url: string;
+    company: string;
+  };
 }
 
 export class PluginContentType {
-    content_type: string;
-    content_name: string;
-    readme_filename: string;
-    readme_html: string;
-    doc_strings: {
-        doc: any;
-        metadata: any;
-        return: any;
-        examples: string;
-    };
+  content_type: string;
+  content_name: string;
+  readme_filename: string;
+  readme_html: string;
+  doc_strings: {
+    doc: any;
+    metadata: any;
+    return: any;
+    examples: string;
+  };
 }
 
 class RoleContentType {
-    content_type: string;
-    content_name: string;
-    readme_filename: string;
-    readme_html: string;
+  content_type: string;
+  content_name: string;
+  readme_filename: string;
+  readme_html: string;
 }
 
 class PlaybookContentType {
-    // not supported yet
-    content_type: string;
-    content_name: string;
+  // not supported yet
+  content_type: string;
+  content_name: string;
 }
 
 export class DocsBlobType {
-    collection_readme: RenderedFile;
-    documentation_files: RenderedFile[];
-    contents: (PluginContentType | RoleContentType | PlaybookContentType)[];
+  collection_readme: RenderedFile;
+  documentation_files: RenderedFile[];
+  contents: (PluginContentType | RoleContentType | PlaybookContentType)[];
 }
 
 export class ContentSummaryType {
-    name: string;
-    content_type: string;
-    description: string;
+  name: string;
+  content_type: string;
+  description: string;
 }
 
 export class CollectionDetailType {
-    deprecated: boolean;
-    all_versions: {
-        id: string;
-        version: string;
-        created: string;
-    }[];
-    latest_version: CollectionVersionDetail;
-
+  deprecated: boolean;
+  all_versions: {
     id: string;
-    name: string;
-    description: string;
-    // download_count: number;
+    version: string;
+    created: string;
+  }[];
+  latest_version: CollectionVersionDetail;
 
-    namespace: {
-        id: number;
-        description: string;
-        name: string;
-        avatar_url: string;
-        company: string;
-    };
+  id: string;
+  name: string;
+  description: string;
+  // download_count: number;
+
+  namespace: {
+    id: number;
+    description: string;
+    name: string;
+    avatar_url: string;
+    company: string;
+  };
 }

--- a/src/api/response-types/import.ts
+++ b/src/api/response-types/import.ts
@@ -1,42 +1,42 @@
 export enum PulpStatus {
-    waiting = 'waiting',
-    skipped = 'skipped',
-    running = 'running',
-    completed = 'completed',
-    failed = 'failed',
-    canceled = 'canceled',
+  waiting = 'waiting',
+  skipped = 'skipped',
+  running = 'running',
+  completed = 'completed',
+  failed = 'failed',
+  canceled = 'canceled',
 }
 
 export enum ImportMessageCodes {
-    error = 'error',
-    failed = 'failed',
-    warning = 'warning',
-    success = 'success',
+  error = 'error',
+  failed = 'failed',
+  warning = 'warning',
+  success = 'success',
 }
 
 export class ImportListType {
-    id: number;
-    state: PulpStatus;
-    started_at: string;
-    finished_at: string;
-    namespace: string;
-    // Collection name
-    name: string;
-    version: string;
+  id: number;
+  state: PulpStatus;
+  started_at: string;
+  finished_at: string;
+  namespace: string;
+  // Collection name
+  name: string;
+  version: string;
 }
 
 export class ImportDetailType extends ImportListType {
-    error?: {
-        code: string;
-        description: string;
-        traceback: string;
-    };
+  error?: {
+    code: string;
+    description: string;
+    traceback: string;
+  };
 
-    job_id: string;
-    imported_version: string;
-    messages: {
-        level: string;
-        message: string;
-        time: string;
-    }[];
+  job_id: string;
+  imported_version: string;
+  messages: {
+    level: string;
+    message: string;
+    time: string;
+  }[];
 }

--- a/src/api/response-types/namespace.ts
+++ b/src/api/response-types/namespace.ts
@@ -1,21 +1,21 @@
 export class NamespaceLink {
-    name: string;
-    url: string;
+  name: string;
+  url: string;
 }
 
 export class NamespaceListType {
-    id: number;
-    name: string;
-    company: string;
-    email: string;
-    avatar_url: string;
-    description: string;
-    num_collections: number;
-    groups: string[];
+  id: number;
+  name: string;
+  company: string;
+  email: string;
+  avatar_url: string;
+  description: string;
+  num_collections: number;
+  groups: string[];
 }
 
 export class NamespaceType extends NamespaceListType {
-    resources: string;
-    owners: any[];
-    links: NamespaceLink[];
+  resources: string;
+  owners: any[];
+  links: NamespaceLink[];
 }

--- a/src/api/response-types/user.ts
+++ b/src/api/response-types/user.ts
@@ -1,22 +1,22 @@
 export class UserAuthType {
-    account_number: string;
-    internal: {
-        account_id: number;
-        org_id: string;
-    };
-    type: string;
-    user: {
-        email: string;
-        first_name: string;
-        is_active: boolean;
-        is_internal: boolean;
-        is_org_admin: boolean;
-        last_name: string;
-        locale: string;
-        username: string;
-    };
+  account_number: string;
+  internal: {
+    account_id: number;
+    org_id: string;
+  };
+  type: string;
+  user: {
+    email: string;
+    first_name: string;
+    is_active: boolean;
+    is_internal: boolean;
+    is_org_admin: boolean;
+    last_name: string;
+    locale: string;
+    username: string;
+  };
 }
 
 export class MeType {
-    is_partner_engineer: boolean;
+  is_partner_engineer: boolean;
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -3,43 +3,43 @@ import { BaseAPI } from './base';
 import { Constants } from '../constants';
 
 class API extends BaseAPI {
-    apiPath = 'v3/_ui/me/';
+  apiPath = 'v3/_ui/me/';
 
-    constructor() {
-        super();
-    }
+  constructor() {
+    super();
+  }
 
-    getUser(): Promise<UserAuthType> {
-        if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
-            return new Promise((resolve, reject) => {
-                (window as any).insights.chrome.auth
-                    .getUser()
-                    // we don't care about entitlements stuff in the UI, so just
-                    // return the user's identity
-                    .then(result => resolve(result.identity))
-                    .catch(result => reject(result));
-            });
-        } else if (DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE) {
-            return new Promise((resolve, reject) => {
-                resolve({} as UserAuthType);
-            });
-        }
+  getUser(): Promise<UserAuthType> {
+    if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
+      return new Promise((resolve, reject) => {
+        (window as any).insights.chrome.auth
+          .getUser()
+          // we don't care about entitlements stuff in the UI, so just
+          // return the user's identity
+          .then(result => resolve(result.identity))
+          .catch(result => reject(result));
+      });
+    } else if (DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE) {
+      return new Promise((resolve, reject) => {
+        resolve({} as UserAuthType);
+      });
     }
+  }
 
-    isPartnerEngineer() {
-        return this.http.get(this.apiPath);
-    }
+  isPartnerEngineer() {
+    return this.http.get(this.apiPath);
+  }
 
-    // insights has some asinine way of loading tokens that involves forcing the
-    // page to refresh before loading the token that can't be done witha single
-    // API request.
-    getToken(): Promise<any> {
-        if (DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE) {
-            return new Promise((resolve, reject) => {
-                resolve({ refresh_token: 'FAKE TEMPORARY TOKEN!!!!' });
-            });
-        }
+  // insights has some asinine way of loading tokens that involves forcing the
+  // page to refresh before loading the token that can't be done witha single
+  // API request.
+  getToken(): Promise<any> {
+    if (DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE) {
+      return new Promise((resolve, reject) => {
+        resolve({ refresh_token: 'FAKE TEMPORARY TOKEN!!!!' });
+      });
     }
+  }
 }
 
 export const UserAPI = new API();

--- a/src/components/api-button/api-button.tsx
+++ b/src/components/api-button/api-button.tsx
@@ -4,20 +4,20 @@ import { Link } from 'react-router-dom';
 import { Paths } from '../../paths';
 
 interface IProps {
-    style?: Object;
-    className?: string;
+  style?: Object;
+  className?: string;
 }
 
 export class APIButton extends React.Component<IProps> {
-    render() {
-        return (
-            <div className={this.props.className} style={this.props.style}>
-                <Link to={Paths.token} target='_blank'>
-                    <Button variant='secondary' isInline>
-                        Get API token
-                    </Button>
-                </Link>
-            </div>
-        );
-    }
+  render() {
+    return (
+      <div className={this.props.className} style={this.props.style}>
+        <Link to={Paths.token} target='_blank'>
+          <Button variant='secondary' isInline>
+            Get API token
+          </Button>
+        </Link>
+      </div>
+    );
+  }
 }

--- a/src/components/card-list-switcher/card-list-switcher.tsx
+++ b/src/components/card-list-switcher/card-list-switcher.tsx
@@ -6,54 +6,46 @@ import { ListIcon, ThLargeIcon } from '@patternfly/react-icons';
 import { ParamHelper } from '../../utilities/param-helper';
 
 interface IProps {
-    params: {
-        view_type?: string;
-    };
-    updateParams: (params) => void;
-    size?: 'sm' | 'md' | 'lg' | 'xl';
-    className?: string;
+  params: {
+    view_type?: string;
+  };
+  updateParams: (params) => void;
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+  className?: string;
 }
 
 export class CardListSwitcher extends React.Component<IProps> {
-    static defaultProps = {
-        size: 'sm',
-    };
+  static defaultProps = {
+    size: 'sm',
+  };
 
-    render() {
-        let disp = this.props.params.view_type;
-        const { updateParams, params, size, className } = this.props;
+  render() {
+    let disp = this.props.params.view_type;
+    const { updateParams, params, size, className } = this.props;
 
-        if (!disp) {
-            disp = 'card';
-        }
-
-        const iconClasses = 'icon clickable ';
-
-        return (
-            <div className={className}>
-                <ThLargeIcon
-                    size={size}
-                    className={
-                        iconClasses + (disp === 'card' ? 'selected' : '')
-                    }
-                    onClick={() =>
-                        updateParams(
-                            ParamHelper.setParam(params, 'view_type', 'card'),
-                        )
-                    }
-                />
-                <ListIcon
-                    size={size}
-                    className={
-                        iconClasses + (disp === 'list' ? 'selected' : '')
-                    }
-                    onClick={() =>
-                        updateParams(
-                            ParamHelper.setParam(params, 'view_type', 'list'),
-                        )
-                    }
-                />
-            </div>
-        );
+    if (!disp) {
+      disp = 'card';
     }
+
+    const iconClasses = 'icon clickable ';
+
+    return (
+      <div className={className}>
+        <ThLargeIcon
+          size={size}
+          className={iconClasses + (disp === 'card' ? 'selected' : '')}
+          onClick={() =>
+            updateParams(ParamHelper.setParam(params, 'view_type', 'card'))
+          }
+        />
+        <ListIcon
+          size={size}
+          className={iconClasses + (disp === 'list' ? 'selected' : '')}
+          onClick={() =>
+            updateParams(ParamHelper.setParam(params, 'view_type', 'list'))
+          }
+        />
+      </div>
+    );
+  }
 }

--- a/src/components/card-list-switcher/switcher.scss
+++ b/src/components/card-list-switcher/switcher.scss
@@ -1,12 +1,12 @@
 .icon:hover {
-    color: var(--pf-global--link--Color--dark);
+  color: var(--pf-global--link--Color--dark);
 }
 
 .icon {
-    margin-left: 8px;
-    color: var(--pf-global--icon--Color--light);
+  margin-left: 8px;
+  color: var(--pf-global--icon--Color--light);
 }
 
 .selected {
-    color: var(--pf-global--link--Color--dark);
+  color: var(--pf-global--link--Color--dark);
 }

--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -1,67 +1,67 @@
 .ns-card-container {
-    width: 310px;
-    height: 150px;
-    display: flex;
-    align-items: center;
-    flex-direction: row;
-    padding: 16px;
+  width: 310px;
+  height: 150px;
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  padding: 16px;
 
-    .logo {
-        margin: 10px;
-    }
+  .logo {
+    margin: 10px;
+  }
 
-    .title {
-        font-weight: bold;
-    }
+  .title {
+    font-weight: bold;
+  }
 
-    .ns-name {
-        text-overflow: ellipsis;
-        overflow: hidden;
-        white-space: nowrap;
-        width: 180px;
-    }
+  .ns-name {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 180px;
+  }
 }
 
 .collection-card-container {
-    width: 280px;
-    height: 280px;
+  width: 280px;
+  height: 280px;
 
-    // For some reason the PF Card components overrides all the defaults for
-    // divs
-    div {
-        display: block;
+  // For some reason the PF Card components overrides all the defaults for
+  // divs
+  div {
+    display: block;
+  }
+
+  .name {
+    font-weight: bold;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    width: 100%;
+  }
+
+  .type-label {
+    font-size: var(--pf-global--FontSize--xs);
+    color: var(--pf-global--color--200);
+    text-transform: capitalize;
+  }
+
+  .type-container {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .logo-row {
+    display: flex;
+    justify-content: space-between;
+
+    .icon {
+      color: var(--pf-global--info-color--100);
+      margin-right: 3px;
     }
+  }
 
-    .name {
-        font-weight: bold;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        white-space: nowrap;
-        width: 100%;
-    }
-
-    .type-label {
-        font-size: var(--pf-global--FontSize--xs);
-        color: var(--pf-global--color--200);
-        text-transform: capitalize;
-    }
-
-    .type-container {
-        display: flex;
-        justify-content: space-between;
-    }
-
-    .logo-row {
-        display: flex;
-        justify-content: space-between;
-
-        .icon {
-            color: var(--pf-global--info-color--100);
-            margin-right: 3px;
-        }
-    }
-
-    .description {
-        vertical-align: center;
-    }
+  .description {
+    vertical-align: center;
+  }
 }

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import {
-    Card,
-    CardHead,
-    CardBody,
-    CardFooter,
-    TextContent,
-    Text,
-    TextVariants,
+  Card,
+  CardHead,
+  CardBody,
+  CardFooter,
+  TextContent,
+  Text,
+  TextVariants,
 } from '@patternfly/react-core';
 
 import { Link } from 'react-router-dom';
@@ -19,93 +19,84 @@ import { formatPath, Paths } from '../../paths';
 import { convertContentSummaryCounts } from '../../utilities';
 
 interface IProps extends CollectionListType {
-    className?: string;
+  className?: string;
 }
 
 export class CollectionCard extends React.Component<IProps> {
-    MAX_DESCRIPTION_LENGTH = 50;
+  MAX_DESCRIPTION_LENGTH = 50;
 
-    render() {
-        const { name, latest_version, namespace, className } = this.props;
+  render() {
+    const { name, latest_version, namespace, className } = this.props;
 
-        const company = namespace.company || namespace.name;
-        const contentSummary = convertContentSummaryCounts(
-            latest_version.contents,
-        );
+    const company = namespace.company || namespace.name;
+    const contentSummary = convertContentSummaryCounts(latest_version.contents);
 
-        return (
-            <Card className={'collection-card-container ' + className}>
-                <CardHead className='logo-row'>
-                    <Logo
-                        image={namespace.avatar_url}
-                        alt={company + ' logo'}
-                        size='40px'
-                    />
-                    <TextContent>
-                        {latest_version.certification ===
-                            CertificationStatus.certified && (
-                            <Text component={TextVariants.small}>
-                                <CertificateIcon className='icon' /> Certified
-                            </Text>
-                        )}
-                    </TextContent>
-                </CardHead>
-                <CardHead>
-                    <div className='name'>
-                        <Link
-                            to={formatPath(Paths.collection, {
-                                collection: name,
-                                namespace: namespace.name,
-                            })}
-                        >
-                            {name}
-                        </Link>
-                    </div>
-                    <div className='author'>
-                        <TextContent>
-                            <Text component={TextVariants.small}>
-                                Provided by {company}
-                            </Text>
-                        </TextContent>
-                    </div>
-                </CardHead>
-                <CardBody className='description'>
-                    {this.getDescription(latest_version.metadata.description)}
-                </CardBody>
-                <CardFooter className='type-container'>
-                    {Object.keys(contentSummary.contents).map(k =>
-                        this.renderTypeCount(k, contentSummary.contents[k]),
-                    )}
-                </CardFooter>
-            </Card>
-        );
+    return (
+      <Card className={'collection-card-container ' + className}>
+        <CardHead className='logo-row'>
+          <Logo
+            image={namespace.avatar_url}
+            alt={company + ' logo'}
+            size='40px'
+          />
+          <TextContent>
+            {latest_version.certification === CertificationStatus.certified && (
+              <Text component={TextVariants.small}>
+                <CertificateIcon className='icon' /> Certified
+              </Text>
+            )}
+          </TextContent>
+        </CardHead>
+        <CardHead>
+          <div className='name'>
+            <Link
+              to={formatPath(Paths.collection, {
+                collection: name,
+                namespace: namespace.name,
+              })}
+            >
+              {name}
+            </Link>
+          </div>
+          <div className='author'>
+            <TextContent>
+              <Text component={TextVariants.small}>Provided by {company}</Text>
+            </TextContent>
+          </div>
+        </CardHead>
+        <CardBody className='description'>
+          {this.getDescription(latest_version.metadata.description)}
+        </CardBody>
+        <CardFooter className='type-container'>
+          {Object.keys(contentSummary.contents).map(k =>
+            this.renderTypeCount(k, contentSummary.contents[k]),
+          )}
+        </CardFooter>
+      </Card>
+    );
+  }
+
+  private getDescription(d: string) {
+    if (!d) {
+      return '';
     }
-
-    private getDescription(d: string) {
-        if (!d) {
-            return '';
-        }
-        if (d.length > this.MAX_DESCRIPTION_LENGTH) {
-            return d.slice(0, this.MAX_DESCRIPTION_LENGTH) + '...';
-        } else {
-            return d;
-        }
+    if (d.length > this.MAX_DESCRIPTION_LENGTH) {
+      return d.slice(0, this.MAX_DESCRIPTION_LENGTH) + '...';
+    } else {
+      return d;
     }
+  }
 
-    private renderTypeCount(type, count) {
-        return (
-            <div key={type}>
-                <div>
-                    <NumericLabel number={count} />
-                </div>
-                <div className='type-label'>
-                    <NumericLabel
-                        number={count}
-                        hideNumber={true}
-                        label={type}
-                    />
-                </div>
-            </div>
-        );
-    }
+  private renderTypeCount(type, count) {
+    return (
+      <div key={type}>
+        <div>
+          <NumericLabel number={count} />
+        </div>
+        <div className='type-label'>
+          <NumericLabel number={count} hideNumber={true} label={type} />
+        </div>
+      </div>
+    );
+  }
 }

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -7,29 +7,29 @@ import { NumericLabel, Logo } from '../../components';
 // Use snake case to match field types provided py python API so that the
 // spread operator can be used.
 interface IProps {
-    avatar_url: string;
-    name: string;
-    company: string;
-    num_collections: string | number;
+  avatar_url: string;
+  name: string;
+  company: string;
+  num_collections: string | number;
 }
 
 export class NamespaceCard extends React.Component<IProps, {}> {
-    render() {
-        const { avatar_url, name, company, num_collections } = this.props;
-        return (
-            <Card className='ns-card-container'>
-                <Logo
-                    className='logo'
-                    image={avatar_url}
-                    alt={company + ' logo'}
-                    size='100px'
-                />
+  render() {
+    const { avatar_url, name, company, num_collections } = this.props;
+    return (
+      <Card className='ns-card-container'>
+        <Logo
+          className='logo'
+          image={avatar_url}
+          alt={company + ' logo'}
+          size='100px'
+        />
 
-                <div>
-                    <div className='title'>{company}</div>
-                    <div className='ns-name'>{name}</div>
-                </div>
-            </Card>
-        );
-    }
+        <div>
+          <div className='title'>{company}</div>
+          <div className='ns-name'>{name}</div>
+        </div>
+      </Card>
+    );
+  }
 }

--- a/src/components/collection-detail/collection-content-list.scss
+++ b/src/components/collection-detail/collection-content-list.scss
@@ -1,19 +1,19 @@
 .content-table {
-    width: 100%;
-    th {
-        font-weight: bold;
-    }
+  width: 100%;
+  th {
+    font-weight: bold;
+  }
 }
 
 .type-selector {
-    margin-left: 16px;
-    text-transform: capitalize;
+  margin-left: 16px;
+  text-transform: capitalize;
 }
 
 .selected-item,
 .type-selector:hover {
-    border-bottom: 2px solid var(--pf-global--link--Color);
-    padding-bottom: 2px;
-    margin-bottom: -4px;
-    background-color: white;
+  border-bottom: 2px solid var(--pf-global--link--Color);
+  padding-bottom: 2px;
+  margin-bottom: -4px;
+  background-color: white;
 }

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -3,10 +3,10 @@ import './collection-content-list.scss';
 
 import { Link } from 'react-router-dom';
 import {
-    TextInput,
-    Toolbar,
-    ToolbarGroup,
-    ToolbarItem,
+  TextInput,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem,
 } from '@patternfly/react-core';
 
 import { ContentSummaryType } from '../../api';
@@ -14,135 +14,117 @@ import { Paths, formatPath } from '../../paths';
 import { ParamHelper } from '../../utilities/param-helper';
 
 interface IProps {
-    contents: ContentSummaryType[];
-    collection: string;
-    namespace: string;
-    params: {
-        keywords?: string;
-        showing?: string;
-    };
-    updateParams: (p) => void;
+  contents: ContentSummaryType[];
+  collection: string;
+  namespace: string;
+  params: {
+    keywords?: string;
+    showing?: string;
+  };
+  updateParams: (p) => void;
 }
 
 export class CollectionContentList extends React.Component<IProps> {
-    ignoredParams = ['keywords', 'showing'];
+  ignoredParams = ['keywords', 'showing'];
 
-    render() {
-        const {
-            contents,
-            collection,
-            namespace,
-            params,
-            updateParams,
-        } = this.props;
+  render() {
+    const {
+      contents,
+      collection,
+      namespace,
+      params,
+      updateParams,
+    } = this.props;
 
-        let toShow: ContentSummaryType[] = [];
-        const summary = { all: 0 };
-        const showing = params.showing || 'all';
-        const keywords = params.keywords || '';
+    let toShow: ContentSummaryType[] = [];
+    const summary = { all: 0 };
+    const showing = params.showing || 'all';
+    const keywords = params.keywords || '';
 
-        for (let c of contents) {
-            summary['all']++;
-            if (summary[c.content_type]) {
-                summary[c.content_type]++;
-            } else {
-                summary[c.content_type] = 1;
-            }
+    for (let c of contents) {
+      summary['all']++;
+      if (summary[c.content_type]) {
+        summary[c.content_type]++;
+      } else {
+        summary[c.content_type] = 1;
+      }
 
-            const typeMatch =
-                showing === 'all' ? true : c.content_type === showing;
+      const typeMatch = showing === 'all' ? true : c.content_type === showing;
 
-            if (typeMatch && c.name.match(keywords)) {
-                toShow.push(c);
-            }
-        }
-
-        return (
-            <div>
-                <div>
-                    <Toolbar>
-                        <ToolbarGroup>
-                            <ToolbarItem>
-                                <TextInput
-                                    value={params.keywords || ''}
-                                    onChange={val =>
-                                        updateParams(
-                                            ParamHelper.setParam(
-                                                params,
-                                                'keywords',
-                                                val,
-                                            ),
-                                        )
-                                    }
-                                    aria-label='find-content'
-                                    placeholder='Find content'
-                                />
-                            </ToolbarItem>
-                        </ToolbarGroup>
-                        <ToolbarGroup>
-                            <ToolbarItem>Showing:</ToolbarItem>
-                            {Object.keys(summary).map(key => (
-                                <ToolbarItem
-                                    key={key}
-                                    className={
-                                        'clickable type-selector' +
-                                        (key === showing
-                                            ? ' selected-item'
-                                            : '')
-                                    }
-                                    onClick={() =>
-                                        updateParams(
-                                            ParamHelper.setParam(
-                                                params,
-                                                'showing',
-                                                key,
-                                            ),
-                                        )
-                                    }
-                                >
-                                    {key} ({summary[key]})
-                                </ToolbarItem>
-                            ))}
-                        </ToolbarGroup>
-                    </Toolbar>
-                </div>
-                <table className='content-table pf-c-table pf-m-compact'>
-                    <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th>Type</th>
-                            <th>Description</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {toShow.map((content, i) => (
-                            <tr key={i}>
-                                <td>
-                                    <Link
-                                        to={formatPath(
-                                            Paths.collectionContentDocs,
-                                            {
-                                                collection: collection,
-                                                namespace: namespace,
-                                                type: content.content_type,
-                                                name: content.name,
-                                            },
-                                            ParamHelper.getReduced(
-                                                params,
-                                                this.ignoredParams,
-                                            ),
-                                        )}
-                                    >
-                                        {content.name}
-                                    </Link>
-                                </td>
-                                <td>{content.content_type}</td>
-                                <td>{content.description}</td>
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
-            </div>
-        );
+      if (typeMatch && c.name.match(keywords)) {
+        toShow.push(c);
+      }
     }
+
+    return (
+      <div>
+        <div>
+          <Toolbar>
+            <ToolbarGroup>
+              <ToolbarItem>
+                <TextInput
+                  value={params.keywords || ''}
+                  onChange={val =>
+                    updateParams(ParamHelper.setParam(params, 'keywords', val))
+                  }
+                  aria-label='find-content'
+                  placeholder='Find content'
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
+            <ToolbarGroup>
+              <ToolbarItem>Showing:</ToolbarItem>
+              {Object.keys(summary).map(key => (
+                <ToolbarItem
+                  key={key}
+                  className={
+                    'clickable type-selector' +
+                    (key === showing ? ' selected-item' : '')
+                  }
+                  onClick={() =>
+                    updateParams(ParamHelper.setParam(params, 'showing', key))
+                  }
+                >
+                  {key} ({summary[key]})
+                </ToolbarItem>
+              ))}
+            </ToolbarGroup>
+          </Toolbar>
+        </div>
+        <table className='content-table pf-c-table pf-m-compact'>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {toShow.map((content, i) => (
+              <tr key={i}>
+                <td>
+                  <Link
+                    to={formatPath(
+                      Paths.collectionContentDocs,
+                      {
+                        collection: collection,
+                        namespace: namespace,
+                        type: content.content_type,
+                        name: content.name,
+                      },
+                      ParamHelper.getReduced(params, this.ignoredParams),
+                    )}
+                  >
+                    {content.name}
+                  </Link>
+                </td>
+                <td>{content.content_type}</td>
+                <td>{content.description}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
 }

--- a/src/components/collection-detail/collection-info.scss
+++ b/src/components/collection-detail/collection-info.scss
@@ -1,35 +1,35 @@
 .install-title {
-    min-width: 100px;
-    vertical-align: middle;
-    display: table-cell;
+  min-width: 100px;
+  vertical-align: middle;
+  display: table-cell;
 }
 
 .readme-container {
-    position: relative;
-    max-height: 300px;
-    min-height: 50px;
-    overflow: hidden;
+  position: relative;
+  max-height: 300px;
+  min-height: 50px;
+  overflow: hidden;
 }
 
 .fade-out {
-    position: absolute;
-    z-index: 1;
-    bottom: 0;
-    left: 0;
-    pointer-events: none;
-    background-image: linear-gradient(
-        to bottom,
-        rgba(255, 255, 255, 0),
-        rgba(255, 255, 255, 1) 90%
-    );
-    width: 100%;
-    height: 50px;
+  position: absolute;
+  z-index: 1;
+  bottom: 0;
+  left: 0;
+  pointer-events: none;
+  background-image: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0),
+    rgba(255, 255, 255, 1) 90%
+  );
+  width: 100%;
+  height: 50px;
 }
 
 .download-button {
-    padding-left: 0px;
+  padding-left: 0px;
 }
 
 .info-panel {
-    padding: 8px;
+  padding: 8px;
 }

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -5,14 +5,14 @@ import * as moment from 'moment';
 import { Link } from 'react-router-dom';
 
 import {
-    ClipboardCopy,
-    Split,
-    SplitItem,
-    Grid,
-    GridItem,
-    FormSelect,
-    FormSelectOption,
-    Button,
+  ClipboardCopy,
+  Split,
+  SplitItem,
+  Grid,
+  GridItem,
+  FormSelect,
+  FormSelectOption,
+  Button,
 } from '@patternfly/react-core';
 
 import { DownloadIcon } from '@patternfly/react-icons';
@@ -23,183 +23,150 @@ import { Paths, formatPath } from '../../paths';
 import { ParamHelper } from '../../utilities/param-helper';
 
 interface IProps extends CollectionDetailType {
-    params: {
-        version?: string;
-    };
-    updateParams: (params) => void;
+  params: {
+    version?: string;
+  };
+  updateParams: (params) => void;
 }
 
 export class CollectionInfo extends React.Component<IProps> {
-    downloadLinkRef: any;
+  downloadLinkRef: any;
 
-    constructor(props) {
-        super(props);
-        this.downloadLinkRef = React.createRef();
+  constructor(props) {
+    super(props);
+    this.downloadLinkRef = React.createRef();
+  }
+
+  render() {
+    const {
+      name,
+      latest_version,
+      namespace,
+      all_versions,
+      params,
+      updateParams,
+    } = this.props;
+
+    let installCommand = `ansible-galaxy collection install ${namespace.name}.${name}`;
+
+    if (params.version) {
+      installCommand += `:${params.version}`;
     }
 
-    render() {
-        const {
-            name,
-            latest_version,
-            namespace,
-            all_versions,
-            params,
-            updateParams,
-        } = this.props;
+    return (
+      <div className='pf-c-content info-panel'>
+        <h1>Info</h1>
+        <Grid gutter='lg'>
+          <GridItem>{latest_version.metadata.description}</GridItem>
+          <GridItem>
+            {latest_version.metadata.tags.map((tag, i) => (
+              <Tag key={i}>{tag}</Tag>
+            ))}
+          </GridItem>
 
-        let installCommand = `ansible-galaxy collection install ${namespace.name}.${name}`;
+          <GridItem>
+            <Split gutter='sm'>
+              <SplitItem className='install-title'>License</SplitItem>
+              <SplitItem isFilled>{latest_version.metadata.license}</SplitItem>
+            </Split>
+          </GridItem>
+          <GridItem>
+            <Split gutter='sm'>
+              <SplitItem className='install-title'>Installation</SplitItem>
+              <SplitItem isFilled>
+                <ClipboardCopy isReadOnly>{installCommand}</ClipboardCopy>
+                <div>
+                  <b>Note:</b> Installing collections with ansible-galaxy is
+                  only supported in ansible 2.9+
+                </div>
+                <div>
+                  <a ref={this.downloadLinkRef} style={{ display: 'none' }}></a>
+                  <Button
+                    className='download-button'
+                    variant='link'
+                    icon={<DownloadIcon />}
+                    onClick={() =>
+                      this.download(namespace, name, latest_version)
+                    }
+                  >
+                    Download tarball
+                  </Button>
+                </div>
+              </SplitItem>
+            </Split>
+          </GridItem>
+          <GridItem>
+            <Split gutter='sm'>
+              <SplitItem className='install-tile'>Install Version</SplitItem>
+              <SplitItem isFilled>
+                <FormSelect
+                  onChange={val =>
+                    updateParams(ParamHelper.setParam(params, 'version', val))
+                  }
+                  value={
+                    params.version ? params.version : latest_version.version
+                  }
+                  aria-label='Select collection version'
+                >
+                  {all_versions.map(v => (
+                    <FormSelectOption
+                      key={v.version}
+                      value={v.version}
+                      label={`${v.version} released ${moment(
+                        v.created,
+                      ).fromNow()} ${
+                        v.version === latest_version.version ? '(latest)' : ''
+                      }`}
+                    />
+                  ))}
+                </FormSelect>
+              </SplitItem>
+            </Split>
+          </GridItem>
 
-        if (params.version) {
-            installCommand += `:${params.version}`;
-        }
+          {latest_version.docs_blob.collection_readme ? (
+            <GridItem>
+              <div className='readme-container'>
+                <div
+                  className='pf-c-content'
+                  dangerouslySetInnerHTML={{
+                    __html: latest_version.docs_blob.collection_readme.html,
+                  }}
+                />
+                <div className='fade-out'></div>
+              </div>
+              <Link
+                to={formatPath(
+                  Paths.collectionDocsIndex,
+                  {
+                    collection: name,
+                    namespace: namespace.name,
+                  },
+                  params,
+                )}
+              >
+                Load full readme
+              </Link>
+            </GridItem>
+          ) : null}
+        </Grid>
+      </div>
+    );
+  }
 
-        return (
-            <div className='pf-c-content info-panel'>
-                <h1>Info</h1>
-                <Grid gutter='lg'>
-                    <GridItem>{latest_version.metadata.description}</GridItem>
-                    <GridItem>
-                        {latest_version.metadata.tags.map((tag, i) => (
-                            <Tag key={i}>{tag}</Tag>
-                        ))}
-                    </GridItem>
-
-                    <GridItem>
-                        <Split gutter='sm'>
-                            <SplitItem className='install-title'>
-                                License
-                            </SplitItem>
-                            <SplitItem isFilled>
-                                {latest_version.metadata.license}
-                            </SplitItem>
-                        </Split>
-                    </GridItem>
-                    <GridItem>
-                        <Split gutter='sm'>
-                            <SplitItem className='install-title'>
-                                Installation
-                            </SplitItem>
-                            <SplitItem isFilled>
-                                <ClipboardCopy isReadOnly>
-                                    {installCommand}
-                                </ClipboardCopy>
-                                <div>
-                                    <b>Note:</b> Installing collections with
-                                    ansible-galaxy is only supported in ansible
-                                    2.9+
-                                </div>
-                                <div>
-                                    <a
-                                        ref={this.downloadLinkRef}
-                                        style={{ display: 'none' }}
-                                    ></a>
-                                    <Button
-                                        className='download-button'
-                                        variant='link'
-                                        icon={<DownloadIcon />}
-                                        onClick={() =>
-                                            this.download(
-                                                namespace,
-                                                name,
-                                                latest_version,
-                                            )
-                                        }
-                                    >
-                                        Download tarball
-                                    </Button>
-                                </div>
-                            </SplitItem>
-                        </Split>
-                    </GridItem>
-                    <GridItem>
-                        <Split gutter='sm'>
-                            <SplitItem className='install-tile'>
-                                Install Version
-                            </SplitItem>
-                            <SplitItem isFilled>
-                                <FormSelect
-                                    onChange={val =>
-                                        updateParams(
-                                            ParamHelper.setParam(
-                                                params,
-                                                'version',
-                                                val,
-                                            ),
-                                        )
-                                    }
-                                    value={
-                                        params.version
-                                            ? params.version
-                                            : latest_version.version
-                                    }
-                                    aria-label='Select collection version'
-                                >
-                                    {all_versions.map(v => (
-                                        <FormSelectOption
-                                            key={v.version}
-                                            value={v.version}
-                                            label={`${
-                                                v.version
-                                            } released ${moment(
-                                                v.created,
-                                            ).fromNow()} ${
-                                                v.version ===
-                                                latest_version.version
-                                                    ? '(latest)'
-                                                    : ''
-                                            }`}
-                                        />
-                                    ))}
-                                </FormSelect>
-                            </SplitItem>
-                        </Split>
-                    </GridItem>
-
-                    {latest_version.docs_blob.collection_readme ? (
-                        <GridItem>
-                            <div className='readme-container'>
-                                <div
-                                    className='pf-c-content'
-                                    dangerouslySetInnerHTML={{
-                                        __html:
-                                            latest_version.docs_blob
-                                                .collection_readme.html,
-                                    }}
-                                />
-                                <div className='fade-out'></div>
-                            </div>
-                            <Link
-                                to={formatPath(
-                                    Paths.collectionDocsIndex,
-                                    {
-                                        collection: name,
-                                        namespace: namespace.name,
-                                    },
-                                    params,
-                                )}
-                            >
-                                Load full readme
-                            </Link>
-                        </GridItem>
-                    ) : null}
-                </Grid>
-            </div>
-        );
-    }
-
-    private download(namespace, name, latest_version) {
-        CollectionAPI.getDownloadURL(
-            namespace.name,
-            name,
-            latest_version.version,
-        ).then((downloadURL: string) => {
-            // By getting a reference to a hidden <a> tag, setting the href and
-            // programmatically clicking it, we can hold off on making the api
-            // calls to get the download URL until it's actually needed. Clicking
-            // the <a> tag also gets around all the problems using a popup with
-            // window.open() causes.
-            this.downloadLinkRef.current.href = downloadURL;
-            this.downloadLinkRef.current.click();
-        });
-    }
+  private download(namespace, name, latest_version) {
+    CollectionAPI.getDownloadURL(
+      namespace.name,
+      name,
+      latest_version.version,
+    ).then((downloadURL: string) => {
+      // By getting a reference to a hidden <a> tag, setting the href and
+      // programmatically clicking it, we can hold off on making the api
+      // calls to get the download URL until it's actually needed. Clicking
+      // the <a> tag also gets around all the problems using a popup with
+      // window.open() causes.
+      this.downloadLinkRef.current.href = downloadURL;
+      this.downloadLinkRef.current.click();
+    });
+  }
 }

--- a/src/components/collection-detail/render-plugin-doc.scss
+++ b/src/components/collection-detail/render-plugin-doc.scss
@@ -1,63 +1,63 @@
 .options-table {
-    td,
-    th {
-        border: 1px solid black;
-        padding: 5px;
-        vertical-align: top;
-    }
-    ul {
-        margin-top: 0px;
-    }
+  td,
+  th {
+    border: 1px solid black;
+    padding: 5px;
+    vertical-align: top;
+  }
+  ul {
+    margin-top: 0px;
+  }
 
-    small {
-        margin-bottom: 0px;
-    }
+  small {
+    margin-bottom: 0px;
+  }
 
-    // ensures the bottom of the table always has a border even
-    // if there is a spacer at the bottom which might otherwise cause
-    // a gap
-    border-bottom: 1px solid black;
-    width: 100%;
+  // ensures the bottom of the table always has a border even
+  // if there is a spacer at the bottom which might otherwise cause
+  // a gap
+  border-bottom: 1px solid black;
+  width: 100%;
 
-    .spacer {
-        width: 20px;
-        border-top: 0px;
-        border-bottom: 0px;
-    }
+  .spacer {
+    width: 20px;
+    border-top: 0px;
+    border-bottom: 0px;
+  }
 
-    .parent {
-        border-bottom: 0px;
-    }
+  .parent {
+    border-bottom: 0px;
+  }
 }
 
 .blue {
-    color: var(--pf-global--info-color--100);
+  color: var(--pf-global--info-color--100);
 }
 
 .red {
-    color: var(--pf-global--danger-color--100);
+  color: var(--pf-global--danger-color--100);
 }
 
 .green {
-    color: var(--pf-global--success-color--200);
+  color: var(--pf-global--success-color--200);
 }
 
 .option-name {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .plugin-config {
-    margin-bottom: 16px;
+  margin-bottom: 16px;
 }
 
 .plugin-raw {
-    white-space: pre-wrap;
+  white-space: pre-wrap;
 }
 
 .inline-code {
-    background-color: #e6e9e9;
-    font-family: var(--pf-global--FontFamily--monospace);
-    display: inline-block;
-    border-radius: 2px;
-    padding: 0px 2px 0px 2px;
+  background-color: #e6e9e9;
+  font-family: var(--pf-global--FontFamily--monospace);
+  display: inline-block;
+  border-radius: 2px;
+  padding: 0px 2px 0px 2px;
 }

--- a/src/components/collection-detail/render-plugin-doc.tsx
+++ b/src/components/collection-detail/render-plugin-doc.tsx
@@ -10,851 +10,819 @@ import { Paths, formatPath } from '../../paths';
 import { sanitizeDocsUrls } from '../../utilities';
 
 interface IProps {
-    plugin: PluginContentType;
-    allContent: ContentSummaryType[];
-    collectionName: string;
-    namespaceName: string;
-    params: {
-        version?: string;
-    };
+  plugin: PluginContentType;
+  allContent: ContentSummaryType[];
+  collectionName: string;
+  namespaceName: string;
+  params: {
+    version?: string;
+  };
 }
 
 class PluginOption {
-    name: string;
-    description: string[];
-    type: string;
-    required: boolean;
-    default?: string | number | boolean;
-    aliases?: string[];
-    suboptions?: PluginOption[];
+  name: string;
+  description: string[];
+  type: string;
+  required: boolean;
+  default?: string | number | boolean;
+  aliases?: string[];
+  suboptions?: PluginOption[];
 }
 
 class PluginDoc {
-    short_description: string;
-    description: string[];
-    options?: PluginOption[];
-    requirements?: string[];
-    notes?: string[];
-    deprecated?: {
-        removed_in?: string;
-        alternate?: string;
-        why?: string;
-    };
+  short_description: string;
+  description: string[];
+  options?: PluginOption[];
+  requirements?: string[];
+  notes?: string[];
+  deprecated?: {
+    removed_in?: string;
+    alternate?: string;
+    why?: string;
+  };
 }
 
 class ReturnedValue {
-    name: string;
-    description: string[];
-    returned: string;
-    type: string;
-    // if string: display the value, if object or list return JSON
-    sample: any;
-    contains: ReturnedValue[];
+  name: string;
+  description: string[];
+  returned: string;
+  type: string;
+  // if string: display the value, if object or list return JSON
+  sample: any;
+  contains: ReturnedValue[];
 }
 
 // Documentation for module doc string spec
 // https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html
 
 interface IState {
-    renderError: boolean;
+  renderError: boolean;
 }
 
 export class RenderPluginDoc extends React.Component<IProps, IState> {
-    // checks if I(), B(), M(), U(), L(), or C() exists. Returns type (ex: B)
-    // and value in parenthesis. Based off of formatters in ansible:
-    // https://github.com/ansible/ansible/blob/devel/hacking/build_library/build_ansible/jinja2/filters.py#L26
-    CUSTOM_FORMATTERS = /([IBMULC])\(([^)]+)\)/gm;
-    subOptionsMaxDepth: number;
-    returnContainMaxDepth: number;
+  // checks if I(), B(), M(), U(), L(), or C() exists. Returns type (ex: B)
+  // and value in parenthesis. Based off of formatters in ansible:
+  // https://github.com/ansible/ansible/blob/devel/hacking/build_library/build_ansible/jinja2/filters.py#L26
+  CUSTOM_FORMATTERS = /([IBMULC])\(([^)]+)\)/gm;
+  subOptionsMaxDepth: number;
+  returnContainMaxDepth: number;
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            renderError: false,
+  constructor(props) {
+    super(props);
+    this.state = {
+      renderError: false,
+    };
+  }
+
+  componentDidCatch(error, info) {
+    console.log(error);
+    this.setState({ renderError: true });
+  }
+
+  render() {
+    const { plugin } = this.props;
+
+    if (!this.state.renderError) {
+      // componentDidCatch doesn't seem to be able to catch errors that
+      // are thrown outside of return(), so we'll wrap everything in a
+      // try just in case
+      let doc: PluginDoc;
+      let example: string;
+      let returnVals: ReturnedValue[];
+      let content: any;
+      try {
+        doc = this.parseDocString(plugin);
+        example = this.parseExamples(plugin);
+        returnVals = this.parseReturn(plugin);
+        content = {
+          synopsis: this.renderSynopsis(doc),
+          parameters: this.renderParameters(
+            doc.options,
+            plugin.content_type,
+            this.subOptionsMaxDepth,
+          ),
+          notes: this.renderNotes(doc),
+          examples: this.renderExample(example),
+          returnValues: this.renderReturnValues(
+            returnVals,
+            this.returnContainMaxDepth,
+          ),
+          shortDescription: this.renderShortDescription(doc),
+          deprecated: this.renderDeprecated(doc, plugin.content_name),
+          requirements: this.renderRequirements(doc),
         };
+      } catch (err) {
+        console.log(err);
+        return this.renderError(plugin);
+      }
+
+      return (
+        <div className='pf-c-content'>
+          <h1>
+            {plugin.content_type} > {plugin.content_name}
+          </h1>
+          <br />
+          {content.shortDescription}
+          {content.deprecated}
+          {this.renderTableOfContents(content)}
+          {content.synopsis}
+          {content.requirements}
+          {content.parameters}
+          {content.notes}
+          {content.examples}
+          {content.returnValues}
+        </div>
+      );
+    } else {
+      return this.renderError(plugin);
+    }
+  }
+
+  private renderError(plugin) {
+    // There's a good chance that something about the plugin doc data will
+    // be malformed since it isn't validated. When that hapens, show an
+    // error instead of crashing the whole app
+    return (
+      <React.Fragment>
+        <Alert
+          isInline
+          variant='warning'
+          title='Documentation Syntax Error: cannot parse plugin documention.'
+        />
+        <br />
+        <div className='pf-c-content'>
+          {plugin.content_type && plugin.content_name ? (
+            <h1>
+              {plugin.content_type} > {plugin.content_name}
+            </h1>
+          ) : null}
+          <p>
+            The documentation object for this plugin seems to contain invalid
+            syntax that makes it impossible for Automation Hub to parse. You can
+            still look at the unformatted documentation object bellow if you
+            need to.
+          </p>
+
+          <h2>Unformatted Documentation</h2>
+
+          <pre className='plugin-raw'>{JSON.stringify(plugin, null, 2)}</pre>
+        </div>
+      </React.Fragment>
+    );
+  }
+
+  private parseDocString(plugin: PluginContentType): PluginDoc {
+    // TODO: if the parser can't figure out what to do with the object
+    // passed to it, it should throw an error that can be displayed to the
+    // user with the piece of the documention that's broken.
+
+    // TODO: make the doc string match the desired output as closely as
+    // possible
+    if (!plugin.doc_strings) {
+      return { description: [], short_description: '' } as PluginDoc;
     }
 
-    componentDidCatch(error, info) {
-        console.log(error);
-        this.setState({ renderError: true });
+    const doc: PluginDoc = { ...plugin.doc_strings.doc };
+
+    let maxDepth = 0;
+
+    const parseOptions = (options: PluginOption[], depth) => {
+      if (depth > maxDepth) {
+        maxDepth = depth;
+      }
+      for (let op of options) {
+        // Description is expected to be an array of strings. If its not,
+        // do what we can to make it one
+        op.description = this.ensureListofStrings(op.description);
+
+        if (typeof op.default === 'object') {
+          op.default = JSON.stringify(op.default);
+        }
+
+        // recursively parse sub options
+        if (op.suboptions) {
+          parseOptions(op.suboptions, depth + 1);
+        }
+      }
+    };
+
+    if (doc.options) {
+      parseOptions(doc.options, 0);
     }
 
-    render() {
-        const { plugin } = this.props;
+    doc.description = this.ensureListofStrings(doc.description);
+    this.subOptionsMaxDepth = maxDepth;
 
-        if (!this.state.renderError) {
-            // componentDidCatch doesn't seem to be able to catch errors that
-            // are thrown outside of return(), so we'll wrap everything in a
-            // try just in case
-            let doc: PluginDoc;
-            let example: string;
-            let returnVals: ReturnedValue[];
-            let content: any;
-            try {
-                doc = this.parseDocString(plugin);
-                example = this.parseExamples(plugin);
-                returnVals = this.parseReturn(plugin);
-                content = {
-                    synopsis: this.renderSynopsis(doc),
-                    parameters: this.renderParameters(
-                        doc.options,
-                        plugin.content_type,
-                        this.subOptionsMaxDepth,
-                    ),
-                    notes: this.renderNotes(doc),
-                    examples: this.renderExample(example),
-                    returnValues: this.renderReturnValues(
-                        returnVals,
-                        this.returnContainMaxDepth,
-                    ),
-                    shortDescription: this.renderShortDescription(doc),
-                    deprecated: this.renderDeprecated(doc, plugin.content_name),
-                    requirements: this.renderRequirements(doc),
-                };
-            } catch (err) {
-                console.log(err);
-                return this.renderError(plugin);
-            }
+    return doc;
+  }
 
+  private parseExamples(plugin: PluginContentType): string {
+    if (!plugin.doc_strings) {
+      return null;
+    }
+
+    if (typeof plugin.doc_strings.examples === 'string') {
+      // the examples always seem to have an annoying new line at the top
+      // so just replace it here if it exists.
+      return plugin.doc_strings.examples.replace('\n', '');
+    } else {
+      return null;
+    }
+  }
+
+  private parseReturn(plugin: PluginContentType): ReturnedValue[] {
+    // TODO: make the return string match the desired output as closely as
+    // possible
+
+    if (!plugin.doc_strings) {
+      return null;
+    }
+
+    if (!plugin.doc_strings.return) {
+      return null;
+    }
+
+    let maxDepth = 0;
+
+    const parseReturnRecursive = (returnV: ReturnedValue[], depth) => {
+      if (depth > maxDepth) {
+        maxDepth = depth;
+      }
+      for (let ret of returnV) {
+        // Description is expected to be an array of strings. If its not,
+        // do what we can to make it one
+        ret.description = this.ensureListofStrings(ret.description);
+
+        // recursively parse sub options
+        if (ret.contains) {
+          parseReturnRecursive(ret.contains, depth + 1);
+        }
+      }
+    };
+
+    const returnValues = [...plugin.doc_strings.return];
+    parseReturnRecursive(returnValues, 0);
+    this.returnContainMaxDepth = maxDepth;
+
+    return returnValues;
+  }
+
+  // This functions similar to how string.replace() works, except it returns
+  // a react object instead of a string
+  private reactReplace(
+    text: string,
+    reg: RegExp,
+    replacement: (matches: string[]) => React.ReactNode,
+  ): React.ReactNode {
+    const fragments = [];
+
+    let match: string[];
+    let prevIndex = 0;
+    while ((match = reg.exec(text)) !== null) {
+      fragments.push(
+        text.substr(prevIndex, reg.lastIndex - prevIndex - match[0].length),
+      );
+      fragments.push(replacement(match));
+      prevIndex = reg.lastIndex;
+    }
+
+    if (fragments.length === 0) {
+      return <span>{text}</span>;
+    }
+
+    // append any text after the last match
+    if (prevIndex != text.length - 1) {
+      fragments.push(text.substring(prevIndex));
+    }
+
+    return (
+      <span>
+        {fragments.map((x, i) => (
+          <React.Fragment key={i}>{x}</React.Fragment>
+        ))}
+      </span>
+    );
+  }
+
+  private applyDocFormatters(text: string): React.ReactNode {
+    const { collectionName, namespaceName, allContent, params } = this.props;
+
+    const nstring = this.reactReplace(text, this.CUSTOM_FORMATTERS, match => {
+      const fullMatch = match[0];
+      const type = match[1];
+      const textMatch = match[2];
+
+      switch (type) {
+        case 'L':
+          const url = textMatch.split(',');
+
+          if (url[1].startsWith('http')) {
             return (
-                <div className='pf-c-content'>
-                    <h1>
-                        {plugin.content_type} > {plugin.content_name}
-                    </h1>
-                    <br />
-                    {content.shortDescription}
-                    {content.deprecated}
-                    {this.renderTableOfContents(content)}
-                    {content.synopsis}
-                    {content.requirements}
-                    {content.parameters}
-                    {content.notes}
-                    {content.examples}
-                    {content.returnValues}
-                </div>
+              <a href={url[1]} target='_blank'>
+                {url[0]}
+              </a>
             );
-        } else {
-            return this.renderError(plugin);
-        }
-    }
-
-    private renderError(plugin) {
-        // There's a good chance that something about the plugin doc data will
-        // be malformed since it isn't validated. When that hapens, show an
-        // error instead of crashing the whole app
-        return (
-            <React.Fragment>
-                <Alert
-                    isInline
-                    variant='warning'
-                    title='Documentation Syntax Error: cannot parse plugin documention.'
-                />
-                <br />
-                <div className='pf-c-content'>
-                    {plugin.content_type && plugin.content_name ? (
-                        <h1>
-                            {plugin.content_type} > {plugin.content_name}
-                        </h1>
-                    ) : null}
-                    <p>
-                        The documentation object for this plugin seems to
-                        contain invalid syntax that makes it impossible for
-                        Automation Hub to parse. You can still look at the
-                        unformatted documentation object bellow if you need to.
-                    </p>
-
-                    <h2>Unformatted Documentation</h2>
-
-                    <pre className='plugin-raw'>
-                        {JSON.stringify(plugin, null, 2)}
-                    </pre>
-                </div>
-            </React.Fragment>
-        );
-    }
-
-    private parseDocString(plugin: PluginContentType): PluginDoc {
-        // TODO: if the parser can't figure out what to do with the object
-        // passed to it, it should throw an error that can be displayed to the
-        // user with the piece of the documention that's broken.
-
-        // TODO: make the doc string match the desired output as closely as
-        // possible
-        if (!plugin.doc_strings) {
-            return { description: [], short_description: '' } as PluginDoc;
-        }
-
-        const doc: PluginDoc = { ...plugin.doc_strings.doc };
-
-        let maxDepth = 0;
-
-        const parseOptions = (options: PluginOption[], depth) => {
-            if (depth > maxDepth) {
-                maxDepth = depth;
-            }
-            for (let op of options) {
-                // Description is expected to be an array of strings. If its not,
-                // do what we can to make it one
-                op.description = this.ensureListofStrings(op.description);
-
-                if (typeof op.default === 'object') {
-                    op.default = JSON.stringify(op.default);
-                }
-
-                // recursively parse sub options
-                if (op.suboptions) {
-                    parseOptions(op.suboptions, depth + 1);
-                }
-            }
-        };
-
-        if (doc.options) {
-            parseOptions(doc.options, 0);
-        }
-
-        doc.description = this.ensureListofStrings(doc.description);
-        this.subOptionsMaxDepth = maxDepth;
-
-        return doc;
-    }
-
-    private parseExamples(plugin: PluginContentType): string {
-        if (!plugin.doc_strings) {
-            return null;
-        }
-
-        if (typeof plugin.doc_strings.examples === 'string') {
-            // the examples always seem to have an annoying new line at the top
-            // so just replace it here if it exists.
-            return plugin.doc_strings.examples.replace('\n', '');
-        } else {
-            return null;
-        }
-    }
-
-    private parseReturn(plugin: PluginContentType): ReturnedValue[] {
-        // TODO: make the return string match the desired output as closely as
-        // possible
-
-        if (!plugin.doc_strings) {
-            return null;
-        }
-
-        if (!plugin.doc_strings.return) {
-            return null;
-        }
-
-        let maxDepth = 0;
-
-        const parseReturnRecursive = (returnV: ReturnedValue[], depth) => {
-            if (depth > maxDepth) {
-                maxDepth = depth;
-            }
-            for (let ret of returnV) {
-                // Description is expected to be an array of strings. If its not,
-                // do what we can to make it one
-                ret.description = this.ensureListofStrings(ret.description);
-
-                // recursively parse sub options
-                if (ret.contains) {
-                    parseReturnRecursive(ret.contains, depth + 1);
-                }
-            }
-        };
-
-        const returnValues = [...plugin.doc_strings.return];
-        parseReturnRecursive(returnValues, 0);
-        this.returnContainMaxDepth = maxDepth;
-
-        return returnValues;
-    }
-
-    // This functions similar to how string.replace() works, except it returns
-    // a react object instead of a string
-    private reactReplace(
-        text: string,
-        reg: RegExp,
-        replacement: (matches: string[]) => React.ReactNode,
-    ): React.ReactNode {
-        const fragments = [];
-
-        let match: string[];
-        let prevIndex = 0;
-        while ((match = reg.exec(text)) !== null) {
-            fragments.push(
-                text.substr(
-                    prevIndex,
-                    reg.lastIndex - prevIndex - match[0].length,
-                ),
+          } else {
+            // TODO: right now this will break if people put
+            // ../ at the front of their urls. Need to find a
+            // way to document this
+            return (
+              <Link
+                to={formatPath(
+                  Paths.collectionDocsPage,
+                  {
+                    namespace: namespaceName,
+                    collection: collectionName,
+                    page: sanitizeDocsUrls(url[1]),
+                  },
+                  params,
+                )}
+              >
+                {url[0]}
+              </Link>
             );
-            fragments.push(replacement(match));
-            prevIndex = reg.lastIndex;
-        }
+          }
+        case 'U':
+          return (
+            <a href={textMatch} target='_blank'>
+              {textMatch}
+            </a>
+          );
+        case 'I':
+          return <i>{textMatch}</i>;
+        case 'C':
+          return <span className='inline-code'>{textMatch}</span>;
+        case 'M':
+          const module = allContent.find(
+            x => x.content_type === 'module' && x.name === textMatch,
+          );
 
-        if (fragments.length === 0) {
-            return <span>{text}</span>;
-        }
-
-        // append any text after the last match
-        if (prevIndex != text.length - 1) {
-            fragments.push(text.substring(prevIndex));
-        }
-
-        return (
-            <span>
-                {fragments.map((x, i) => (
-                    <React.Fragment key={i}>{x}</React.Fragment>
-                ))}
-            </span>
-        );
-    }
-
-    private applyDocFormatters(text: string): React.ReactNode {
-        const {
-            collectionName,
-            namespaceName,
-            allContent,
-            params,
-        } = this.props;
-
-        const nstring = this.reactReplace(
-            text,
-            this.CUSTOM_FORMATTERS,
-            match => {
-                const fullMatch = match[0];
-                const type = match[1];
-                const textMatch = match[2];
-
-                switch (type) {
-                    case 'L':
-                        const url = textMatch.split(',');
-
-                        if (url[1].startsWith('http')) {
-                            return (
-                                <a href={url[1]} target='_blank'>
-                                    {url[0]}
-                                </a>
-                            );
-                        } else {
-                            // TODO: right now this will break if people put
-                            // ../ at the front of their urls. Need to find a
-                            // way to document this
-                            return (
-                                <Link
-                                    to={formatPath(
-                                        Paths.collectionDocsPage,
-                                        {
-                                            namespace: namespaceName,
-                                            collection: collectionName,
-                                            page: sanitizeDocsUrls(url[1]),
-                                        },
-                                        params,
-                                    )}
-                                >
-                                    {url[0]}
-                                </Link>
-                            );
-                        }
-                    case 'U':
-                        return (
-                            <a href={textMatch} target='_blank'>
-                                {textMatch}
-                            </a>
-                        );
-                    case 'I':
-                        return <i>{textMatch}</i>;
-                    case 'C':
-                        return <span className='inline-code'>{textMatch}</span>;
-                    case 'M':
-                        const module = allContent.find(
-                            x =>
-                                x.content_type === 'module' &&
-                                x.name === textMatch,
-                        );
-
-                        if (module) {
-                            return (
-                                <Link
-                                    to={formatPath(
-                                        Paths.collectionContentDocs,
-                                        {
-                                            namespace: namespaceName,
-                                            collection: collectionName,
-                                            type: module.content_type,
-                                            name: module.name,
-                                        },
-                                        params,
-                                    )}
-                                >
-                                    {textMatch}
-                                </Link>
-                            );
-                        } else {
-                            return textMatch;
-                        }
-                    case 'B':
-                        return <b>{textMatch}</b>;
-
-                    default:
-                        return fullMatch;
-                }
-            },
-        );
-
-        return nstring;
-    }
-
-    private ensureListofStrings(v) {
-        if (typeof v === 'string') {
-            return [v];
-        } else if (!v) {
-            return [];
-        } else {
-            return v;
-        }
-    }
-
-    private renderDeprecated(doc: PluginDoc, pluginName: string) {
-        const isDeprecated = doc.deprecated || pluginName.startsWith('_');
-
-        if (!isDeprecated) {
-            return null;
-        }
-
-        const deprecated = doc.deprecated || {};
-
-        return (
-            <React.Fragment>
-                <h2>DEPRECATED</h2>
-                {deprecated.removed_in ? (
-                    <div>
-                        <b>Removed in version</b> {doc.deprecated.removed_in}
-                    </div>
-                ) : null}
-
-                <div>
-                    <b>Why: </b>
-                    {deprecated.why
-                        ? doc.deprecated.why
-                        : 'No reason specified.'}
-                </div>
-
-                <div>
-                    <b>Alternative: </b>
-                    {deprecated.why
-                        ? doc.deprecated.why
-                        : 'No alternatives specified.'}
-                </div>
-            </React.Fragment>
-        );
-    }
-
-    private renderTableOfContents(content: any) {
-        return (
-            <ul>
-                {content['synopsis'] !== null && (
-                    <li>
-                        <HashLink to='#synopsis'>Synopsis</HashLink>
-                    </li>
+          if (module) {
+            return (
+              <Link
+                to={formatPath(
+                  Paths.collectionContentDocs,
+                  {
+                    namespace: namespaceName,
+                    collection: collectionName,
+                    type: module.content_type,
+                    name: module.name,
+                  },
+                  params,
                 )}
-                {content['parameters'] !== null && (
-                    <li>
-                        <HashLink to='#parameters'>Parameters</HashLink>
-                    </li>
-                )}
-                {content['notes'] !== null && (
-                    <li>
-                        <HashLink to='#notes'>Notes</HashLink>
-                    </li>
-                )}
-                {content['examples'] !== null && (
-                    <li>
-                        <HashLink to='#examples'>Examples</HashLink>
-                    </li>
-                )}
-                {content['returnValues'] !== null && (
-                    <li>
-                        <HashLink to='#return-values'>Return Values</HashLink>
-                    </li>
-                )}
-            </ul>
-        );
+              >
+                {textMatch}
+              </Link>
+            );
+          } else {
+            return textMatch;
+          }
+        case 'B':
+          return <b>{textMatch}</b>;
+
+        default:
+          return fullMatch;
+      }
+    });
+
+    return nstring;
+  }
+
+  private ensureListofStrings(v) {
+    if (typeof v === 'string') {
+      return [v];
+    } else if (!v) {
+      return [];
+    } else {
+      return v;
+    }
+  }
+
+  private renderDeprecated(doc: PluginDoc, pluginName: string) {
+    const isDeprecated = doc.deprecated || pluginName.startsWith('_');
+
+    if (!isDeprecated) {
+      return null;
     }
 
-    private renderShortDescription(doc: PluginDoc) {
-        return <div>{doc.short_description}</div>;
+    const deprecated = doc.deprecated || {};
+
+    return (
+      <React.Fragment>
+        <h2>DEPRECATED</h2>
+        {deprecated.removed_in ? (
+          <div>
+            <b>Removed in version</b> {doc.deprecated.removed_in}
+          </div>
+        ) : null}
+
+        <div>
+          <b>Why: </b>
+          {deprecated.why ? doc.deprecated.why : 'No reason specified.'}
+        </div>
+
+        <div>
+          <b>Alternative: </b>
+          {deprecated.why ? doc.deprecated.why : 'No alternatives specified.'}
+        </div>
+      </React.Fragment>
+    );
+  }
+
+  private renderTableOfContents(content: any) {
+    return (
+      <ul>
+        {content['synopsis'] !== null && (
+          <li>
+            <HashLink to='#synopsis'>Synopsis</HashLink>
+          </li>
+        )}
+        {content['parameters'] !== null && (
+          <li>
+            <HashLink to='#parameters'>Parameters</HashLink>
+          </li>
+        )}
+        {content['notes'] !== null && (
+          <li>
+            <HashLink to='#notes'>Notes</HashLink>
+          </li>
+        )}
+        {content['examples'] !== null && (
+          <li>
+            <HashLink to='#examples'>Examples</HashLink>
+          </li>
+        )}
+        {content['returnValues'] !== null && (
+          <li>
+            <HashLink to='#return-values'>Return Values</HashLink>
+          </li>
+        )}
+      </ul>
+    );
+  }
+
+  private renderShortDescription(doc: PluginDoc) {
+    return <div>{doc.short_description}</div>;
+  }
+
+  private renderSynopsis(doc: PluginDoc) {
+    return (
+      <React.Fragment>
+        <h2 id='synopsis'>Synopsis</h2>
+        <ul>
+          {doc.description.map((d, i) => (
+            <li key={i}>{this.applyDocFormatters(d)}</li>
+          ))}
+        </ul>
+      </React.Fragment>
+    );
+  }
+
+  private renderParameters(
+    parameters: PluginOption[],
+    content_type: string,
+    maxDepth: number,
+  ) {
+    if (!parameters) {
+      return null;
     }
 
-    private renderSynopsis(doc: PluginDoc) {
-        return (
-            <React.Fragment>
-                <h2 id='synopsis'>Synopsis</h2>
-                <ul>
-                    {doc.description.map((d, i) => (
-                        <li key={i}>{this.applyDocFormatters(d)}</li>
-                    ))}
-                </ul>
-            </React.Fragment>
-        );
-    }
+    // render the entries first,
+    const paramEntries = this.renderParameterEntries(
+      parameters,
+      content_type,
+      0,
+      maxDepth,
+      '',
+    );
 
-    private renderParameters(
-        parameters: PluginOption[],
-        content_type: string,
-        maxDepth: number,
-    ) {
-        if (!parameters) {
-            return null;
-        }
+    return (
+      <React.Fragment>
+        <h2 id='parameters'>Parameters</h2>
+        <table className='options-table'>
+          <tbody>
+            <tr>
+              <th colSpan={maxDepth + 1}>Parameter</th>
+              <th>
+                Choices/<span className='blue'>Defaults</span>
+              </th>
+              {content_type !== 'module' ? <th>Configuration</th> : null}
+              <th>Comments</th>
+            </tr>
+            {paramEntries}
+          </tbody>
+        </table>
+      </React.Fragment>
+    );
+  }
 
-        // render the entries first,
-        const paramEntries = this.renderParameterEntries(
-            parameters,
+  private renderParameterEntries(
+    parameters: PluginOption[],
+    content_type: string,
+    depth: number,
+    maxDepth: number,
+    parent: string,
+  ) {
+    let output = [];
+    parameters.forEach((option, i) => {
+      const spacers = [];
+      const key = `${parent}-${option.name}`;
+      for (let x = 0; x < depth; x++) {
+        spacers.push(<td key={x} className='spacer' />);
+      }
+      output.push(
+        <tr key={key}>
+          {
+            // PARAMETER --------------------------------
+          }
+          {spacers}
+          <td
+            colSpan={maxDepth + 1 - depth}
+            className={option.suboptions ? 'parent' : ''}
+          >
+            <span className='option-name'>{option.name}</span>
+            <small>
+              {this.documentedType(option['type'])}
+              {option['elements'] ? (
+                <span>
+                  {' '}
+                  / elements ={this.documentedType(option['elements'])}
+                </span>
+              ) : null}
+              {option['required'] ? (
+                <span>
+                  {' '}
+                  / <span className='red'>required</span>
+                </span>
+              ) : null}
+            </small>
+          </td>
+          {
+            // CHOICES -------------------------------
+          }
+          <td>{this.renderChoices(option)}</td>
+          {
+            // CONFIGURATION (non module only) -------
+          }
+          {content_type !== 'module' ? (
+            <td>{this.renderPluginConfiguration(option)}</td>
+          ) : null}
+          {
+            // COMMENTS ------------------------------
+          }
+          <td>
+            {option.description.map((d, i) => (
+              <p key={i}>{this.applyDocFormatters(d)}</p>
+            ))}
+
+            {option['aliases'] ? (
+              <small>
+                <span className='green'>
+                  aliases: {option['aliases'].join(', ')}
+                </span>
+              </small>
+            ) : null}
+          </td>
+        </tr>,
+      );
+
+      // recursively render sub options
+      if (option.suboptions) {
+        output = output.concat(
+          this.renderParameterEntries(
+            option.suboptions,
             content_type,
-            0,
+            depth + 1,
             maxDepth,
-            '',
+            key,
+          ),
         );
+      }
+    });
 
-        return (
-            <React.Fragment>
-                <h2 id='parameters'>Parameters</h2>
-                <table className='options-table'>
-                    <tbody>
-                        <tr>
-                            <th colSpan={maxDepth + 1}>Parameter</th>
-                            <th>
-                                Choices/<span className='blue'>Defaults</span>
-                            </th>
-                            {content_type !== 'module' ? (
-                                <th>Configuration</th>
-                            ) : null}
-                            <th>Comments</th>
-                        </tr>
-                        {paramEntries}
-                    </tbody>
-                </table>
-            </React.Fragment>
+    return output;
+  }
+
+  private renderPluginConfiguration(option) {
+    return (
+      <React.Fragment>
+        {option['ini'] ? (
+          <div className='plugin-config'>
+            ini entries:
+            {option['ini'].map((v, i) => (
+              <p key={i}>
+                [{v.section}]
+                <br />
+                {v.key} = {v.default ? v.default : 'VALUE'}
+              </p>
+            ))}
+          </div>
+        ) : null}
+
+        {option['env'] ? (
+          <div className='plugin-config'>
+            {option['env'].map((v, i) => (
+              <div key={i}>env: {v.name}</div>
+            ))}
+          </div>
+        ) : null}
+
+        {option['vars'] ? (
+          <div className='plugin-config'>
+            {option['vars'].map((v, i) => (
+              <div>var: {v.name}</div>
+            ))}
+          </div>
+        ) : null}
+      </React.Fragment>
+    );
+  }
+
+  private renderChoices(option) {
+    let choices, defaul;
+
+    if (option['type'] === 'bool') {
+      choices = ['no', 'yes'];
+      if (option['default'] === true) {
+        defaul = 'yes';
+      } else if (option['default'] === false) {
+        defaul = 'no';
+      }
+    } else {
+      choices = option['choices'] || [];
+      defaul = option['default'];
+    }
+
+    return (
+      <React.Fragment>
+        {choices && Array.isArray(choices) && choices.length !== 0 ? (
+          <div>
+            <span className='option-name'>Choices: </span>
+            <ul>
+              {choices.map((c, i) => (
+                <li key={i}>
+                  {c === defaul ? (
+                    <span className='blue'>{c} &nbsp;&larr;</span>
+                  ) : (
+                    c
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {defaul && !choices.includes(defaul) ? (
+          <span>
+            <span className='option-name'>Default: </span>
+            <span className='blue'>{defaul}</span>
+          </span>
+        ) : null}
+      </React.Fragment>
+    );
+  }
+
+  private renderNotes(doc: PluginDoc) {
+    if (!doc.notes) {
+      return null;
+    }
+
+    return (
+      <React.Fragment>
+        <h2 id='notes'>Notes</h2>
+        <ul>
+          {doc.notes.map((note, i) => (
+            <li key={i}>{this.applyDocFormatters(note)}</li>
+          ))}
+        </ul>
+      </React.Fragment>
+    );
+  }
+
+  private renderRequirements(doc: PluginDoc) {
+    if (!doc.requirements) {
+      return null;
+    }
+
+    return (
+      <React.Fragment>
+        <h2>Requirements</h2>
+        <ul>
+          {doc.requirements.map((req, i) => (
+            <li key={i}>{req}</li>
+          ))}
+        </ul>
+      </React.Fragment>
+    );
+  }
+
+  private renderExample(example: string) {
+    if (!example) {
+      return null;
+    }
+    return (
+      <React.Fragment>
+        <h2 id='examples'>Examples</h2>
+        <pre>{example}</pre>
+      </React.Fragment>
+    );
+  }
+
+  private renderReturnValues(returnV: ReturnedValue[], maxDepth: number) {
+    if (!returnV) {
+      return null;
+    }
+    return (
+      <React.Fragment>
+        <h2 id='return-values'>Return Values</h2>
+        <table className='options-table'>
+          <tbody>
+            <tr>
+              <th colSpan={maxDepth + 1}>Key</th>
+              <th>Returned</th>
+              <th>Description</th>
+            </tr>
+            {this.renderReturnValueEntries(returnV, 0, maxDepth, '')}
+          </tbody>
+        </table>
+      </React.Fragment>
+    );
+  }
+
+  private renderReturnValueEntries(
+    returnValues: ReturnedValue[],
+    depth: number,
+    maxDepth: number,
+    parent: string,
+  ) {
+    let entries = [];
+
+    returnValues.forEach((option, i) => {
+      const spacers = [];
+      for (let x = 0; x < depth; x++) {
+        spacers.push(<td key={x} colSpan={1} className='spacer' />);
+      }
+      const key = `${parent}-${option.name}`;
+      entries.push(
+        <tr key={key}>
+          {spacers}
+          <td
+            colSpan={maxDepth + 1 - depth}
+            className={option.contains ? 'parent' : ''}
+          >
+            {option.name} <br /> ({option.type})
+          </td>
+          <td>{option.returned}</td>
+          <td>
+            {option.description.map((d, i) => (
+              <p key={i}>{this.applyDocFormatters(d)}</p>
+            ))}
+
+            {option.sample ? (
+              <div>
+                <br />
+                sample:
+                {typeof option.sample === 'string' ? (
+                  option.sample
+                ) : (
+                  <pre>{JSON.stringify(option.sample, null, 2)}</pre>
+                )}
+              </div>
+            ) : null}
+          </td>
+        </tr>,
+      );
+
+      if (option.contains) {
+        entries = entries.concat(
+          // recursively render values
+          this.renderReturnValueEntries(
+            option.contains,
+            depth + 1,
+            maxDepth,
+            key,
+          ),
         );
+      }
+    });
+    return entries;
+  }
+
+  // https://github.com/ansible/ansible/blob/1b8aa798df6f6fa96ba5ea2a9dbf01b3f1de555c/hacking/build_library/build_ansible/jinja2/filters.py#L53
+  private documentedType(text) {
+    switch (text) {
+      case 'str':
+        return 'string';
+      case 'bool':
+        return 'boolean';
+      case 'int':
+        return 'integer';
+      case 'dict':
+        return 'dictionary';
+      case undefined:
+        return '-';
+      default:
+        return text;
     }
-
-    private renderParameterEntries(
-        parameters: PluginOption[],
-        content_type: string,
-        depth: number,
-        maxDepth: number,
-        parent: string,
-    ) {
-        let output = [];
-        parameters.forEach((option, i) => {
-            const spacers = [];
-            const key = `${parent}-${option.name}`;
-            for (let x = 0; x < depth; x++) {
-                spacers.push(<td key={x} className='spacer' />);
-            }
-            output.push(
-                <tr key={key}>
-                    {
-                        // PARAMETER --------------------------------
-                    }
-                    {spacers}
-                    <td
-                        colSpan={maxDepth + 1 - depth}
-                        className={option.suboptions ? 'parent' : ''}
-                    >
-                        <span className='option-name'>{option.name}</span>
-                        <small>
-                            {this.documentedType(option['type'])}
-                            {option['elements'] ? (
-                                <span>
-                                    {' '}
-                                    / elements =
-                                    {this.documentedType(option['elements'])}
-                                </span>
-                            ) : null}
-                            {option['required'] ? (
-                                <span>
-                                    {' '}
-                                    / <span className='red'>required</span>
-                                </span>
-                            ) : null}
-                        </small>
-                    </td>
-                    {
-                        // CHOICES -------------------------------
-                    }
-                    <td>{this.renderChoices(option)}</td>
-                    {
-                        // CONFIGURATION (non module only) -------
-                    }
-                    {content_type !== 'module' ? (
-                        <td>{this.renderPluginConfiguration(option)}</td>
-                    ) : null}
-                    {
-                        // COMMENTS ------------------------------
-                    }
-                    <td>
-                        {option.description.map((d, i) => (
-                            <p key={i}>{this.applyDocFormatters(d)}</p>
-                        ))}
-
-                        {option['aliases'] ? (
-                            <small>
-                                <span className='green'>
-                                    aliases: {option['aliases'].join(', ')}
-                                </span>
-                            </small>
-                        ) : null}
-                    </td>
-                </tr>,
-            );
-
-            // recursively render sub options
-            if (option.suboptions) {
-                output = output.concat(
-                    this.renderParameterEntries(
-                        option.suboptions,
-                        content_type,
-                        depth + 1,
-                        maxDepth,
-                        key,
-                    ),
-                );
-            }
-        });
-
-        return output;
-    }
-
-    private renderPluginConfiguration(option) {
-        return (
-            <React.Fragment>
-                {option['ini'] ? (
-                    <div className='plugin-config'>
-                        ini entries:
-                        {option['ini'].map((v, i) => (
-                            <p key={i}>
-                                [{v.section}]
-                                <br />
-                                {v.key} = {v.default ? v.default : 'VALUE'}
-                            </p>
-                        ))}
-                    </div>
-                ) : null}
-
-                {option['env'] ? (
-                    <div className='plugin-config'>
-                        {option['env'].map((v, i) => (
-                            <div key={i}>env: {v.name}</div>
-                        ))}
-                    </div>
-                ) : null}
-
-                {option['vars'] ? (
-                    <div className='plugin-config'>
-                        {option['vars'].map((v, i) => (
-                            <div>var: {v.name}</div>
-                        ))}
-                    </div>
-                ) : null}
-            </React.Fragment>
-        );
-    }
-
-    private renderChoices(option) {
-        let choices, defaul;
-
-        if (option['type'] === 'bool') {
-            choices = ['no', 'yes'];
-            if (option['default'] === true) {
-                defaul = 'yes';
-            } else if (option['default'] === false) {
-                defaul = 'no';
-            }
-        } else {
-            choices = option['choices'] || [];
-            defaul = option['default'];
-        }
-
-        return (
-            <React.Fragment>
-                {choices && Array.isArray(choices) && choices.length !== 0 ? (
-                    <div>
-                        <span className='option-name'>Choices: </span>
-                        <ul>
-                            {choices.map((c, i) => (
-                                <li key={i}>
-                                    {c === defaul ? (
-                                        <span className='blue'>
-                                            {c} &nbsp;&larr;
-                                        </span>
-                                    ) : (
-                                        c
-                                    )}
-                                </li>
-                            ))}
-                        </ul>
-                    </div>
-                ) : null}
-
-                {defaul && !choices.includes(defaul) ? (
-                    <span>
-                        <span className='option-name'>Default: </span>
-                        <span className='blue'>{defaul}</span>
-                    </span>
-                ) : null}
-            </React.Fragment>
-        );
-    }
-
-    private renderNotes(doc: PluginDoc) {
-        if (!doc.notes) {
-            return null;
-        }
-
-        return (
-            <React.Fragment>
-                <h2 id='notes'>Notes</h2>
-                <ul>
-                    {doc.notes.map((note, i) => (
-                        <li key={i}>{this.applyDocFormatters(note)}</li>
-                    ))}
-                </ul>
-            </React.Fragment>
-        );
-    }
-
-    private renderRequirements(doc: PluginDoc) {
-        if (!doc.requirements) {
-            return null;
-        }
-
-        return (
-            <React.Fragment>
-                <h2>Requirements</h2>
-                <ul>
-                    {doc.requirements.map((req, i) => (
-                        <li key={i}>{req}</li>
-                    ))}
-                </ul>
-            </React.Fragment>
-        );
-    }
-
-    private renderExample(example: string) {
-        if (!example) {
-            return null;
-        }
-        return (
-            <React.Fragment>
-                <h2 id='examples'>Examples</h2>
-                <pre>{example}</pre>
-            </React.Fragment>
-        );
-    }
-
-    private renderReturnValues(returnV: ReturnedValue[], maxDepth: number) {
-        if (!returnV) {
-            return null;
-        }
-        return (
-            <React.Fragment>
-                <h2 id='return-values'>Return Values</h2>
-                <table className='options-table'>
-                    <tbody>
-                        <tr>
-                            <th colSpan={maxDepth + 1}>Key</th>
-                            <th>Returned</th>
-                            <th>Description</th>
-                        </tr>
-                        {this.renderReturnValueEntries(
-                            returnV,
-                            0,
-                            maxDepth,
-                            '',
-                        )}
-                    </tbody>
-                </table>
-            </React.Fragment>
-        );
-    }
-
-    private renderReturnValueEntries(
-        returnValues: ReturnedValue[],
-        depth: number,
-        maxDepth: number,
-        parent: string,
-    ) {
-        let entries = [];
-
-        returnValues.forEach((option, i) => {
-            const spacers = [];
-            for (let x = 0; x < depth; x++) {
-                spacers.push(<td key={x} colSpan={1} className='spacer' />);
-            }
-            const key = `${parent}-${option.name}`;
-            entries.push(
-                <tr key={key}>
-                    {spacers}
-                    <td
-                        colSpan={maxDepth + 1 - depth}
-                        className={option.contains ? 'parent' : ''}
-                    >
-                        {option.name} <br /> ({option.type})
-                    </td>
-                    <td>{option.returned}</td>
-                    <td>
-                        {option.description.map((d, i) => (
-                            <p key={i}>{this.applyDocFormatters(d)}</p>
-                        ))}
-
-                        {option.sample ? (
-                            <div>
-                                <br />
-                                sample:
-                                {typeof option.sample === 'string' ? (
-                                    option.sample
-                                ) : (
-                                    <pre>
-                                        {JSON.stringify(option.sample, null, 2)}
-                                    </pre>
-                                )}
-                            </div>
-                        ) : null}
-                    </td>
-                </tr>,
-            );
-
-            if (option.contains) {
-                entries = entries.concat(
-                    // recursively render values
-                    this.renderReturnValueEntries(
-                        option.contains,
-                        depth + 1,
-                        maxDepth,
-                        key,
-                    ),
-                );
-            }
-        });
-        return entries;
-    }
-
-    // https://github.com/ansible/ansible/blob/1b8aa798df6f6fa96ba5ea2a9dbf01b3f1de555c/hacking/build_library/build_ansible/jinja2/filters.py#L53
-    private documentedType(text) {
-        switch (text) {
-            case 'str':
-                return 'string';
-            case 'bool':
-                return 'boolean';
-            case 'int':
-                return 'integer';
-            case 'dict':
-                return 'dictionary';
-            case undefined:
-                return '-';
-            default:
-                return text;
-        }
-    }
+  }
 }

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -10,256 +10,245 @@ import { Paths, formatPath } from '../../paths';
 import { ParamHelper, sanitizeDocsUrls } from '../../utilities';
 
 class DocsEntry {
-    display: string;
-    name: string;
-    type: string;
-    url?: string;
+  display: string;
+  name: string;
+  type: string;
+  url?: string;
 }
 
 class Table {
-    documentation: DocsEntry[];
-    modules: DocsEntry[];
-    roles: DocsEntry[];
-    plugins: DocsEntry[];
-    playbooks: DocsEntry[];
+  documentation: DocsEntry[];
+  modules: DocsEntry[];
+  roles: DocsEntry[];
+  plugins: DocsEntry[];
+  playbooks: DocsEntry[];
 }
 
 interface IState {
-    collapsedCategories: string[];
+  collapsedCategories: string[];
 }
 
 interface IProps {
-    docs_blob: DocsBlobType;
-    namespace: string;
-    collection: string;
-    params: object;
-    selectedName?: string;
-    selectedType?: string;
-    className?: string;
+  docs_blob: DocsBlobType;
+  namespace: string;
+  collection: string;
+  params: object;
+  selectedName?: string;
+  selectedType?: string;
+  className?: string;
 }
 
 export class TableOfContents extends React.Component<IProps, IState> {
-    docsBlobCache: DocsBlobType;
-    tableCache: Table;
+  docsBlobCache: DocsBlobType;
+  tableCache: Table;
 
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = { collapsedCategories: [] };
+    this.state = { collapsedCategories: [] };
+  }
+
+  render() {
+    const { className, docs_blob } = this.props;
+
+    // There's a lot of heavy processing that goes into formatting the table
+    // variable. To prevent running everything each time the component renders,
+    // cache the value as an object property.
+    // This is a lazy anti pattern. I should be using memoization or something
+    // like that, but the react docs recommend using a third party memoization
+    // library and I am not going to add extra dependencies just for this
+    // component https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization
+
+    if (!this.tableCache || this.docsBlobCache !== docs_blob) {
+      this.tableCache = this.parseLinks(docs_blob);
+      this.docsBlobCache = docs_blob;
     }
 
-    render() {
-        const { className, docs_blob } = this.props;
+    const table = this.tableCache;
 
-        // There's a lot of heavy processing that goes into formatting the table
-        // variable. To prevent running everything each time the component renders,
-        // cache the value as an object property.
-        // This is a lazy anti pattern. I should be using memoization or something
-        // like that, but the react docs recommend using a third party memoization
-        // library and I am not going to add extra dependencies just for this
-        // component https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html#what-about-memoization
+    return (
+      <div className={className}>
+        <Nav>
+          <NavList>
+            {Object.keys(table).map(key =>
+              table[key].length === 0
+                ? null
+                : this.renderLinks(table[key], key),
+            )}
+          </NavList>
+        </Nav>
+      </div>
+    );
+  }
 
-        if (!this.tableCache || this.docsBlobCache !== docs_blob) {
-            this.tableCache = this.parseLinks(docs_blob);
-            this.docsBlobCache = docs_blob;
-        }
+  private parseLinks(docs_blob: DocsBlobType): Table {
+    const { namespace, collection } = this.props;
 
-        const table = this.tableCache;
+    const baseUrlParams = {
+      namespace: namespace,
+      collection: collection,
+    };
 
-        return (
-            <div className={className}>
-                <Nav>
-                    <NavList>
-                        {Object.keys(table).map(key =>
-                            table[key].length === 0
-                                ? null
-                                : this.renderLinks(table[key], key),
-                        )}
-                    </NavList>
-                </Nav>
-            </div>
-        );
-    }
+    const table = {
+      documentation: [] as DocsEntry[],
+      modules: [] as DocsEntry[],
+      roles: [] as DocsEntry[],
+      plugins: [] as DocsEntry[],
+      playbooks: [] as DocsEntry[],
+    };
 
-    private parseLinks(docs_blob: DocsBlobType): Table {
-        const { namespace, collection } = this.props;
+    table.documentation.push({
+      display: 'Readme',
+      url: formatPath(Paths.collectionDocsIndex, baseUrlParams),
+      type: 'docs',
+      name: 'readme',
+    });
 
-        const baseUrlParams = {
-            namespace: namespace,
-            collection: collection,
-        };
-
-        const table = {
-            documentation: [] as DocsEntry[],
-            modules: [] as DocsEntry[],
-            roles: [] as DocsEntry[],
-            plugins: [] as DocsEntry[],
-            playbooks: [] as DocsEntry[],
-        };
-
+    if (docs_blob.documentation_files) {
+      for (const file of docs_blob.documentation_files) {
+        const url = sanitizeDocsUrls(file.name);
         table.documentation.push({
-            display: 'Readme',
-            url: formatPath(Paths.collectionDocsIndex, baseUrlParams),
-            type: 'docs',
-            name: 'readme',
+          display: this.capitalize(
+            file.name
+              .split('.')[0]
+              .split('_')
+              .join(' '),
+          ),
+          url: formatPath(Paths.collectionDocsPage, {
+            ...baseUrlParams,
+            page: url,
+          }),
+          // selected: selectedType === 'docs' && selectedName === url,
+          type: 'docs',
+          name: url,
         });
-
-        if (docs_blob.documentation_files) {
-            for (const file of docs_blob.documentation_files) {
-                const url = sanitizeDocsUrls(file.name);
-                table.documentation.push({
-                    display: this.capitalize(
-                        file.name
-                            .split('.')[0]
-                            .split('_')
-                            .join(' '),
-                    ),
-                    url: formatPath(Paths.collectionDocsPage, {
-                        ...baseUrlParams,
-                        page: url,
-                    }),
-                    // selected: selectedType === 'docs' && selectedName === url,
-                    type: 'docs',
-                    name: url,
-                });
-            }
-        }
-
-        if (docs_blob.contents) {
-            for (const content of docs_blob.contents) {
-                switch (content.content_type) {
-                    case 'role':
-                        table.roles.push(
-                            this.getContentEntry(content, baseUrlParams),
-                        );
-                        break;
-                    case 'module':
-                        table.modules.push(
-                            this.getContentEntry(content, baseUrlParams),
-                        );
-                        break;
-                    case 'playbook':
-                        table.playbooks.push(
-                            this.getContentEntry(content, baseUrlParams),
-                        );
-                        break;
-                    default:
-                        table.plugins.push(
-                            this.getContentEntry(content, baseUrlParams),
-                        );
-                        break;
-                }
-            }
-        }
-
-        // Sort docs
-        for (const k of Object.keys(table)) {
-            table[k].sort((a, b) => {
-                // Make sure that anything starting with _ goes to the bottom
-                // of the list
-                if (a.display.startsWith('_') && !b.display.startsWith('_')) {
-                    return 1;
-                }
-                if (!a.display.startsWith('_') && b.display.startsWith('_')) {
-                    return -1;
-                }
-                return a.display > b.display ? 1 : -1;
-            });
-        }
-
-        return table;
+      }
     }
 
-    private renderLinks(links, title) {
-        const isExpanded = !this.state.collapsedCategories.includes(title);
+    if (docs_blob.contents) {
+      for (const content of docs_blob.contents) {
+        switch (content.content_type) {
+          case 'role':
+            table.roles.push(this.getContentEntry(content, baseUrlParams));
+            break;
+          case 'module':
+            table.modules.push(this.getContentEntry(content, baseUrlParams));
+            break;
+          case 'playbook':
+            table.playbooks.push(this.getContentEntry(content, baseUrlParams));
+            break;
+          default:
+            table.plugins.push(this.getContentEntry(content, baseUrlParams));
+            break;
+        }
+      }
+    }
 
-        return (
-            <NavExpandable
-                key={title}
-                title={capitalize(`${title} (${links.length})`)}
-                isExpanded={isExpanded}
-                isActive={this.getSelectedCategory() === title}
+    // Sort docs
+    for (const k of Object.keys(table)) {
+      table[k].sort((a, b) => {
+        // Make sure that anything starting with _ goes to the bottom
+        // of the list
+        if (a.display.startsWith('_') && !b.display.startsWith('_')) {
+          return 1;
+        }
+        if (!a.display.startsWith('_') && b.display.startsWith('_')) {
+          return -1;
+        }
+        return a.display > b.display ? 1 : -1;
+      });
+    }
+
+    return table;
+  }
+
+  private renderLinks(links, title) {
+    const isExpanded = !this.state.collapsedCategories.includes(title);
+
+    return (
+      <NavExpandable
+        key={title}
+        title={capitalize(`${title} (${links.length})`)}
+        isExpanded={isExpanded}
+        isActive={this.getSelectedCategory() === title}
+      >
+        {links.map((link: DocsEntry, index) => (
+          <NavItem key={index} isActive={this.isSelected(link)}>
+            <Link
+              style={{
+                textOverflow: 'ellipses',
+                overflow: 'hidden',
+                whiteSpace: 'nowrap',
+              }}
+              to={
+                link.url +
+                (Object.keys(this.props.params).length != 0
+                  ? '?' + ParamHelper.getQueryString(this.props.params)
+                  : '')
+              }
             >
-                {links.map((link: DocsEntry, index) => (
-                    <NavItem key={index} isActive={this.isSelected(link)}>
-                        <Link
-                            style={{
-                                textOverflow: 'ellipses',
-                                overflow: 'hidden',
-                                whiteSpace: 'nowrap',
-                            }}
-                            to={
-                                link.url +
-                                (Object.keys(this.props.params).length != 0
-                                    ? '?' +
-                                      ParamHelper.getQueryString(
-                                          this.props.params,
-                                      )
-                                    : '')
-                            }
-                        >
-                            <span
-                                style={{
-                                    textOverflow: 'ellipsis',
-                                    overflow: 'hidden',
-                                    whiteSpace: 'nowrap',
-                                    display: 'block',
-                                }}
-                            >
-                                {link.display}
-                            </span>
-                        </Link>
-                    </NavItem>
-                ))}
-            </NavExpandable>
-        );
+              <span
+                style={{
+                  textOverflow: 'ellipsis',
+                  overflow: 'hidden',
+                  whiteSpace: 'nowrap',
+                  display: 'block',
+                }}
+              >
+                {link.display}
+              </span>
+            </Link>
+          </NavItem>
+        ))}
+      </NavExpandable>
+    );
+  }
+
+  private isSelected(entry: DocsEntry): boolean {
+    // the readme's url is always docs/, so load it when the name is null
+    if (!this.props.selectedName && entry.name === 'readme') {
+      return true;
     }
 
-    private isSelected(entry: DocsEntry): boolean {
-        // the readme's url is always docs/, so load it when the name is null
-        if (!this.props.selectedName && entry.name === 'readme') {
-            return true;
-        }
+    return (
+      // selected name and type are the values found for type and name
+      // in the page url
+      this.props.selectedName === entry.name &&
+      this.props.selectedType === entry.type
+    );
+  }
 
-        return (
-            // selected name and type are the values found for type and name
-            // in the page url
-            this.props.selectedName === entry.name &&
-            this.props.selectedType === entry.type
-        );
+  private getSelectedCategory(): string {
+    const { selectedType } = this.props;
+    if (!selectedType || selectedType === 'docs') {
+      return 'documentation';
     }
 
-    private getSelectedCategory(): string {
-        const { selectedType } = this.props;
-        if (!selectedType || selectedType === 'docs') {
-            return 'documentation';
-        }
-
-        if (selectedType === 'role') {
-            return 'roles';
-        }
-
-        if (selectedType === 'module') {
-            return 'modules';
-        }
-
-        return 'plugins';
+    if (selectedType === 'role') {
+      return 'roles';
     }
 
-    private capitalize(s: string) {
-        return s.slice(0, 1).toUpperCase() + s.slice(1);
+    if (selectedType === 'module') {
+      return 'modules';
     }
 
-    private getContentEntry(content, base): DocsEntry {
-        return {
-            display: content.content_name,
-            url: formatPath(Paths.collectionContentDocs, {
-                ...base,
-                type: content.content_type,
-                name: content.content_name,
-            }),
-            name: content.content_name,
-            type: content.content_type,
-        };
-    }
+    return 'plugins';
+  }
+
+  private capitalize(s: string) {
+    return s.slice(0, 1).toUpperCase() + s.slice(1);
+  }
+
+  private getContentEntry(content, base): DocsEntry {
+    return {
+      display: content.content_name,
+      url: formatPath(Paths.collectionContentDocs, {
+        ...base,
+        type: content.content_type,
+        name: content.content_name,
+      }),
+      name: content.content_name,
+      type: content.content_type,
+    };
+  }
 }

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import './list-item.scss';
 
 import {
-    DataListItem,
-    DataListItemRow,
-    DataListItemCells,
-    DataListCell,
-    TextContent,
-    Text,
-    TextVariants,
+  DataListItem,
+  DataListItemRow,
+  DataListItemCells,
+  DataListCell,
+  TextContent,
+  Text,
+  TextVariants,
 } from '@patternfly/react-core';
 
 import { Link } from 'react-router-dom';
@@ -20,107 +20,98 @@ import { CollectionListType } from '../../api';
 import { convertContentSummaryCounts } from '../../utilities';
 
 interface IProps extends CollectionListType {
-    showNamespace?: boolean;
-    controls?: React.ReactNode;
+  showNamespace?: boolean;
+  controls?: React.ReactNode;
 }
 
 export class CollectionListItem extends React.Component<IProps, {}> {
-    render() {
-        const {
-            name,
-            // download_count,
-            latest_version,
-            namespace,
-            showNamespace,
-            controls,
-            deprecated,
-        } = this.props;
+  render() {
+    const {
+      name,
+      // download_count,
+      latest_version,
+      namespace,
+      showNamespace,
+      controls,
+      deprecated,
+    } = this.props;
 
-        const cells = [];
+    const cells = [];
 
-        const company = namespace.company || namespace.name;
+    const company = namespace.company || namespace.name;
 
-        if (showNamespace) {
-            cells.push(
-                <DataListCell isFilled={false} alignRight={false} key='ns'>
-                    <Logo
-                        alt={company + ' logo'}
-                        image={namespace.avatar_url}
-                        size='50px'
-                    />
-                </DataListCell>,
-            );
-        }
-
-        const contentSummary = convertContentSummaryCounts(
-            latest_version.contents,
-        );
-
-        cells.push(
-            <DataListCell key='content'>
-                <div>
-                    <Link
-                        to={formatPath(Paths.collection, {
-                            namespace: namespace.name,
-                            collection: name,
-                        })}
-                    >
-                        {name}
-                    </Link>
-                    {deprecated && <DeprecatedTag />}
-                    {showNamespace ? (
-                        <TextContent>
-                            <Text component={TextVariants.small}>
-                                Provided by {company}
-                            </Text>
-                        </TextContent>
-                    ) : null}
-                </div>
-                <div className='entry'>
-                    {latest_version.metadata.description}
-                </div>
-                <div className='entry pf-l-flex pf-m-wrap content'>
-                    {Object.keys(contentSummary.contents).map(k => (
-                        <div key={k}>
-                            <NumericLabel
-                                label={k}
-                                number={contentSummary.contents[k]}
-                            />
-                        </div>
-                    ))}
-                </div>
-                <div className='entry pf-l-flex pf-m-wrap'>
-                    {latest_version.metadata.tags.map((tag, index) => (
-                        <Tag key={index}>{tag}</Tag>
-                    ))}
-                </div>
-            </DataListCell>,
-        );
-
-        cells.push(
-            <DataListCell isFilled={false} alignRight key='stats'>
-                {controls ? <div className='entry'>{controls}</div> : null}
-                {
-                    // <div className='right-col entry'>
-                    //     <NumericLabel
-                    //         number={download_count}
-                    //         label='Download'
-                    //     />
-                    // </div>
-                }
-                <div className='right-col entry'>
-                    Updated {moment(latest_version.created_at).fromNow()}
-                </div>
-                <div className='entry'>v{latest_version.version}</div>
-            </DataListCell>,
-        );
-
-        return (
-            <DataListItem aria-labelledby='simple-item1'>
-                <DataListItemRow>
-                    <DataListItemCells dataListCells={cells} />
-                </DataListItemRow>
-            </DataListItem>
-        );
+    if (showNamespace) {
+      cells.push(
+        <DataListCell isFilled={false} alignRight={false} key='ns'>
+          <Logo
+            alt={company + ' logo'}
+            image={namespace.avatar_url}
+            size='50px'
+          />
+        </DataListCell>,
+      );
     }
+
+    const contentSummary = convertContentSummaryCounts(latest_version.contents);
+
+    cells.push(
+      <DataListCell key='content'>
+        <div>
+          <Link
+            to={formatPath(Paths.collection, {
+              namespace: namespace.name,
+              collection: name,
+            })}
+          >
+            {name}
+          </Link>
+          {deprecated && <DeprecatedTag />}
+          {showNamespace ? (
+            <TextContent>
+              <Text component={TextVariants.small}>Provided by {company}</Text>
+            </TextContent>
+          ) : null}
+        </div>
+        <div className='entry'>{latest_version.metadata.description}</div>
+        <div className='entry pf-l-flex pf-m-wrap content'>
+          {Object.keys(contentSummary.contents).map(k => (
+            <div key={k}>
+              <NumericLabel label={k} number={contentSummary.contents[k]} />
+            </div>
+          ))}
+        </div>
+        <div className='entry pf-l-flex pf-m-wrap'>
+          {latest_version.metadata.tags.map((tag, index) => (
+            <Tag key={index}>{tag}</Tag>
+          ))}
+        </div>
+      </DataListCell>,
+    );
+
+    cells.push(
+      <DataListCell isFilled={false} alignRight key='stats'>
+        {controls ? <div className='entry'>{controls}</div> : null}
+        {
+          // <div className='right-col entry'>
+          //     <NumericLabel
+          //         number={download_count}
+          //         label='Download'
+          //     />
+          // </div>
+        }
+        <div className='right-col entry'>
+          Updated {moment(latest_version.created_at).fromNow()}
+        </div>
+        <div className='entry'>v{latest_version.version}</div>
+      </DataListCell>,
+    );
+
+    return (
+      <DataListItem aria-labelledby='simple-item1'>
+        <DataListItemRow>
+          <DataListItemCells dataListCells={cells} />
+        </DataListItemRow>
+      </DataListItem>
+    );
+  }
 }

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -2,171 +2,152 @@ import * as React from 'react';
 import './list.scss';
 
 import {
-    TextInput,
-    Button,
-    DropdownItem,
-    DataList,
-    EmptyState,
-    EmptyStateIcon,
-    Title,
-    EmptyStateVariant,
-    EmptyStateBody,
+  TextInput,
+  Button,
+  DropdownItem,
+  DataList,
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+  EmptyStateVariant,
+  EmptyStateBody,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 
 import { CollectionListType } from '../../api';
 import {
-    CollectionListItem,
-    Toolbar,
-    Pagination,
-    StatefulDropdown,
+  CollectionListItem,
+  Toolbar,
+  Pagination,
+  StatefulDropdown,
 } from '../../components';
 import { ParamHelper } from '../../utilities/param-helper';
 
 interface IProps {
-    collections: CollectionListType[];
-    params: {
-        sort?: string;
-        page?: number;
-        page_size?: number;
-    };
-    updateParams: (params) => void;
-    itemCount: number;
+  collections: CollectionListType[];
+  params: {
+    sort?: string;
+    page?: number;
+    page_size?: number;
+  };
+  updateParams: (params) => void;
+  itemCount: number;
 
-    showNamespace?: boolean;
-    showControls?: boolean;
-    handleControlClick?: (id, event) => void;
+  showNamespace?: boolean;
+  showControls?: boolean;
+  handleControlClick?: (id, event) => void;
 }
 
 interface IState {
-    kwField: string;
+  kwField: string;
 }
 
 export class CollectionList extends React.Component<IProps, IState> {
-    constructor(props) {
-        super(props);
-        this.state = { kwField: props.params['keywords'] || '' };
+  constructor(props) {
+    super(props);
+    this.state = { kwField: props.params['keywords'] || '' };
+  }
+
+  render() {
+    const {
+      collections,
+      params,
+      updateParams,
+      itemCount,
+      showControls,
+    } = this.props;
+
+    return (
+      <React.Fragment>
+        <div className='controls top'>
+          <Toolbar
+            searchPlaceholder='Find collection by name'
+            updateParams={updateParams}
+            params={params}
+          />
+
+          <div>
+            <Pagination
+              params={params}
+              updateParams={p => updateParams(p)}
+              count={itemCount}
+              isTop
+            />
+          </div>
+        </div>
+
+        <DataList aria-label={'List of Collections'}>
+          {collections.length > 0 ? (
+            collections.map(c => (
+              <CollectionListItem
+                controls={
+                  showControls ? this.renderCollectionControls(c) : null
+                }
+                key={c.id}
+                {...c}
+              />
+            ))
+          ) : (
+            <EmptyState className='empty' variant={EmptyStateVariant.full}>
+              <EmptyStateIcon icon={SearchIcon} />
+              <Title headingLevel='h2' size='lg'>
+                No results found
+              </Title>
+              <EmptyStateBody>
+                No results match the filter criteria. Remove all filters or
+                clear all filters to show results.
+              </EmptyStateBody>
+              <Button variant='link' onClick={() => updateParams({})}>
+                Clear all filters
+              </Button>
+            </EmptyState>
+          )}
+        </DataList>
+
+        <div className='controls bottom'>
+          <div></div>
+          <div>
+            <Pagination
+              params={params}
+              updateParams={p => updateParams(p)}
+              count={itemCount}
+            />
+          </div>
+        </div>
+      </React.Fragment>
+    );
+  }
+
+  private handleEnter(e) {
+    if (e.key === 'Enter') {
+      this.props.updateParams(
+        ParamHelper.setParam(this.props.params, 'keywords', this.state.kwField),
+      );
     }
+  }
 
-    render() {
-        const {
-            collections,
-            params,
-            updateParams,
-            itemCount,
-            showControls,
-        } = this.props;
-
-        return (
-            <React.Fragment>
-                <div className='controls top'>
-                    <Toolbar
-                        searchPlaceholder='Find collection by name'
-                        updateParams={updateParams}
-                        params={params}
-                    />
-
-                    <div>
-                        <Pagination
-                            params={params}
-                            updateParams={p => updateParams(p)}
-                            count={itemCount}
-                            isTop
-                        />
-                    </div>
-                </div>
-
-                <DataList aria-label={'List of Collections'}>
-                    {collections.length > 0 ? (
-                        collections.map(c => (
-                            <CollectionListItem
-                                controls={
-                                    showControls
-                                        ? this.renderCollectionControls(c)
-                                        : null
-                                }
-                                key={c.id}
-                                {...c}
-                            />
-                        ))
-                    ) : (
-                        <EmptyState
-                            className='empty'
-                            variant={EmptyStateVariant.full}
-                        >
-                            <EmptyStateIcon icon={SearchIcon} />
-                            <Title headingLevel='h2' size='lg'>
-                                No results found
-                            </Title>
-                            <EmptyStateBody>
-                                No results match the filter criteria. Remove all
-                                filters or clear all filters to show results.
-                            </EmptyStateBody>
-                            <Button
-                                variant='link'
-                                onClick={() => updateParams({})}
-                            >
-                                Clear all filters
-                            </Button>
-                        </EmptyState>
-                    )}
-                </DataList>
-
-                <div className='controls bottom'>
-                    <div></div>
-                    <div>
-                        <Pagination
-                            params={params}
-                            updateParams={p => updateParams(p)}
-                            count={itemCount}
-                        />
-                    </div>
-                </div>
-            </React.Fragment>
-        );
-    }
-
-    private handleEnter(e) {
-        if (e.key === 'Enter') {
-            this.props.updateParams(
-                ParamHelper.setParam(
-                    this.props.params,
-                    'keywords',
-                    this.state.kwField,
-                ),
-            );
-        }
-    }
-
-    private renderCollectionControls(collection: CollectionListType) {
-        return (
-            <div style={{ display: 'flex', alignItems: 'center' }}>
-                <Button
-                    onClick={() =>
-                        this.props.handleControlClick(collection.id, 'upload')
-                    }
-                    variant='secondary'
-                >
-                    Upload new version
-                </Button>
-                <StatefulDropdown
-                    items={[
-                        <DropdownItem
-                            onClick={e =>
-                                this.props.handleControlClick(
-                                    collection.id,
-                                    'deprecate',
-                                )
-                            }
-                            key='1'
-                        >
-                            {collection.deprecated
-                                ? 'Undeprecate'
-                                : 'Deprecate'}
-                        </DropdownItem>,
-                    ]}
-                />
-            </div>
-        );
-    }
+  private renderCollectionControls(collection: CollectionListType) {
+    return (
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <Button
+          onClick={() => this.props.handleControlClick(collection.id, 'upload')}
+          variant='secondary'
+        >
+          Upload new version
+        </Button>
+        <StatefulDropdown
+          items={[
+            <DropdownItem
+              onClick={e =>
+                this.props.handleControlClick(collection.id, 'deprecate')
+              }
+              key='1'
+            >
+              {collection.deprecated ? 'Undeprecate' : 'Deprecate'}
+            </DropdownItem>,
+          ]}
+        />
+      </div>
+    );
+  }
 }

--- a/src/components/collection-list/list-item.scss
+++ b/src/components/collection-list/list-item.scss
@@ -1,11 +1,11 @@
 .entry {
-    margin-top: 5px;
+  margin-top: 5px;
 }
 
 .right-col {
-    width: 200px;
+  width: 200px;
 }
 
 .content {
-    text-transform: capitalize;
+  text-transform: capitalize;
 }

--- a/src/components/collection-list/list.scss
+++ b/src/components/collection-list/list.scss
@@ -1,16 +1,16 @@
 .controls {
-    display: flex;
-    justify-content: space-between;
+  display: flex;
+  justify-content: space-between;
 
-    padding-left: 24px;
-    padding-right: 24px;
+  padding-left: 24px;
+  padding-right: 24px;
 }
 .top {
-    padding-top: 0px;
-    padding-bottom: 16px;
+  padding-top: 0px;
+  padding-bottom: 16px;
 }
 
 .bottom {
-    padding-top: 16px;
-    padding-bottom: 0px;
+  padding-top: 16px;
+  padding-bottom: 0px;
 }

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -6,57 +6,57 @@ import { PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 import { Logo } from '../../components';
 
 interface IProps {
-    title: string;
-    imageURL?: string;
-    breadcrumbs?: React.ReactNode;
-    pageControls?: React.ReactNode;
-    children?: React.ReactNode;
-    className?: string;
+  title: string;
+  imageURL?: string;
+  breadcrumbs?: React.ReactNode;
+  pageControls?: React.ReactNode;
+  children?: React.ReactNode;
+  className?: string;
 }
 
 export class BaseHeader extends React.Component<IProps, {}> {
-    render() {
-        const {
-            title,
-            imageURL,
-            pageControls,
-            children,
-            breadcrumbs,
-            className,
-        } = this.props;
-        return (
-            <div className={'background ' + className}>
-                {breadcrumbs ? (
-                    <div className='breadcrumb-container'>{breadcrumbs}</div>
-                ) : (
-                    <div className='placeholder' />
-                )}
-                <div className='column-section'>
-                    <div className='title-box'>
-                        {imageURL ? (
-                            <Logo
-                                className='image'
-                                alt='Page logo'
-                                image={imageURL}
-                                size='50px'
-                            />
-                        ) : null}
-                        <div>
-                            <PageHeaderTitle title={title} />
-                        </div>
-                    </div>
-
-                    {pageControls ? (
-                        <div className='header-right'>{pageControls}</div>
-                    ) : null}
-                </div>
-
-                {children ? (
-                    <div className='header-bottom'>{children}</div>
-                ) : (
-                    <div className='placeholder' />
-                )}
+  render() {
+    const {
+      title,
+      imageURL,
+      pageControls,
+      children,
+      breadcrumbs,
+      className,
+    } = this.props;
+    return (
+      <div className={'background ' + className}>
+        {breadcrumbs ? (
+          <div className='breadcrumb-container'>{breadcrumbs}</div>
+        ) : (
+          <div className='placeholder' />
+        )}
+        <div className='column-section'>
+          <div className='title-box'>
+            {imageURL ? (
+              <Logo
+                className='image'
+                alt='Page logo'
+                image={imageURL}
+                size='50px'
+              />
+            ) : null}
+            <div>
+              <PageHeaderTitle title={title} />
             </div>
-        );
-    }
+          </div>
+
+          {pageControls ? (
+            <div className='header-right'>{pageControls}</div>
+          ) : null}
+        </div>
+
+        {children ? (
+          <div className='header-bottom'>{children}</div>
+        ) : (
+          <div className='placeholder' />
+        )}
+      </div>
+    );
+  }
 }

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -11,230 +11,205 @@ import { Paths, formatPath } from '../../paths';
 import { ParamHelper } from '../../utilities/param-helper';
 
 interface IProps {
-    collection: CollectionDetailType;
-    params: {
-        version?: string;
-    };
-    updateParams: (params) => void;
-    breadcrumbs: {
-        url?: string;
-        name: string;
-    }[];
-    activeTab: string;
-    className?: string;
+  collection: CollectionDetailType;
+  params: {
+    version?: string;
+  };
+  updateParams: (params) => void;
+  breadcrumbs: {
+    url?: string;
+    name: string;
+  }[];
+  activeTab: string;
+  className?: string;
 }
 
 export class CollectionHeader extends React.Component<IProps> {
-    ignorParams = ['showing', 'keyords'];
+  ignorParams = ['showing', 'keyords'];
 
-    render() {
-        const {
-            collection,
-            params,
-            updateParams,
-            breadcrumbs,
-            activeTab,
-            className,
-        } = this.props;
+  render() {
+    const {
+      collection,
+      params,
+      updateParams,
+      breadcrumbs,
+      activeTab,
+      className,
+    } = this.props;
 
-        const all_versions = [...collection.all_versions];
+    const all_versions = [...collection.all_versions];
 
-        const match = all_versions.find(
-            x => x.version === collection.latest_version.version,
-        );
+    const match = all_versions.find(
+      x => x.version === collection.latest_version.version,
+    );
 
-        if (!match) {
-            all_versions.push({
-                id: collection.latest_version.id,
-                version: collection.latest_version.version,
-                created: collection.latest_version.created_at,
-            });
-        }
+    if (!match) {
+      all_versions.push({
+        id: collection.latest_version.id,
+        version: collection.latest_version.version,
+        created: collection.latest_version.created_at,
+      });
+    }
 
-        const urlKeys = [
-            { key: 'documentation', name: 'Docs site' },
-            { key: 'homepage', name: 'Website' },
-            { key: 'issues', name: 'Issue tracker' },
-            { key: 'repository', name: 'Repo' },
-        ];
+    const urlKeys = [
+      { key: 'documentation', name: 'Docs site' },
+      { key: 'homepage', name: 'Website' },
+      { key: 'issues', name: 'Issue tracker' },
+      { key: 'repository', name: 'Repo' },
+    ];
 
-        return (
-            <BaseHeader
-                className={className}
-                title={collection.name}
-                imageURL={collection.namespace.avatar_url}
-                breadcrumbs={<Breadcrumbs links={breadcrumbs} />}
-                pageControls={
-                    <div style={{ display: 'flex', alignItems: 'center' }}>
-                        <APIButton style={{ marginRight: '8px' }} />
-                        <FormSelect
-                            onChange={val =>
-                                updateParams(
-                                    ParamHelper.setParam(
-                                        params,
-                                        'version',
-                                        val,
-                                    ),
-                                )
-                            }
-                            value={collection.latest_version.version}
-                            aria-label='Select collection version'
-                        >
-                            {all_versions.map(v => (
-                                <FormSelectOption
-                                    key={v.version}
-                                    value={v.version}
-                                    label={'v' + v.version}
-                                />
-                            ))}
-                        </FormSelect>
-                    </div>
-                }
+    return (
+      <BaseHeader
+        className={className}
+        title={collection.name}
+        imageURL={collection.namespace.avatar_url}
+        breadcrumbs={<Breadcrumbs links={breadcrumbs} />}
+        pageControls={
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            <APIButton style={{ marginRight: '8px' }} />
+            <FormSelect
+              onChange={val =>
+                updateParams(ParamHelper.setParam(params, 'version', val))
+              }
+              value={collection.latest_version.version}
+              aria-label='Select collection version'
             >
-                {collection.deprecated && (
-                    <Alert
-                        variant='danger'
-                        isInline
-                        title='This collection has been deprecated.'
-                    />
-                )}
-                <div className='tab-link-container'>
-                    <div className='tabs'>{this.renderTabs(activeTab)}</div>
-                    <div className='links'>
-                        <div>
-                            <ExternalLinkAltIcon />
-                        </div>
-                        {urlKeys.map(link => {
-                            const l =
-                                collection.latest_version.metadata[link.key];
-                            if (!l) {
-                                return null;
-                            }
-
-                            return (
-                                <div className='link' key={link.key}>
-                                    <a href={l} target='blank'>
-                                        {link.name}
-                                    </a>
-                                </div>
-                            );
-                        })}
-                    </div>
-                </div>
-            </BaseHeader>
-        );
-    }
-
-    private renderTabs(active) {
-        // We're not using the Tab react component because they don't support
-        // links.
-        const { params } = this.props;
-
-        return (
-            <div className='pf-c-tabs' id='primary'>
-                <ul className='pf-c-tabs__list'>
-                    <li
-                        className={
-                            'pf-c-tabs__item' +
-                            (active === 'details' ? ' pf-m-current' : '')
-                        }
-                    >
-                        <Link
-                            to={formatPath(
-                                Paths.collection,
-                                {
-                                    namespace: this.props.collection.namespace
-                                        .name,
-                                    collection: this.props.collection.name,
-                                },
-                                ParamHelper.getReduced(
-                                    params,
-                                    this.ignorParams,
-                                ),
-                            )}
-                            className='pf-c-tabs__button'
-                            id='details-tab'
-                        >
-                            Details
-                        </Link>
-                    </li>
-                    <li
-                        className={
-                            'pf-c-tabs__item' +
-                            (active === 'documentation' ? ' pf-m-current' : '')
-                        }
-                    >
-                        <Link
-                            to={formatPath(
-                                Paths.collectionDocsIndex,
-                                {
-                                    namespace: this.props.collection.namespace
-                                        .name,
-                                    collection: this.props.collection.name,
-                                },
-                                ParamHelper.getReduced(
-                                    params,
-                                    this.ignorParams,
-                                ),
-                            )}
-                            className='pf-c-tabs__button'
-                            id='documentation-tab'
-                        >
-                            Documentation
-                        </Link>
-                    </li>
-                    <li
-                        className={
-                            'pf-c-tabs__item' +
-                            (active === 'contents' ? ' pf-m-current' : '')
-                        }
-                    >
-                        <Link
-                            to={formatPath(
-                                Paths.collectionContentList,
-                                {
-                                    namespace: this.props.collection.namespace
-                                        .name,
-                                    collection: this.props.collection.name,
-                                },
-                                ParamHelper.getReduced(
-                                    params,
-                                    this.ignorParams,
-                                ),
-                            )}
-                            className='pf-c-tabs__button'
-                            id='contents-tab'
-                        >
-                            Contents
-                        </Link>
-                    </li>
-                    <li
-                        className={
-                            'pf-c-tabs__item' +
-                            (active === 'import-log' ? ' pf-m-current' : '')
-                        }
-                    >
-                        <Link
-                            to={formatPath(
-                                Paths.collectionImportLog,
-                                {
-                                    namespace: this.props.collection.namespace
-                                        .name,
-                                    collection: this.props.collection.name,
-                                },
-                                ParamHelper.getReduced(
-                                    params,
-                                    this.ignorParams,
-                                ),
-                            )}
-                            className='pf-c-tabs__button'
-                            id='contents-tab'
-                        >
-                            Import log
-                        </Link>
-                    </li>
-                </ul>
+              {all_versions.map(v => (
+                <FormSelectOption
+                  key={v.version}
+                  value={v.version}
+                  label={'v' + v.version}
+                />
+              ))}
+            </FormSelect>
+          </div>
+        }
+      >
+        {collection.deprecated && (
+          <Alert
+            variant='danger'
+            isInline
+            title='This collection has been deprecated.'
+          />
+        )}
+        <div className='tab-link-container'>
+          <div className='tabs'>{this.renderTabs(activeTab)}</div>
+          <div className='links'>
+            <div>
+              <ExternalLinkAltIcon />
             </div>
-        );
-    }
+            {urlKeys.map(link => {
+              const l = collection.latest_version.metadata[link.key];
+              if (!l) {
+                return null;
+              }
+
+              return (
+                <div className='link' key={link.key}>
+                  <a href={l} target='blank'>
+                    {link.name}
+                  </a>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </BaseHeader>
+    );
+  }
+
+  private renderTabs(active) {
+    // We're not using the Tab react component because they don't support
+    // links.
+    const { params } = this.props;
+
+    return (
+      <div className='pf-c-tabs' id='primary'>
+        <ul className='pf-c-tabs__list'>
+          <li
+            className={
+              'pf-c-tabs__item' + (active === 'details' ? ' pf-m-current' : '')
+            }
+          >
+            <Link
+              to={formatPath(
+                Paths.collection,
+                {
+                  namespace: this.props.collection.namespace.name,
+                  collection: this.props.collection.name,
+                },
+                ParamHelper.getReduced(params, this.ignorParams),
+              )}
+              className='pf-c-tabs__button'
+              id='details-tab'
+            >
+              Details
+            </Link>
+          </li>
+          <li
+            className={
+              'pf-c-tabs__item' +
+              (active === 'documentation' ? ' pf-m-current' : '')
+            }
+          >
+            <Link
+              to={formatPath(
+                Paths.collectionDocsIndex,
+                {
+                  namespace: this.props.collection.namespace.name,
+                  collection: this.props.collection.name,
+                },
+                ParamHelper.getReduced(params, this.ignorParams),
+              )}
+              className='pf-c-tabs__button'
+              id='documentation-tab'
+            >
+              Documentation
+            </Link>
+          </li>
+          <li
+            className={
+              'pf-c-tabs__item' + (active === 'contents' ? ' pf-m-current' : '')
+            }
+          >
+            <Link
+              to={formatPath(
+                Paths.collectionContentList,
+                {
+                  namespace: this.props.collection.namespace.name,
+                  collection: this.props.collection.name,
+                },
+                ParamHelper.getReduced(params, this.ignorParams),
+              )}
+              className='pf-c-tabs__button'
+              id='contents-tab'
+            >
+              Contents
+            </Link>
+          </li>
+          <li
+            className={
+              'pf-c-tabs__item' +
+              (active === 'import-log' ? ' pf-m-current' : '')
+            }
+          >
+            <Link
+              to={formatPath(
+                Paths.collectionImportLog,
+                {
+                  namespace: this.props.collection.namespace.name,
+                  collection: this.props.collection.name,
+                },
+                ParamHelper.getReduced(params, this.ignorParams),
+              )}
+              className='pf-c-tabs__button'
+              id='contents-tab'
+            >
+              Import log
+            </Link>
+          </li>
+        </ul>
+      </div>
+    );
+  }
 }

--- a/src/components/headers/header.scss
+++ b/src/components/headers/header.scss
@@ -1,74 +1,74 @@
 @import '../../global-variables.scss';
 
 .image {
-    padding-right: 16px;
+  padding-right: 16px;
 }
 
 .title-box {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 
 .column-section {
-    display: flex;
-    justify-content: space-between;
+  display: flex;
+  justify-content: space-between;
 
-    .header-right {
-        align-items: right;
-    }
+  .header-right {
+    align-items: right;
+  }
 }
 
 .background {
-    background-color: white;
-    padding: 0px 24px 0px 24px;
+  background-color: white;
+  padding: 0px 24px 0px 24px;
 }
 
 .placeholder {
-    height: 24px;
+  height: 24px;
 }
 
 .breadcrumb-container {
-    padding-top: 10px;
-    padding-bottom: 10px;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 .header-bottom {
-    padding-top: 10px;
+  padding-top: 10px;
 }
 
 .tab-link-container {
-    display: flex;
-    margin-top: 10px;
+  display: flex;
+  margin-top: 10px;
+  @media (max-width: $breakpoint-md) {
+    flex-direction: column-reverse;
+  }
+
+  .tabs {
+    flex-grow: 0;
+  }
+
+  .links {
+    @media (min-width: $breakpoint-md) {
+      justify-content: flex-end;
+    }
     @media (max-width: $breakpoint-md) {
-        flex-direction: column-reverse;
+      margin-bottom: 10px;
     }
 
-    .tabs {
-        flex-grow: 0;
+    flex-grow: 1;
+
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+
+    div {
+      @media (min-width: $breakpoint-md) {
+        margin-left: 20px;
+      }
+
+      @media (max-width: $breakpoint-md) {
+        margin-right: 20px;
+      }
     }
-
-    .links {
-        @media (min-width: $breakpoint-md) {
-            justify-content: flex-end;
-        }
-        @media (max-width: $breakpoint-md) {
-            margin-bottom: 10px;
-        }
-
-        flex-grow: 1;
-
-        display: flex;
-        align-items: center;
-        flex-wrap: wrap;
-
-        div {
-            @media (min-width: $breakpoint-md) {
-                margin-left: 20px;
-            }
-
-            @media (max-width: $breakpoint-md) {
-                margin-right: 20px;
-            }
-        }
-    }
+  }
 }

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -7,65 +7,63 @@ import { BaseHeader, Tabs, Breadcrumbs } from '../../components';
 import { NamespaceType } from '../../api';
 
 interface IProps {
-    namespace: NamespaceType;
-    tabs: string[];
-    breadcrumbs: {
-        url?: string;
-        name: string;
-    }[];
-    params: { tab?: string };
-    updateParams: (p) => void;
+  namespace: NamespaceType;
+  tabs: string[];
+  breadcrumbs: {
+    url?: string;
+    name: string;
+  }[];
+  params: { tab?: string };
+  updateParams: (p) => void;
 
-    pageControls?: React.ReactNode;
+  pageControls?: React.ReactNode;
 }
 
 export class PartnerHeader extends React.Component<IProps, {}> {
-    render() {
-        const {
-            namespace,
-            breadcrumbs,
-            tabs,
-            pageControls,
-            params,
-            updateParams,
-        } = this.props;
-        return (
-            <BaseHeader
-                title={namespace.company || namespace.name}
-                imageURL={namespace.avatar_url}
-                breadcrumbs={<Breadcrumbs links={breadcrumbs} />}
-                pageControls={pageControls}
-            >
-                {namespace.description ? (
-                    <div>{namespace.description}</div>
-                ) : null}
+  render() {
+    const {
+      namespace,
+      breadcrumbs,
+      tabs,
+      pageControls,
+      params,
+      updateParams,
+    } = this.props;
+    return (
+      <BaseHeader
+        title={namespace.company || namespace.name}
+        imageURL={namespace.avatar_url}
+        breadcrumbs={<Breadcrumbs links={breadcrumbs} />}
+        pageControls={pageControls}
+      >
+        {namespace.description ? <div>{namespace.description}</div> : null}
 
-                <div className='tab-link-container'>
-                    <div className='tabs'>
-                        <Tabs
-                            tabs={tabs}
-                            params={params}
-                            updateParams={p => updateParams(p)}
-                        />
-                    </div>
-                    {namespace.links.length > 0 ? (
-                        <div className='links'>
-                            <div>
-                                <ExternalLinkAltIcon />
-                            </div>
-                            {namespace.links.map((x, i) => {
-                                return (
-                                    <div className='link' key={i}>
-                                        <a href={x.url} target='blank'>
-                                            {x.name}
-                                        </a>
-                                    </div>
-                                );
-                            })}
-                        </div>
-                    ) : null}
-                </div>
-            </BaseHeader>
-        );
-    }
+        <div className='tab-link-container'>
+          <div className='tabs'>
+            <Tabs
+              tabs={tabs}
+              params={params}
+              updateParams={p => updateParams(p)}
+            />
+          </div>
+          {namespace.links.length > 0 ? (
+            <div className='links'>
+              <div>
+                <ExternalLinkAltIcon />
+              </div>
+              {namespace.links.map((x, i) => {
+                return (
+                  <div className='link' key={i}>
+                    <a href={x.url} target='blank'>
+                      {x.name}
+                    </a>
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
+      </BaseHeader>
+    );
+  }
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -25,7 +25,7 @@ export { CollectionHeader } from './headers/collection-header';
 export { TableOfContents } from './collection-detail/table-of-contents';
 export { RenderPluginDoc } from './collection-detail/render-plugin-doc';
 export {
-    CollectionContentList,
+  CollectionContentList,
 } from './collection-detail/collection-content-list';
 export { LoadingPageSpinner } from './loading/loading-page-spinner';
 export { LoadingPageWithHeader } from './loading/loading-with-header';
@@ -33,9 +33,9 @@ export { CompoundFilter } from './patternfly-wrappers/compound-filter';
 export { AppliedFilters } from './patternfly-wrappers/applied-filters';
 export { DeprecatedTag } from './tags/deprecated-tag';
 export {
-    AlertList,
-    closeAlertMixin,
-    AlertType,
+  AlertList,
+  closeAlertMixin,
+  AlertType,
 } from './patternfly-wrappers/alert-list';
 export { APIButton } from './api-button/api-button';
 export { Main } from './patternfly-wrappers/main';

--- a/src/components/loading/loading-page-spinner.tsx
+++ b/src/components/loading/loading-page-spinner.tsx
@@ -3,11 +3,11 @@ import { Spinner } from '@redhat-cloud-services/frontend-components';
 import { Bullseye } from '@patternfly/react-core';
 
 export class LoadingPageSpinner extends React.Component<{}> {
-    render() {
-        return (
-            <Bullseye style={{ width: '100%', height: '100%' }}>
-                <Spinner />
-            </Bullseye>
-        );
-    }
+  render() {
+    return (
+      <Bullseye style={{ width: '100%', height: '100%' }}>
+        <Spinner />
+      </Bullseye>
+    );
+  }
 }

--- a/src/components/loading/loading-with-header.tsx
+++ b/src/components/loading/loading-with-header.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 
 import {
-    Skeleton,
-    PageHeaderTitle,
-    PageHeader,
-    Section,
+  Skeleton,
+  PageHeaderTitle,
+  PageHeader,
+  Section,
 } from '@redhat-cloud-services/frontend-components';
 
 import { Main } from '../../components';
@@ -12,20 +12,20 @@ import { Main } from '../../components';
 import { LoadingPageSpinner } from '../../components';
 
 export class LoadingPageWithHeader extends React.Component<{}> {
-    render() {
-        return (
-            <React.Fragment>
-                <PageHeader>
-                    <PageHeaderTitle
-                        title={<Skeleton size='sm'></Skeleton>}
-                    ></PageHeaderTitle>
-                </PageHeader>
-                <Main>
-                    <Section>
-                        <LoadingPageSpinner></LoadingPageSpinner>
-                    </Section>
-                </Main>
-            </React.Fragment>
-        );
-    }
+  render() {
+    return (
+      <React.Fragment>
+        <PageHeader>
+          <PageHeaderTitle
+            title={<Skeleton size='sm'></Skeleton>}
+          ></PageHeaderTitle>
+        </PageHeader>
+        <Main>
+          <Section>
+            <LoadingPageSpinner></LoadingPageSpinner>
+          </Section>
+        </Main>
+      </React.Fragment>
+    );
+  }
 }

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -3,35 +3,35 @@ import * as React from 'react';
 import DefaultLogo from '../../../static/images/default-logo.svg';
 
 interface IProps {
-    // size should be css length measurment: '100px'
-    size: string;
-    image: string;
-    alt: string;
-    className?: string;
+  // size should be css length measurment: '100px'
+  size: string;
+  image: string;
+  alt: string;
+  className?: string;
 }
 
 export class Logo extends React.Component<IProps> {
-    render() {
-        const { size, image, alt, className } = this.props;
+  render() {
+    const { size, image, alt, className } = this.props;
 
-        // use inline css so we can set size
-        return (
-            <div
-                className={className}
-                style={{
-                    width: size,
-                    height: size,
-                    display: 'flex',
-                    justifyContent: 'center',
-                    alignItems: 'center',
-                }}
-            >
-                <img
-                    style={{ objectFit: 'contain', maxHeight: size }}
-                    src={image || DefaultLogo}
-                    alt={alt}
-                />
-            </div>
-        );
-    }
+    // use inline css so we can set size
+    return (
+      <div
+        className={className}
+        style={{
+          width: size,
+          height: size,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <img
+          style={{ objectFit: 'contain', maxHeight: size }}
+          src={image || DefaultLogo}
+          alt={alt}
+        />
+      </div>
+    );
+  }
 }

--- a/src/components/my-imports/import-console.tsx
+++ b/src/components/my-imports/import-console.tsx
@@ -9,193 +9,183 @@ import { formatPath, Paths } from '../../paths';
 import { ImportListType, ImportDetailType, PulpStatus } from '../../api';
 
 interface IProps {
-    task: ImportDetailType;
-    followMessages: boolean;
-    selectedImport: ImportListType;
-    loading: boolean;
-    apiError?: string;
+  task: ImportDetailType;
+  followMessages: boolean;
+  selectedImport: ImportListType;
+  loading: boolean;
+  apiError?: string;
 
-    setFollowMessages: (follow: boolean) => void;
-    hideCollectionName?: boolean;
+  setFollowMessages: (follow: boolean) => void;
+  hideCollectionName?: boolean;
 }
 
 export class ImportConsole extends React.Component<IProps, {}> {
-    lastImport: any;
-    isLoading = false;
+  lastImport: any;
+  isLoading = false;
 
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.lastImport = React.createRef();
+    this.lastImport = React.createRef();
+  }
+
+  componentDidUpdate() {
+    this.followLogs();
+  }
+
+  componentDidMount() {
+    this.followLogs();
+  }
+
+  render() {
+    const { selectedImport, task, apiError, loading } = this.props;
+
+    if (loading || apiError) {
+      return (
+        <div className='import-console'>
+          {selectedImport ? this.renderTitle(selectedImport) : null}
+          <div className='loading message-list'>
+            {apiError ? (
+              <div className='message'>{apiError}</div>
+            ) : (
+              <Spinner centered={false} />
+            )}
+          </div>
+        </div>
+      );
     }
 
-    componentDidUpdate() {
-        this.followLogs();
-    }
+    this.isLoading =
+      selectedImport.state === PulpStatus.running ||
+      selectedImport.state === PulpStatus.waiting;
 
-    componentDidMount() {
-        this.followLogs();
-    }
+    return (
+      <div className='import-console pf-c-content'>
+        {this.renderTitle(selectedImport)}
+        <div className='message-list'>
+          <div
+            className={
+              this.props.followMessages
+                ? 'log-follow-button follow-active'
+                : 'log-follow-button'
+            }
+          >
+            <Tooltip
+              position='left'
+              content={this.isLoading ? 'Follow logs' : 'Scroll to end'}
+            >
+              <span
+                onClick={() => this.handleScrollClick()}
+                className='fa fa-arrow-circle-down clickable'
+              />
+            </Tooltip>
+          </div>
 
-    render() {
-        const { selectedImport, task, apiError, loading } = this.props;
+          {task.messages.map((x, i) => {
+            return this.renderMessage(x, i);
+          })}
 
-        if (loading || apiError) {
-            return (
-                <div className='import-console'>
-                    {selectedImport ? this.renderTitle(selectedImport) : null}
-                    <div className='loading message-list'>
-                        {apiError ? (
-                            <div className='message'>{apiError}</div>
-                        ) : (
-                            <Spinner centered={false} />
-                        )}
-                    </div>
-                </div>
-            );
-        }
-
-        this.isLoading =
-            selectedImport.state === PulpStatus.running ||
-            selectedImport.state === PulpStatus.waiting;
-
-        return (
-            <div className='import-console pf-c-content'>
-                {this.renderTitle(selectedImport)}
-                <div className='message-list'>
-                    <div
-                        className={
-                            this.props.followMessages
-                                ? 'log-follow-button follow-active'
-                                : 'log-follow-button'
-                        }
-                    >
-                        <Tooltip
-                            position='left'
-                            content={
-                                this.isLoading ? 'Follow logs' : 'Scroll to end'
-                            }
-                        >
-                            <span
-                                onClick={() => this.handleScrollClick()}
-                                className='fa fa-arrow-circle-down clickable'
-                            />
-                        </Tooltip>
-                    </div>
-
-                    {task.messages.map((x, i) => {
-                        return this.renderMessage(x, i);
-                    })}
-
-                    {task.messages.length === 0 ? (
-                        <div className='message'>
-                            <span className='error'>
-                                No task messages available
-                            </span>
-                        </div>
-                    ) : null}
-
-                    {task.state === PulpStatus.completed && (
-                        <div className='message'>
-                            <br />
-                            <span className='success'>Done</span>
-                        </div>
-                    )}
-
-                    {task.state === PulpStatus.failed && (
-                        <div className='message'>
-                            <br />
-                            <span className='failed'>Failed</span>
-                        </div>
-                    )}
-                </div>
-                <div
-                    className='last-message'
-                    key={'last'}
-                    ref={this.lastImport}
-                />
+          {task.messages.length === 0 ? (
+            <div className='message'>
+              <span className='error'>No task messages available</span>
             </div>
-        );
-    }
+          ) : null}
 
-    private renderMessage(item, i) {
-        return (
-            <div className='message' key={i}>
-                <span className={item.level.toLowerCase()}>
-                    {item.message}&nbsp;
-                </span>
+          {task.state === PulpStatus.completed && (
+            <div className='message'>
+              <br />
+              <span className='success'>Done</span>
             </div>
-        );
-    }
+          )}
 
-    private renderTitle(selectedImport) {
-        const { task, hideCollectionName } = this.props;
-        return (
+          {task.state === PulpStatus.failed && (
+            <div className='message'>
+              <br />
+              <span className='failed'>Failed</span>
+            </div>
+          )}
+        </div>
+        <div className='last-message' key={'last'} ref={this.lastImport} />
+      </div>
+    );
+  }
+
+  private renderMessage(item, i) {
+    return (
+      <div className='message' key={i}>
+        <span className={item.level.toLowerCase()}>{item.message}&nbsp;</span>
+      </div>
+    );
+  }
+
+  private renderTitle(selectedImport) {
+    const { task, hideCollectionName } = this.props;
+    return (
+      <div>
+        {!hideCollectionName && (
+          <div className='title-container'>
+            <Link
+              className='title'
+              to={formatPath(
+                Paths.collection,
+                {
+                  namespace: selectedImport.namespace,
+                  collection: selectedImport.name,
+                },
+                {
+                  version: selectedImport.version,
+                },
+              )}
+            >
+              {selectedImport.namespace}.{selectedImport.name}
+            </Link>
+          </div>
+        )}
+
+        <div className='title-bar'>
+          <div>
+            <span className='data-title'>Status: </span>
+            {selectedImport.state}
+          </div>
+          <div>
+            <span className='data-title'>Version: </span>
+            {selectedImport.version}
+          </div>
+
+          {task && task.error ? (
             <div>
-                {!hideCollectionName && (
-                    <div className='title-container'>
-                        <Link
-                            className='title'
-                            to={formatPath(
-                                Paths.collection,
-                                {
-                                    namespace: selectedImport.namespace,
-                                    collection: selectedImport.name,
-                                },
-                                {
-                                    version: selectedImport.version,
-                                },
-                            )}
-                        >
-                            {selectedImport.namespace}.{selectedImport.name}
-                        </Link>
-                    </div>
-                )}
-
-                <div className='title-bar'>
-                    <div>
-                        <span className='data-title'>Status: </span>
-                        {selectedImport.state}
-                    </div>
-                    <div>
-                        <span className='data-title'>Version: </span>
-                        {selectedImport.version}
-                    </div>
-
-                    {task && task.error ? (
-                        <div>
-                            <span className='data-title'>Error message: </span>
-                            {task.error.code}
-                            <pre>
-                                <code>{task.error.description}</code>
-                            </pre>
-                            <pre>
-                                <code>{task.error.traceback}</code>
-                            </pre>
-                        </div>
-                    ) : null}
-                </div>
+              <span className='data-title'>Error message: </span>
+              {task.error.code}
+              <pre>
+                <code>{task.error.description}</code>
+              </pre>
+              <pre>
+                <code>{task.error.traceback}</code>
+              </pre>
             </div>
-        );
-    }
+          ) : null}
+        </div>
+      </div>
+    );
+  }
 
-    private handleScrollClick() {
-        if (this.isLoading) {
-            this.props.setFollowMessages(!this.props.followMessages);
-        } else {
-            this.lastImport.current.scrollIntoView({ behavior: 'smooth' });
+  private handleScrollClick() {
+    if (this.isLoading) {
+      this.props.setFollowMessages(!this.props.followMessages);
+    } else {
+      this.lastImport.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }
+
+  private followLogs() {
+    if (this.props.followMessages && this.lastImport.current) {
+      window.requestAnimationFrame(() => {
+        this.lastImport.current.scrollIntoView({ behavior: 'smooth' });
+
+        if (!this.isLoading) {
+          this.props.setFollowMessages(false);
         }
+      });
     }
-
-    private followLogs() {
-        if (this.props.followMessages && this.lastImport.current) {
-            window.requestAnimationFrame(() => {
-                this.lastImport.current.scrollIntoView({ behavior: 'smooth' });
-
-                if (!this.isLoading) {
-                    this.props.setFollowMessages(false);
-                }
-            });
-        }
-    }
+  }
 }

--- a/src/components/my-imports/my-imports.scss
+++ b/src/components/my-imports/my-imports.scss
@@ -1,142 +1,142 @@
 @import '../../global-variables.scss';
 
 .selected-item {
-    background-color: #edf8ff;
+  background-color: #edf8ff;
 }
 
 .status-icon {
-    font-size: 12px;
+  font-size: 12px;
 }
 
 .sub-text {
-    font-weight: normal;
+  font-weight: normal;
 }
 
 .namespace-selector {
-    width: 100%;
+  width: 100%;
 }
 
 .loading {
-    height: 500px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  height: 500px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .namespace-selector-wrapper {
-    display: flex;
-    align-items: center;
-    margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  margin-bottom: 16px;
 
-    .label {
-        width: 100px;
-        color: black;
-        text-align: left;
-    }
+  .label {
+    width: 100px;
+    color: black;
+    text-align: left;
+  }
 
-    .selector {
-        flex-grow: 1;
-    }
+  .selector {
+    flex-grow: 1;
+  }
 }
 
 .import-list {
-    .list-container {
-        display: flex;
-        align-items: center;
-        padding: 10px;
-        .left {
-            margin-right: 10px;
-        }
-        border-bottom: 1px solid #ededed;
+  .list-container {
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    .left {
+      margin-right: 10px;
     }
+    border-bottom: 1px solid #ededed;
+  }
 
-    .list-container:hover {
-        background-color: #edf8ff;
-    }
+  .list-container:hover {
+    background-color: #edf8ff;
+  }
 
-    .search-box {
-        margin-bottom: 24px;
-    }
+  .search-box {
+    margin-bottom: 24px;
+  }
 }
 
 .import-console {
-    .title-bar {
-        position: relative;
-        margin-top: 15px;
-        margin-bottom: 20px;
-        background-color: #f0f0f0;
-        min-height: 25px;
-        padding: 10px;
-        border: 1px solid #e1e1e1;
-        border-radius: 2px;
+  .title-bar {
+    position: relative;
+    margin-top: 15px;
+    margin-bottom: 20px;
+    background-color: #f0f0f0;
+    min-height: 25px;
+    padding: 10px;
+    border: 1px solid #e1e1e1;
+    border-radius: 2px;
 
-        .data-title {
-            font-weight: bold;
-        }
-
-        .stats {
-            text-align: right;
-            font-size: 12px;
-            color: $black;
-        }
+    .data-title {
+      font-weight: bold;
     }
 
-    .title-container {
-        display: inline-block;
-        .title {
-            display: inline;
-            font-size: 18px;
-        }
-        .refreshing-icon {
-            display: inline;
-            font-size: 18px;
-            margin-left: 10px;
-            opacity: 0;
-            transition: 2s ease;
-        }
-        .refreshing-icon.refreshing {
-            opacity: 1;
-        }
+    .stats {
+      text-align: right;
+      font-size: 12px;
+      color: $black;
+    }
+  }
+
+  .title-container {
+    display: inline-block;
+    .title {
+      display: inline;
+      font-size: 18px;
+    }
+    .refreshing-icon {
+      display: inline;
+      font-size: 18px;
+      margin-left: 10px;
+      opacity: 0;
+      transition: 2s ease;
+    }
+    .refreshing-icon.refreshing {
+      opacity: 1;
+    }
+  }
+
+  // Give the last element some extra height so that it doesn't cut off
+  // messages when scroling down to it.
+  .last-message {
+    height: 100px;
+    width: 5px;
+    position: relative;
+    top: -150px;
+  }
+
+  .message-list {
+    background-color: $black;
+    padding: 10px;
+    border: 1px solid $black;
+    border-radius: 2px;
+    color: $white;
+    line-height: 18px;
+    margin-bottom: 50px;
+
+    .log-follow-button {
+      position: relative;
+      top: 0;
+      float: right;
+      font-size: 18px;
     }
 
-    // Give the last element some extra height so that it doesn't cut off
-    // messages when scroling down to it.
-    .last-message {
-        height: 100px;
-        width: 5px;
-        position: relative;
-        top: -150px;
+    .follow-active {
+      color: $green;
     }
-
-    .message-list {
-        background-color: $black;
-        padding: 10px;
-        border: 1px solid $black;
-        border-radius: 2px;
-        color: $white;
-        line-height: 18px;
-        margin-bottom: 50px;
-
-        .log-follow-button {
-            position: relative;
-            top: 0;
-            float: right;
-            font-size: 18px;
-        }
-
-        .follow-active {
-            color: $green;
-        }
-    }
+  }
 }
 
 .error,
 .failed {
-    color: $red;
+  color: $red;
 }
 .warning {
-    color: $warning;
+  color: $warning;
 }
 .success {
-    color: $green;
+  color: $green;
 }

--- a/src/components/namespace-form/namespace-form.scss
+++ b/src/components/namespace-form/namespace-form.scss
@@ -1,98 +1,98 @@
 @import '../../global-variables.scss';
 .card-row {
-    @media (max-width: $breakpoint-md) {
-        flex-direction: column-reverse;
-    }
+  @media (max-width: $breakpoint-md) {
+    flex-direction: column-reverse;
+  }
 
-    display: flex;
+  display: flex;
 
-    .fields {
-        flex-grow: 1;
-        margin-right: 15px;
-    }
+  .fields {
+    flex-grow: 1;
+    margin-right: 15px;
+  }
 
-    .card {
-        @media (min-width: $breakpoint-md) {
-            border-left: 24px solid #ededed;
-            border-bottom: 24px solid #ededed;
-            margin-top: -15px;
-            margin-right: -15px;
-        }
+  .card {
+    @media (min-width: $breakpoint-md) {
+      border-left: 24px solid #ededed;
+      border-bottom: 24px solid #ededed;
+      margin-top: -15px;
+      margin-right: -15px;
     }
+  }
 }
 
 .markdown-editor {
-    display: flex;
+  display: flex;
 
-    @media (max-width: $breakpoint-md) {
-        flex-direction: column-reverse;
-    }
+  @media (max-width: $breakpoint-md) {
+    flex-direction: column-reverse;
+  }
 
-    .column {
-        flex-grow: 1;
-        margin-right: 15px;
-        margin-bottom: 15px;
-    }
+  .column {
+    flex-grow: 1;
+    margin-right: 15px;
+    margin-bottom: 15px;
+  }
 
-    .preview-container {
-        .preview {
-            overflow: scroll;
-            height: 500px;
-            border: 1px solid #ededed;
-            padding: 5px;
-        }
+  .preview-container {
+    .preview {
+      overflow: scroll;
+      height: 500px;
+      border: 1px solid #ededed;
+      padding: 5px;
     }
+  }
 
-    .editor {
-        // I don't know why, but just setting width causes this element to get
-        // shrunk whenever the preview window expands.
-        min-width: 500px;
-        max-width: 500px;
-    }
+  .editor {
+    // I don't know why, but just setting width causes this element to get
+    // shrunk whenever the preview window expands.
+    min-width: 500px;
+    max-width: 500px;
+  }
 }
 
 .useful-links {
+  display: flex;
+  margin-bottom: 10px;
+
+  .link-name {
+    flex-grow: 1;
+  }
+
+  .link-url {
+    flex-grow: 2;
+    margin-left: 20px;
+  }
+
+  .link-button {
     display: flex;
-    margin-bottom: 10px;
-
-    .link-name {
-        flex-grow: 1;
-    }
-
-    .link-url {
-        flex-grow: 2;
-        margin-left: 20px;
-    }
-
-    .link-button {
-        display: flex;
-        align-items: center;
-        margin-left: 10px;
-    }
+    align-items: center;
+    margin-left: 10px;
+  }
 }
 
 .account-ids {
+  display: flex;
+  margin-bottom: 10px;
+
+  .account-id {
+    flex-grow: 1;
+  }
+
+  .account-add {
+    flex-grow: 2;
+    margin-left: 20px;
+    margin-top: 5px;
+  }
+
+  .account-button {
     display: flex;
-    margin-bottom: 10px;
-
-    .account-id {
-        flex-grow: 1;
-    }
-
-    .account-add {
-        flex-grow: 2;
-        margin-left: 20px;
-        margin-top: 5px;
-    }
-
-    .account-button {
-        display: flex;
-        align-items: center;
-        margin-left: 10px;
-    }
+    align-items: center;
+    margin-left: 10px;
+  }
 }
 
 .resources-editor {
-    height: 500px;
-    resize: none;
+  height: 500px;
+  resize: none;
 }

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -10,312 +10,287 @@ import { NamespaceCard } from '../../components';
 import { NamespaceType } from '../../api';
 
 interface IProps {
-    namespace: NamespaceType;
-    errorMessages: any;
-    userId: string;
+  namespace: NamespaceType;
+  errorMessages: any;
+  userId: string;
 
-    updateNamespace: (namespace) => void;
+  updateNamespace: (namespace) => void;
 }
 
 interface IState {
-    newLinkName: string;
-    newLinkURL: string;
-    newNamespaceGroup: string;
+  newLinkName: string;
+  newLinkURL: string;
+  newNamespaceGroup: string;
 }
 
 export class NamespaceForm extends React.Component<IProps, IState> {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            newLinkURL: '',
-            newLinkName: '',
-            newNamespaceGroup: '',
-        };
+    this.state = {
+      newLinkURL: '',
+      newLinkName: '',
+      newNamespaceGroup: '',
+    };
+  }
+
+  render() {
+    const { namespace, errorMessages, userId } = this.props;
+
+    if (!namespace) {
+      return null;
     }
+    return (
+      <Form>
+        <div className='card-row'>
+          <div className='fields'>
+            <FormGroup fieldId='name' label='Name' isRequired>
+              <TextInput
+                isRequired
+                isDisabled
+                id='name'
+                type='text'
+                value={namespace.name}
+              />
+            </FormGroup>
 
-    render() {
-        const { namespace, errorMessages, userId } = this.props;
+            <br />
 
-        if (!namespace) {
-            return null;
-        }
-        return (
-            <Form>
-                <div className='card-row'>
-                    <div className='fields'>
-                        <FormGroup fieldId='name' label='Name' isRequired>
-                            <TextInput
-                                isRequired
-                                isDisabled
-                                id='name'
-                                type='text'
-                                value={namespace.name}
-                            />
-                        </FormGroup>
+            <FormGroup
+              fieldId='company'
+              label='Company name'
+              helperTextInvalid={errorMessages['company']}
+              isValid={!('company' in errorMessages)}
+            >
+              <TextInput
+                isRequired
+                id='company'
+                type='text'
+                value={namespace.company}
+                onChange={(value, event) => this.updateField(value, event)}
+              />
+            </FormGroup>
+          </div>
+          <div className='card'>
+            <NamespaceCard {...namespace} />
+          </div>
+        </div>
 
-                        <br />
+        <FormGroup
+          fieldId='groups'
+          label='Namespace owners'
+          helperTextInvalid={errorMessages['groups']}
+          isValid={!('groups' in errorMessages)}
+        >
+          <br />
 
-                        <FormGroup
-                            fieldId='company'
-                            label='Company name'
-                            helperTextInvalid={errorMessages['company']}
-                            isValid={!('company' in errorMessages)}
-                        >
-                            <TextInput
-                                isRequired
-                                id='company'
-                                type='text'
-                                value={namespace.company}
-                                onChange={(value, event) =>
-                                    this.updateField(value, event)
-                                }
-                            />
-                        </FormGroup>
-                    </div>
-                    <div className='card'>
-                        <NamespaceCard {...namespace} />
-                    </div>
-                </div>
+          <ChipGroup>
+            {this.props.namespace.groups.map(group => (
+              <Chip
+                key={group}
+                onClick={() => this.deleteItem(group)}
+                isReadOnly={group === Constants.ADMIN_GROUP || userId === group}
+              >
+                {group}
+              </Chip>
+            ))}
+          </ChipGroup>
 
-                <FormGroup
-                    fieldId='groups'
-                    label='Namespace owners'
-                    helperTextInvalid={errorMessages['groups']}
-                    isValid={!('groups' in errorMessages)}
-                >
-                    <br />
-
-                    <ChipGroup>
-                        {this.props.namespace.groups.map(group => (
-                            <Chip
-                                key={group}
-                                onClick={() => this.deleteItem(group)}
-                                isReadOnly={
-                                    group === Constants.ADMIN_GROUP ||
-                                    userId === group
-                                }
-                            >
-                                {group}
-                            </Chip>
-                        ))}
-                    </ChipGroup>
-
-                    <div className='account-ids'>
-                        <br />
-                        <TextInput
-                            id='url'
-                            type='text'
-                            placeholder='Red Hat account ID'
-                            value={this.state.newNamespaceGroup}
-                            isValid={
-                                !isNaN(Number(this.state.newNamespaceGroup))
-                            }
-                            onChange={value =>
-                                this.setState({
-                                    newNamespaceGroup: value,
-                                })
-                            }
-                            onKeyDown={e => {
-                                if (e.key === 'Enter') {
-                                    this.addGroup();
-                                }
-                            }}
-                        />
-                        <div className='account-add'>
-                            <div className='clickable account-button'>
-                                <PlusCircleIcon
-                                    onClick={() => this.addGroup()}
-                                    size='md'
-                                />
-                            </div>
-                        </div>
-                    </div>
-                </FormGroup>
-
-                <FormGroup
-                    fieldId='avatar_url'
-                    label='Logo URL'
-                    helperTextInvalid={errorMessages['avatar_url']}
-                    isValid={!('avatar_url' in errorMessages)}
-                >
-                    <TextInput
-                        id='avatar_url'
-                        type='text'
-                        value={namespace.avatar_url}
-                        onChange={(value, event) =>
-                            this.updateField(value, event)
-                        }
-                    />
-                </FormGroup>
-
-                <FormGroup
-                    fieldId='description'
-                    label='Description'
-                    helperTextInvalid={errorMessages['description']}
-                    isValid={!('description' in errorMessages)}
-                >
-                    <TextArea
-                        id='description'
-                        type='text'
-                        value={namespace.description}
-                        onChange={(value, event) =>
-                            this.updateField(value, event)
-                        }
-                    />
-                </FormGroup>
-
-                {namespace.links.length > 0 ? (
-                    <FormGroup
-                        fieldId='links'
-                        label='Useful links'
-                        helperTextInvalid={
-                            errorMessages['name'] || errorMessages['url']
-                        }
-                        isValid={
-                            !('name' in errorMessages || 'url' in errorMessages)
-                        }
-                    >
-                        {namespace.links.map((link, index) =>
-                            this.renderLinkGroup(link, index),
-                        )}
-                    </FormGroup>
-                ) : null}
-
-                <FormGroup fieldId='add_link' label='Add link'>
-                    <div className='useful-links'>
-                        <div className='link-name'>
-                            <TextInput
-                                id='name'
-                                type='text'
-                                placeholder='Link text'
-                                value={this.state.newLinkName}
-                                onChange={value => {
-                                    this.setState({
-                                        newLinkName: value,
-                                    });
-                                }}
-                            />
-                        </div>
-                        <div className='link-url'>
-                            <TextInput
-                                id='url'
-                                type='text'
-                                placeholder='Link URL'
-                                value={this.state.newLinkURL}
-                                onChange={value =>
-                                    this.setState({
-                                        newLinkURL: value,
-                                    })
-                                }
-                                onKeyDown={e => {
-                                    if (e.key === 'Enter') {
-                                        this.addLink();
-                                    }
-                                }}
-                            />
-                        </div>
-                        <div className='clickable link-button'>
-                            <PlusCircleIcon
-                                onClick={() => this.addLink()}
-                                size='md'
-                            />
-                        </div>
-                    </div>
-                </FormGroup>
-            </Form>
-        );
-    }
-
-    private updateField(value, event) {
-        const update = { ...this.props.namespace };
-        update[event.target.id] = value;
-        this.props.updateNamespace(update);
-    }
-
-    private updateLink(index, value, event) {
-        const update = { ...this.props.namespace };
-        update.links[index][event.target.id] = value;
-        this.props.updateNamespace(update);
-    }
-
-    private removeLink(index) {
-        const update = { ...this.props.namespace };
-        update.links.splice(index, 1);
-        this.props.updateNamespace(update);
-    }
-
-    private addLink() {
-        const update = { ...this.props.namespace };
-        update.links.push({
-            name: this.state.newLinkName,
-            url: this.state.newLinkURL,
-        });
-        this.setState(
-            {
-                newLinkURL: '',
-                newLinkName: '',
-            },
-            () => this.props.updateNamespace(update),
-        );
-    }
-
-    private addGroup() {
-        const update = { ...this.props.namespace };
-        if (
-            this.state.newNamespaceGroup.trim() == '' ||
-            isNaN(Number(this.state.newNamespaceGroup.trim()))
-        ) {
-            return;
-        }
-        update.groups.push(this.state.newNamespaceGroup.trim());
-        this.setState({ newNamespaceGroup: '' }, () =>
-            this.props.updateNamespace(update),
-        );
-    }
-
-    private deleteItem(id) {
-        const update = { ...this.props.namespace };
-        const index = update.groups.indexOf(id);
-        if (index !== -1) {
-            update.groups.splice(index, 1);
-            this.props.updateNamespace(update);
-        }
-    }
-
-    private renderLinkGroup(link, index) {
-        return (
-            <div className='useful-links' key={index}>
-                <div className='link-name'>
-                    <TextInput
-                        id='name'
-                        type='text'
-                        placeholder='Link text'
-                        value={link.name}
-                        onChange={(value, event) =>
-                            this.updateLink(index, value, event)
-                        }
-                    />
-                </div>
-                <div className='link-url'>
-                    <TextInput
-                        id='url'
-                        type='text'
-                        placeholder='Link URL'
-                        value={link.url}
-                        onChange={(value, event) =>
-                            this.updateLink(index, value, event)
-                        }
-                    />
-                </div>
-                <div className='link-button'>
-                    <MinusCircleIcon
-                        className='clickable'
-                        onClick={() => this.removeLink(index)}
-                        size='md'
-                    />
-                </div>
+          <div className='account-ids'>
+            <br />
+            <TextInput
+              id='url'
+              type='text'
+              placeholder='Red Hat account ID'
+              value={this.state.newNamespaceGroup}
+              isValid={!isNaN(Number(this.state.newNamespaceGroup))}
+              onChange={value =>
+                this.setState({
+                  newNamespaceGroup: value,
+                })
+              }
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  this.addGroup();
+                }
+              }}
+            />
+            <div className='account-add'>
+              <div className='clickable account-button'>
+                <PlusCircleIcon onClick={() => this.addGroup()} size='md' />
+              </div>
             </div>
-        );
+          </div>
+        </FormGroup>
+
+        <FormGroup
+          fieldId='avatar_url'
+          label='Logo URL'
+          helperTextInvalid={errorMessages['avatar_url']}
+          isValid={!('avatar_url' in errorMessages)}
+        >
+          <TextInput
+            id='avatar_url'
+            type='text'
+            value={namespace.avatar_url}
+            onChange={(value, event) => this.updateField(value, event)}
+          />
+        </FormGroup>
+
+        <FormGroup
+          fieldId='description'
+          label='Description'
+          helperTextInvalid={errorMessages['description']}
+          isValid={!('description' in errorMessages)}
+        >
+          <TextArea
+            id='description'
+            type='text'
+            value={namespace.description}
+            onChange={(value, event) => this.updateField(value, event)}
+          />
+        </FormGroup>
+
+        {namespace.links.length > 0 ? (
+          <FormGroup
+            fieldId='links'
+            label='Useful links'
+            helperTextInvalid={errorMessages['name'] || errorMessages['url']}
+            isValid={!('name' in errorMessages || 'url' in errorMessages)}
+          >
+            {namespace.links.map((link, index) =>
+              this.renderLinkGroup(link, index),
+            )}
+          </FormGroup>
+        ) : null}
+
+        <FormGroup fieldId='add_link' label='Add link'>
+          <div className='useful-links'>
+            <div className='link-name'>
+              <TextInput
+                id='name'
+                type='text'
+                placeholder='Link text'
+                value={this.state.newLinkName}
+                onChange={value => {
+                  this.setState({
+                    newLinkName: value,
+                  });
+                }}
+              />
+            </div>
+            <div className='link-url'>
+              <TextInput
+                id='url'
+                type='text'
+                placeholder='Link URL'
+                value={this.state.newLinkURL}
+                onChange={value =>
+                  this.setState({
+                    newLinkURL: value,
+                  })
+                }
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    this.addLink();
+                  }
+                }}
+              />
+            </div>
+            <div className='clickable link-button'>
+              <PlusCircleIcon onClick={() => this.addLink()} size='md' />
+            </div>
+          </div>
+        </FormGroup>
+      </Form>
+    );
+  }
+
+  private updateField(value, event) {
+    const update = { ...this.props.namespace };
+    update[event.target.id] = value;
+    this.props.updateNamespace(update);
+  }
+
+  private updateLink(index, value, event) {
+    const update = { ...this.props.namespace };
+    update.links[index][event.target.id] = value;
+    this.props.updateNamespace(update);
+  }
+
+  private removeLink(index) {
+    const update = { ...this.props.namespace };
+    update.links.splice(index, 1);
+    this.props.updateNamespace(update);
+  }
+
+  private addLink() {
+    const update = { ...this.props.namespace };
+    update.links.push({
+      name: this.state.newLinkName,
+      url: this.state.newLinkURL,
+    });
+    this.setState(
+      {
+        newLinkURL: '',
+        newLinkName: '',
+      },
+      () => this.props.updateNamespace(update),
+    );
+  }
+
+  private addGroup() {
+    const update = { ...this.props.namespace };
+    if (
+      this.state.newNamespaceGroup.trim() == '' ||
+      isNaN(Number(this.state.newNamespaceGroup.trim()))
+    ) {
+      return;
     }
+    update.groups.push(this.state.newNamespaceGroup.trim());
+    this.setState({ newNamespaceGroup: '' }, () =>
+      this.props.updateNamespace(update),
+    );
+  }
+
+  private deleteItem(id) {
+    const update = { ...this.props.namespace };
+    const index = update.groups.indexOf(id);
+    if (index !== -1) {
+      update.groups.splice(index, 1);
+      this.props.updateNamespace(update);
+    }
+  }
+
+  private renderLinkGroup(link, index) {
+    return (
+      <div className='useful-links' key={index}>
+        <div className='link-name'>
+          <TextInput
+            id='name'
+            type='text'
+            placeholder='Link text'
+            value={link.name}
+            onChange={(value, event) => this.updateLink(index, value, event)}
+          />
+        </div>
+        <div className='link-url'>
+          <TextInput
+            id='url'
+            type='text'
+            placeholder='Link URL'
+            value={link.url}
+            onChange={(value, event) => this.updateLink(index, value, event)}
+          />
+        </div>
+        <div className='link-button'>
+          <MinusCircleIcon
+            className='clickable'
+            onClick={() => this.removeLink(index)}
+            size='md'
+          />
+        </div>
+      </div>
+    );
+  }
 }

--- a/src/components/namespace-form/resources-form.tsx
+++ b/src/components/namespace-form/resources-form.tsx
@@ -20,54 +20,54 @@ Consider using it for:
 `;
 
 interface IProps {
-    namespace: NamespaceType;
+  namespace: NamespaceType;
 
-    updateNamespace: (data) => void;
+  updateNamespace: (data) => void;
 }
 
 export class ResourcesForm extends React.Component<IProps, {}> {
-    render() {
-        const { namespace } = this.props;
+  render() {
+    const { namespace } = this.props;
 
-        return (
-            <Form>
-                <div className='markdown-editor'>
-                    <div className='column editor'>
-                        <FormGroup
-                            fieldId='resources'
-                            helperText='You can can customize the Resources tab on your profile by entering custom markdown here.'
-                        >
-                            Raw Markdown
-                            <TextArea
-                                className='resources-editor'
-                                id='resources'
-                                value={namespace.resources}
-                                onChange={value => this.updateResources(value)}
-                                placeholder={placeholder}
-                            />
-                        </FormGroup>
-                    </div>
+    return (
+      <Form>
+        <div className='markdown-editor'>
+          <div className='column editor'>
+            <FormGroup
+              fieldId='resources'
+              helperText='You can can customize the Resources tab on your profile by entering custom markdown here.'
+            >
+              Raw Markdown
+              <TextArea
+                className='resources-editor'
+                id='resources'
+                value={namespace.resources}
+                onChange={value => this.updateResources(value)}
+                placeholder={placeholder}
+              />
+            </FormGroup>
+          </div>
 
-                    <div className='column preview-container'>
-                        Preview
-                        <div className='pf-c-content preview'>
-                            {namespace.resources ? (
-                                <ReactMarkdown source={namespace.resources} />
-                            ) : (
-                                <ReactMarkdown source={placeholder} />
-                            )}
-                        </div>
-                    </div>
-                </div>
-            </Form>
-        );
-    }
+          <div className='column preview-container'>
+            Preview
+            <div className='pf-c-content preview'>
+              {namespace.resources ? (
+                <ReactMarkdown source={namespace.resources} />
+              ) : (
+                <ReactMarkdown source={placeholder} />
+              )}
+            </div>
+          </div>
+        </div>
+      </Form>
+    );
+  }
 
-    private updateResources(data) {
-        const update = { ...this.props.namespace };
-        update.resources = data;
-        this.props.updateNamespace(update);
-    }
+  private updateResources(data) {
+    const update = { ...this.props.namespace };
+    update.resources = data;
+    this.props.updateNamespace(update);
+  }
 }
 
 // {this.props.saving ? <Spinner></Spinner> : null}

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -2,222 +2,208 @@ import * as React from 'react';
 import { Modal } from '@patternfly/react-core';
 import { Form, FormGroup, ActionGroup } from '@patternfly/react-core';
 import {
-    Button,
-    ButtonVariant,
-    InputGroup,
-    Popover,
-    PopoverPosition,
-    TextInput,
+  Button,
+  ButtonVariant,
+  InputGroup,
+  Popover,
+  PopoverPosition,
+  TextInput,
 } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { NamespaceAPI } from '../../api';
 import { Constants } from '../../constants';
 
 interface IProps {
-    isOpen: boolean;
-    toggleModal: object;
-    onCreateSuccess: (result) => void;
+  isOpen: boolean;
+  toggleModal: object;
+  onCreateSuccess: (result) => void;
 }
 
 interface IState {
-    newNamespaceName: string;
-    newNamespaceNameValid: boolean;
-    newNamespaceGroupIds: string;
-    newNamespaceGroupIdsValid: boolean;
-    errorMessages: any;
+  newNamespaceName: string;
+  newNamespaceNameValid: boolean;
+  newNamespaceGroupIds: string;
+  newNamespaceGroupIdsValid: boolean;
+  errorMessages: any;
 }
 
 export class NamespaceModal extends React.Component<IProps, IState> {
-    toggleModal;
+  toggleModal;
 
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.toggleModal = this.props.toggleModal;
-        this.state = {
-            newNamespaceName: '',
-            newNamespaceNameValid: true,
-            newNamespaceGroupIds: '',
-            newNamespaceGroupIdsValid: true,
-            errorMessages: {},
-        };
-    }
-
-    private namespaceOwners() {
-        if (this.state.newNamespaceGroupIds === '') {
-            return [];
-        }
-        const ids = this.state.newNamespaceGroupIds.split(',');
-        return ids.map(id => id.trim());
-    }
-
-    private namespaceOwnersValid() {
-        const error: any = this.state.errorMessages;
-
-        const isNumber = currentValue => !isNaN(Number(currentValue));
-        const valid = this.namespaceOwners().every(isNumber);
-
-        if (valid) {
-            delete error['groups'];
-        } else {
-            error['groups'] = 'Provided identifications are not numbers';
-        }
-
-        this.setState({
-            newNamespaceGroupIdsValid: !('groups' in error),
-            errorMessages: error,
-        });
-    }
-
-    private newNamespaceNameIsValid() {
-        const error: any = this.state.errorMessages;
-        const name: string = this.state.newNamespaceName;
-
-        if (name == '') {
-            error['name'] = 'Please, provide the namespace name';
-        } else if (!/^[a-zA-Z0-9_]+$/.test(name)) {
-            error['name'] = 'Name can only contain [A-Za-z0-9_]';
-        } else if (name.length <= 2) {
-            error['name'] = 'Name must be longer than 2 characters';
-        } else if (name.startsWith('_')) {
-            error['name'] = "Name cannot begin with '_'";
-        } else {
-            delete error['name'];
-        }
-
-        this.setState({
-            newNamespaceNameValid: !('name' in error),
-            errorMessages: error,
-        });
-    }
-
-    private handleSubmit = event => {
-        const groups = this.namespaceOwners();
-        groups.push(Constants.ADMIN_GROUP);
-        const data: any = {
-            name: this.state.newNamespaceName,
-            groups: groups,
-        };
-        NamespaceAPI.create(data)
-            .then(results => {
-                this.toggleModal();
-                this.setState({
-                    newNamespaceName: '',
-                    newNamespaceGroupIds: '',
-                    errorMessages: {},
-                });
-                this.props.onCreateSuccess(data);
-            })
-            .catch(error => {
-                const result = error.response;
-                const messages: any = this.state.errorMessages;
-                for (const e of result.data.errors) {
-                    messages[e.source.parameter] = e.detail;
-                }
-                this.setState({
-                    errorMessages: messages,
-                    newNamespaceNameValid: !('name' in messages),
-                    newNamespaceGroupIdsValid: !('groups' in messages),
-                });
-            });
+    this.toggleModal = this.props.toggleModal;
+    this.state = {
+      newNamespaceName: '',
+      newNamespaceNameValid: true,
+      newNamespaceGroupIds: '',
+      newNamespaceGroupIdsValid: true,
+      errorMessages: {},
     };
+  }
 
-    render() {
-        const {
-            newNamespaceName,
-            newNamespaceGroupIds,
-            errorMessages,
-        } = this.state;
-
-        return (
-            <Modal
-                isLarge
-                title='Create a new namespace'
-                isOpen={this.props.isOpen}
-                onClose={this.toggleModal}
-                actions={[
-                    <Button
-                        key='confirm'
-                        variant='primary'
-                        onClick={this.handleSubmit}
-                    >
-                        Create
-                    </Button>,
-                    <Button
-                        key='cancel'
-                        variant='link'
-                        onClick={this.toggleModal}
-                    >
-                        Cancel
-                    </Button>,
-                ]}
-                isFooterLeftAligned
-            >
-                <Form>
-                    <FormGroup
-                        label='Name'
-                        isRequired
-                        fieldId='name'
-                        helperText='Please, provide the namespace name'
-                        helperTextInvalid={this.state.errorMessages['name']}
-                        // This prop will be deprecated. You should use validated instead.
-                        isValid={this.state.newNamespaceNameValid}
-                    >
-                        <InputGroup>
-                            <TextInput
-                                isRequired
-                                type='text'
-                                id='newNamespaceName'
-                                name='newNamespaceName'
-                                value={newNamespaceName}
-                                onChange={value => {
-                                    this.setState(
-                                        { newNamespaceName: value },
-                                        () => {
-                                            this.newNamespaceNameIsValid();
-                                        },
-                                    );
-                                }}
-                            />
-                            <Popover
-                                aria-label='popover example'
-                                position={PopoverPosition.top}
-                                bodyContent='Namespace names are limited to lowercase word characters ([a-zA-Z0-9_]), must have a minimum length of 2 characters and cannot start with an ‘_’.'
-                            >
-                                <Button
-                                    variant={ButtonVariant.control}
-                                    aria-label='popover for input'
-                                >
-                                    <QuestionCircleIcon />
-                                </Button>
-                            </Popover>
-                        </InputGroup>
-                    </FormGroup>
-                    <FormGroup
-                        label='Namespace owners'
-                        fieldId='groups'
-                        helperText='Please, provide comma-separated Red Hat account identifications'
-                        helperTextInvalid={this.state.errorMessages['groups']}
-                        isValid={this.state.newNamespaceGroupIdsValid}
-                    >
-                        <TextInput
-                            isRequired
-                            type='text'
-                            id='newNamespaceGroupIds'
-                            name='newNamespaceGroupIds'
-                            value={newNamespaceGroupIds}
-                            onChange={value => {
-                                this.setState(
-                                    { newNamespaceGroupIds: value },
-                                    () => {
-                                        this.namespaceOwnersValid();
-                                    },
-                                );
-                            }}
-                        />
-                    </FormGroup>
-                </Form>
-            </Modal>
-        );
+  private namespaceOwners() {
+    if (this.state.newNamespaceGroupIds === '') {
+      return [];
     }
+    const ids = this.state.newNamespaceGroupIds.split(',');
+    return ids.map(id => id.trim());
+  }
+
+  private namespaceOwnersValid() {
+    const error: any = this.state.errorMessages;
+
+    const isNumber = currentValue => !isNaN(Number(currentValue));
+    const valid = this.namespaceOwners().every(isNumber);
+
+    if (valid) {
+      delete error['groups'];
+    } else {
+      error['groups'] = 'Provided identifications are not numbers';
+    }
+
+    this.setState({
+      newNamespaceGroupIdsValid: !('groups' in error),
+      errorMessages: error,
+    });
+  }
+
+  private newNamespaceNameIsValid() {
+    const error: any = this.state.errorMessages;
+    const name: string = this.state.newNamespaceName;
+
+    if (name == '') {
+      error['name'] = 'Please, provide the namespace name';
+    } else if (!/^[a-zA-Z0-9_]+$/.test(name)) {
+      error['name'] = 'Name can only contain [A-Za-z0-9_]';
+    } else if (name.length <= 2) {
+      error['name'] = 'Name must be longer than 2 characters';
+    } else if (name.startsWith('_')) {
+      error['name'] = "Name cannot begin with '_'";
+    } else {
+      delete error['name'];
+    }
+
+    this.setState({
+      newNamespaceNameValid: !('name' in error),
+      errorMessages: error,
+    });
+  }
+
+  private handleSubmit = event => {
+    const groups = this.namespaceOwners();
+    groups.push(Constants.ADMIN_GROUP);
+    const data: any = {
+      name: this.state.newNamespaceName,
+      groups: groups,
+    };
+    NamespaceAPI.create(data)
+      .then(results => {
+        this.toggleModal();
+        this.setState({
+          newNamespaceName: '',
+          newNamespaceGroupIds: '',
+          errorMessages: {},
+        });
+        this.props.onCreateSuccess(data);
+      })
+      .catch(error => {
+        const result = error.response;
+        const messages: any = this.state.errorMessages;
+        for (const e of result.data.errors) {
+          messages[e.source.parameter] = e.detail;
+        }
+        this.setState({
+          errorMessages: messages,
+          newNamespaceNameValid: !('name' in messages),
+          newNamespaceGroupIdsValid: !('groups' in messages),
+        });
+      });
+  };
+
+  render() {
+    const {
+      newNamespaceName,
+      newNamespaceGroupIds,
+      errorMessages,
+    } = this.state;
+
+    return (
+      <Modal
+        isLarge
+        title='Create a new namespace'
+        isOpen={this.props.isOpen}
+        onClose={this.toggleModal}
+        actions={[
+          <Button key='confirm' variant='primary' onClick={this.handleSubmit}>
+            Create
+          </Button>,
+          <Button key='cancel' variant='link' onClick={this.toggleModal}>
+            Cancel
+          </Button>,
+        ]}
+        isFooterLeftAligned
+      >
+        <Form>
+          <FormGroup
+            label='Name'
+            isRequired
+            fieldId='name'
+            helperText='Please, provide the namespace name'
+            helperTextInvalid={this.state.errorMessages['name']}
+            // This prop will be deprecated. You should use validated instead.
+            isValid={this.state.newNamespaceNameValid}
+          >
+            <InputGroup>
+              <TextInput
+                isRequired
+                type='text'
+                id='newNamespaceName'
+                name='newNamespaceName'
+                value={newNamespaceName}
+                onChange={value => {
+                  this.setState({ newNamespaceName: value }, () => {
+                    this.newNamespaceNameIsValid();
+                  });
+                }}
+              />
+              <Popover
+                aria-label='popover example'
+                position={PopoverPosition.top}
+                bodyContent='Namespace names are limited to lowercase word characters ([a-zA-Z0-9_]), must have a minimum length of 2 characters and cannot start with an ‘_’.'
+              >
+                <Button
+                  variant={ButtonVariant.control}
+                  aria-label='popover for input'
+                >
+                  <QuestionCircleIcon />
+                </Button>
+              </Popover>
+            </InputGroup>
+          </FormGroup>
+          <FormGroup
+            label='Namespace owners'
+            fieldId='groups'
+            helperText='Please, provide comma-separated Red Hat account identifications'
+            helperTextInvalid={this.state.errorMessages['groups']}
+            isValid={this.state.newNamespaceGroupIdsValid}
+          >
+            <TextInput
+              isRequired
+              type='text'
+              id='newNamespaceGroupIds'
+              name='newNamespaceGroupIds'
+              value={newNamespaceGroupIds}
+              onChange={value => {
+                this.setState({ newNamespaceGroupIds: value }, () => {
+                  this.namespaceOwnersValid();
+                });
+              }}
+            />
+          </FormGroup>
+        </Form>
+      </Modal>
+    );
+  }
 }

--- a/src/components/numeric-label/numeric-label.tsx
+++ b/src/components/numeric-label/numeric-label.tsx
@@ -1,52 +1,52 @@
 import * as React from 'react';
 
 interface IProps {
-    number: number | string;
-    label?: string;
-    hideNumber?: boolean;
+  number: number | string;
+  label?: string;
+  hideNumber?: boolean;
 }
 
 export class NumericLabel extends React.Component<IProps, {}> {
-    render() {
-        const { number, label, hideNumber } = this.props;
-        let convertedNum: number;
+  render() {
+    const { number, label, hideNumber } = this.props;
+    let convertedNum: number;
 
-        if (typeof number === 'string') {
-            convertedNum = Number(number);
-        } else {
-            convertedNum = number;
-        }
-
-        const plural = number === 1 ? '' : 's';
-
-        return (
-            <span>
-                {hideNumber ? null : NumericLabel.roundNumber(convertedNum)}{' '}
-                {label ? label + plural : null}
-            </span>
-        );
+    if (typeof number === 'string') {
+      convertedNum = Number(number);
+    } else {
+      convertedNum = number;
     }
 
-    // Make this a static property so that we can use this function outside of
-    // rendering the whole component
-    static roundNumber(n: number): string {
-        if (n < 1000) {
-            // returns 1 to 999
-            return n.toString();
-        } else if (n < 10000) {
-            // returns 1K to 9.9K
-            return (Math.floor(n / 100) / 10).toString() + 'K';
-        } else if (n < 1000000) {
-            // returns 10K to 999K
-            return Math.floor(n / 1000).toString() + 'K';
-        } else if (n < 100000000) {
-            // returns 1M to 9.9M
-            return (Math.floor(n / 100000) / 10).toString() + 'M';
-        } else if (n < 1000000000) {
-            return Math.floor(n / 1000000).toString() + 'M';
-        }
+    const plural = number === 1 ? '' : 's';
 
-        // If larger than a billion, don't even bother.
-        return '1B+';
+    return (
+      <span>
+        {hideNumber ? null : NumericLabel.roundNumber(convertedNum)}{' '}
+        {label ? label + plural : null}
+      </span>
+    );
+  }
+
+  // Make this a static property so that we can use this function outside of
+  // rendering the whole component
+  static roundNumber(n: number): string {
+    if (n < 1000) {
+      // returns 1 to 999
+      return n.toString();
+    } else if (n < 10000) {
+      // returns 1K to 9.9K
+      return (Math.floor(n / 100) / 10).toString() + 'K';
+    } else if (n < 1000000) {
+      // returns 10K to 999K
+      return Math.floor(n / 1000).toString() + 'K';
+    } else if (n < 100000000) {
+      // returns 1M to 9.9M
+      return (Math.floor(n / 100000) / 10).toString() + 'M';
+    } else if (n < 1000000000) {
+      return Math.floor(n / 1000000).toString() + 'M';
     }
+
+    // If larger than a billion, don't even bother.
+    return '1B+';
+  }
 }

--- a/src/components/patternfly-wrappers/alert-list.tsx
+++ b/src/components/patternfly-wrappers/alert-list.tsx
@@ -1,63 +1,59 @@
 import * as React from 'react';
 import {
-    Alert,
-    AlertActionCloseButton,
-    AlertProps,
+  Alert,
+  AlertActionCloseButton,
+  AlertProps,
 } from '@patternfly/react-core';
 
 interface IProps {
-    alerts: AlertType[];
-    closeAlert: (alertIndex) => void;
+  alerts: AlertType[];
+  closeAlert: (alertIndex) => void;
 }
 
 export class AlertType {
-    variant: AlertProps['variant'];
-    title: string;
-    description?: string;
+  variant: AlertProps['variant'];
+  title: string;
+  description?: string;
 }
 
 export class AlertList extends React.Component<IProps, {}> {
-    render() {
-        const { alerts, closeAlert } = this.props;
-        return (
-            <div
-                style={{
-                    position: 'fixed',
-                    right: '5px',
-                    top: '80px',
-                    zIndex: 300,
-                    display: 'flex',
-                    flexDirection: 'column',
-                }}
-            >
-                {alerts.map((alert, i) => (
-                    <Alert
-                        style={{ marginBottom: '16px' }}
-                        key={i}
-                        title={alert.title}
-                        variant={alert.variant}
-                        action={
-                            <AlertActionCloseButton
-                                onClose={() => closeAlert(i)}
-                            />
-                        }
-                    >
-                        {alert.description}
-                    </Alert>
-                ))}
-            </div>
-        );
-    }
+  render() {
+    const { alerts, closeAlert } = this.props;
+    return (
+      <div
+        style={{
+          position: 'fixed',
+          right: '5px',
+          top: '80px',
+          zIndex: 300,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {alerts.map((alert, i) => (
+          <Alert
+            style={{ marginBottom: '16px' }}
+            key={i}
+            title={alert.title}
+            variant={alert.variant}
+            action={<AlertActionCloseButton onClose={() => closeAlert(i)} />}
+          >
+            {alert.description}
+          </Alert>
+        ))}
+      </div>
+    );
+  }
 }
 
 export function closeAlertMixin(alertStateVariable) {
-    return function(alertIndex) {
-        const newList = [...this.state['alerts']];
-        newList.splice(alertIndex, 1);
+  return function(alertIndex) {
+    const newList = [...this.state['alerts']];
+    newList.splice(alertIndex, 1);
 
-        const newState = {};
-        newState[alertStateVariable] = newList;
+    const newState = {};
+    newState[alertStateVariable] = newList;
 
-        this.setState(newState);
-    };
+    this.setState(newState);
+  };
 }

--- a/src/components/patternfly-wrappers/applied-filters.tsx
+++ b/src/components/patternfly-wrappers/applied-filters.tsx
@@ -1,71 +1,66 @@
 import * as React from 'react';
 
 import {
-    Badge,
-    Chip,
-    ChipGroup,
-    ChipGroupToolbarItem,
+  Badge,
+  Chip,
+  ChipGroup,
+  ChipGroupToolbarItem,
 } from '@patternfly/react-core';
 
 import { ParamHelper } from '../../utilities';
 
 interface IProps {
-    updateParams: (p) => void;
-    params: object;
-    ignoredParams?: string[];
+  updateParams: (p) => void;
+  params: object;
+  ignoredParams?: string[];
 
-    // If k from param[k] is in nice names, use niceNames[k] instead of k
-    // when displaying the param field name
-    niceNames?: object;
+  // If k from param[k] is in nice names, use niceNames[k] instead of k
+  // when displaying the param field name
+  niceNames?: object;
 }
 
 export class AppliedFilters extends React.Component<IProps, {}> {
-    static defaultProps = {
-        ignoredParams: [],
-        niceNames: {},
-    };
+  static defaultProps = {
+    ignoredParams: [],
+    niceNames: {},
+  };
 
-    render() {
-        const { params, ignoredParams } = this.props;
+  render() {
+    const { params, ignoredParams } = this.props;
 
-        return (
-            <ChipGroup withToolbar>
-                {Object.keys(ParamHelper.getReduced(params, ignoredParams)).map(
-                    key => this.renderGroup(key),
-                )}
-            </ChipGroup>
-        );
+    return (
+      <ChipGroup withToolbar>
+        {Object.keys(ParamHelper.getReduced(params, ignoredParams)).map(key =>
+          this.renderGroup(key),
+        )}
+      </ChipGroup>
+    );
+  }
+
+  private renderGroup(key: string) {
+    const { niceNames, params, updateParams } = this.props;
+
+    let chips;
+
+    if (Array.isArray(params[key])) {
+      chips = params[key];
+    } else {
+      chips = [params[key]];
     }
 
-    private renderGroup(key: string) {
-        const { niceNames, params, updateParams } = this.props;
-
-        let chips;
-
-        if (Array.isArray(params[key])) {
-            chips = params[key];
-        } else {
-            chips = [params[key]];
-        }
-
-        return (
-            <ChipGroupToolbarItem
-                categoryName={niceNames[key] || key}
-                key={key}
-            >
-                {chips.map((v, i) => (
-                    <Chip
-                        key={i}
-                        onClick={() =>
-                            updateParams(
-                                ParamHelper.deleteParam(params, key, v),
-                            )
-                        }
-                    >
-                        {v}
-                    </Chip>
-                ))}
-            </ChipGroupToolbarItem>
-        );
-    }
+    return (
+      <ChipGroupToolbarItem categoryName={niceNames[key] || key} key={key}>
+        {chips.map((v, i) => (
+          <Chip
+            key={i}
+            onClick={() =>
+              updateParams(ParamHelper.deleteParam(params, key, v))
+            }
+          >
+            {v}
+          </Chip>
+        ))}
+      </ChipGroupToolbarItem>
+    );
+  }
 }

--- a/src/components/patternfly-wrappers/breadcrumbs.tsx
+++ b/src/components/patternfly-wrappers/breadcrumbs.tsx
@@ -3,29 +3,29 @@ import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 
 interface IProps {
-    links: {
-        name: string;
-        url?: string;
-    }[];
+  links: {
+    name: string;
+    url?: string;
+  }[];
 }
 
 export class Breadcrumbs extends React.Component<IProps> {
-    render() {
-        return (
-            <Breadcrumb>
-                {this.props.links.map((link, i) => this.renderLink(link, i))}
-            </Breadcrumb>
-        );
-    }
+  render() {
+    return (
+      <Breadcrumb>
+        {this.props.links.map((link, i) => this.renderLink(link, i))}
+      </Breadcrumb>
+    );
+  }
 
-    renderLink(link, index) {
-        return (
-            <BreadcrumbItem
-                key={index}
-                isActive={index + 1 === this.props.links.length}
-            >
-                {link.url ? <Link to={link.url}>{link.name}</Link> : link.name}
-            </BreadcrumbItem>
-        );
-    }
+  renderLink(link, index) {
+    return (
+      <BreadcrumbItem
+        key={index}
+        isActive={index + 1 === this.props.links.length}
+      >
+        {link.url ? <Link to={link.url}>{link.name}</Link> : link.name}
+      </BreadcrumbItem>
+    );
+  }
 }

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
 import {
-    TextInput,
-    InputGroup,
-    Button,
-    ButtonVariant,
-    DropdownItem,
+  TextInput,
+  InputGroup,
+  Button,
+  ButtonVariant,
+  DropdownItem,
 } from '@patternfly/react-core';
 
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
@@ -14,130 +14,125 @@ import { StatefulDropdown } from '../../components';
 import { ParamHelper } from '../../utilities';
 
 class FilterOption {
-    id: string;
-    title: string;
-    placeholder?: string;
-    inputType?: 'text-field' | 'select';
-    options?: { id: string; title: string }[];
+  id: string;
+  title: string;
+  placeholder?: string;
+  inputType?: 'text-field' | 'select';
+  options?: { id: string; title: string }[];
 }
 
 interface IProps {
-    filterConfig: FilterOption[];
-    params: any;
-    updateParams: (params) => void;
+  filterConfig: FilterOption[];
+  params: any;
+  updateParams: (params) => void;
 }
 
 interface IState {
-    selectedFilter: FilterOption;
-    inputText: string;
+  selectedFilter: FilterOption;
+  inputText: string;
 }
 
 export class CompoundFilter extends React.Component<IProps, IState> {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            selectedFilter: props.filterConfig[0],
-            inputText: '',
-        };
-    }
+    this.state = {
+      selectedFilter: props.filterConfig[0],
+      inputText: '',
+    };
+  }
 
-    render() {
-        const { params, filterConfig } = this.props;
-        const { selectedFilter, inputText } = this.state;
+  render() {
+    const { params, filterConfig } = this.props;
+    const { selectedFilter, inputText } = this.state;
 
-        const filterOptions = filterConfig.map(v => (
-            <DropdownItem
+    const filterOptions = filterConfig.map(v => (
+      <DropdownItem
+        onClick={() => this.setState({ selectedFilter: v, inputText: '' })}
+        key={v.id}
+      >
+        {v.title}
+      </DropdownItem>
+    ));
+
+    return (
+      <InputGroup>
+        <StatefulDropdown
+          toggleType='dropdown'
+          defaultText={
+            <span>
+              <FilterIcon />
+              {'   '}
+              {selectedFilter.title}
+            </span>
+          }
+          position='left'
+          isPlain={false}
+          items={filterOptions}
+        />
+        {this.renderInput(selectedFilter)}
+        <Button
+          onClick={() => this.submitFilter()}
+          variant={ButtonVariant.control}
+        >
+          <SearchIcon></SearchIcon>
+        </Button>
+      </InputGroup>
+    );
+  }
+
+  private renderInput(selectedFilter: FilterOption) {
+    switch (selectedFilter.inputType) {
+      case 'select':
+        return (
+          <StatefulDropdown
+            toggleType='dropdown'
+            defaultText={
+              this.state.inputText ||
+              selectedFilter.placeholder ||
+              selectedFilter.title
+            }
+            isPlain={false}
+            position='left'
+            items={selectedFilter.options.map((v, i) => (
+              <DropdownItem
                 onClick={() =>
-                    this.setState({ selectedFilter: v, inputText: '' })
+                  this.setState({ inputText: v.id }, () => this.submitFilter())
                 }
                 key={v.id}
-            >
+              >
                 {v.title}
-            </DropdownItem>
-        ));
-
+              </DropdownItem>
+            ))}
+          />
+        );
+      default:
         return (
-            <InputGroup>
-                <StatefulDropdown
-                    toggleType='dropdown'
-                    defaultText={
-                        <span>
-                            <FilterIcon />
-                            {'   '}
-                            {selectedFilter.title}
-                        </span>
-                    }
-                    position='left'
-                    isPlain={false}
-                    items={filterOptions}
-                />
-                {this.renderInput(selectedFilter)}
-                <Button
-                    onClick={() => this.submitFilter()}
-                    variant={ButtonVariant.control}
-                >
-                    <SearchIcon></SearchIcon>
-                </Button>
-            </InputGroup>
+          <TextInput
+            placeholder={
+              selectedFilter.placeholder || `Filter by ${selectedFilter.title}`
+            }
+            value={this.state.inputText}
+            onChange={k => this.setState({ inputText: k })}
+            onKeyPress={e => this.handleEnter(e)}
+          />
         );
     }
+  }
 
-    private renderInput(selectedFilter: FilterOption) {
-        switch (selectedFilter.inputType) {
-            case 'select':
-                return (
-                    <StatefulDropdown
-                        toggleType='dropdown'
-                        defaultText={
-                            this.state.inputText ||
-                            selectedFilter.placeholder ||
-                            selectedFilter.title
-                        }
-                        isPlain={false}
-                        position='left'
-                        items={selectedFilter.options.map((v, i) => (
-                            <DropdownItem
-                                onClick={() =>
-                                    this.setState({ inputText: v.id }, () =>
-                                        this.submitFilter(),
-                                    )
-                                }
-                                key={v.id}
-                            >
-                                {v.title}
-                            </DropdownItem>
-                        ))}
-                    />
-                );
-            default:
-                return (
-                    <TextInput
-                        placeholder={
-                            selectedFilter.placeholder ||
-                            `Filter by ${selectedFilter.title}`
-                        }
-                        value={this.state.inputText}
-                        onChange={k => this.setState({ inputText: k })}
-                        onKeyPress={e => this.handleEnter(e)}
-                    />
-                );
-        }
+  private handleEnter(e) {
+    if (e.key === 'Enter') {
+      this.submitFilter();
     }
+  }
 
-    private handleEnter(e) {
-        if (e.key === 'Enter') {
-            this.submitFilter();
-        }
-    }
-
-    private submitFilter() {
-        this.props.updateParams(
-            ParamHelper.setParam(
-                this.props.params,
-                this.state.selectedFilter.id,
-                this.state.inputText,
-            ),
-        );
-    }
+  private submitFilter() {
+    this.props.updateParams(
+      ParamHelper.setParam(
+        this.props.params,
+        this.state.selectedFilter.id,
+        this.state.inputText,
+      ),
+    );
+  }
 }

--- a/src/components/patternfly-wrappers/main.tsx
+++ b/src/components/patternfly-wrappers/main.tsx
@@ -1,18 +1,17 @@
 import * as React from 'react';
 
 export class Main extends React.Component<any> {
-    render() {
-        const { children, className, ...extra } = this.props;
-        return (
-            <section
-                className={
-                    'pf-l-page__main-section pf-c-page__main-section ' +
-                    className
-                }
-                {...extra}
-            >
-                {children}
-            </section>
-        );
-    }
+  render() {
+    const { children, className, ...extra } = this.props;
+    return (
+      <section
+        className={
+          'pf-l-page__main-section pf-c-page__main-section ' + className
+        }
+        {...extra}
+      >
+        {children}
+      </section>
+    );
+  }
 }

--- a/src/components/patternfly-wrappers/pagination.tsx
+++ b/src/components/patternfly-wrappers/pagination.tsx
@@ -1,66 +1,66 @@
 import * as React from 'react';
 
 import {
-    Pagination as PaginationPF,
-    PaginationVariant,
+  Pagination as PaginationPF,
+  PaginationVariant,
 } from '@patternfly/react-core';
 
 import { Constants } from '../../constants';
 import { ParamHelper } from '../../utilities/param-helper';
 
 interface IProps {
-    count: number;
-    params: {
-        page_size?: number;
-        page?: number;
-    };
-    updateParams: (params) => void;
-    isTop?: boolean;
-    isCompact?: boolean;
-    perPageOptions?: number[];
+  count: number;
+  params: {
+    page_size?: number;
+    page?: number;
+  };
+  updateParams: (params) => void;
+  isTop?: boolean;
+  isCompact?: boolean;
+  perPageOptions?: number[];
 }
 
 export class Pagination extends React.Component<IProps> {
-    render() {
-        const {
-            count,
-            params,
-            updateParams,
-            isTop,
-            perPageOptions,
-            isCompact,
-        } = this.props;
+  render() {
+    const {
+      count,
+      params,
+      updateParams,
+      isTop,
+      perPageOptions,
+      isCompact,
+    } = this.props;
 
-        const extraProps = {};
-        if (!isTop) {
-            extraProps['widgetId'] = 'pagination-options-menu-bottom';
-            extraProps['variant'] = PaginationVariant.bottom;
+    const extraProps = {};
+    if (!isTop) {
+      extraProps['widgetId'] = 'pagination-options-menu-bottom';
+      extraProps['variant'] = PaginationVariant.bottom;
+    }
+
+    return (
+      <PaginationPF
+        itemCount={count}
+        perPage={params.page_size || Constants.DEFAULT_PAGE_SIZE}
+        page={params.page || 1}
+        onSetPage={(_, p) =>
+          updateParams(ParamHelper.setParam(params, 'page', p))
         }
+        onPerPageSelect={(_, p) => {
+          updateParams({ ...params, page: 1, page_size: p });
+        }}
+        {...extraProps}
+        isCompact={isTop || isCompact}
+        perPageOptions={this.mapPerPageOptions(
+          perPageOptions || Constants.DEFAULT_PAGINATION_OPTIONS,
+        )}
+      />
+    );
+  }
 
-        return (
-            <PaginationPF
-                itemCount={count}
-                perPage={params.page_size || Constants.DEFAULT_PAGE_SIZE}
-                page={params.page || 1}
-                onSetPage={(_, p) =>
-                    updateParams(ParamHelper.setParam(params, 'page', p))
-                }
-                onPerPageSelect={(_, p) => {
-                    updateParams({ ...params, page: 1, page_size: p });
-                }}
-                {...extraProps}
-                isCompact={isTop || isCompact}
-                perPageOptions={this.mapPerPageOptions(
-                    perPageOptions || Constants.DEFAULT_PAGINATION_OPTIONS,
-                )}
-            />
-        );
-    }
-
-    private mapPerPageOptions(options) {
-        return options.map(option => ({
-            title: String(option),
-            value: option,
-        }));
-    }
+  private mapPerPageOptions(options) {
+    return options.map(option => ({
+      title: String(option),
+      value: option,
+    }));
+  }
 }

--- a/src/components/patternfly-wrappers/sort.scss
+++ b/src/components/patternfly-wrappers/sort.scss
@@ -1,8 +1,8 @@
 .sort-wrapper {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 }
 
 .asc-button {
-    margin-left: 5px;
+  margin-left: 5px;
 }

--- a/src/components/patternfly-wrappers/sort.tsx
+++ b/src/components/patternfly-wrappers/sort.tsx
@@ -3,167 +3,164 @@ import './sort.scss';
 
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import {
-    SortAmountDownIcon,
-    SortAmountUpIcon,
-    SortAlphaDownIcon,
-    SortAlphaUpIcon,
+  SortAmountDownIcon,
+  SortAmountUpIcon,
+  SortAlphaDownIcon,
+  SortAlphaUpIcon,
 } from '@patternfly/react-icons';
 
 import { ParamHelper } from '../../utilities/param-helper';
 
 export class SortFieldType {
-    id: string;
-    title: string;
-    type: 'numeric' | 'alpha';
+  id: string;
+  title: string;
+  type: 'numeric' | 'alpha';
 }
 
 interface IProps {
-    options: SortFieldType[];
-    params: object;
-    updateParams: (params) => void;
-    sortParamName?: string;
+  options: SortFieldType[];
+  params: object;
+  updateParams: (params) => void;
+  sortParamName?: string;
 }
 
 interface IState {
-    isExpanded: boolean;
+  isExpanded: boolean;
 }
 
 export class Sort extends React.Component<IProps, IState> {
-    options: any;
-    static defaultProps = {
-        sortParamName: 'sort',
+  options: any;
+  static defaultProps = {
+    sortParamName: 'sort',
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isExpanded: false,
     };
+  }
 
-    constructor(props) {
-        super(props);
+  private onToggle(isExpanded) {
+    this.setState({
+      isExpanded,
+    });
+  }
 
-        this.state = {
-            isExpanded: false,
-        };
+  private onSelect(name) {
+    let isDescending = this.getIsDescending(this.props.params);
+
+    const option = this.props.options.find(i => i.title === name);
+
+    // Alphabetical sorting is inverted in Django, so flip it here to make
+    // things match up with the UI.
+    if (option.type === 'alpha') {
+      isDescending = !isDescending;
+    }
+    const desc = isDescending ? '-' : '';
+
+    this.setState({ isExpanded: false }, () =>
+      this.props.updateParams(
+        ParamHelper.setParam(
+          this.props.params,
+          this.props.sortParamName,
+          desc + option.id,
+        ),
+      ),
+    );
+  }
+
+  private setDescending() {
+    let field = this.getSelected(this.props.params);
+    const descending = !this.getIsDescending(this.props.params);
+
+    this.props.updateParams(
+      ParamHelper.setParam(
+        this.props.params,
+        this.props.sortParamName,
+        (descending ? '-' : '') + field.id,
+      ),
+    );
+  }
+
+  private getIsDescending(params) {
+    const sort = params[this.props.sortParamName];
+
+    // The ?sort= url param is not always guaranteed to be set. If it's
+    // not set, return the default
+    if (!sort) {
+      return true;
+    }
+    return sort.startsWith('-');
+  }
+
+  private getSelected(params) {
+    let sort = params[this.props.sortParamName];
+    const def = this.props.options[0];
+
+    if (!sort) {
+      return def;
     }
 
-    private onToggle(isExpanded) {
-        this.setState({
-            isExpanded,
-        });
+    if (sort.startsWith('-')) {
+      sort = sort.substring(1, sort.length);
     }
 
-    private onSelect(name) {
-        let isDescending = this.getIsDescending(this.props.params);
+    const option = this.props.options.find(x => x.id === sort);
 
-        const option = this.props.options.find(i => i.title === name);
+    return option ? option : def;
+  }
 
-        // Alphabetical sorting is inverted in Django, so flip it here to make
-        // things match up with the UI.
-        if (option.type === 'alpha') {
-            isDescending = !isDescending;
-        }
-        const desc = isDescending ? '-' : '';
+  render() {
+    const { options, params } = this.props;
+    const { isExpanded } = this.state;
 
-        this.setState({ isExpanded: false }, () =>
-            this.props.updateParams(
-                ParamHelper.setParam(
-                    this.props.params,
-                    this.props.sortParamName,
-                    desc + option.id,
-                ),
-            ),
-        );
+    const selectedOption = this.getSelected(params);
+
+    let IconDesc;
+    let IconAsc;
+
+    if (selectedOption.type === 'alpha') {
+      IconAsc = SortAlphaDownIcon;
+      IconDesc = SortAlphaUpIcon;
+    } else {
+      IconDesc = SortAmountDownIcon;
+      IconAsc = SortAmountUpIcon;
     }
 
-    private setDescending() {
-        let field = this.getSelected(this.props.params);
-        const descending = !this.getIsDescending(this.props.params);
+    return (
+      <div className='sort-wrapper'>
+        {options.length > 1 ? (
+          <Select
+            variant={SelectVariant.single}
+            aria-label='Select input'
+            onToggle={e => this.onToggle(e)}
+            onSelect={(_, name) => this.onSelect(name)}
+            selections={selectedOption.title}
+            isExpanded={isExpanded}
+            ariaLabelledBy='Sort results'
+          >
+            {options.map(option => (
+              <SelectOption key={option.id} value={option.title} />
+            ))}
+          </Select>
+        ) : null}
 
-        this.props.updateParams(
-            ParamHelper.setParam(
-                this.props.params,
-                this.props.sortParamName,
-                (descending ? '-' : '') + field.id,
-            ),
-        );
-    }
-
-    private getIsDescending(params) {
-        const sort = params[this.props.sortParamName];
-
-        // The ?sort= url param is not always guaranteed to be set. If it's
-        // not set, return the default
-        if (!sort) {
-            return true;
-        }
-        return sort.startsWith('-');
-    }
-
-    private getSelected(params) {
-        let sort = params[this.props.sortParamName];
-        const def = this.props.options[0];
-
-        if (!sort) {
-            return def;
-        }
-
-        if (sort.startsWith('-')) {
-            sort = sort.substring(1, sort.length);
-        }
-
-        const option = this.props.options.find(x => x.id === sort);
-
-        return option ? option : def;
-    }
-
-    render() {
-        const { options, params } = this.props;
-        const { isExpanded } = this.state;
-
-        const selectedOption = this.getSelected(params);
-
-        let IconDesc;
-        let IconAsc;
-
-        if (selectedOption.type === 'alpha') {
-            IconAsc = SortAlphaDownIcon;
-            IconDesc = SortAlphaUpIcon;
-        } else {
-            IconDesc = SortAmountDownIcon;
-            IconAsc = SortAmountUpIcon;
-        }
-
-        return (
-            <div className='sort-wrapper'>
-                {options.length > 1 ? (
-                    <Select
-                        variant={SelectVariant.single}
-                        aria-label='Select input'
-                        onToggle={e => this.onToggle(e)}
-                        onSelect={(_, name) => this.onSelect(name)}
-                        selections={selectedOption.title}
-                        isExpanded={isExpanded}
-                        ariaLabelledBy='Sort results'
-                    >
-                        {options.map(option => (
-                            <SelectOption
-                                key={option.id}
-                                value={option.title}
-                            />
-                        ))}
-                    </Select>
-                ) : null}
-
-                {this.getIsDescending(params) ? (
-                    <IconDesc
-                        className='clickable asc-button'
-                        size='md'
-                        onClick={() => this.setDescending()}
-                    />
-                ) : (
-                    <IconAsc
-                        className='clickable asc-button'
-                        size='md'
-                        onClick={() => this.setDescending()}
-                    />
-                )}
-            </div>
-        );
-    }
+        {this.getIsDescending(params) ? (
+          <IconDesc
+            className='clickable asc-button'
+            size='md'
+            onClick={() => this.setDescending()}
+          />
+        ) : (
+          <IconAsc
+            className='clickable asc-button'
+            size='md'
+            onClick={() => this.setDescending()}
+          />
+        )}
+      </div>
+    );
+  }
 }

--- a/src/components/patternfly-wrappers/stateful-dropdown.tsx
+++ b/src/components/patternfly-wrappers/stateful-dropdown.tsx
@@ -1,94 +1,88 @@
 import * as React from 'react';
 
 import {
-    Dropdown,
-    DropdownPosition,
-    KebabToggle,
-    DropdownToggle,
+  Dropdown,
+  DropdownPosition,
+  KebabToggle,
+  DropdownToggle,
 } from '@patternfly/react-core';
 
 interface IProps {
-    items: React.ReactNodeArray;
-    onSelect?: (event) => void;
-    toggleType?: string;
-    defaultText?: React.ReactNode;
-    position?: 'left' | 'right';
-    isPlain?: boolean;
+  items: React.ReactNodeArray;
+  onSelect?: (event) => void;
+  toggleType?: string;
+  defaultText?: React.ReactNode;
+  position?: 'left' | 'right';
+  isPlain?: boolean;
 }
 
 interface IState {
-    isOpen: boolean;
-    selected: string;
+  isOpen: boolean;
+  selected: string;
 }
 
 export class StatefulDropdown extends React.Component<IProps, IState> {
-    static defaultProps = {
-        isPlain: true,
+  static defaultProps = {
+    isPlain: true,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false,
+      selected: undefined,
     };
+  }
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            isOpen: false,
-            selected: undefined,
-        };
-    }
+  render() {
+    const { isOpen } = this.state;
+    const { items, toggleType, defaultText, position, isPlain } = this.props;
 
-    render() {
-        const { isOpen } = this.state;
-        const {
-            items,
-            toggleType,
-            defaultText,
-            position,
-            isPlain,
-        } = this.props;
+    return (
+      <Dropdown
+        onSelect={e => this.onSelect(e)}
+        toggle={this.renderToggle(toggleType, defaultText)}
+        isOpen={isOpen}
+        isPlain={isPlain}
+        dropdownItems={items}
+        position={position || DropdownPosition.right}
+        autoFocus={false}
+      />
+    );
+  }
 
+  private renderToggle(toggleType, defaultText) {
+    switch (toggleType) {
+      case 'dropdown':
         return (
-            <Dropdown
-                onSelect={e => this.onSelect(e)}
-                toggle={this.renderToggle(toggleType, defaultText)}
-                isOpen={isOpen}
-                isPlain={isPlain}
-                dropdownItems={items}
-                position={position || DropdownPosition.right}
-                autoFocus={false}
-            />
+          <DropdownToggle onToggle={e => this.onToggle(e)}>
+            {this.state.selected
+              ? this.state.selected
+              : defaultText || 'Dropdown'}
+          </DropdownToggle>
         );
+      default:
+        return <KebabToggle onToggle={e => this.onToggle(e)} />;
     }
+  }
 
-    private renderToggle(toggleType, defaultText) {
-        switch (toggleType) {
-            case 'dropdown':
-                return (
-                    <DropdownToggle onToggle={e => this.onToggle(e)}>
-                        {this.state.selected
-                            ? this.state.selected
-                            : defaultText || 'Dropdown'}
-                    </DropdownToggle>
-                );
-            default:
-                return <KebabToggle onToggle={e => this.onToggle(e)} />;
+  private onToggle(isOpen) {
+    this.setState({
+      isOpen,
+    });
+  }
+
+  private onSelect(event) {
+    this.setState(
+      {
+        isOpen: !this.state.isOpen,
+        selected: event.currentTarget.value,
+      },
+      () => {
+        if (this.props.onSelect) {
+          this.props.onSelect(event);
         }
-    }
-
-    private onToggle(isOpen) {
-        this.setState({
-            isOpen,
-        });
-    }
-
-    private onSelect(event) {
-        this.setState(
-            {
-                isOpen: !this.state.isOpen,
-                selected: event.currentTarget.value,
-            },
-            () => {
-                if (this.props.onSelect) {
-                    this.props.onSelect(event);
-                }
-            },
-        );
-    }
+      },
+    );
+  }
 }

--- a/src/components/patternfly-wrappers/tabs.tsx
+++ b/src/components/patternfly-wrappers/tabs.tsx
@@ -5,49 +5,45 @@ import { Tab, Tabs as PFTabs } from '@patternfly/react-core';
 import { ParamHelper } from '../../utilities/param-helper';
 
 interface IProps {
-    tabs: string[];
-    params: { tab?: string };
-    updateParams: (params) => void;
+  tabs: string[];
+  params: { tab?: string };
+  updateParams: (params) => void;
 }
 
 export class Tabs extends React.Component<IProps> {
-    render() {
-        const { tabs, params, updateParams } = this.props;
-        return (
-            <PFTabs
-                activeKey={this.getActiveTab()}
-                onSelect={(_, key) =>
-                    updateParams(
-                        ParamHelper.setParam(
-                            params,
-                            'tab',
-                            tabs[key].toLowerCase(),
-                        ),
-                    )
-                }
-            >
-                {tabs.map((tab, i) => (
-                    <Tab key={i} eventKey={i} title={tab} />
-                ))}
-            </PFTabs>
-        );
-    }
-
-    private getActiveTab() {
-        const { params, tabs } = this.props;
-        if (params.tab) {
-            const i = tabs.findIndex(
-                x => x.toLowerCase() === params.tab.toLowerCase(),
-            );
-
-            // If tab is not found, default to the first tab.
-            if (i === -1) {
-                return 0;
-            } else {
-                return i;
-            }
-        } else {
-            return 0;
+  render() {
+    const { tabs, params, updateParams } = this.props;
+    return (
+      <PFTabs
+        activeKey={this.getActiveTab()}
+        onSelect={(_, key) =>
+          updateParams(
+            ParamHelper.setParam(params, 'tab', tabs[key].toLowerCase()),
+          )
         }
+      >
+        {tabs.map((tab, i) => (
+          <Tab key={i} eventKey={i} title={tab} />
+        ))}
+      </PFTabs>
+    );
+  }
+
+  private getActiveTab() {
+    const { params, tabs } = this.props;
+    if (params.tab) {
+      const i = tabs.findIndex(
+        x => x.toLowerCase() === params.tab.toLowerCase(),
+      );
+
+      // If tab is not found, default to the first tab.
+      if (i === -1) {
+        return 0;
+      } else {
+        return i;
+      }
+    } else {
+      return 0;
     }
+  }
 }

--- a/src/components/patternfly-wrappers/toolbar.tsx
+++ b/src/components/patternfly-wrappers/toolbar.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 
 import {
-    Toolbar as ToolbarPF,
-    ToolbarGroup,
-    ToolbarItem,
-    TextInput,
-    InputGroup,
-    Button,
-    ButtonVariant,
+  Toolbar as ToolbarPF,
+  ToolbarGroup,
+  ToolbarItem,
+  TextInput,
+  InputGroup,
+  Button,
+  ButtonVariant,
 } from '@patternfly/react-core';
 
 import { SearchIcon } from '@patternfly/react-icons';
@@ -18,99 +18,95 @@ import { Sort } from '../../components';
 import { SortFieldType } from './sort';
 
 interface IProps {
-    params: {
-        sort?: string;
-        keywords?: string;
-    };
+  params: {
+    sort?: string;
+    keywords?: string;
+  };
 
-    sortOptions?: SortFieldType[];
+  sortOptions?: SortFieldType[];
 
-    updateParams: (params) => void;
-    searchPlaceholder: string;
-    extraInputs?: React.ReactNode[];
+  updateParams: (params) => void;
+  searchPlaceholder: string;
+  extraInputs?: React.ReactNode[];
 }
 
 interface IState {
-    kwField: string;
+  kwField: string;
 }
 
 export class Toolbar extends React.Component<IProps, IState> {
-    static defaultProps = {
-        extraInputs: [],
+  static defaultProps = {
+    extraInputs: [],
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      kwField: props.params.keywords || '',
     };
+  }
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            kwField: props.params.keywords || '',
-        };
-    }
+  render() {
+    const {
+      params,
+      sortOptions,
+      updateParams,
+      searchPlaceholder,
+      extraInputs,
+    } = this.props;
+    const { kwField } = this.state;
+    return (
+      <ToolbarPF>
+        <ToolbarGroup>
+          <ToolbarItem>
+            <InputGroup>
+              <TextInput
+                value={kwField}
+                onChange={k => this.setState({ kwField: k })}
+                onKeyPress={e => this.handleEnter(e)}
+                type='search'
+                aria-label='search text input'
+                placeholder={searchPlaceholder}
+              />
+              <Button
+                variant={ButtonVariant.control}
+                aria-label='search button'
+                onClick={() => this.submitKeywords()}
+              >
+                <SearchIcon />
+              </Button>
+            </InputGroup>
+          </ToolbarItem>
+        </ToolbarGroup>
+        {sortOptions && (
+          <ToolbarGroup>
+            <ToolbarItem>
+              <Sort
+                options={sortOptions}
+                params={params}
+                updateParams={updateParams}
+              />
+            </ToolbarItem>
+          </ToolbarGroup>
+        )}
+        {extraInputs.map((v, i) => (
+          <ToolbarGroup key={i}>
+            <ToolbarItem>{v}</ToolbarItem>
+          </ToolbarGroup>
+        ))}
+      </ToolbarPF>
+    );
+  }
 
-    render() {
-        const {
-            params,
-            sortOptions,
-            updateParams,
-            searchPlaceholder,
-            extraInputs,
-        } = this.props;
-        const { kwField } = this.state;
-        return (
-            <ToolbarPF>
-                <ToolbarGroup>
-                    <ToolbarItem>
-                        <InputGroup>
-                            <TextInput
-                                value={kwField}
-                                onChange={k => this.setState({ kwField: k })}
-                                onKeyPress={e => this.handleEnter(e)}
-                                type='search'
-                                aria-label='search text input'
-                                placeholder={searchPlaceholder}
-                            />
-                            <Button
-                                variant={ButtonVariant.control}
-                                aria-label='search button'
-                                onClick={() => this.submitKeywords()}
-                            >
-                                <SearchIcon />
-                            </Button>
-                        </InputGroup>
-                    </ToolbarItem>
-                </ToolbarGroup>
-                {sortOptions && (
-                    <ToolbarGroup>
-                        <ToolbarItem>
-                            <Sort
-                                options={sortOptions}
-                                params={params}
-                                updateParams={updateParams}
-                            />
-                        </ToolbarItem>
-                    </ToolbarGroup>
-                )}
-                {extraInputs.map((v, i) => (
-                    <ToolbarGroup key={i}>
-                        <ToolbarItem>{v}</ToolbarItem>
-                    </ToolbarGroup>
-                ))}
-            </ToolbarPF>
-        );
+  private handleEnter(e) {
+    if (e.key === 'Enter') {
+      this.submitKeywords();
     }
+  }
 
-    private handleEnter(e) {
-        if (e.key === 'Enter') {
-            this.submitKeywords();
-        }
-    }
-
-    private submitKeywords() {
-        this.props.updateParams(
-            ParamHelper.setParam(
-                this.props.params,
-                'keywords',
-                this.state.kwField,
-            ),
-        );
-    }
+  private submitKeywords() {
+    this.props.updateParams(
+      ParamHelper.setParam(this.props.params, 'keywords', this.state.kwField),
+    );
+  }
 }

--- a/src/components/tags/deprecated-tag.tsx
+++ b/src/components/tags/deprecated-tag.tsx
@@ -1,24 +1,24 @@
 import * as React from 'react';
 
 export class DeprecatedTag extends React.Component<{}, {}> {
-    render() {
-        return (
-            <div
-                style={{
-                    display: 'inline-block',
-                    margin: '4px',
-                    backgroundColor: '#C9190B',
-                    color: 'white',
-                    fontSize: '14px',
-                    paddingLeft: '5px',
-                    paddingRight: '5px',
-                    paddingBottom: '2px',
-                    paddingTop: '2px',
-                    borderRadius: '3px',
-                }}
-            >
-                DEPRECATED
-            </div>
-        );
-    }
+  render() {
+    return (
+      <div
+        style={{
+          display: 'inline-block',
+          margin: '4px',
+          backgroundColor: '#C9190B',
+          color: 'white',
+          fontSize: '14px',
+          paddingLeft: '5px',
+          paddingRight: '5px',
+          paddingBottom: '2px',
+          paddingTop: '2px',
+          borderRadius: '3px',
+        }}
+      >
+        DEPRECATED
+      </div>
+    );
+  }
 }

--- a/src/components/tags/tag-filter.tsx
+++ b/src/components/tags/tag-filter.tsx
@@ -4,66 +4,62 @@ import { Checkbox } from '@patternfly/react-core';
 import { ParamHelper } from '../../utilities/param-helper';
 
 interface IProps {
-    tags: string[];
-    params: {
-        tags?: string | string[];
-    };
-    updateParams: (params) => void;
+  tags: string[];
+  params: {
+    tags?: string | string[];
+  };
+  updateParams: (params) => void;
 }
 
 export class TagFilter extends React.Component<IProps> {
-    tagParam = 'tags';
+  tagParam = 'tags';
 
-    render() {
-        const { tags, params } = this.props;
-        return (
-            <div>
-                <div className='pf-c-content'>
-                    <h4>Tags</h4>
-                </div>
-                {tags.map(t => (
-                    <div
-                        key={t}
-                        style={{
-                            marginLeft: '10px',
-                            marginTop: '5px',
-                        }}
-                    >
-                        <Checkbox
-                            label={
-                                <span
-                                    style={{
-                                        textTransform: 'capitalize',
-                                    }}
-                                >
-                                    {t}
-                                </span>
-                            }
-                            id={t}
-                            isChecked={ParamHelper.paramExists(
-                                params,
-                                this.tagParam,
-                                t,
-                            )}
-                            onChange={checked => this.updateTags(t, checked)}
-                        />
-                    </div>
-                ))}
-            </div>
-        );
+  render() {
+    const { tags, params } = this.props;
+    return (
+      <div>
+        <div className='pf-c-content'>
+          <h4>Tags</h4>
+        </div>
+        {tags.map(t => (
+          <div
+            key={t}
+            style={{
+              marginLeft: '10px',
+              marginTop: '5px',
+            }}
+          >
+            <Checkbox
+              label={
+                <span
+                  style={{
+                    textTransform: 'capitalize',
+                  }}
+                >
+                  {t}
+                </span>
+              }
+              id={t}
+              isChecked={ParamHelper.paramExists(params, this.tagParam, t)}
+              onChange={checked => this.updateTags(t, checked)}
+            />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  private updateTags(tag, checked) {
+    const { params } = this.props;
+
+    let newParams;
+
+    if (checked) {
+      newParams = ParamHelper.appendParam(params, this.tagParam, tag);
+    } else {
+      newParams = ParamHelper.deleteParam(params, this.tagParam, tag);
     }
 
-    private updateTags(tag, checked) {
-        const { params } = this.props;
-
-        let newParams;
-
-        if (checked) {
-            newParams = ParamHelper.appendParam(params, this.tagParam, tag);
-        } else {
-            newParams = ParamHelper.deleteParam(params, this.tagParam, tag);
-        }
-
-        this.props.updateParams(newParams);
-    }
+    this.props.updateParams(newParams);
+  }
 }

--- a/src/components/tags/tag.scss
+++ b/src/components/tags/tag.scss
@@ -1,3 +1,3 @@
 .tag {
-    margin: 4px;
+  margin: 4px;
 }

--- a/src/components/tags/tag.tsx
+++ b/src/components/tags/tag.tsx
@@ -4,15 +4,15 @@ import './tag.scss';
 import { Chip } from '@patternfly/react-core';
 
 interface IProps {
-    children: string;
+  children: string;
 }
 
 export class Tag extends React.Component<IProps, {}> {
-    render() {
-        return (
-            <Chip className='tag' isReadOnly>
-                {this.props.children}
-            </Chip>
-        );
-    }
+  render() {
+    return (
+      <Chip className='tag' isReadOnly>
+        {this.props.children}
+      </Chip>
+    );
+  }
 }

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,12 +1,12 @@
 export class Constants {
-    static readonly SEARCH_VIEW_TYPE_LOCAL_KEY = 'search_view_type';
-    static readonly DEFAULT_PAGE_SIZE = 10;
-    static readonly DEFAULT_PAGINATION_OPTIONS = [10, 20, 50, 100];
+  static readonly SEARCH_VIEW_TYPE_LOCAL_KEY = 'search_view_type';
+  static readonly DEFAULT_PAGE_SIZE = 10;
+  static readonly DEFAULT_PAGINATION_OPTIONS = [10, 20, 50, 100];
 
-    static readonly CARD_DEFAULT_PAGE_SIZE = 12;
-    static readonly CARD_DEFAULT_PAGINATION_OPTIONS = [12, 24, 60, 120];
-    static readonly INSIGHTS_DEPLOYMENT_MODE = 'insights';
-    static readonly STANDALONE_DEPLOYMENT_MODE = 'standalone';
+  static readonly CARD_DEFAULT_PAGE_SIZE = 12;
+  static readonly CARD_DEFAULT_PAGINATION_OPTIONS = [12, 24, 60, 120];
+  static readonly INSIGHTS_DEPLOYMENT_MODE = 'insights';
+  static readonly STANDALONE_DEPLOYMENT_MODE = 'standalone';
 
-    static readonly ADMIN_GROUP = 'system:partner-engineers';
+  static readonly ADMIN_GROUP = 'system:partner-engineers';
 }

--- a/src/containers/certification-dashboard/certification-dashboard.scss
+++ b/src/containers/certification-dashboard/certification-dashboard.scss
@@ -1,31 +1,31 @@
 .toolbar {
-    padding-bottom: 16px;
-    display: flex;
-    justify-content: space-between;
+  padding-bottom: 16px;
+  display: flex;
+  justify-content: space-between;
 }
 
 .certified-icon {
-    color: var(--pf-global--success-color--100);
+  color: var(--pf-global--success-color--100);
 }
 
 .rejected-icon {
-    color: var(--pf-global--danger-color--100);
+  color: var(--pf-global--danger-color--100);
 }
 
 .needs-review-icon {
-    color: var(--pf-global--info-color--100);
+  color: var(--pf-global--info-color--100);
 }
 
 .control-column {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
 }
 
 .footer {
-    padding-top: 16px;
+  padding-top: 16px;
 }
 
 .updating-spinner {
-    color: var(--pf-global--info-color--100);
+  color: var(--pf-global--info-color--100);
 }

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -3,529 +3,498 @@ import './certification-dashboard.scss';
 
 import * as moment from 'moment';
 import {
-    withRouter,
-    RouteComponentProps,
-    Link,
-    Redirect,
+  withRouter,
+  RouteComponentProps,
+  Link,
+  Redirect,
 } from 'react-router-dom';
 import { BaseHeader, Main } from '../../components';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import {
-    Toolbar,
-    ToolbarGroup,
-    ToolbarItem,
-    Button,
-    DropdownItem,
-    EmptyState,
-    EmptyStateIcon,
-    Title,
-    EmptyStateBody,
-    EmptyStateVariant,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem,
+  Button,
+  DropdownItem,
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+  EmptyStateBody,
+  EmptyStateVariant,
 } from '@patternfly/react-core';
 
 import {
-    InfoCircleIcon,
-    ExclamationCircleIcon,
-    CheckCircleIcon,
-    WarningTriangleIcon,
+  InfoCircleIcon,
+  ExclamationCircleIcon,
+  CheckCircleIcon,
+  WarningTriangleIcon,
 } from '@patternfly/react-icons';
 
 import {
-    CollectionVersionAPI,
-    CollectionVersion,
-    CertificationStatus,
-    UserAPI,
-    MeType,
+  CollectionVersionAPI,
+  CollectionVersion,
+  CertificationStatus,
+  UserAPI,
+  MeType,
 } from '../../api';
 import { ParamHelper } from '../../utilities';
 import {
-    LoadingPageWithHeader,
-    StatefulDropdown,
-    CompoundFilter,
-    LoadingPageSpinner,
-    AppliedFilters,
-    Pagination,
-    Sort,
-    AlertList,
-    closeAlertMixin,
-    AlertType,
-    SortFieldType,
+  LoadingPageWithHeader,
+  StatefulDropdown,
+  CompoundFilter,
+  LoadingPageSpinner,
+  AppliedFilters,
+  Pagination,
+  Sort,
+  AlertList,
+  closeAlertMixin,
+  AlertType,
+  SortFieldType,
 } from '../../components';
 import { Paths, formatPath } from '../../paths';
 
 interface IState {
-    params: {
-        certification?: string;
-        namespace?: string;
-        collection?: string;
-        page?: number;
-        page_size?: number;
-    };
-    alerts: AlertType[];
-    versions: CollectionVersion[];
-    itemCount: number;
-    loading: boolean;
-    updatingVersions: string[];
-    redirect: string;
+  params: {
+    certification?: string;
+    namespace?: string;
+    collection?: string;
+    page?: number;
+    page_size?: number;
+  };
+  alerts: AlertType[];
+  versions: CollectionVersion[];
+  itemCount: number;
+  loading: boolean;
+  updatingVersions: string[];
+  redirect: string;
 }
 
 class CertificationDashboard extends React.Component<
-    RouteComponentProps,
-    IState
+  RouteComponentProps,
+  IState
 > {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        const params = ParamHelper.parseParamString(props.location.search, [
-            'page',
-            'page_size',
-        ]);
+    const params = ParamHelper.parseParamString(props.location.search, [
+      'page',
+      'page_size',
+    ]);
 
-        if (!params['page_size']) {
-            params['page_size'] = 10;
-        }
-
-        if (!params['sort']) {
-            params['sort'] = '-pulp_created';
-        }
-
-        if (!params['certification']) {
-            params['certification'] = CertificationStatus.needsReview;
-        }
-
-        this.state = {
-            versions: undefined,
-            itemCount: 0,
-            params: params,
-            loading: true,
-            updatingVersions: [],
-            redirect: undefined,
-            alerts: [],
-        };
+    if (!params['page_size']) {
+      params['page_size'] = 10;
     }
 
-    componentDidMount() {
-        UserAPI.isPartnerEngineer().then(response => {
-            const me: MeType = response.data;
-            if (!me.is_partner_engineer) {
-                this.setState({ redirect: Paths.notFound });
-            } else {
-                this.queryCollections();
-            }
-        });
+    if (!params['sort']) {
+      params['sort'] = '-pulp_created';
     }
 
-    render() {
-        const { versions, params, itemCount, loading, redirect } = this.state;
-
-        if (redirect) {
-            return <Redirect to={redirect}></Redirect>;
-        }
-
-        const sortOptions: SortFieldType[] = [
-            {
-                id: 'pulp_created',
-                title: 'Date created',
-                type: 'numeric',
-            },
-            { id: 'namespace', title: 'Namespace name', type: 'alpha' },
-            { id: 'version', title: 'Version number', type: 'numeric' },
-            { id: 'name', title: 'Collection name', type: 'alpha' },
-        ];
-
-        if (!versions) {
-            return <LoadingPageWithHeader></LoadingPageWithHeader>;
-        }
-        return (
-            <React.Fragment>
-                <BaseHeader title='Certification dashboard'></BaseHeader>
-                <AlertList
-                    alerts={this.state.alerts}
-                    closeAlert={i => this.closeAlert(i)}
-                />
-                <Main>
-                    <Section className='body'>
-                        <div className='toolbar'>
-                            <Toolbar>
-                                <ToolbarGroup>
-                                    <ToolbarItem>
-                                        <CompoundFilter
-                                            updateParams={p =>
-                                                this.updateParams(p, () =>
-                                                    this.queryCollections(),
-                                                )
-                                            }
-                                            params={params}
-                                            filterConfig={[
-                                                {
-                                                    id: 'namespace',
-                                                    title: 'Namespace',
-                                                },
-                                                {
-                                                    id: 'name',
-                                                    title: 'Collection Name',
-                                                },
-                                                {
-                                                    id: 'certification',
-                                                    title:
-                                                        'Certification Status',
-                                                    inputType: 'select',
-                                                    options: [
-                                                        {
-                                                            id: 'not_certified',
-                                                            title: 'Rejected',
-                                                        },
-                                                        {
-                                                            id: 'needs_review',
-                                                            title:
-                                                                'Needs Review',
-                                                        },
-                                                        {
-                                                            id: 'certified',
-                                                            title: 'Certified',
-                                                        },
-                                                    ],
-                                                },
-                                            ]}
-                                        />
-                                    </ToolbarItem>
-                                </ToolbarGroup>
-                                <ToolbarGroup>
-                                    <ToolbarItem>
-                                        <Sort
-                                            options={sortOptions}
-                                            params={params}
-                                            updateParams={p =>
-                                                this.updateParams(p, () =>
-                                                    this.queryCollections(),
-                                                )
-                                            }
-                                        />
-                                    </ToolbarItem>
-                                </ToolbarGroup>
-                            </Toolbar>
-
-                            <Pagination
-                                params={params}
-                                updateParams={p =>
-                                    this.updateParams(p, () =>
-                                        this.queryCollections(),
-                                    )
-                                }
-                                count={itemCount}
-                                isTop
-                            />
-                        </div>
-                        <div>
-                            <AppliedFilters
-                                updateParams={p =>
-                                    this.updateParams(p, () =>
-                                        this.queryCollections(),
-                                    )
-                                }
-                                params={params}
-                                ignoredParams={['page_size', 'page', 'sort']}
-                            />
-                        </div>
-                        {loading ? (
-                            <LoadingPageSpinner />
-                        ) : (
-                            this.renderTable(versions)
-                        )}
-
-                        <div className='footer'>
-                            <Pagination
-                                params={params}
-                                updateParams={p =>
-                                    this.updateParams(p, () =>
-                                        this.queryCollections(),
-                                    )
-                                }
-                                count={itemCount}
-                            />
-                        </div>
-                    </Section>
-                </Main>
-            </React.Fragment>
-        );
+    if (!params['certification']) {
+      params['certification'] = CertificationStatus.needsReview;
     }
 
-    private renderTable(versions) {
-        if (versions.length === 0) {
-            return (
-                <EmptyState className='empty' variant={EmptyStateVariant.full}>
-                    <EmptyStateIcon icon={WarningTriangleIcon} />
-                    <Title headingLevel='h2' size='lg'>
-                        No matches
-                    </Title>
-                    <EmptyStateBody>
-                        Please try adjusting your search query.
-                    </EmptyStateBody>
-                </EmptyState>
-            );
-        }
+    this.state = {
+      versions: undefined,
+      itemCount: 0,
+      params: params,
+      loading: true,
+      updatingVersions: [],
+      redirect: undefined,
+      alerts: [],
+    };
+  }
 
-        return (
-            <table
-                aria-label='Collection versions'
-                className='content-table pf-c-table'
-            >
-                <thead>
-                    <tr aria-labelledby='headers'>
-                        <th>Namespace</th>
-                        <th>Collection</th>
-                        <th>Version</th>
-                        <th>Date created</th>
-                        <th>Status</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {versions.map((version, i) => this.renderRow(version, i))}
-                </tbody>
-            </table>
-        );
+  componentDidMount() {
+    UserAPI.isPartnerEngineer().then(response => {
+      const me: MeType = response.data;
+      if (!me.is_partner_engineer) {
+        this.setState({ redirect: Paths.notFound });
+      } else {
+        this.queryCollections();
+      }
+    });
+  }
+
+  render() {
+    const { versions, params, itemCount, loading, redirect } = this.state;
+
+    if (redirect) {
+      return <Redirect to={redirect}></Redirect>;
     }
 
-    private renderStatus(version: CollectionVersion) {
-        if (this.state.updatingVersions.includes(version.id)) {
-            return <span className='fa fa-lg fa-spin fa-spinner' />;
-        }
-        switch (version.certification) {
-            case CertificationStatus.certified:
-                return (
-                    <span>
-                        <CheckCircleIcon className='certified-icon' /> Certified
-                    </span>
-                );
-            case CertificationStatus.notCertified:
-                return (
-                    <span>
-                        <ExclamationCircleIcon className='rejected-icon' />{' '}
-                        Rejected
-                    </span>
-                );
-            case CertificationStatus.needsReview:
-                return (
-                    <span>
-                        <InfoCircleIcon className='needs-review-icon' /> Needs
-                        Review
-                    </span>
-                );
-        }
-    }
+    const sortOptions: SortFieldType[] = [
+      {
+        id: 'pulp_created',
+        title: 'Date created',
+        type: 'numeric',
+      },
+      { id: 'namespace', title: 'Namespace name', type: 'alpha' },
+      { id: 'version', title: 'Version number', type: 'numeric' },
+      { id: 'name', title: 'Collection name', type: 'alpha' },
+    ];
 
-    private renderRow(version: CollectionVersion, index) {
-        return (
-            <tr
-                aria-labelledby={`${version.namespace}.${version.name} v${version.version}`}
-                key={index}
-            >
-                <td>{version.namespace}</td>
-                <td>{version.name}</td>
-                <td>
-                    <Link
-                        to={formatPath(
-                            Paths.collection,
+    if (!versions) {
+      return <LoadingPageWithHeader></LoadingPageWithHeader>;
+    }
+    return (
+      <React.Fragment>
+        <BaseHeader title='Certification dashboard'></BaseHeader>
+        <AlertList
+          alerts={this.state.alerts}
+          closeAlert={i => this.closeAlert(i)}
+        />
+        <Main>
+          <Section className='body'>
+            <div className='toolbar'>
+              <Toolbar>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    <CompoundFilter
+                      updateParams={p =>
+                        this.updateParams(p, () => this.queryCollections())
+                      }
+                      params={params}
+                      filterConfig={[
+                        {
+                          id: 'namespace',
+                          title: 'Namespace',
+                        },
+                        {
+                          id: 'name',
+                          title: 'Collection Name',
+                        },
+                        {
+                          id: 'certification',
+                          title: 'Certification Status',
+                          inputType: 'select',
+                          options: [
                             {
-                                namespace: version.namespace,
-                                collection: version.name,
+                              id: 'not_certified',
+                              title: 'Rejected',
                             },
                             {
-                                version: version.version,
+                              id: 'needs_review',
+                              title: 'Needs Review',
                             },
-                        )}
-                    >
-                        {version.version}
-                    </Link>
-                </td>
-                <td>{moment(version.created_at).fromNow()}</td>
-                <td>{this.renderStatus(version)}</td>
-                <td>
-                    <div className='control-column'>
-                        <div>{this.renderButtons(version)}</div>
-                    </div>
-                </td>
-            </tr>
-        );
-    }
-
-    private renderButtons(version: CollectionVersion) {
-        const importsLink = (
-            <DropdownItem
-                key='imports'
-                component={
-                    <Link
-                        to={formatPath(
-                            Paths.myImports,
-                            {},
                             {
-                                namespace: version.namespace,
-                                name: version.name,
-                                version: version.version,
+                              id: 'certified',
+                              title: 'Certified',
                             },
-                        )}
-                    >
-                        View Import Logs
-                    </Link>
+                          ],
+                        },
+                      ]}
+                    />
+                  </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    <Sort
+                      options={sortOptions}
+                      params={params}
+                      updateParams={p =>
+                        this.updateParams(p, () => this.queryCollections())
+                      }
+                    />
+                  </ToolbarItem>
+                </ToolbarGroup>
+              </Toolbar>
+
+              <Pagination
+                params={params}
+                updateParams={p =>
+                  this.updateParams(p, () => this.queryCollections())
                 }
+                count={itemCount}
+                isTop
+              />
+            </div>
+            <div>
+              <AppliedFilters
+                updateParams={p =>
+                  this.updateParams(p, () => this.queryCollections())
+                }
+                params={params}
+                ignoredParams={['page_size', 'page', 'sort']}
+              />
+            </div>
+            {loading ? <LoadingPageSpinner /> : this.renderTable(versions)}
+
+            <div className='footer'>
+              <Pagination
+                params={params}
+                updateParams={p =>
+                  this.updateParams(p, () => this.queryCollections())
+                }
+                count={itemCount}
+              />
+            </div>
+          </Section>
+        </Main>
+      </React.Fragment>
+    );
+  }
+
+  private renderTable(versions) {
+    if (versions.length === 0) {
+      return (
+        <EmptyState className='empty' variant={EmptyStateVariant.full}>
+          <EmptyStateIcon icon={WarningTriangleIcon} />
+          <Title headingLevel='h2' size='lg'>
+            No matches
+          </Title>
+          <EmptyStateBody>
+            Please try adjusting your search query.
+          </EmptyStateBody>
+        </EmptyState>
+      );
+    }
+
+    return (
+      <table
+        aria-label='Collection versions'
+        className='content-table pf-c-table'
+      >
+        <thead>
+          <tr aria-labelledby='headers'>
+            <th>Namespace</th>
+            <th>Collection</th>
+            <th>Version</th>
+            <th>Date created</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {versions.map((version, i) => this.renderRow(version, i))}
+        </tbody>
+      </table>
+    );
+  }
+
+  private renderStatus(version: CollectionVersion) {
+    if (this.state.updatingVersions.includes(version.id)) {
+      return <span className='fa fa-lg fa-spin fa-spinner' />;
+    }
+    switch (version.certification) {
+      case CertificationStatus.certified:
+        return (
+          <span>
+            <CheckCircleIcon className='certified-icon' /> Certified
+          </span>
+        );
+      case CertificationStatus.notCertified:
+        return (
+          <span>
+            <ExclamationCircleIcon className='rejected-icon' /> Rejected
+          </span>
+        );
+      case CertificationStatus.needsReview:
+        return (
+          <span>
+            <InfoCircleIcon className='needs-review-icon' /> Needs Review
+          </span>
+        );
+    }
+  }
+
+  private renderRow(version: CollectionVersion, index) {
+    return (
+      <tr
+        aria-labelledby={`${version.namespace}.${version.name} v${version.version}`}
+        key={index}
+      >
+        <td>{version.namespace}</td>
+        <td>{version.name}</td>
+        <td>
+          <Link
+            to={formatPath(
+              Paths.collection,
+              {
+                namespace: version.namespace,
+                collection: version.name,
+              },
+              {
+                version: version.version,
+              },
+            )}
+          >
+            {version.version}
+          </Link>
+        </td>
+        <td>{moment(version.created_at).fromNow()}</td>
+        <td>{this.renderStatus(version)}</td>
+        <td>
+          <div className='control-column'>
+            <div>{this.renderButtons(version)}</div>
+          </div>
+        </td>
+      </tr>
+    );
+  }
+
+  private renderButtons(version: CollectionVersion) {
+    const importsLink = (
+      <DropdownItem
+        key='imports'
+        component={
+          <Link
+            to={formatPath(
+              Paths.myImports,
+              {},
+              {
+                namespace: version.namespace,
+                name: version.name,
+                version: version.version,
+              },
+            )}
+          >
+            View Import Logs
+          </Link>
+        }
+      />
+    );
+
+    const certifyDropDown = (isDisabled: boolean) => (
+      <DropdownItem
+        onClick={() =>
+          this.updateCertification(version, CertificationStatus.certified)
+        }
+        isDisabled={isDisabled}
+        key='certify'
+      >
+        Certify
+      </DropdownItem>
+    );
+
+    const rejectDropDown = (isDisabled: boolean) => (
+      <DropdownItem
+        onClick={() =>
+          this.updateCertification(version, CertificationStatus.notCertified)
+        }
+        isDisabled={isDisabled}
+        className='rejected-icon'
+        key='reject'
+      >
+        Reject
+      </DropdownItem>
+    );
+
+    switch (version.certification) {
+      case CertificationStatus.certified:
+        return (
+          <span>
+            <StatefulDropdown
+              items={[
+                certifyDropDown(true),
+                rejectDropDown(false),
+                importsLink,
+              ]}
             />
+          </span>
         );
-
-        const certifyDropDown = (isDisabled: boolean) => (
-            <DropdownItem
-                onClick={() =>
-                    this.updateCertification(
-                        version,
-                        CertificationStatus.certified,
-                    )
-                }
-                isDisabled={isDisabled}
-                key='certify'
+      case CertificationStatus.notCertified:
+        return (
+          <span>
+            <StatefulDropdown
+              items={[
+                certifyDropDown(false),
+                rejectDropDown(true),
+                importsLink,
+              ]}
+            />
+          </span>
+        );
+      case CertificationStatus.needsReview:
+        return (
+          <span>
+            <Button
+              onClick={() =>
+                this.updateCertification(version, CertificationStatus.certified)
+              }
             >
-                Certify
-            </DropdownItem>
-        );
-
-        const rejectDropDown = (isDisabled: boolean) => (
-            <DropdownItem
-                onClick={() =>
-                    this.updateCertification(
-                        version,
-                        CertificationStatus.notCertified,
-                    )
-                }
-                isDisabled={isDisabled}
-                className='rejected-icon'
-                key='reject'
-            >
-                Reject
-            </DropdownItem>
-        );
-
-        switch (version.certification) {
-            case CertificationStatus.certified:
-                return (
-                    <span>
-                        <StatefulDropdown
-                            items={[
-                                certifyDropDown(true),
-                                rejectDropDown(false),
-                                importsLink,
-                            ]}
-                        />
-                    </span>
-                );
-            case CertificationStatus.notCertified:
-                return (
-                    <span>
-                        <StatefulDropdown
-                            items={[
-                                certifyDropDown(false),
-                                rejectDropDown(true),
-                                importsLink,
-                            ]}
-                        />
-                    </span>
-                );
-            case CertificationStatus.needsReview:
-                return (
-                    <span>
-                        <Button
-                            onClick={() =>
-                                this.updateCertification(
-                                    version,
-                                    CertificationStatus.certified,
-                                )
-                            }
-                        >
-                            <span>Certify</span>
-                        </Button>
-                        <StatefulDropdown
-                            items={[rejectDropDown(false), importsLink]}
-                        />
-                    </span>
-                );
-        }
-    }
-
-    private updateCertification(version, certification) {
-        // Set the selected version to loading
-        this.setState(
-            {
-                updatingVersions: this.state.updatingVersions.concat([
-                    version.id,
-                ]),
-            },
-            () =>
-                // Perform the PUT request
-                CollectionVersionAPI.setCertifiation(
-                    version.namespace,
-                    version.name,
-                    version.version,
-                    certification,
-                )
-                    .then(() =>
-                        // Since pulp doesn't reply with the new object, perform a
-                        // second query to get the updated data
-                        CollectionVersionAPI.list({
-                            namespace: version.namespace,
-                            name: version.name,
-                            version: version.version,
-                        }).then(result => {
-                            const updatedVersion = result.data.data[0];
-                            const newVersionList = [...this.state.versions];
-                            const ind = newVersionList.findIndex(
-                                x => x.id === updatedVersion.id,
-                            );
-                            newVersionList[ind] = updatedVersion;
-
-                            this.setState({
-                                versions: newVersionList,
-                                updatingVersions: this.state.updatingVersions.filter(
-                                    v => v != updatedVersion.id,
-                                ),
-                            });
-                        }),
-                    )
-                    .catch(error => {
-                        this.setState({
-                            updatingVersions: this.state.updatingVersions.filter(
-                                v => v != version.id,
-                            ),
-                            alerts: this.state.alerts.concat({
-                                variant: 'danger',
-                                title: `API Error: ${error.response.status}`,
-                                description:
-                                    `Could not update the certification ` +
-                                    `status for ${version.namespace}.` +
-                                    `${version.name}.${version.version}.`,
-                            }),
-                        });
-                    }),
+              <span>Certify</span>
+            </Button>
+            <StatefulDropdown items={[rejectDropDown(false), importsLink]} />
+          </span>
         );
     }
+  }
 
-    private queryCollections() {
-        this.setState({ loading: true }, () =>
-            CollectionVersionAPI.list(this.state.params).then(result =>
-                this.setState({
-                    versions: result.data.data,
-                    itemCount: result.data.meta.count,
-                    loading: false,
-                    updatingVersions: [],
-                }),
-            ),
-        );
-    }
+  private updateCertification(version, certification) {
+    // Set the selected version to loading
+    this.setState(
+      {
+        updatingVersions: this.state.updatingVersions.concat([version.id]),
+      },
+      () =>
+        // Perform the PUT request
+        CollectionVersionAPI.setCertifiation(
+          version.namespace,
+          version.name,
+          version.version,
+          certification,
+        )
+          .then(() =>
+            // Since pulp doesn't reply with the new object, perform a
+            // second query to get the updated data
+            CollectionVersionAPI.list({
+              namespace: version.namespace,
+              name: version.name,
+              version: version.version,
+            }).then(result => {
+              const updatedVersion = result.data.data[0];
+              const newVersionList = [...this.state.versions];
+              const ind = newVersionList.findIndex(
+                x => x.id === updatedVersion.id,
+              );
+              newVersionList[ind] = updatedVersion;
 
-    private get updateParams() {
-        return ParamHelper.updateParamsMixin();
-    }
+              this.setState({
+                versions: newVersionList,
+                updatingVersions: this.state.updatingVersions.filter(
+                  v => v != updatedVersion.id,
+                ),
+              });
+            }),
+          )
+          .catch(error => {
+            this.setState({
+              updatingVersions: this.state.updatingVersions.filter(
+                v => v != version.id,
+              ),
+              alerts: this.state.alerts.concat({
+                variant: 'danger',
+                title: `API Error: ${error.response.status}`,
+                description:
+                  `Could not update the certification ` +
+                  `status for ${version.namespace}.` +
+                  `${version.name}.${version.version}.`,
+              }),
+            });
+          }),
+    );
+  }
 
-    private get closeAlert() {
-        return closeAlertMixin('alerts');
-    }
+  private queryCollections() {
+    this.setState({ loading: true }, () =>
+      CollectionVersionAPI.list(this.state.params).then(result =>
+        this.setState({
+          versions: result.data.data,
+          itemCount: result.data.meta.count,
+          loading: false,
+          updatingVersions: [],
+        }),
+      ),
+    );
+  }
+
+  private get updateParams() {
+    return ParamHelper.updateParamsMixin();
+  }
+
+  private get closeAlert() {
+    return closeAlertMixin('alerts');
+  }
 }
 
 export default withRouter(CertificationDashboard);

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -2,25 +2,25 @@ import { CollectionDetailType, CollectionAPI } from '../../api';
 import { Paths } from '../../paths';
 
 export interface IBaseCollectionState {
-    params: {
-        version?: string;
-        showing?: string;
-        keywords?: string;
-    };
-    collection: CollectionDetailType;
+  params: {
+    version?: string;
+    showing?: string;
+    keywords?: string;
+  };
+  collection: CollectionDetailType;
 }
 
 export function loadCollection(forceReload = false, callback = () => null) {
-    CollectionAPI.getCached(
-        this.props.match.params['namespace'],
-        this.props.match.params['collection'],
-        this.state.params,
-        forceReload,
-    )
-        .then(result => {
-            this.setState({ collection: result }, callback);
-        })
-        .catch(result => {
-            this.props.history.push(Paths.notFound);
-        });
+  CollectionAPI.getCached(
+    this.props.match.params['namespace'],
+    this.props.match.params['collection'],
+    this.state.params,
+    forceReload,
+  )
+    .then(result => {
+      this.setState({ collection: result }, callback);
+    })
+    .catch(result => {
+      this.props.history.push(Paths.notFound);
+    });
 }

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -4,10 +4,10 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 
 import {
-    CollectionHeader,
-    CollectionContentList,
-    LoadingPageWithHeader,
-    Main,
+  CollectionHeader,
+  CollectionContentList,
+  LoadingPageWithHeader,
+  Main,
 } from '../../components';
 import { loadCollection, IBaseCollectionState } from './base';
 import { ParamHelper } from '../../utilities/param-helper';
@@ -15,84 +15,82 @@ import { formatPath, Paths } from '../../paths';
 
 // renders list of contents in a collection
 class CollectionImportLog extends React.Component<
-    RouteComponentProps,
-    IBaseCollectionState
+  RouteComponentProps,
+  IBaseCollectionState
 > {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        const params = ParamHelper.parseParamString(props.location.search);
+    const params = ParamHelper.parseParamString(props.location.search);
 
-        this.state = {
-            collection: undefined,
-            params: params,
-        };
+    this.state = {
+      collection: undefined,
+      params: params,
+    };
+  }
+
+  componentDidMount() {
+    this.loadCollection();
+  }
+
+  render() {
+    const { collection, params } = this.state;
+
+    if (!collection) {
+      return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    componentDidMount() {
-        this.loadCollection();
-    }
+    const breadcrumbs = [
+      { url: Paths.partners, name: 'Partners' },
+      {
+        url: formatPath(Paths.namespace, {
+          namespace: collection.namespace.name,
+        }),
+        name: collection.namespace.name,
+      },
+      {
+        url: formatPath(Paths.collection, {
+          namespace: collection.namespace.name,
+          collection: collection.name,
+        }),
+        name: collection.name,
+      },
+      { name: 'Content' },
+    ];
 
-    render() {
-        const { collection, params } = this.state;
+    return (
+      <React.Fragment>
+        <CollectionHeader
+          collection={collection}
+          params={params}
+          updateParams={params =>
+            this.updateParams(params, () => this.loadCollection(true))
+          }
+          breadcrumbs={breadcrumbs}
+          activeTab='contents'
+        />
+        <Main>
+          <Section className='body'>
+            <CollectionContentList
+              contents={collection.latest_version.contents}
+              collection={collection.name}
+              namespace={collection.namespace.name}
+              params={params}
+              updateParams={p => this.updateParams(p)}
+            ></CollectionContentList>
+          </Section>
+        </Main>
+      </React.Fragment>
+    );
+  }
 
-        if (!collection) {
-            return <LoadingPageWithHeader></LoadingPageWithHeader>;
-        }
+  get loadCollection() {
+    return loadCollection;
+  }
 
-        const breadcrumbs = [
-            { url: Paths.partners, name: 'Partners' },
-            {
-                url: formatPath(Paths.namespace, {
-                    namespace: collection.namespace.name,
-                }),
-                name: collection.namespace.name,
-            },
-            {
-                url: formatPath(Paths.collection, {
-                    namespace: collection.namespace.name,
-                    collection: collection.name,
-                }),
-                name: collection.name,
-            },
-            { name: 'Content' },
-        ];
-
-        return (
-            <React.Fragment>
-                <CollectionHeader
-                    collection={collection}
-                    params={params}
-                    updateParams={params =>
-                        this.updateParams(params, () =>
-                            this.loadCollection(true),
-                        )
-                    }
-                    breadcrumbs={breadcrumbs}
-                    activeTab='contents'
-                />
-                <Main>
-                    <Section className='body'>
-                        <CollectionContentList
-                            contents={collection.latest_version.contents}
-                            collection={collection.name}
-                            namespace={collection.namespace.name}
-                            params={params}
-                            updateParams={p => this.updateParams(p)}
-                        ></CollectionContentList>
-                    </Section>
-                </Main>
-            </React.Fragment>
-        );
-    }
-
-    get loadCollection() {
-        return loadCollection;
-    }
-
-    get updateParams() {
-        return ParamHelper.updateParamsMixin();
-    }
+  get updateParams() {
+    return ParamHelper.updateParamsMixin();
+  }
 }
 
 export default withRouter(CollectionImportLog);

--- a/src/containers/collection-detail/collection-detail.scss
+++ b/src/containers/collection-detail/collection-detail.scss
@@ -1,48 +1,48 @@
 @import '../../global-variables.scss';
 
 .main {
-    margin: 0px;
-    padding: 0px;
+  margin: 0px;
+  padding: 0px;
 }
 
 .header {
-    border-bottom: 1px solid #d8d8d8;
+  border-bottom: 1px solid #d8d8d8;
 }
 
 .docs-container {
-    padding-top: 24px;
-    background-color: white;
-    @media (min-width: $breakpoint-md) {
-        display: flex;
+  padding-top: 24px;
+  background-color: white;
+  @media (min-width: $breakpoint-md) {
+    display: flex;
+  }
+
+  .sidebar {
+    // This width lines up the border nicely with the tabs
+    min-width: 294px;
+    max-width: 294px;
+    border-right: 1px solid #d8d8d8;
+    padding: 0px;
+    padding-top: 0px;
+  }
+
+  .docs {
+    flex-grow: 1;
+    padding: 24px;
+    padding-top: 0px;
+
+    // make the height close to the height ofthe page so short docs don't
+    // look weird
+    min-height: calc(100vh - 250px);
+
+    table {
+      tr:nth-child(2n) {
+        background-color: #f2f2f2;
+      }
+      td,
+      th {
+        border: 1px solid #ccc;
+        padding: 5px;
+      }
     }
-
-    .sidebar {
-        // This width lines up the border nicely with the tabs
-        min-width: 294px;
-        max-width: 294px;
-        border-right: 1px solid #d8d8d8;
-        padding: 0px;
-        padding-top: 0px;
-    }
-
-    .docs {
-        flex-grow: 1;
-        padding: 24px;
-        padding-top: 0px;
-
-        // make the height close to the height ofthe page so short docs don't
-        // look weird
-        min-height: calc(100vh - 250px);
-
-        table {
-            tr:nth-child(2n) {
-                background-color: #f2f2f2;
-            }
-            td,
-            th {
-                border: 1px solid #ccc;
-                padding: 5px;
-            }
-        }
-    }
+  }
 }

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -4,10 +4,10 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 
 import {
-    CollectionHeader,
-    CollectionInfo,
-    LoadingPageWithHeader,
-    Main,
+  CollectionHeader,
+  CollectionInfo,
+  LoadingPageWithHeader,
+  Main,
 } from '../../components';
 import { loadCollection, IBaseCollectionState } from './base';
 import { ParamHelper } from '../../utilities/param-helper';
@@ -15,75 +15,75 @@ import { formatPath, Paths } from '../../paths';
 
 // renders collection level information
 class CollectionDetail extends React.Component<
-    RouteComponentProps,
-    IBaseCollectionState
+  RouteComponentProps,
+  IBaseCollectionState
 > {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        const params = ParamHelper.parseParamString(props.location.search);
+    const params = ParamHelper.parseParamString(props.location.search);
 
-        this.state = {
-            collection: undefined,
-            params: params,
-        };
+    this.state = {
+      collection: undefined,
+      params: params,
+    };
+  }
+
+  componentDidMount() {
+    this.loadCollection();
+  }
+
+  render() {
+    const { collection, params } = this.state;
+
+    if (!collection) {
+      return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    componentDidMount() {
-        this.loadCollection();
-    }
+    const breadcrumbs = [
+      { url: Paths.partners, name: 'Partners' },
+      {
+        url: formatPath(Paths.namespace, {
+          namespace: collection.namespace.name,
+        }),
+        name: collection.namespace.name,
+      },
+      {
+        name: collection.name,
+      },
+    ];
 
-    render() {
-        const { collection, params } = this.state;
+    return (
+      <React.Fragment>
+        <CollectionHeader
+          collection={collection}
+          params={params}
+          updateParams={p =>
+            this.updateParams(p, () => this.loadCollection(true))
+          }
+          breadcrumbs={breadcrumbs}
+          activeTab='details'
+        />
+        <Main>
+          <Section className='body'>
+            <CollectionInfo
+              {...collection}
+              updateParams={p => this.updateParams(p)}
+              params={this.state.params}
+            />
+          </Section>
+        </Main>
+      </React.Fragment>
+    );
+  }
 
-        if (!collection) {
-            return <LoadingPageWithHeader></LoadingPageWithHeader>;
-        }
+  get loadCollection() {
+    return loadCollection;
+  }
 
-        const breadcrumbs = [
-            { url: Paths.partners, name: 'Partners' },
-            {
-                url: formatPath(Paths.namespace, {
-                    namespace: collection.namespace.name,
-                }),
-                name: collection.namespace.name,
-            },
-            {
-                name: collection.name,
-            },
-        ];
-
-        return (
-            <React.Fragment>
-                <CollectionHeader
-                    collection={collection}
-                    params={params}
-                    updateParams={p =>
-                        this.updateParams(p, () => this.loadCollection(true))
-                    }
-                    breadcrumbs={breadcrumbs}
-                    activeTab='details'
-                />
-                <Main>
-                    <Section className='body'>
-                        <CollectionInfo
-                            {...collection}
-                            updateParams={p => this.updateParams(p)}
-                            params={this.state.params}
-                        />
-                    </Section>
-                </Main>
-            </React.Fragment>
-        );
-    }
-
-    get loadCollection() {
-        return loadCollection;
-    }
-
-    get updateParams() {
-        return ParamHelper.updateParamsMixin();
-    }
+  get updateParams() {
+    return ParamHelper.updateParamsMixin();
+  }
 }
 
 export default withRouter(CollectionDetail);

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -5,21 +5,21 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 
 import {
-    EmptyState,
-    EmptyStateBody,
-    EmptyStateVariant,
-    Title,
-    EmptyStateIcon,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateVariant,
+  Title,
+  EmptyStateIcon,
 } from '@patternfly/react-core';
 
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 
 import {
-    CollectionHeader,
-    TableOfContents,
-    RenderPluginDoc,
-    LoadingPageWithHeader,
-    Main,
+  CollectionHeader,
+  TableOfContents,
+  RenderPluginDoc,
+  LoadingPageWithHeader,
+  Main,
 } from '../../components';
 import { loadCollection, IBaseCollectionState } from './base';
 import { ParamHelper, sanitizeDocsUrls } from '../../utilities';
@@ -27,180 +27,174 @@ import { formatPath, Paths } from '../../paths';
 
 // renders markdown files in collection docs/ directory
 class CollectionDocs extends React.Component<
-    RouteComponentProps,
-    IBaseCollectionState
+  RouteComponentProps,
+  IBaseCollectionState
 > {
-    docsRef: any;
+  docsRef: any;
 
-    constructor(props) {
-        super(props);
-        const params = ParamHelper.parseParamString(props.location.search);
+  constructor(props) {
+    super(props);
+    const params = ParamHelper.parseParamString(props.location.search);
 
-        this.state = {
-            collection: undefined,
-            params: params,
-        };
+    this.state = {
+      collection: undefined,
+      params: params,
+    };
 
-        this.docsRef = React.createRef();
+    this.docsRef = React.createRef();
+  }
+
+  componentDidMount() {
+    this.loadCollection();
+  }
+
+  render() {
+    const { params, collection } = this.state;
+    const urlFields = this.props.match.params;
+
+    if (!collection) {
+      return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    componentDidMount() {
-        this.loadCollection();
+    // If the parser can't find anything that matches the URL, neither of
+    // these variables should be set
+    let displayHTML: string;
+    let pluginData;
+
+    const contentType = urlFields['type'] || 'docs';
+    const contentName = urlFields['name'] || urlFields['page'] || null;
+
+    if (contentType === 'docs' && contentName) {
+      if (collection.latest_version.docs_blob.documentation_files) {
+        const file = collection.latest_version.docs_blob.documentation_files.find(
+          x => sanitizeDocsUrls(x.name) === urlFields['page'],
+        );
+
+        if (file) {
+          displayHTML = file.html;
+        }
+      }
+    } else if (contentName) {
+      // check if contents exists
+      if (collection.latest_version.docs_blob.contents) {
+        const content = collection.latest_version.docs_blob.contents.find(
+          x => x.content_type === contentType && x.content_name === contentName,
+        );
+
+        if (content) {
+          if (contentType === 'role') {
+            displayHTML = content['readme_html'];
+          } else {
+            pluginData = content;
+          }
+        }
+      }
+    } else {
+      if (collection.latest_version.docs_blob.collection_readme) {
+        displayHTML =
+          collection.latest_version.docs_blob.collection_readme.html;
+      }
     }
 
-    render() {
-        const { params, collection } = this.state;
-        const urlFields = this.props.match.params;
+    const breadcrumbs = [
+      { url: Paths.partners, name: 'Partners' },
+      {
+        url: formatPath(Paths.namespace, {
+          namespace: collection.namespace.name,
+        }),
+        name: collection.namespace.name,
+      },
+      {
+        url: formatPath(Paths.collection, {
+          namespace: collection.namespace.name,
+          collection: collection.name,
+        }),
+        name: collection.name,
+      },
+      { name: 'Documentation' },
+    ];
 
-        if (!collection) {
-            return <LoadingPageWithHeader></LoadingPageWithHeader>;
-        }
+    // scroll to top of page
+    if (this.docsRef.current) {
+      this.docsRef.current.scrollIntoView();
+    }
 
-        // If the parser can't find anything that matches the URL, neither of
-        // these variables should be set
-        let displayHTML: string;
-        let pluginData;
-
-        const contentType = urlFields['type'] || 'docs';
-        const contentName = urlFields['name'] || urlFields['page'] || null;
-
-        if (contentType === 'docs' && contentName) {
-            if (collection.latest_version.docs_blob.documentation_files) {
-                const file = collection.latest_version.docs_blob.documentation_files.find(
-                    x => sanitizeDocsUrls(x.name) === urlFields['page'],
-                );
-
-                if (file) {
-                    displayHTML = file.html;
-                }
-            }
-        } else if (contentName) {
-            // check if contents exists
-            if (collection.latest_version.docs_blob.contents) {
-                const content = collection.latest_version.docs_blob.contents.find(
-                    x =>
-                        x.content_type === contentType &&
-                        x.content_name === contentName,
-                );
-
-                if (content) {
-                    if (contentType === 'role') {
-                        displayHTML = content['readme_html'];
-                    } else {
-                        pluginData = content;
-                    }
-                }
-            }
-        } else {
-            if (collection.latest_version.docs_blob.collection_readme) {
-                displayHTML =
-                    collection.latest_version.docs_blob.collection_readme.html;
-            }
-        }
-
-        const breadcrumbs = [
-            { url: Paths.partners, name: 'Partners' },
-            {
-                url: formatPath(Paths.namespace, {
-                    namespace: collection.namespace.name,
-                }),
-                name: collection.namespace.name,
-            },
-            {
-                url: formatPath(Paths.collection, {
-                    namespace: collection.namespace.name,
-                    collection: collection.name,
-                }),
-                name: collection.name,
-            },
-            { name: 'Documentation' },
-        ];
-
-        // scroll to top of page
-        if (this.docsRef.current) {
-            this.docsRef.current.scrollIntoView();
-        }
-
-        return (
-            <React.Fragment>
-                <CollectionHeader
-                    collection={collection}
+    return (
+      <React.Fragment>
+        <CollectionHeader
+          collection={collection}
+          params={params}
+          updateParams={p =>
+            this.updateParams(p, () => this.loadCollection(true))
+          }
+          breadcrumbs={breadcrumbs}
+          activeTab='documentation'
+          className='header'
+        />
+        <Main className='main'>
+          <Section className='docs-container'>
+            <TableOfContents
+              className='sidebar'
+              namespace={collection.namespace.name}
+              collection={collection.name}
+              docs_blob={collection.latest_version.docs_blob}
+              selectedName={contentName}
+              selectedType={contentType}
+              params={params}
+            ></TableOfContents>
+            <div className='body docs' ref={this.docsRef}>
+              {displayHTML || pluginData ? (
+                // if neither variable is set, render not found
+                displayHTML ? (
+                  // if displayHTML is set, render it
+                  <div
+                    className='pf-c-content'
+                    dangerouslySetInnerHTML={{
+                      __html: displayHTML,
+                    }}
+                  ></div>
+                ) : (
+                  // if plugin data is set render it
+                  <RenderPluginDoc
+                    plugin={pluginData}
+                    collectionName={collection.name}
+                    namespaceName={collection.namespace.name}
+                    allContent={collection.latest_version.contents}
                     params={params}
-                    updateParams={p =>
-                        this.updateParams(p, () => this.loadCollection(true))
-                    }
-                    breadcrumbs={breadcrumbs}
-                    activeTab='documentation'
-                    className='header'
-                />
-                <Main className='main'>
-                    <Section className='docs-container'>
-                        <TableOfContents
-                            className='sidebar'
-                            namespace={collection.namespace.name}
-                            collection={collection.name}
-                            docs_blob={collection.latest_version.docs_blob}
-                            selectedName={contentName}
-                            selectedType={contentType}
-                            params={params}
-                        ></TableOfContents>
-                        <div className='body docs' ref={this.docsRef}>
-                            {displayHTML || pluginData ? (
-                                // if neither variable is set, render not found
-                                displayHTML ? (
-                                    // if displayHTML is set, render it
-                                    <div
-                                        className='pf-c-content'
-                                        dangerouslySetInnerHTML={{
-                                            __html: displayHTML,
-                                        }}
-                                    ></div>
-                                ) : (
-                                    // if plugin data is set render it
-                                    <RenderPluginDoc
-                                        plugin={pluginData}
-                                        collectionName={collection.name}
-                                        namespaceName={
-                                            collection.namespace.name
-                                        }
-                                        allContent={
-                                            collection.latest_version.contents
-                                        }
-                                        params={params}
-                                    />
-                                )
-                            ) : (
-                                this.renderNotFound(collection.name)
-                            )}
-                        </div>
-                    </Section>
-                </Main>
-            </React.Fragment>
-        );
-    }
+                  />
+                )
+              ) : (
+                this.renderNotFound(collection.name)
+              )}
+            </div>
+          </Section>
+        </Main>
+      </React.Fragment>
+    );
+  }
 
-    private renderNotFound(collectionName) {
-        return (
-            <EmptyState className='empty' variant={EmptyStateVariant.full}>
-                <EmptyStateIcon icon={WarningTriangleIcon} />
-                <Title headingLevel='h2' size='lg'>
-                    Not found
-                </Title>
-                <EmptyStateBody>
-                    The file you're looking for doesn't seem to be available in
-                    this version of {collectionName}.
-                </EmptyStateBody>
-            </EmptyState>
-        );
-    }
+  private renderNotFound(collectionName) {
+    return (
+      <EmptyState className='empty' variant={EmptyStateVariant.full}>
+        <EmptyStateIcon icon={WarningTriangleIcon} />
+        <Title headingLevel='h2' size='lg'>
+          Not found
+        </Title>
+        <EmptyStateBody>
+          The file you're looking for doesn't seem to be available in this
+          version of {collectionName}.
+        </EmptyStateBody>
+      </EmptyState>
+    );
+  }
 
-    get loadCollection() {
-        return loadCollection;
-    }
+  get loadCollection() {
+    return loadCollection;
+  }
 
-    get updateParams() {
-        return ParamHelper.updateParamsMixin();
-    }
+  get updateParams() {
+    return ParamHelper.updateParamsMixin();
+  }
 }
 
 export default withRouter(CollectionDocs);

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -5,9 +5,9 @@ import { Main, Section } from '@redhat-cloud-services/frontend-components';
 
 import { ImportAPI, ImportDetailType, ImportListType } from '../../api';
 import {
-    CollectionHeader,
-    LoadingPageWithHeader,
-    ImportConsole,
+  CollectionHeader,
+  LoadingPageWithHeader,
+  ImportConsole,
 } from '../../components';
 
 import { loadCollection, IBaseCollectionState } from './base';
@@ -15,138 +15,137 @@ import { ParamHelper } from '../../utilities/param-helper';
 import { formatPath, Paths } from '../../paths';
 
 interface IState extends IBaseCollectionState {
-    loadingImports: boolean;
-    selectedImportDetail: ImportDetailType;
-    selectedImport: ImportListType;
-    apiError: string;
+  loadingImports: boolean;
+  selectedImportDetail: ImportDetailType;
+  selectedImport: ImportListType;
+  apiError: string;
 }
 
 class CollectionImportLog extends React.Component<RouteComponentProps, IState> {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        const params = ParamHelper.parseParamString(props.location.search);
+    const params = ParamHelper.parseParamString(props.location.search);
 
-        this.state = {
-            collection: undefined,
-            params: params,
-            loadingImports: true,
-            selectedImportDetail: undefined,
-            selectedImport: undefined,
-            apiError: undefined,
-        };
+    this.state = {
+      collection: undefined,
+      params: params,
+      loadingImports: true,
+      selectedImportDetail: undefined,
+      selectedImport: undefined,
+      apiError: undefined,
+    };
+  }
+
+  componentDidMount() {
+    this.loadData();
+  }
+
+  render() {
+    const {
+      collection,
+      params,
+      loadingImports,
+      selectedImportDetail,
+      selectedImport,
+      apiError,
+    } = this.state;
+
+    if (!collection) {
+      return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    componentDidMount() {
-        this.loadData();
-    }
+    const breadcrumbs = [
+      { url: Paths.partners, name: 'Partners' },
+      {
+        url: formatPath(Paths.namespace, {
+          namespace: collection.namespace.name,
+        }),
+        name: collection.namespace.name,
+      },
+      {
+        url: formatPath(Paths.collection, {
+          namespace: collection.namespace.name,
+          collection: collection.name,
+        }),
+        name: collection.name,
+      },
+      { name: 'Import log' },
+    ];
 
-    render() {
-        const {
-            collection,
-            params,
-            loadingImports,
-            selectedImportDetail,
-            selectedImport,
-            apiError,
-        } = this.state;
+    return (
+      <React.Fragment>
+        <CollectionHeader
+          collection={collection}
+          params={params}
+          updateParams={params =>
+            this.updateParams(params, () => this.loadData(true))
+          }
+          breadcrumbs={breadcrumbs}
+          activeTab='import-log'
+        />
+        <Main>
+          <Section className='body'>
+            <ImportConsole
+              loading={loadingImports}
+              task={selectedImportDetail}
+              followMessages={false}
+              setFollowMessages={_ => null}
+              selectedImport={selectedImport}
+              apiError={apiError}
+              hideCollectionName={true}
+            />
+          </Section>
+        </Main>
+      </React.Fragment>
+    );
+  }
 
-        if (!collection) {
-            return <LoadingPageWithHeader></LoadingPageWithHeader>;
-        }
-
-        const breadcrumbs = [
-            { url: Paths.partners, name: 'Partners' },
-            {
-                url: formatPath(Paths.namespace, {
-                    namespace: collection.namespace.name,
-                }),
-                name: collection.namespace.name,
-            },
-            {
-                url: formatPath(Paths.collection, {
-                    namespace: collection.namespace.name,
-                    collection: collection.name,
-                }),
-                name: collection.name,
-            },
-            { name: 'Import log' },
-        ];
-
-        return (
-            <React.Fragment>
-                <CollectionHeader
-                    collection={collection}
-                    params={params}
-                    updateParams={params =>
-                        this.updateParams(params, () => this.loadData(true))
-                    }
-                    breadcrumbs={breadcrumbs}
-                    activeTab='import-log'
-                />
-                <Main>
-                    <Section className='body'>
-                        <ImportConsole
-                            loading={loadingImports}
-                            task={selectedImportDetail}
-                            followMessages={false}
-                            setFollowMessages={_ => null}
-                            selectedImport={selectedImport}
-                            apiError={apiError}
-                            hideCollectionName={true}
-                        />
-                    </Section>
-                </Main>
-            </React.Fragment>
-        );
-    }
-
-    private loadData(forceReload = false) {
-        const failMsg = 'Could not load import log';
-        this.setState({ loadingImports: true }, () => {
-            this.loadCollection(forceReload, () => {
-                ImportAPI.list({
-                    namespace: this.state.collection.namespace.name,
-                    name: this.state.collection.name,
-                    version: this.state.collection.latest_version.version,
-                    sort: '-created',
-                })
-                    .then(importListResult => {
-                        const importObj = importListResult.data.data[0];
-                        ImportAPI.get(importObj.id)
-                            .then(importDetailResult => {
-                                this.setState({
-                                    apiError: undefined,
-                                    loadingImports: false,
-                                    selectedImport: importObj,
-                                    selectedImportDetail:
-                                        importDetailResult.data,
-                                });
-                            })
-                            .catch(err => {
-                                this.setState({
-                                    apiError: failMsg,
-                                    loadingImports: false,
-                                });
-                            });
-                    })
-                    .catch(err => {
-                        this.setState({
-                            apiError: failMsg,
-                            loadingImports: false,
-                        });
-                    });
+  private loadData(forceReload = false) {
+    const failMsg = 'Could not load import log';
+    this.setState({ loadingImports: true }, () => {
+      this.loadCollection(forceReload, () => {
+        ImportAPI.list({
+          namespace: this.state.collection.namespace.name,
+          name: this.state.collection.name,
+          version: this.state.collection.latest_version.version,
+          sort: '-created',
+        })
+          .then(importListResult => {
+            const importObj = importListResult.data.data[0];
+            ImportAPI.get(importObj.id)
+              .then(importDetailResult => {
+                this.setState({
+                  apiError: undefined,
+                  loadingImports: false,
+                  selectedImport: importObj,
+                  selectedImportDetail: importDetailResult.data,
+                });
+              })
+              .catch(err => {
+                this.setState({
+                  apiError: failMsg,
+                  loadingImports: false,
+                });
+              });
+          })
+          .catch(err => {
+            this.setState({
+              apiError: failMsg,
+              loadingImports: false,
             });
-        });
-    }
+          });
+      });
+    });
+  }
 
-    get loadCollection() {
-        return loadCollection;
-    }
+  get loadCollection() {
+    return loadCollection;
+  }
 
-    get updateParams() {
-        return ParamHelper.updateParamsMixin();
-    }
+  get updateParams() {
+    return ParamHelper.updateParamsMixin();
+  }
 }
 
 export default withRouter(CollectionImportLog);

--- a/src/containers/edit-namespace/namespace-form.tsx
+++ b/src/containers/edit-namespace/namespace-form.tsx
@@ -4,13 +4,13 @@ import { Section, Spinner } from '@redhat-cloud-services/frontend-components';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
 import {
-    PartnerHeader,
-    NamespaceForm,
-    ResourcesForm,
-    AlertList,
-    closeAlertMixin,
-    AlertType,
-    Main,
+  PartnerHeader,
+  NamespaceForm,
+  ResourcesForm,
+  AlertList,
+  closeAlertMixin,
+  AlertType,
+  Main,
 } from '../../components';
 import { MyNamespaceAPI, NamespaceType, UserAPI } from '../../api';
 import { Constants } from '../../constants';
@@ -21,229 +21,216 @@ import { Paths, formatPath } from '../../paths';
 import { ParamHelper } from '../../utilities/param-helper';
 
 interface IState {
-    namespace: NamespaceType;
-    newLinkName: string;
-    newLinkURL: string;
-    errorMessages: any;
-    saving: boolean;
-    redirect: string;
-    unsavedData: boolean;
-    alerts: AlertType[];
-    params: {
-        tab?: string;
-    };
-    userId: string;
+  namespace: NamespaceType;
+  newLinkName: string;
+  newLinkURL: string;
+  errorMessages: any;
+  saving: boolean;
+  redirect: string;
+  unsavedData: boolean;
+  alerts: AlertType[];
+  params: {
+    tab?: string;
+  };
+  userId: string;
 }
 
 class EditNamespace extends React.Component<RouteComponentProps, IState> {
-    queryParams: URLSearchParams;
+  queryParams: URLSearchParams;
 
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        const params = ParamHelper.parseParamString(props.location.search);
+    const params = ParamHelper.parseParamString(props.location.search);
 
-        if (!params['tab']) {
-            params['tab'] = 'edit details';
-        }
+    if (!params['tab']) {
+      params['tab'] = 'edit details';
+    }
 
-        this.state = {
-            alerts: [],
-            namespace: null,
-            userId: '',
-            newLinkURL: '',
-            newLinkName: '',
+    this.state = {
+      alerts: [],
+      namespace: null,
+      userId: '',
+      newLinkURL: '',
+      newLinkName: '',
+      errorMessages: {},
+      saving: false,
+      redirect: null,
+      unsavedData: false,
+      params: params,
+    };
+  }
+
+  componentDidMount() {
+    UserAPI.getUser().then(result => {
+      this.setState({ userId: result.account_number }, () =>
+        this.loadNamespace(),
+      );
+    });
+  }
+
+  render() {
+    const {
+      namespace,
+      errorMessages,
+      saving,
+      redirect,
+      params,
+      userId,
+    } = this.state;
+
+    if (redirect) {
+      return <Redirect to={redirect} />;
+    }
+
+    if (!namespace) {
+      return null;
+    }
+    return (
+      <React.Fragment>
+        <PartnerHeader
+          namespace={namespace}
+          breadcrumbs={[
+            { name: 'My namespaces', url: Paths.myNamespaces },
+            {
+              name: namespace.name,
+              url: formatPath(Paths.myCollections, {
+                namespace: namespace.name,
+              }),
+            },
+            { name: 'Edit' },
+          ]}
+          tabs={['Edit details', 'Edit resources']}
+          params={params}
+          updateParams={p => this.updateParams(p)}
+        ></PartnerHeader>
+        <AlertList
+          alerts={this.state.alerts}
+          closeAlert={i => this.closeAlert(i)}
+        />
+        <Main>
+          <Section className='body'>
+            {params.tab.toLowerCase() === 'edit details' ? (
+              <NamespaceForm
+                userId={userId}
+                namespace={namespace}
+                errorMessages={errorMessages}
+                updateNamespace={namespace =>
+                  this.setState({
+                    namespace: namespace,
+                    unsavedData: true,
+                  })
+                }
+              />
+            ) : (
+              <ResourcesForm
+                updateNamespace={namespace =>
+                  this.setState({
+                    namespace: namespace,
+                    unsavedData: true,
+                  })
+                }
+                namespace={namespace}
+              />
+            )}
+            <Form>
+              <ActionGroup>
+                <Button variant='primary' onClick={() => this.saveNamespace()}>
+                  Save
+                </Button>
+                <Button variant='secondary' onClick={() => this.cancel()}>
+                  Cancel
+                </Button>
+
+                {saving ? <Spinner></Spinner> : null}
+              </ActionGroup>
+              {this.state.unsavedData ? (
+                <div style={{ color: 'red' }}>You have unsaved changes</div>
+              ) : null}
+            </Form>
+          </Section>
+        </Main>
+      </React.Fragment>
+    );
+  }
+
+  get updateParams() {
+    return ParamHelper.updateParamsMixin();
+  }
+
+  private removeGroupsPrefix(groups) {
+    let unprefixedGroupOwners = [Constants.ADMIN_GROUP];
+    for (const owner of groups) {
+      if (owner == Constants.ADMIN_GROUP) {
+        continue;
+      }
+      // 'rh-identity-account', '<id>'
+      else unprefixedGroupOwners.push(owner.split(':')[1]);
+    }
+    return unprefixedGroupOwners;
+  }
+
+  private loadNamespace() {
+    MyNamespaceAPI.get(this.props.match.params['namespace'])
+      .then(response => {
+        response.data.groups = this.removeGroupsPrefix(response.data.groups);
+        this.setState({ namespace: response.data });
+      })
+      .catch(response => {
+        this.setState({ redirect: Paths.notFound });
+      });
+  }
+
+  private saveNamespace() {
+    this.setState({ saving: true }, () => {
+      MyNamespaceAPI.update(this.state.namespace.name, this.state.namespace)
+        .then(result => {
+          this.setState({
+            namespace: result.data,
             errorMessages: {},
             saving: false,
-            redirect: null,
             unsavedData: false,
-            params: params,
-        };
-    }
-
-    componentDidMount() {
-        UserAPI.getUser().then(result => {
-            this.setState({ userId: result.account_number }, () =>
-                this.loadNamespace(),
-            );
-        });
-    }
-
-    render() {
-        const {
-            namespace,
-            errorMessages,
-            saving,
-            redirect,
-            params,
-            userId,
-        } = this.state;
-
-        if (redirect) {
-            return <Redirect to={redirect} />;
-        }
-
-        if (!namespace) {
-            return null;
-        }
-        return (
-            <React.Fragment>
-                <PartnerHeader
-                    namespace={namespace}
-                    breadcrumbs={[
-                        { name: 'My namespaces', url: Paths.myNamespaces },
-                        {
-                            name: namespace.name,
-                            url: formatPath(Paths.myCollections, {
-                                namespace: namespace.name,
-                            }),
-                        },
-                        { name: 'Edit' },
-                    ]}
-                    tabs={['Edit details', 'Edit resources']}
-                    params={params}
-                    updateParams={p => this.updateParams(p)}
-                ></PartnerHeader>
-                <AlertList
-                    alerts={this.state.alerts}
-                    closeAlert={i => this.closeAlert(i)}
-                />
-                <Main>
-                    <Section className='body'>
-                        {params.tab.toLowerCase() === 'edit details' ? (
-                            <NamespaceForm
-                                userId={userId}
-                                namespace={namespace}
-                                errorMessages={errorMessages}
-                                updateNamespace={namespace =>
-                                    this.setState({
-                                        namespace: namespace,
-                                        unsavedData: true,
-                                    })
-                                }
-                            />
-                        ) : (
-                            <ResourcesForm
-                                updateNamespace={namespace =>
-                                    this.setState({
-                                        namespace: namespace,
-                                        unsavedData: true,
-                                    })
-                                }
-                                namespace={namespace}
-                            />
-                        )}
-                        <Form>
-                            <ActionGroup>
-                                <Button
-                                    variant='primary'
-                                    onClick={() => this.saveNamespace()}
-                                >
-                                    Save
-                                </Button>
-                                <Button
-                                    variant='secondary'
-                                    onClick={() => this.cancel()}
-                                >
-                                    Cancel
-                                </Button>
-
-                                {saving ? <Spinner></Spinner> : null}
-                            </ActionGroup>
-                            {this.state.unsavedData ? (
-                                <div style={{ color: 'red' }}>
-                                    You have unsaved changes
-                                </div>
-                            ) : null}
-                        </Form>
-                    </Section>
-                </Main>
-            </React.Fragment>
-        );
-    }
-
-    get updateParams() {
-        return ParamHelper.updateParamsMixin();
-    }
-
-    private removeGroupsPrefix(groups) {
-        let unprefixedGroupOwners = [Constants.ADMIN_GROUP];
-        for (const owner of groups) {
-            if (owner == Constants.ADMIN_GROUP) {
-                continue;
-            }
-            // 'rh-identity-account', '<id>'
-            else unprefixedGroupOwners.push(owner.split(':')[1]);
-        }
-        return unprefixedGroupOwners;
-    }
-
-    private loadNamespace() {
-        MyNamespaceAPI.get(this.props.match.params['namespace'])
-            .then(response => {
-                response.data.groups = this.removeGroupsPrefix(
-                    response.data.groups,
-                );
-                this.setState({ namespace: response.data });
-            })
-            .catch(response => {
-                this.setState({ redirect: Paths.notFound });
-            });
-    }
-
-    private saveNamespace() {
-        this.setState({ saving: true }, () => {
-            MyNamespaceAPI.update(
-                this.state.namespace.name,
-                this.state.namespace,
-            )
-                .then(result => {
-                    this.setState({
-                        namespace: result.data,
-                        errorMessages: {},
-                        saving: false,
-                        unsavedData: false,
-                        redirect: formatPath(Paths.myCollections, {
-                            namespace: this.state.namespace.name,
-                        }),
-                    });
-                })
-                .catch(error => {
-                    const result = error.response;
-                    if (result.status === 400) {
-                        const messages: any = {};
-                        for (const e of result.data.errors) {
-                            messages[e.source.parameter] = e.detail;
-                        }
-
-                        this.setState({
-                            errorMessages: messages,
-                            saving: false,
-                        });
-                    } else if (result.status === 404) {
-                        this.setState({
-                            alerts: this.state.alerts.concat({
-                                variant: 'danger',
-                                title: `API Error: ${error.response.status}`,
-                                description: `You don't have permissions to update this namespace.`,
-                            }),
-                            saving: false,
-                        });
-                    }
-                });
-        });
-    }
-    private get closeAlert() {
-        return closeAlertMixin('alerts');
-    }
-
-    private cancel() {
-        this.setState({
             redirect: formatPath(Paths.myCollections, {
-                namespace: this.state.namespace.name,
+              namespace: this.state.namespace.name,
             }),
+          });
+        })
+        .catch(error => {
+          const result = error.response;
+          if (result.status === 400) {
+            const messages: any = {};
+            for (const e of result.data.errors) {
+              messages[e.source.parameter] = e.detail;
+            }
+
+            this.setState({
+              errorMessages: messages,
+              saving: false,
+            });
+          } else if (result.status === 404) {
+            this.setState({
+              alerts: this.state.alerts.concat({
+                variant: 'danger',
+                title: `API Error: ${error.response.status}`,
+                description: `You don't have permissions to update this namespace.`,
+              }),
+              saving: false,
+            });
+          }
         });
-    }
+    });
+  }
+  private get closeAlert() {
+    return closeAlertMixin('alerts');
+  }
+
+  private cancel() {
+    this.setState({
+      redirect: formatPath(Paths.myCollections, {
+        namespace: this.state.namespace.name,
+      }),
+    });
+  }
 }
 
 export default withRouter(EditNamespace);

--- a/src/containers/my-imports/my-imports.scss
+++ b/src/containers/my-imports/my-imports.scss
@@ -1,13 +1,13 @@
 @import '../../global-variables.scss';
 
 .page-container {
-    display: flex;
-    .import-list {
-        width: 400px;
-    }
+  display: flex;
+  .import-list {
+    width: 400px;
+  }
 
-    .import-console {
-        flex-grow: 1;
-        margin-left: 10px;
-    }
+  .import-console {
+    flex-grow: 1;
+    margin-left: 10px;
+  }
 }

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -8,285 +8,273 @@ import { cloneDeep } from 'lodash';
 import { BaseHeader, ImportConsole, ImportList, Main } from '../../components';
 
 import {
-    ImportAPI,
-    ImportDetailType,
-    ImportListType,
-    NamespaceType,
-    PulpStatus,
-    MyNamespaceAPI,
+  ImportAPI,
+  ImportDetailType,
+  ImportListType,
+  NamespaceType,
+  PulpStatus,
+  MyNamespaceAPI,
 } from '../../api';
 
 import { ParamHelper } from '../../utilities/param-helper';
 
 interface IState {
-    selectedImport: ImportListType;
-    importList: ImportListType[];
-    selectedImportDetails: ImportDetailType;
-    params: {
-        page_size?: number;
-        page?: number;
-        keyword?: string;
-        namespace?: string;
-    };
-    namespaces: NamespaceType[];
-    resultsCount: number;
-    importDetailError: string;
-    followLogs: boolean;
-    loadingImports: boolean;
-    loadingImportDetails: boolean;
+  selectedImport: ImportListType;
+  importList: ImportListType[];
+  selectedImportDetails: ImportDetailType;
+  params: {
+    page_size?: number;
+    page?: number;
+    keyword?: string;
+    namespace?: string;
+  };
+  namespaces: NamespaceType[];
+  resultsCount: number;
+  importDetailError: string;
+  followLogs: boolean;
+  loadingImports: boolean;
+  loadingImportDetails: boolean;
 }
 
 class MyImports extends React.Component<RouteComponentProps, IState> {
-    polling: any;
-    topOfPage: any;
+  polling: any;
+  topOfPage: any;
 
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        const params = ParamHelper.parseParamString(props.location.search, [
-            'page',
-            'page_size',
-        ]);
+    const params = ParamHelper.parseParamString(props.location.search, [
+      'page',
+      'page_size',
+    ]);
 
-        this.topOfPage = React.createRef();
+    this.topOfPage = React.createRef();
 
-        this.state = {
-            selectedImport: undefined,
-            importList: [],
-            params: params,
-            namespaces: [],
-            selectedImportDetails: undefined,
-            resultsCount: 0,
-            importDetailError: '',
-            followLogs: false,
-            loadingImports: true,
-            loadingImportDetails: true,
-        };
+    this.state = {
+      selectedImport: undefined,
+      importList: [],
+      params: params,
+      namespaces: [],
+      selectedImportDetails: undefined,
+      resultsCount: 0,
+      importDetailError: '',
+      followLogs: false,
+      loadingImports: true,
+      loadingImportDetails: true,
+    };
+  }
+
+  componentDidMount() {
+    // Load namespaces, use the namespaces to query the import list,
+    // use the import list to load the task details
+    this.loadNamespaces(() =>
+      this.loadImportList(() => this.loadTaskDetails()),
+    );
+
+    this.polling = setInterval(() => {
+      if (
+        this.state.selectedImportDetails &&
+        (this.state.selectedImportDetails.state === PulpStatus.running ||
+          this.state.selectedImportDetails.state === PulpStatus.waiting)
+      ) {
+        this.poll();
+      }
+    }, 10000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.polling);
+  }
+
+  render() {
+    const {
+      selectedImport,
+      importList,
+      params,
+      namespaces,
+      selectedImportDetails,
+      resultsCount,
+      loadingImports,
+      loadingImportDetails,
+      importDetailError,
+      followLogs,
+    } = this.state;
+
+    if (!importList) {
+      return null;
     }
 
-    componentDidMount() {
-        // Load namespaces, use the namespaces to query the import list,
-        // use the import list to load the task details
-        this.loadNamespaces(() =>
-            this.loadImportList(() => this.loadTaskDetails()),
+    return (
+      <React.Fragment>
+        <div ref={this.topOfPage}></div>
+        <BaseHeader title='My imports' />
+        <Main>
+          <Section className='body'>
+            <div className='page-container'>
+              <div className='import-list'>
+                <ImportList
+                  importList={importList}
+                  selectedImport={selectedImport}
+                  loading={loadingImports}
+                  numberOfResults={resultsCount}
+                  params={params}
+                  namespaces={namespaces}
+                  selectImport={sImport => this.selectImport(sImport)}
+                  updateParams={params => {
+                    this.updateParams(params, () =>
+                      this.setState(
+                        {
+                          loadingImports: true,
+                          loadingImportDetails: true,
+                        },
+                        () => this.loadImportList(() => this.loadTaskDetails()),
+                      ),
+                    );
+                  }}
+                />
+              </div>
+
+              <div className='import-console'>
+                <ImportConsole
+                  loading={loadingImportDetails}
+                  task={selectedImportDetails}
+                  followMessages={followLogs}
+                  setFollowMessages={isFollowing => {
+                    this.setState({
+                      followLogs: isFollowing,
+                    });
+                  }}
+                  selectedImport={selectedImport}
+                  apiError={importDetailError}
+                />
+              </div>
+            </div>
+          </Section>
+        </Main>
+      </React.Fragment>
+    );
+  }
+
+  private get updateParams() {
+    return ParamHelper.updateParamsMixin();
+  }
+
+  private selectImport(sImport) {
+    this.setState(
+      { selectedImport: sImport, loadingImportDetails: true },
+      () => {
+        this.topOfPage.current.scrollIntoView({
+          behavior: 'smooth',
+        });
+        this.loadTaskDetails();
+      },
+    );
+  }
+
+  private poll() {
+    this.loadTaskDetails(() => {
+      // Update the state of the selected import in the list if it's
+      // different from the one loaded from the API.
+      const { selectedImport, selectedImportDetails, importList } = this.state;
+
+      if (!selectedImportDetails) {
+        return;
+      }
+
+      if (selectedImport.state !== selectedImportDetails.state) {
+        const importIndex = importList.findIndex(
+          x => x.id === selectedImport.id,
         );
 
-        this.polling = setInterval(() => {
-            if (
-                this.state.selectedImportDetails &&
-                (this.state.selectedImportDetails.state ===
-                    PulpStatus.running ||
-                    this.state.selectedImportDetails.state ===
-                        PulpStatus.waiting)
-            ) {
-                this.poll();
-            }
-        }, 10000);
-    }
+        const imports = cloneDeep(importList);
+        const newSelectedImport = cloneDeep(selectedImport);
 
-    componentWillUnmount() {
-        clearInterval(this.polling);
-    }
+        newSelectedImport.state = selectedImportDetails.state;
+        newSelectedImport.finished_at = selectedImportDetails.finished_at;
 
-    render() {
-        const {
-            selectedImport,
-            importList,
-            params,
-            namespaces,
-            selectedImportDetails,
-            resultsCount,
-            loadingImports,
-            loadingImportDetails,
-            importDetailError,
-            followLogs,
-        } = this.state;
+        imports[importIndex] = newSelectedImport;
 
-        if (!importList) {
-            return null;
+        this.setState({
+          selectedImport: newSelectedImport,
+          importList: imports,
+        });
+      }
+    });
+  }
+
+  private loadNamespaces(callback?: () => void) {
+    MyNamespaceAPI.list({ page_size: 1000 })
+      .then(result => {
+        const namespaces = result.data.data;
+        let selectedNS;
+
+        if (this.state.params.namespace) {
+          selectedNS = namespaces.find(
+            x => x.name === this.state.params.namespace,
+          );
         }
 
-        return (
-            <React.Fragment>
-                <div ref={this.topOfPage}></div>
-                <BaseHeader title='My imports' />
-                <Main>
-                    <Section className='body'>
-                        <div className='page-container'>
-                            <div className='import-list'>
-                                <ImportList
-                                    importList={importList}
-                                    selectedImport={selectedImport}
-                                    loading={loadingImports}
-                                    numberOfResults={resultsCount}
-                                    params={params}
-                                    namespaces={namespaces}
-                                    selectImport={sImport =>
-                                        this.selectImport(sImport)
-                                    }
-                                    updateParams={params => {
-                                        this.updateParams(params, () =>
-                                            this.setState(
-                                                {
-                                                    loadingImports: true,
-                                                    loadingImportDetails: true,
-                                                },
-                                                () =>
-                                                    this.loadImportList(() =>
-                                                        this.loadTaskDetails(),
-                                                    ),
-                                            ),
-                                        );
-                                    }}
-                                />
-                            </div>
+        if (!selectedNS) {
+          selectedNS = namespaces[0];
+        }
 
-                            <div className='import-console'>
-                                <ImportConsole
-                                    loading={loadingImportDetails}
-                                    task={selectedImportDetails}
-                                    followMessages={followLogs}
-                                    setFollowMessages={isFollowing => {
-                                        this.setState({
-                                            followLogs: isFollowing,
-                                        });
-                                    }}
-                                    selectedImport={selectedImport}
-                                    apiError={importDetailError}
-                                />
-                            </div>
-                        </div>
-                    </Section>
-                </Main>
-            </React.Fragment>
-        );
-    }
-
-    private get updateParams() {
-        return ParamHelper.updateParamsMixin();
-    }
-
-    private selectImport(sImport) {
         this.setState(
-            { selectedImport: sImport, loadingImportDetails: true },
-            () => {
-                this.topOfPage.current.scrollIntoView({
-                    behavior: 'smooth',
-                });
-                this.loadTaskDetails();
+          {
+            namespaces: namespaces,
+            params: {
+              ...this.state.params,
+              namespace: selectedNS.name,
             },
+          },
+          callback,
         );
-    }
+      })
+      .catch(result => console.log(result));
+  }
 
-    private poll() {
-        this.loadTaskDetails(() => {
-            // Update the state of the selected import in the list if it's
-            // different from the one loaded from the API.
-            const {
-                selectedImport,
-                selectedImportDetails,
-                importList,
-            } = this.state;
+  private loadImportList(callback?: () => void) {
+    ImportAPI.list({ ...this.state.params, sort: '-created' })
+      .then(importList => {
+        this.setState(
+          {
+            importList: importList.data.data,
+            selectedImport: importList.data.data[0],
+            resultsCount: importList.data.meta.count,
+            loadingImports: false,
+          },
+          callback,
+        );
+      })
+      .catch(result => console.log(result));
+  }
 
-            if (!selectedImportDetails) {
-                return;
-            }
-
-            if (selectedImport.state !== selectedImportDetails.state) {
-                const importIndex = importList.findIndex(
-                    x => x.id === selectedImport.id,
-                );
-
-                const imports = cloneDeep(importList);
-                const newSelectedImport = cloneDeep(selectedImport);
-
-                newSelectedImport.state = selectedImportDetails.state;
-                newSelectedImport.finished_at =
-                    selectedImportDetails.finished_at;
-
-                imports[importIndex] = newSelectedImport;
-
-                this.setState({
-                    selectedImport: newSelectedImport,
-                    importList: imports,
-                });
-            }
+  private loadTaskDetails(callback?: () => void) {
+    if (!this.state.selectedImport) {
+      this.setState({
+        importDetailError: 'No data',
+        loadingImportDetails: false,
+      });
+    } else {
+      ImportAPI.get(this.state.selectedImport.id)
+        .then(result => {
+          this.setState(
+            {
+              importDetailError: '',
+              loadingImportDetails: false,
+              selectedImportDetails: result.data,
+            },
+            callback,
+          );
+        })
+        .catch(result => {
+          this.setState({
+            selectedImportDetails: undefined,
+            importDetailError: 'Error fetching import from API',
+            loadingImportDetails: false,
+          });
         });
     }
-
-    private loadNamespaces(callback?: () => void) {
-        MyNamespaceAPI.list({ page_size: 1000 })
-            .then(result => {
-                const namespaces = result.data.data;
-                let selectedNS;
-
-                if (this.state.params.namespace) {
-                    selectedNS = namespaces.find(
-                        x => x.name === this.state.params.namespace,
-                    );
-                }
-
-                if (!selectedNS) {
-                    selectedNS = namespaces[0];
-                }
-
-                this.setState(
-                    {
-                        namespaces: namespaces,
-                        params: {
-                            ...this.state.params,
-                            namespace: selectedNS.name,
-                        },
-                    },
-                    callback,
-                );
-            })
-            .catch(result => console.log(result));
-    }
-
-    private loadImportList(callback?: () => void) {
-        ImportAPI.list({ ...this.state.params, sort: '-created' })
-            .then(importList => {
-                this.setState(
-                    {
-                        importList: importList.data.data,
-                        selectedImport: importList.data.data[0],
-                        resultsCount: importList.data.meta.count,
-                        loadingImports: false,
-                    },
-                    callback,
-                );
-            })
-            .catch(result => console.log(result));
-    }
-
-    private loadTaskDetails(callback?: () => void) {
-        if (!this.state.selectedImport) {
-            this.setState({
-                importDetailError: 'No data',
-                loadingImportDetails: false,
-            });
-        } else {
-            ImportAPI.get(this.state.selectedImport.id)
-                .then(result => {
-                    this.setState(
-                        {
-                            importDetailError: '',
-                            loadingImportDetails: false,
-                            selectedImportDetails: result.data,
-                        },
-                        callback,
-                    );
-                })
-                .catch(result => {
-                    this.setState({
-                        selectedImportDetails: undefined,
-                        importDetailError: 'Error fetching import from API',
-                        loadingImportDetails: false,
-                    });
-                });
-        }
-    }
+  }
 }
 
 export default withRouter(MyImports);

--- a/src/containers/namespace-detail/import-modal/import-modal.scss
+++ b/src/containers/namespace-detail/import-modal/import-modal.scss
@@ -1,60 +1,60 @@
 @import '../../../global-variables.scss';
 
 .upload-collection {
-    .file-error-messages {
-        color: #cc0000;
-    }
+  .file-error-messages {
+    color: #cc0000;
+  }
 
-    .upload-file {
-        width: 0.1px;
-        height: 0.1px;
-        opacity: 0;
-        overflow: hidden;
-        position: absolute;
-        z-index: -1;
-    }
+  .upload-file {
+    width: 0.1px;
+    height: 0.1px;
+    opacity: 0;
+    overflow: hidden;
+    position: absolute;
+    z-index: -1;
+  }
 
-    .upload-file-label {
-        display: inline-block;
-        cursor: pointer;
+  .upload-file-label {
+    display: inline-block;
+    cursor: pointer;
+    width: 100%;
+    font-weight: normal;
+
+    .upload-box {
+      display: flex;
+      border-style: solid;
+      border-width: thin;
+      width: 100%;
+      border-radius: 3px;
+
+      .upload-button,
+      .upload-text {
+        padding: 5px;
+      }
+
+      .upload-button {
+        border-right: thin solid;
+        padding-left: 10px;
+        padding-right: 10px;
+      }
+
+      .upload-button:hover {
+        color: white;
+        background-color: $charcoal;
+      }
+
+      .upload-text {
+        position: relative;
         width: 100%;
-        font-weight: normal;
+      }
 
-        .upload-box {
-            display: flex;
-            border-style: solid;
-            border-width: thin;
-            width: 100%;
-            border-radius: 3px;
-
-            .upload-button,
-            .upload-text {
-                padding: 5px;
-            }
-
-            .upload-button {
-                border-right: thin solid;
-                padding-left: 10px;
-                padding-right: 10px;
-            }
-
-            .upload-button:hover {
-                color: white;
-                background-color: $charcoal;
-            }
-
-            .upload-text {
-                position: relative;
-                width: 100%;
-            }
-
-            .loading-bar {
-                position: absolute;
-                height: 3px;
-                background-color: $green;
-                bottom: 0px;
-                left: 0px;
-            }
-        }
+      .loading-bar {
+        position: absolute;
+        height: 3px;
+        background-color: $green;
+        bottom: 0px;
+        left: 0px;
+      }
     }
+  }
 }

--- a/src/containers/namespace-detail/import-modal/import-modal.tsx
+++ b/src/containers/namespace-detail/import-modal/import-modal.tsx
@@ -6,261 +6,251 @@ import { Modal, Button } from '@patternfly/react-core';
 import { FolderOpenIcon, SpinnerIcon } from '@patternfly/react-icons';
 
 import {
-    CollectionListType,
-    CollectionAPI,
-    CollectionUploadType,
+  CollectionListType,
+  CollectionAPI,
+  CollectionUploadType,
 } from '../../../api';
 
 enum Status {
-    uploading = 'uploading',
-    waiting = 'waiting',
+  uploading = 'uploading',
+  waiting = 'waiting',
 }
 
 interface IProps {
-    isOpen: boolean;
-    setOpen: (isOpen, warnings?) => void;
-    onUploadSuccess: (result) => void;
+  isOpen: boolean;
+  setOpen: (isOpen, warnings?) => void;
+  onUploadSuccess: (result) => void;
 
-    collection?: CollectionListType;
-    namespace: string;
+  collection?: CollectionListType;
+  namespace: string;
 }
 
 interface IState {
-    file?: File;
-    errors?: string;
-    uploadProgress: number;
-    uploadStatus: Status;
+  file?: File;
+  errors?: string;
+  uploadProgress: number;
+  uploadStatus: Status;
 }
 
 export class ImportModal extends React.Component<IProps, IState> {
-    acceptedFileTypes = ['application/x-gzip', 'application/gzip'];
-    cancelToken: any;
-    COLLECTION_NAME_REGEX = /[0-9a-z_]+\-[0-9a-z_]+\-[0-9A-Za-z.+-]+/;
+  acceptedFileTypes = ['application/x-gzip', 'application/gzip'];
+  cancelToken: any;
+  COLLECTION_NAME_REGEX = /[0-9a-z_]+\-[0-9a-z_]+\-[0-9A-Za-z.+-]+/;
 
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            file: undefined,
-            errors: '',
-            uploadProgress: 0,
-            uploadStatus: Status.waiting,
-        };
-    }
-    render() {
-        const { isOpen, collection } = this.props;
+    this.state = {
+      file: undefined,
+      errors: '',
+      uploadProgress: 0,
+      uploadStatus: Status.waiting,
+    };
+  }
+  render() {
+    const { isOpen, collection } = this.props;
 
-        const { file, errors, uploadProgress, uploadStatus } = this.state;
-        return (
-            <Modal
-                isSmall
-                title={
-                    collection
-                        ? 'New version of ' + collection.name
-                        : 'New collection'
-                }
-                isOpen={isOpen}
-                onClose={() => this.handleClose()}
-                actions={[
-                    <Button
-                        key='confirm'
-                        variant='primary'
-                        onClick={() => this.saveFile()}
-                        isDisabled={!this.canUpload()}
-                    >
-                        Upload
-                    </Button>,
-                    <Button
-                        key='cancel'
-                        variant='secondary'
-                        onClick={() => this.handleClose()}
-                    >
-                        Cancel
-                    </Button>,
-                ]}
-                isFooterLeftAligned
-            >
-                <div className='upload-collection'>
-                    <form>
-                        <input
-                            disabled={uploadStatus !== Status.waiting}
-                            className='upload-file'
-                            type='file'
-                            id='collection-widget'
-                            onChange={e =>
-                                this.handleFileUpload(e.target.files)
-                            }
-                        />
-                        <label
-                            className='upload-file-label'
-                            htmlFor='collection-widget'
-                        >
-                            <div className='upload-box'>
-                                <div className='upload-button'>
-                                    {this.renderFileIcon()}
-                                </div>
-                                <div className='upload-text'>
-                                    {file != null ? file.name : 'Select file'}
-                                    <div
-                                        className='loading-bar'
-                                        style={{
-                                            width: uploadProgress * 100 + '%',
-                                        }}
-                                    />
-                                </div>
-                            </div>
-                        </label>
-                    </form>
-                    {errors ? (
-                        <span className='file-error-messages'>
-                            <i className='pficon-error-circle-o' /> {errors}
-                        </span>
-                    ) : null}
+    const { file, errors, uploadProgress, uploadStatus } = this.state;
+    return (
+      <Modal
+        isSmall
+        title={
+          collection ? 'New version of ' + collection.name : 'New collection'
+        }
+        isOpen={isOpen}
+        onClose={() => this.handleClose()}
+        actions={[
+          <Button
+            key='confirm'
+            variant='primary'
+            onClick={() => this.saveFile()}
+            isDisabled={!this.canUpload()}
+          >
+            Upload
+          </Button>,
+          <Button
+            key='cancel'
+            variant='secondary'
+            onClick={() => this.handleClose()}
+          >
+            Cancel
+          </Button>,
+        ]}
+        isFooterLeftAligned
+      >
+        <div className='upload-collection'>
+          <form>
+            <input
+              disabled={uploadStatus !== Status.waiting}
+              className='upload-file'
+              type='file'
+              id='collection-widget'
+              onChange={e => this.handleFileUpload(e.target.files)}
+            />
+            <label className='upload-file-label' htmlFor='collection-widget'>
+              <div className='upload-box'>
+                <div className='upload-button'>{this.renderFileIcon()}</div>
+                <div className='upload-text'>
+                  {file != null ? file.name : 'Select file'}
+                  <div
+                    className='loading-bar'
+                    style={{
+                      width: uploadProgress * 100 + '%',
+                    }}
+                  />
                 </div>
-            </Modal>
-        );
+              </div>
+            </label>
+          </form>
+          {errors ? (
+            <span className='file-error-messages'>
+              <i className='pficon-error-circle-o' /> {errors}
+            </span>
+          ) : null}
+        </div>
+      </Modal>
+    );
+  }
+
+  private canUpload() {
+    if (this.state.errors) {
+      return false;
     }
 
-    private canUpload() {
-        if (this.state.errors) {
-            return false;
-        }
-
-        if (this.state.uploadStatus !== Status.waiting) {
-            return false;
-        }
-
-        if (!this.state.file) {
-            return false;
-        }
-
-        return true;
+    if (this.state.uploadStatus !== Status.waiting) {
+      return false;
     }
 
-    private renderFileIcon() {
-        switch (this.state.uploadStatus) {
-            case Status.uploading:
-                return <SpinnerIcon className='fa-spin'></SpinnerIcon>;
-            default:
-                return <FolderOpenIcon></FolderOpenIcon>;
-        }
+    if (!this.state.file) {
+      return false;
     }
 
-    private handleFileUpload(files) {
-        // Selects the artifact that will be uploaded and performs some basic
-        // preliminary checks on it.
-        const newCollection = files[0];
-        const { collection } = this.props;
+    return true;
+  }
 
-        if (files.length > 1) {
-            this.setState({
-                errors: 'Please select no more than one file.',
-            });
-        } else if (!this.acceptedFileTypes.includes(newCollection.type)) {
-            this.setState({
-                errors: 'Invalid file format.',
-                file: newCollection,
-                uploadProgress: 0,
-            });
-        } else if (!this.COLLECTION_NAME_REGEX.test(newCollection.name)) {
-            this.setState({
-                errors: `Invalid file name. Collections must be formatted as 'namespace-collection_name-1.0.0'`,
-                file: newCollection,
-                uploadProgress: 0,
-            });
-        } else if (
-            collection &&
-            collection.name !== newCollection.name.split('-')[1]
-        ) {
-            this.setState({
-                errors: `The collection you have selected doesn't appear to match ${collection.name}`,
-                file: newCollection,
-                uploadProgress: 0,
-            });
-        } else if (this.props.namespace != newCollection.name.split('-')[0]) {
-            this.setState({
-                errors: `The collection you have selected does not match this namespace.`,
-                file: newCollection,
-                uploadProgress: 0,
-            });
-        } else {
-            this.setState({
-                errors: '',
-                file: newCollection,
-                uploadProgress: 0,
-            });
-        }
+  private renderFileIcon() {
+    switch (this.state.uploadStatus) {
+      case Status.uploading:
+        return <SpinnerIcon className='fa-spin'></SpinnerIcon>;
+      default:
+        return <FolderOpenIcon></FolderOpenIcon>;
     }
+  }
 
-    saveFile() {
-        this.setState({ uploadStatus: Status.uploading });
-        const artifact = {
-            file: this.state.file,
-            sha256: '',
-        } as CollectionUploadType;
+  private handleFileUpload(files) {
+    // Selects the artifact that will be uploaded and performs some basic
+    // preliminary checks on it.
+    const newCollection = files[0];
+    const { collection } = this.props;
 
-        this.cancelToken = CollectionAPI.getCancelToken();
-
-        CollectionAPI.upload(
-            artifact,
-            e => {
-                this.setState({
-                    uploadProgress: e.loaded / e.total,
-                });
-            },
-            this.cancelToken,
-        )
-            .then(response => {
-                this.props.onUploadSuccess(response);
-            })
-            .catch(errors => {
-                let errorMessage = '';
-
-                // If request was canceled by the user
-                if (!axios.isCancel(errors)) {
-                    // Upload fails
-                    if (errors.response.data.errors) {
-                        const messages = [];
-                        for (let err of errors.response.data.errors) {
-                            messages.push(
-                                err.detail ||
-                                    err.title ||
-                                    err.code ||
-                                    'API error. Status code: ' + err.status,
-                            );
-                        }
-                        errorMessage = messages.join(', ');
-                    } else {
-                        errorMessage =
-                            'API error. Status code: ' + errors.response.status;
-                    }
-                }
-
-                this.setState({
-                    uploadStatus: Status.waiting,
-                    errors: errorMessage,
-                });
-            })
-            .finally(_ => {
-                this.cancelToken = null;
-            });
+    if (files.length > 1) {
+      this.setState({
+        errors: 'Please select no more than one file.',
+      });
+    } else if (!this.acceptedFileTypes.includes(newCollection.type)) {
+      this.setState({
+        errors: 'Invalid file format.',
+        file: newCollection,
+        uploadProgress: 0,
+      });
+    } else if (!this.COLLECTION_NAME_REGEX.test(newCollection.name)) {
+      this.setState({
+        errors: `Invalid file name. Collections must be formatted as 'namespace-collection_name-1.0.0'`,
+        file: newCollection,
+        uploadProgress: 0,
+      });
+    } else if (
+      collection &&
+      collection.name !== newCollection.name.split('-')[1]
+    ) {
+      this.setState({
+        errors: `The collection you have selected doesn't appear to match ${collection.name}`,
+        file: newCollection,
+        uploadProgress: 0,
+      });
+    } else if (this.props.namespace != newCollection.name.split('-')[0]) {
+      this.setState({
+        errors: `The collection you have selected does not match this namespace.`,
+        file: newCollection,
+        uploadProgress: 0,
+      });
+    } else {
+      this.setState({
+        errors: '',
+        file: newCollection,
+        uploadProgress: 0,
+      });
     }
+  }
 
-    handleClose() {
-        let msg = null;
-        if (this.cancelToken && this.state.uploadStatus === Status.uploading) {
-            msg = 'Collection upload canceled';
-            this.cancelToken.cancel(msg);
+  saveFile() {
+    this.setState({ uploadStatus: Status.uploading });
+    const artifact = {
+      file: this.state.file,
+      sha256: '',
+    } as CollectionUploadType;
+
+    this.cancelToken = CollectionAPI.getCancelToken();
+
+    CollectionAPI.upload(
+      artifact,
+      e => {
+        this.setState({
+          uploadProgress: e.loaded / e.total,
+        });
+      },
+      this.cancelToken,
+    )
+      .then(response => {
+        this.props.onUploadSuccess(response);
+      })
+      .catch(errors => {
+        let errorMessage = '';
+
+        // If request was canceled by the user
+        if (!axios.isCancel(errors)) {
+          // Upload fails
+          if (errors.response.data.errors) {
+            const messages = [];
+            for (let err of errors.response.data.errors) {
+              messages.push(
+                err.detail ||
+                  err.title ||
+                  err.code ||
+                  'API error. Status code: ' + err.status,
+              );
+            }
+            errorMessage = messages.join(', ');
+          } else {
+            errorMessage = 'API error. Status code: ' + errors.response.status;
+          }
         }
 
-        this.setState(
-            {
-                file: undefined,
-                errors: '',
-                uploadProgress: 0,
-                uploadStatus: Status.waiting,
-            },
-            () => this.props.setOpen(false, msg),
-        );
+        this.setState({
+          uploadStatus: Status.waiting,
+          errors: errorMessage,
+        });
+      })
+      .finally(_ => {
+        this.cancelToken = null;
+      });
+  }
+
+  handleClose() {
+    let msg = null;
+    if (this.cancelToken && this.state.uploadStatus === Status.uploading) {
+      msg = 'Collection upload canceled';
+      this.cancelToken.cancel(msg);
     }
+
+    this.setState(
+      {
+        file: undefined,
+        errors: '',
+        uploadProgress: 0,
+        uploadStatus: Status.waiting,
+      },
+      () => this.props.setOpen(false, msg),
+    );
+  }
 }

--- a/src/containers/namespace-detail/manage-namespace.tsx
+++ b/src/containers/namespace-detail/manage-namespace.tsx
@@ -6,17 +6,15 @@ import { NamespaceDetail } from './namespace-detail';
 import { Paths } from '../../paths';
 
 class ManageNamespace extends React.Component<RouteComponentProps> {
-    render() {
-        return (
-            <NamespaceDetail
-                {...this.props}
-                showControls={true}
-                breadcrumbs={[
-                    { url: Paths.myNamespaces, name: 'My namespaces' },
-                ]}
-            ></NamespaceDetail>
-        );
-    }
+  render() {
+    return (
+      <NamespaceDetail
+        {...this.props}
+        showControls={true}
+        breadcrumbs={[{ url: Paths.myNamespaces, name: 'My namespaces' }]}
+      ></NamespaceDetail>
+    );
+  }
 }
 
 export default withRouter(ManageNamespace);

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -3,29 +3,29 @@ import * as React from 'react';
 import { RouteComponentProps, Redirect, Link } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import {
-    Button,
-    DropdownItem,
-    Alert,
-    AlertActionCloseButton,
+  Button,
+  DropdownItem,
+  Alert,
+  AlertActionCloseButton,
 } from '@patternfly/react-core';
 
 import * as ReactMarkdown from 'react-markdown';
 
 import {
-    CollectionListType,
-    CollectionAPI,
-    NamespaceAPI,
-    NamespaceType,
-    CertificationStatus,
+  CollectionListType,
+  CollectionAPI,
+  NamespaceAPI,
+  NamespaceType,
+  CertificationStatus,
 } from '../../api';
 
 import {
-    CollectionList,
-    PartnerHeader,
-    StatefulDropdown,
-    LoadingPageWithHeader,
-    Main,
-    APIButton,
+  CollectionList,
+  PartnerHeader,
+  StatefulDropdown,
+  LoadingPageWithHeader,
+  Main,
+  APIButton,
 } from '../../components';
 
 import { ImportModal } from './import-modal/import-modal';
@@ -34,293 +34,286 @@ import { ParamHelper } from '../../utilities/param-helper';
 import { Paths, formatPath } from '../../paths';
 
 interface IState {
-    collections: CollectionListType[];
-    namespace: NamespaceType;
-    params: {
-        sort?: string;
-        page?: number;
-        page_size?: number;
-        tab?: string;
-        keywords?: string;
-        namespace?: string;
-    };
-    redirect: string;
-    itemCount: number;
-    showImportModal: boolean;
-    warning: string;
-    updateCollection: CollectionListType;
+  collections: CollectionListType[];
+  namespace: NamespaceType;
+  params: {
+    sort?: string;
+    page?: number;
+    page_size?: number;
+    tab?: string;
+    keywords?: string;
+    namespace?: string;
+  };
+  redirect: string;
+  itemCount: number;
+  showImportModal: boolean;
+  warning: string;
+  updateCollection: CollectionListType;
 }
 
 interface IProps extends RouteComponentProps {
-    showControls: boolean;
-    breadcrumbs: { name: string; url?: string }[];
+  showControls: boolean;
+  breadcrumbs: { name: string; url?: string }[];
 }
 
 export class NamespaceDetail extends React.Component<IProps, IState> {
-    nonAPIParams = ['tab'];
-    persistentParams = { certification: CertificationStatus.certified };
+  nonAPIParams = ['tab'];
+  persistentParams = { certification: CertificationStatus.certified };
 
-    // namespace is a positional url argument, so don't include it in the
-    // query params
-    nonQueryStringParams = ['namespace'];
+  // namespace is a positional url argument, so don't include it in the
+  // query params
+  nonQueryStringParams = ['namespace'];
 
-    constructor(props) {
-        super(props);
-        const params = ParamHelper.parseParamString(props.location.search, [
-            'page',
-            'page_size',
-        ]);
+  constructor(props) {
+    super(props);
+    const params = ParamHelper.parseParamString(props.location.search, [
+      'page',
+      'page_size',
+    ]);
 
-        params['namespace'] = props.match.params['namespace'];
+    params['namespace'] = props.match.params['namespace'];
 
-        this.state = {
-            collections: [],
-            namespace: null,
-            params: params,
-            redirect: null,
-            itemCount: 0,
-            showImportModal: false,
-            warning: '',
-            updateCollection: null,
-        };
+    this.state = {
+      collections: [],
+      namespace: null,
+      params: params,
+      redirect: null,
+      itemCount: 0,
+      showImportModal: false,
+      warning: '',
+      updateCollection: null,
+    };
+  }
+
+  componentDidMount() {
+    this.loadAll();
+  }
+
+  render() {
+    const {
+      collections,
+      namespace,
+      params,
+      redirect,
+      itemCount,
+      showImportModal,
+      warning,
+      updateCollection,
+    } = this.state;
+
+    const { breadcrumbs } = this.props;
+
+    if (redirect) {
+      return <Redirect to={redirect} />;
     }
 
-    componentDidMount() {
-        this.loadAll();
+    if (!namespace) {
+      return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    render() {
-        const {
-            collections,
-            namespace,
-            params,
-            redirect,
-            itemCount,
-            showImportModal,
-            warning,
-            updateCollection,
-        } = this.state;
+    const tabs = ['Collections'];
 
-        const { breadcrumbs } = this.props;
+    const tab = params['tab'] || 'collections';
 
-        if (redirect) {
-            return <Redirect to={redirect} />;
-        }
-
-        if (!namespace) {
-            return <LoadingPageWithHeader></LoadingPageWithHeader>;
-        }
-
-        const tabs = ['Collections'];
-
-        const tab = params['tab'] || 'collections';
-
-        if (namespace.resources) {
-            tabs.push('Resources');
-        }
-
-        return (
-            <React.Fragment>
-                <ImportModal
-                    isOpen={showImportModal}
-                    onUploadSuccess={result =>
-                        this.props.history.push(
-                            formatPath(
-                                Paths.myImports,
-                                {},
-                                {
-                                    namespace: namespace.name,
-                                },
-                            ),
-                        )
-                    }
-                    // onCancel
-                    setOpen={(isOpen, warn) =>
-                        this.toggleImportModal(isOpen, warn)
-                    }
-                    collection={updateCollection}
-                    namespace={namespace.name}
-                />
-                {warning ? (
-                    <Alert
-                        style={{
-                            position: 'fixed',
-                            right: '5px',
-                            top: '80px',
-                            zIndex: 300,
-                        }}
-                        variant='warning'
-                        title={warning}
-                        action={
-                            <AlertActionCloseButton
-                                onClose={() => this.setState({ warning: '' })}
-                            />
-                        }
-                    ></Alert>
-                ) : null}
-                <PartnerHeader
-                    namespace={namespace}
-                    breadcrumbs={breadcrumbs.concat([{ name: namespace.name }])}
-                    tabs={tabs}
-                    params={params}
-                    updateParams={p => this.updateParams(p)}
-                    pageControls={this.renderPageControls()}
-                ></PartnerHeader>
-                <Main>
-                    <Section className='body'>
-                        {tab.toLowerCase() === 'collections' ? (
-                            <CollectionList
-                                updateParams={params =>
-                                    this.updateParams(params, () =>
-                                        this.loadCollections(),
-                                    )
-                                }
-                                params={params}
-                                collections={collections}
-                                itemCount={itemCount}
-                                showControls={this.props.showControls}
-                                handleControlClick={(id, action) =>
-                                    this.handleCollectionAction(id, action)
-                                }
-                            />
-                        ) : (
-                            this.renderResources(namespace)
-                        )}
-                    </Section>
-                </Main>
-            </React.Fragment>
-        );
+    if (namespace.resources) {
+      tabs.push('Resources');
     }
 
-    private handleCollectionAction(id, action) {
-        const collection = this.state.collections.find(x => x.id === id);
+    return (
+      <React.Fragment>
+        <ImportModal
+          isOpen={showImportModal}
+          onUploadSuccess={result =>
+            this.props.history.push(
+              formatPath(
+                Paths.myImports,
+                {},
+                {
+                  namespace: namespace.name,
+                },
+              ),
+            )
+          }
+          // onCancel
+          setOpen={(isOpen, warn) => this.toggleImportModal(isOpen, warn)}
+          collection={updateCollection}
+          namespace={namespace.name}
+        />
+        {warning ? (
+          <Alert
+            style={{
+              position: 'fixed',
+              right: '5px',
+              top: '80px',
+              zIndex: 300,
+            }}
+            variant='warning'
+            title={warning}
+            action={
+              <AlertActionCloseButton
+                onClose={() => this.setState({ warning: '' })}
+              />
+            }
+          ></Alert>
+        ) : null}
+        <PartnerHeader
+          namespace={namespace}
+          breadcrumbs={breadcrumbs.concat([{ name: namespace.name }])}
+          tabs={tabs}
+          params={params}
+          updateParams={p => this.updateParams(p)}
+          pageControls={this.renderPageControls()}
+        ></PartnerHeader>
+        <Main>
+          <Section className='body'>
+            {tab.toLowerCase() === 'collections' ? (
+              <CollectionList
+                updateParams={params =>
+                  this.updateParams(params, () => this.loadCollections())
+                }
+                params={params}
+                collections={collections}
+                itemCount={itemCount}
+                showControls={this.props.showControls}
+                handleControlClick={(id, action) =>
+                  this.handleCollectionAction(id, action)
+                }
+              />
+            ) : (
+              this.renderResources(namespace)
+            )}
+          </Section>
+        </Main>
+      </React.Fragment>
+    );
+  }
 
-        switch (action) {
-            case 'upload':
-                this.setState({
-                    updateCollection: collection,
-                    showImportModal: true,
-                });
-                break;
-            case 'deprecate':
-                CollectionAPI.setDeprecation(collection, !collection.deprecated)
-                    .then(() => this.loadCollections())
-                    .catch(error => {
-                        this.setState({
-                            warning: 'API Error: Failed to set deprecation.',
-                        });
-                    });
-                break;
-        }
-    }
+  private handleCollectionAction(id, action) {
+    const collection = this.state.collections.find(x => x.id === id);
 
-    private renderResources(namespace: NamespaceType) {
-        return (
-            <div className='pf-c-content preview'>
-                <ReactMarkdown source={namespace.resources} />
-            </div>
-        );
-    }
-
-    private loadCollections() {
-        CollectionAPI.list({
-            ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
-            ...this.persistentParams,
-        }).then(result => {
-            this.setState({
-                collections: result.data.data,
-                itemCount: result.data.meta.count,
-            });
+    switch (action) {
+      case 'upload':
+        this.setState({
+          updateCollection: collection,
+          showImportModal: true,
         });
-    }
-
-    private loadAll() {
-        Promise.all([
-            CollectionAPI.list({
-                ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
-                ...this.persistentParams,
-            }),
-            NamespaceAPI.get(this.props.match.params['namespace']),
-        ])
-            .then(val => {
-                this.setState({
-                    collections: val[0].data.data,
-                    itemCount: val[0].data.meta.count,
-                    namespace: val[1].data,
-                });
-            })
-            .catch(response => {
-                this.setState({ redirect: Paths.notFound });
+        break;
+      case 'deprecate':
+        CollectionAPI.setDeprecation(collection, !collection.deprecated)
+          .then(() => this.loadCollections())
+          .catch(error => {
+            this.setState({
+              warning: 'API Error: Failed to set deprecation.',
             });
+          });
+        break;
     }
+  }
 
-    private get updateParams() {
-        return ParamHelper.updateParamsMixin(this.nonQueryStringParams);
+  private renderResources(namespace: NamespaceType) {
+    return (
+      <div className='pf-c-content preview'>
+        <ReactMarkdown source={namespace.resources} />
+      </div>
+    );
+  }
+
+  private loadCollections() {
+    CollectionAPI.list({
+      ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
+      ...this.persistentParams,
+    }).then(result => {
+      this.setState({
+        collections: result.data.data,
+        itemCount: result.data.meta.count,
+      });
+    });
+  }
+
+  private loadAll() {
+    Promise.all([
+      CollectionAPI.list({
+        ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
+        ...this.persistentParams,
+      }),
+      NamespaceAPI.get(this.props.match.params['namespace']),
+    ])
+      .then(val => {
+        this.setState({
+          collections: val[0].data.data,
+          itemCount: val[0].data.meta.count,
+          namespace: val[1].data,
+        });
+      })
+      .catch(response => {
+        this.setState({ redirect: Paths.notFound });
+      });
+  }
+
+  private get updateParams() {
+    return ParamHelper.updateParamsMixin(this.nonQueryStringParams);
+  }
+
+  private renderPageControls() {
+    if (!this.props.showControls) {
+      return (
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <APIButton style={{ marginLeft: '8px' }} />
+        </div>
+      );
     }
-
-    private renderPageControls() {
-        if (!this.props.showControls) {
-            return (
-                <div style={{ display: 'flex', alignItems: 'center' }}>
-                    <APIButton style={{ marginLeft: '8px' }} />
-                </div>
-            );
-        }
-        return (
-            <div style={{ display: 'flex', alignItems: 'center' }}>
-                <Button
-                    onClick={() => this.setState({ showImportModal: true })}
+    return (
+      <div style={{ display: 'flex', alignItems: 'center' }}>
+        <Button onClick={() => this.setState({ showImportModal: true })}>
+          Upload collection
+        </Button>
+        <APIButton style={{ marginLeft: '8px' }} />
+        <StatefulDropdown
+          items={[
+            <DropdownItem
+              key='1'
+              component={
+                <Link
+                  to={formatPath(Paths.editNamespace, {
+                    namespace: this.state.namespace.name,
+                  })}
                 >
-                    Upload collection
-                </Button>
-                <APIButton style={{ marginLeft: '8px' }} />
-                <StatefulDropdown
-                    items={[
-                        <DropdownItem
-                            key='1'
-                            component={
-                                <Link
-                                    to={formatPath(Paths.editNamespace, {
-                                        namespace: this.state.namespace.name,
-                                    })}
-                                >
-                                    Edit namespace
-                                </Link>
-                            }
-                        />,
-                        <DropdownItem
-                            key='2'
-                            component={
-                                <Link
-                                    to={formatPath(
-                                        Paths.myImports,
-                                        {},
-                                        {
-                                            namespace: this.state.namespace
-                                                .name,
-                                        },
-                                    )}
-                                >
-                                    Imports
-                                </Link>
-                            }
-                        />,
-                    ]}
-                />
-            </div>
-        );
+                  Edit namespace
+                </Link>
+              }
+            />,
+            <DropdownItem
+              key='2'
+              component={
+                <Link
+                  to={formatPath(
+                    Paths.myImports,
+                    {},
+                    {
+                      namespace: this.state.namespace.name,
+                    },
+                  )}
+                >
+                  Imports
+                </Link>
+              }
+            />,
+          ]}
+        />
+      </div>
+    );
+  }
+
+  private toggleImportModal(isOpen: boolean, warning?: string) {
+    const newState = { showImportModal: isOpen };
+    if (warning) {
+      newState['warning'] = warning;
     }
 
-    private toggleImportModal(isOpen: boolean, warning?: string) {
-        const newState = { showImportModal: isOpen };
-        if (warning) {
-            newState['warning'] = warning;
-        }
-
-        if (!isOpen) {
-            newState['updateCollection'] = null;
-        }
-
-        this.setState(newState);
+    if (!isOpen) {
+      newState['updateCollection'] = null;
     }
+
+    this.setState(newState);
+  }
 }

--- a/src/containers/namespace-detail/partner-detail.tsx
+++ b/src/containers/namespace-detail/partner-detail.tsx
@@ -6,15 +6,15 @@ import { NamespaceDetail } from './namespace-detail';
 import { Paths } from '../../paths';
 
 class PartnerDetail extends React.Component<RouteComponentProps> {
-    render() {
-        return (
-            <NamespaceDetail
-                {...this.props}
-                showControls={false}
-                breadcrumbs={[{ url: Paths.partners, name: 'Partners' }]}
-            ></NamespaceDetail>
-        );
-    }
+  render() {
+    return (
+      <NamespaceDetail
+        {...this.props}
+        showControls={false}
+        breadcrumbs={[{ url: Paths.partners, name: 'Partners' }]}
+      ></NamespaceDetail>
+    );
+  }
 }
 
 export default withRouter(PartnerDetail);

--- a/src/containers/namespace-list/my-namespaces.tsx
+++ b/src/containers/namespace-list/my-namespaces.tsx
@@ -6,16 +6,16 @@ import { NamespaceList } from './namespace-list';
 import { Paths } from '../../paths';
 
 class MyNamespaces extends React.Component<RouteComponentProps, {}> {
-    render() {
-        return (
-            <NamespaceList
-                {...this.props}
-                namespacePath={Paths.myCollections}
-                title='My namespaces'
-                filterOwner={true}
-            />
-        );
-    }
+  render() {
+    return (
+      <NamespaceList
+        {...this.props}
+        namespacePath={Paths.myCollections}
+        title='My namespaces'
+        filterOwner={true}
+      />
+    );
+  }
 }
 
 export default withRouter(MyNamespaces);

--- a/src/containers/namespace-list/namespace-list.scss
+++ b/src/containers/namespace-list/namespace-list.scss
@@ -1,15 +1,15 @@
 .card-layout {
-    display: flex;
-    flex-wrap: wrap;
+  display: flex;
+  flex-wrap: wrap;
 
-    .card-wrapper {
-        margin-right: 24px;
-        margin-bottom: 24px;
-    }
+  .card-wrapper {
+    margin-right: 24px;
+    margin-bottom: 24px;
+  }
 }
 
 .toolbar {
-    padding-bottom: 24px;
-    display: flex;
-    justify-content: space-between;
+  padding-bottom: 24px;
+  display: flex;
+  justify-content: space-between;
 }

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -4,282 +4,267 @@ import './namespace-list.scss';
 import { RouteComponentProps, Link } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import {
-    EmptyState,
-    EmptyStateIcon,
-    Title,
-    EmptyStateBody,
-    EmptyStateVariant,
+  EmptyState,
+  EmptyStateIcon,
+  Title,
+  EmptyStateBody,
+  EmptyStateVariant,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 
 import { ParamHelper } from '../../utilities/param-helper';
 import {
-    BaseHeader,
-    NamespaceCard,
-    Toolbar,
-    Pagination,
-    NamespaceModal,
-    LoadingPageWithHeader,
-    Main,
-    LoadingPageSpinner,
+  BaseHeader,
+  NamespaceCard,
+  Toolbar,
+  Pagination,
+  NamespaceModal,
+  LoadingPageWithHeader,
+  Main,
+  LoadingPageSpinner,
 } from '../../components';
 import { Button } from '@patternfly/react-core';
 import { DataToolbarItem } from '@patternfly/react-core/dist/esm/experimental';
 import {
-    NamespaceAPI,
-    NamespaceListType,
-    UserAPI,
-    MeType,
-    MyNamespaceAPI,
+  NamespaceAPI,
+  NamespaceListType,
+  UserAPI,
+  MeType,
+  MyNamespaceAPI,
 } from '../../api';
 import { Paths, formatPath } from '../../paths';
 import { Constants } from '../../constants';
 
 interface IState {
-    namespaces: NamespaceListType[];
-    itemCount: number;
-    params: {
-        name?: string;
-        sort?: string;
-        page?: number;
-        page_size?: number;
-        tenant?: string;
-    };
-    hasPermission: boolean;
-    partnerEngineer: boolean;
-    isModalOpen: boolean;
-    loading: boolean;
+  namespaces: NamespaceListType[];
+  itemCount: number;
+  params: {
+    name?: string;
+    sort?: string;
+    page?: number;
+    page_size?: number;
+    tenant?: string;
+  };
+  hasPermission: boolean;
+  partnerEngineer: boolean;
+  isModalOpen: boolean;
+  loading: boolean;
 }
 
 interface IProps extends RouteComponentProps {
-    title: string;
-    namespacePath: Paths;
-    filterOwner?: boolean;
+  title: string;
+  namespacePath: Paths;
+  filterOwner?: boolean;
 }
 
 export class NamespaceList extends React.Component<IProps, IState> {
-    nonURLParams = ['tenant'];
-    handleSubmit;
+  nonURLParams = ['tenant'];
+  handleSubmit;
 
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        const params = ParamHelper.parseParamString(props.location.search, [
-            'page',
-            'page_size',
-        ]);
+    const params = ParamHelper.parseParamString(props.location.search, [
+      'page',
+      'page_size',
+    ]);
 
-        if (!params['page_size']) {
-            params['page_size'] = 24;
-        }
-
-        if (!params['sort']) {
-            params['sort'] = 'name';
-        }
-
-        this.state = {
-            namespaces: undefined,
-            itemCount: 0,
-            params: params,
-            hasPermission: true,
-            isModalOpen: false,
-            partnerEngineer: false,
-            loading: true,
-        };
+    if (!params['page_size']) {
+      params['page_size'] = 24;
     }
 
-    private handleModalToggle = () => {
-        this.setState(({ isModalOpen }) => ({
-            isModalOpen: !isModalOpen,
-        }));
+    if (!params['sort']) {
+      params['sort'] = 'name';
+    }
+
+    this.state = {
+      namespaces: undefined,
+      itemCount: 0,
+      params: params,
+      hasPermission: true,
+      isModalOpen: false,
+      partnerEngineer: false,
+      loading: true,
     };
+  }
 
-    componentDidMount() {
-        this.isPartnerEngineer();
-        if (this.props.filterOwner) {
-            // Make a query with no params and see if it returns results to tell
-            // if the user can edit namespaces
-            MyNamespaceAPI.list({}).then(results => {
-                if (results.data.meta.count !== 0) {
-                    this.loadNamespaces();
-                } else {
-                    this.setState({
-                        hasPermission: false,
-                        namespaces: [],
-                        loading: false,
-                    });
+  private handleModalToggle = () => {
+    this.setState(({ isModalOpen }) => ({
+      isModalOpen: !isModalOpen,
+    }));
+  };
+
+  componentDidMount() {
+    this.isPartnerEngineer();
+    if (this.props.filterOwner) {
+      // Make a query with no params and see if it returns results to tell
+      // if the user can edit namespaces
+      MyNamespaceAPI.list({}).then(results => {
+        if (results.data.meta.count !== 0) {
+          this.loadNamespaces();
+        } else {
+          this.setState({
+            hasPermission: false,
+            namespaces: [],
+            loading: false,
+          });
+        }
+      });
+    } else {
+      this.loadNamespaces();
+    }
+  }
+
+  render() {
+    const { namespaces, params, itemCount, partnerEngineer } = this.state;
+    const { title } = this.props;
+
+    if (!namespaces) {
+      return <LoadingPageWithHeader></LoadingPageWithHeader>;
+    }
+
+    const createButton = partnerEngineer && (
+      <React.Fragment>
+        <DataToolbarItem variant='separator' />
+        <DataToolbarItem>
+          <Button variant='primary' onClick={this.handleModalToggle}>
+            Create
+          </Button>
+        </DataToolbarItem>
+      </React.Fragment>
+    );
+
+    return (
+      <React.Fragment>
+        <BaseHeader title={title}>
+          <div className='toolbar'>
+            <Toolbar
+              params={params}
+              sortOptions={[{ title: 'Name', id: 'name', type: 'alpha' }]}
+              searchPlaceholder={'Search ' + title.toLowerCase()}
+              updateParams={p =>
+                this.updateParams(p, () => this.loadNamespaces())
+              }
+              extraInputs={[createButton]}
+            />
+            <div>
+              <Pagination
+                params={params}
+                updateParams={p =>
+                  this.updateParams(p, () => this.loadNamespaces())
                 }
-            });
-        } else {
-            this.loadNamespaces();
-        }
+                count={itemCount}
+                isCompact
+                perPageOptions={Constants.CARD_DEFAULT_PAGINATION_OPTIONS}
+              />
+            </div>
+          </div>
+        </BaseHeader>
+        <Main>
+          <Section>{this.renderBody()}</Section>
+          <NamespaceModal
+            isOpen={this.state.isModalOpen}
+            toggleModal={this.handleModalToggle}
+            onCreateSuccess={result =>
+              this.props.history.push(
+                formatPath(Paths.myCollections, {
+                  namespace: result['name'],
+                }),
+              )
+            }
+          ></NamespaceModal>
+        </Main>
+      </React.Fragment>
+    );
+  }
+
+  private renderBody() {
+    const { namespaces, hasPermission } = this.state;
+    const { namespacePath } = this.props;
+    const { loading } = this.state;
+
+    if (loading) {
+      return (
+        <Section>
+          <LoadingPageSpinner></LoadingPageSpinner>;
+        </Section>
+      );
     }
 
-    render() {
-        const { namespaces, params, itemCount, partnerEngineer } = this.state;
-        const { title } = this.props;
-
-        if (!namespaces) {
-            return <LoadingPageWithHeader></LoadingPageWithHeader>;
-        }
-
-        const createButton = partnerEngineer && (
-            <React.Fragment>
-                <DataToolbarItem variant='separator' />
-                <DataToolbarItem>
-                    <Button variant='primary' onClick={this.handleModalToggle}>
-                        Create
-                    </Button>
-                </DataToolbarItem>
-            </React.Fragment>
-        );
-
-        return (
-            <React.Fragment>
-                <BaseHeader title={title}>
-                    <div className='toolbar'>
-                        <Toolbar
-                            params={params}
-                            sortOptions={[
-                                { title: 'Name', id: 'name', type: 'alpha' },
-                            ]}
-                            searchPlaceholder={'Search ' + title.toLowerCase()}
-                            updateParams={p =>
-                                this.updateParams(p, () =>
-                                    this.loadNamespaces(),
-                                )
-                            }
-                            extraInputs={[createButton]}
-                        />
-                        <div>
-                            <Pagination
-                                params={params}
-                                updateParams={p =>
-                                    this.updateParams(p, () =>
-                                        this.loadNamespaces(),
-                                    )
-                                }
-                                count={itemCount}
-                                isCompact
-                                perPageOptions={
-                                    Constants.CARD_DEFAULT_PAGINATION_OPTIONS
-                                }
-                            />
-                        </div>
-                    </div>
-                </BaseHeader>
-                <Main>
-                    <Section>{this.renderBody()}</Section>
-                    <NamespaceModal
-                        isOpen={this.state.isModalOpen}
-                        toggleModal={this.handleModalToggle}
-                        onCreateSuccess={result =>
-                            this.props.history.push(
-                                formatPath(Paths.myCollections, {
-                                    namespace: result['name'],
-                                }),
-                            )
-                        }
-                    ></NamespaceModal>
-                </Main>
-            </React.Fragment>
-        );
+    if (namespaces.length === 0) {
+      return (
+        <Section>
+          <EmptyState className='empty' variant={EmptyStateVariant.full}>
+            <EmptyStateIcon icon={SearchIcon} />
+            <Title headingLevel='h2' size='lg'>
+              {hasPermission ? 'No results found' : 'No managed namespaces'}
+            </Title>
+            <EmptyStateBody>
+              {hasPermission
+                ? 'No results match the filter criteria.' +
+                  ' Remove all filters or clear all filters' +
+                  ' to show results.'
+                : 'This account is not set up to manage any namespaces.'}
+            </EmptyStateBody>
+            {hasPermission && (
+              <Button
+                variant='link'
+                onClick={() =>
+                  this.updateParams({}, () => this.loadNamespaces())
+                }
+              >
+                Clear all filters
+              </Button>
+            )}
+          </EmptyState>
+        </Section>
+      );
     }
 
-    private renderBody() {
-        const { namespaces, hasPermission } = this.state;
-        const { namespacePath } = this.props;
-        const { loading } = this.state;
+    return (
+      <Section className='card-layout'>
+        {namespaces.map((ns, i) => (
+          <div key={i} className='card-wrapper'>
+            <Link
+              to={formatPath(namespacePath, {
+                namespace: ns.name,
+              })}
+            >
+              <NamespaceCard key={i} {...ns}></NamespaceCard>
+            </Link>
+          </div>
+        ))}
+      </Section>
+    );
+  }
 
-        if (loading) {
-            return (
-                <Section>
-                    <LoadingPageSpinner></LoadingPageSpinner>;
-                </Section>
-            );
-        }
+  private loadNamespaces() {
+    let apiFunc: any;
 
-        if (namespaces.length === 0) {
-            return (
-                <Section>
-                    <EmptyState
-                        className='empty'
-                        variant={EmptyStateVariant.full}
-                    >
-                        <EmptyStateIcon icon={SearchIcon} />
-                        <Title headingLevel='h2' size='lg'>
-                            {hasPermission
-                                ? 'No results found'
-                                : 'No managed namespaces'}
-                        </Title>
-                        <EmptyStateBody>
-                            {hasPermission
-                                ? 'No results match the filter criteria.' +
-                                  ' Remove all filters or clear all filters' +
-                                  ' to show results.'
-                                : 'This account is not set up to manage any namespaces.'}
-                        </EmptyStateBody>
-                        {hasPermission && (
-                            <Button
-                                variant='link'
-                                onClick={() =>
-                                    this.updateParams({}, () =>
-                                        this.loadNamespaces(),
-                                    )
-                                }
-                            >
-                                Clear all filters
-                            </Button>
-                        )}
-                    </EmptyState>
-                </Section>
-            );
-        }
-
-        return (
-            <Section className='card-layout'>
-                {namespaces.map((ns, i) => (
-                    <div key={i} className='card-wrapper'>
-                        <Link
-                            to={formatPath(namespacePath, {
-                                namespace: ns.name,
-                            })}
-                        >
-                            <NamespaceCard key={i} {...ns}></NamespaceCard>
-                        </Link>
-                    </div>
-                ))}
-            </Section>
-        );
+    if (this.props.filterOwner) {
+      apiFunc = p => MyNamespaceAPI.list(p);
+    } else {
+      apiFunc = p => NamespaceAPI.list(p);
     }
-
-    private loadNamespaces() {
-        let apiFunc: any;
-
-        if (this.props.filterOwner) {
-            apiFunc = p => MyNamespaceAPI.list(p);
-        } else {
-            apiFunc = p => NamespaceAPI.list(p);
-        }
-        this.setState({ loading: true }, () => {
-            apiFunc(this.state.params).then(results => {
-                this.setState({
-                    namespaces: results.data.data,
-                    itemCount: results.data.meta.count,
-                    loading: false,
-                });
-            });
+    this.setState({ loading: true }, () => {
+      apiFunc(this.state.params).then(results => {
+        this.setState({
+          namespaces: results.data.data,
+          itemCount: results.data.meta.count,
+          loading: false,
         });
-    }
+      });
+    });
+  }
 
-    private get updateParams() {
-        return ParamHelper.updateParamsMixin(this.nonURLParams);
-    }
+  private get updateParams() {
+    return ParamHelper.updateParamsMixin(this.nonURLParams);
+  }
 
-    private isPartnerEngineer() {
-        UserAPI.isPartnerEngineer().then(response => {
-            const me: MeType = response.data;
-            this.setState({ partnerEngineer: me.is_partner_engineer });
-        });
-    }
+  private isPartnerEngineer() {
+    UserAPI.isPartnerEngineer().then(response => {
+      const me: MeType = response.data;
+      this.setState({ partnerEngineer: me.is_partner_engineer });
+    });
+  }
 }

--- a/src/containers/namespace-list/partners.tsx
+++ b/src/containers/namespace-list/partners.tsx
@@ -5,15 +5,15 @@ import { NamespaceList } from './namespace-list';
 import { Paths } from '../../paths';
 
 class Partners extends React.Component<RouteComponentProps, {}> {
-    render() {
-        return (
-            <NamespaceList
-                {...this.props}
-                namespacePath={Paths.namespace}
-                title='Partners'
-            />
-        );
-    }
+  render() {
+    return (
+      <NamespaceList
+        {...this.props}
+        namespacePath={Paths.namespace}
+        title='Partners'
+      />
+    );
+  }
 }
 
 export default withRouter(Partners);

--- a/src/containers/not-found/not-found.scss
+++ b/src/containers/not-found/not-found.scss
@@ -1,13 +1,13 @@
 .bullseye-center {
-    display: flex;
-    align-items: center;
-    flex-direction: column;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
 }
 
 .bullseye {
-    min-height: calc(100vh - 230px);
+  min-height: calc(100vh - 230px);
 }
 
 .four-oh-four {
-    font-size: 30pt;
+  font-size: 30pt;
 }

--- a/src/containers/not-found/not-found.tsx
+++ b/src/containers/not-found/not-found.tsx
@@ -10,29 +10,26 @@ import { Bullseye } from '@patternfly/react-core';
 import { BaseHeader, Main } from '../../components';
 
 class NotFound extends React.Component<RouteComponentProps, {}> {
-    render() {
-        return (
-            <React.Fragment>
-                <BaseHeader title='404 - Page not found'></BaseHeader>
-                <Main>
-                    <Section className='body'>
-                        <Bullseye className='bullseye'>
-                            <div className='bullseye-center'>
-                                <img src={RageTater} alt='AWX Spud' />
-                                <div>
-                                    We couldn't find the page you're looking
-                                    for!
-                                </div>
-                                <div className='pf-c-content'>
-                                    <span className='four-oh-four'>404</span>
-                                </div>
-                            </div>
-                        </Bullseye>
-                    </Section>
-                </Main>
-            </React.Fragment>
-        );
-    }
+  render() {
+    return (
+      <React.Fragment>
+        <BaseHeader title='404 - Page not found'></BaseHeader>
+        <Main>
+          <Section className='body'>
+            <Bullseye className='bullseye'>
+              <div className='bullseye-center'>
+                <img src={RageTater} alt='AWX Spud' />
+                <div>We couldn't find the page you're looking for!</div>
+                <div className='pf-c-content'>
+                  <span className='four-oh-four'>404</span>
+                </div>
+              </div>
+            </Bullseye>
+          </Section>
+        </Main>
+      </React.Fragment>
+    );
+  }
 }
 
 export default withRouter(NotFound);

--- a/src/containers/search/search.scss
+++ b/src/containers/search/search.scss
@@ -1,83 +1,83 @@
 @import '../../global-variables.scss';
 
 .toolbar {
-    padding-bottom: 24px;
+  padding-bottom: 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .pagination-container {
     display: flex;
-    justify-content: space-between;
     align-items: center;
 
-    .pagination-container {
-        display: flex;
-        align-items: center;
-
-        .card-list-switcher {
-            margin-right: 24px;
-        }
+    .card-list-switcher {
+      margin-right: 24px;
     }
+  }
 }
 
 .header {
-    border-bottom: 1px solid #d8d8d8;
+  border-bottom: 1px solid #d8d8d8;
 }
 
 .collection-container {
-    // Should be the height of the page minus the header and the footer.
-    // This makes it so the footer stays at the bottom.
-    min-height: calc(100vh - 285px);
+  // Should be the height of the page minus the header and the footer.
+  // This makes it so the footer stays at the bottom.
+  min-height: calc(100vh - 285px);
 
-    @media (min-width: $breakpoint-md) {
-        display: flex;
+  @media (min-width: $breakpoint-md) {
+    display: flex;
+  }
+
+  .sidebar {
+    margin-left: -24px;
+    margin-top: -24px;
+    background-color: white;
+    min-width: 190px;
+    padding: 24px;
+    padding-top: 24px;
+
+    @media (max-width: $breakpoint-md) {
+      margin-bottom: 24px;
+      margin-right: -24px;
     }
+  }
 
-    .sidebar {
-        margin-left: -24px;
-        margin-top: -24px;
-        background-color: white;
-        min-width: 190px;
-        padding: 24px;
-        padding-top: 24px;
+  .cards {
+    display: flex;
+    flex-wrap: wrap;
+    align-content: flex-start;
 
-        @media (max-width: $breakpoint-md) {
-            margin-bottom: 24px;
-            margin-right: -24px;
-        }
+    .card {
+      margin-left: 24px;
+      margin-bottom: 24px;
     }
+  }
 
-    .cards {
-        display: flex;
-        flex-wrap: wrap;
-        align-content: flex-start;
+  .list-container {
+    width: 100%;
+  }
 
-        .card {
-            margin-left: 24px;
-            margin-bottom: 24px;
-        }
+  .list {
+    margin-bottom: 24px;
+    margin-left: 24px;
+    padding-top: 16px;
+    padding-bottom: 16px;
+
+    // Hack to hide the annoying line at the top of the data list.
+    overflow: hidden;
+    .data-list {
+      margin-top: -17px;
+      margin-bottom: -17px;
     }
+  }
 
-    .list-container {
-        width: 100%;
-    }
-
-    .list {
-        margin-bottom: 24px;
-        margin-left: 24px;
-        padding-top: 16px;
-        padding-bottom: 16px;
-
-        // Hack to hide the annoying line at the top of the data list.
-        overflow: hidden;
-        .data-list {
-            margin-top: -17px;
-            margin-bottom: -17px;
-        }
-    }
-
-    .empty {
-        flex-grow: 1;
-    }
+  .empty {
+    flex-grow: 1;
+  }
 }
 
 .footer {
-    border-top: 1px solid #d8d8d8;
-    margin: 0px -24px -24px -24px;
+  border-top: 1px solid #d8d8d8;
+  margin: 0px -24px -24px -24px;
 }

--- a/src/containers/token/token.tsx
+++ b/src/containers/token/token.tsx
@@ -9,90 +9,82 @@ import { Constants } from '../../constants';
 import { UserAPI } from '../../api';
 
 interface IState {
-    tokenData: {
-        access_token: string;
-        expires_in: number;
-        id_token: string;
-        refresh_expires_in: number;
-        refresh_token: string;
-        scope: string;
-        session_state: string;
-        token_type: string;
-    };
+  tokenData: {
+    access_token: string;
+    expires_in: number;
+    id_token: string;
+    refresh_expires_in: number;
+    refresh_token: string;
+    scope: string;
+    session_state: string;
+    token_type: string;
+  };
 }
 
 class TokenPage extends React.Component<RouteComponentProps, IState> {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            tokenData: undefined,
-        };
+    this.state = {
+      tokenData: undefined,
+    };
+  }
+
+  componentDidMount() {
+    if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
+      // this function will fail if chrome.auth.doOffline() hasn't been called
+      (window as any).insights.chrome.auth.getOfflineToken().then(result => {
+        this.setState({ tokenData: result.data });
+      });
     }
+  }
 
-    componentDidMount() {
-        if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
-            // this function will fail if chrome.auth.doOffline() hasn't been called
-            (window as any).insights.chrome.auth
-                .getOfflineToken()
-                .then(result => {
-                    this.setState({ tokenData: result.data });
-                });
-        }
+  render() {
+    const { tokenData } = this.state;
+
+    return (
+      <React.Fragment>
+        <BaseHeader title='Token management'></BaseHeader>
+        <Main>
+          <Section className='body pf-c-content'>
+            <h2>Offline token</h2>
+            <p>
+              Use this token to authenticate the <code>ansible-galaxy</code>{' '}
+              client.
+            </p>
+            {tokenData ? (
+              <div>
+                <ClipboardCopy>{tokenData.refresh_token}</ClipboardCopy>
+              </div>
+            ) : (
+              <Button onClick={() => this.loadToken()}>Load token</Button>
+            )}
+            <h2>Manage tokens</h2>
+            To remove an existing token, visit{' '}
+            <a
+              href='https://sso.redhat.com/auth/realms/redhat-external/account/'
+              target='_blank'
+            >
+              Red Hat SSO account managment
+            </a>
+            .
+          </Section>
+        </Main>
+      </React.Fragment>
+    );
+  }
+
+  private loadToken() {
+    if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
+      (window as any).insights.chrome.auth
+        // doOffline causes the page to refresh and will make the data
+        // available to getOfflineToken() when the component mounts after
+        // the reload
+        .doOffline();
+    } else {
+      UserAPI.getToken().then(result => this.setState({ tokenData: result }));
     }
-
-    render() {
-        const { tokenData } = this.state;
-
-        return (
-            <React.Fragment>
-                <BaseHeader title='Token management'></BaseHeader>
-                <Main>
-                    <Section className='body pf-c-content'>
-                        <h2>Offline token</h2>
-                        <p>
-                            Use this token to authenticate the{' '}
-                            <code>ansible-galaxy</code> client.
-                        </p>
-                        {tokenData ? (
-                            <div>
-                                <ClipboardCopy>
-                                    {tokenData.refresh_token}
-                                </ClipboardCopy>
-                            </div>
-                        ) : (
-                            <Button onClick={() => this.loadToken()}>
-                                Load token
-                            </Button>
-                        )}
-                        <h2>Manage tokens</h2>
-                        To remove an existing token, visit{' '}
-                        <a
-                            href='https://sso.redhat.com/auth/realms/redhat-external/account/'
-                            target='_blank'
-                        >
-                            Red Hat SSO account managment
-                        </a>
-                        .
-                    </Section>
-                </Main>
-            </React.Fragment>
-        );
-    }
-
-    private loadToken() {
-        if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
-            (window as any).insights.chrome.auth
-                // doOffline causes the page to refresh and will make the data
-                // available to getOfflineToken() when the component mounts after
-                // the reload
-                .doOffline();
-        } else {
-            UserAPI.getToken().then(result =>
-                this.setState({ tokenData: result }),
-            );
-        }
-    }
+  }
 }
 
 export default withRouter(TokenPage);

--- a/src/entry-standalone.tsx
+++ b/src/entry-standalone.tsx
@@ -7,9 +7,9 @@ import App from './loaders/standalone-loader';
 // other than on the insights/cloud services environment)
 
 ReactDOM.render(
-    <Router basename={UI_BASE_PATH}>
-        <App />
-    </Router>,
+  <Router basename={UI_BASE_PATH}>
+    <App />
+  </Router>,
 
-    document.getElementById('root'),
+  document.getElementById('root'),
 );

--- a/src/loaders/app.scss
+++ b/src/loaders/app.scss
@@ -3,33 +3,33 @@
 @import '~@redhat-cloud-services/frontend-components/index.css';
 
 .body {
-    background-color: white;
-    padding: 16px;
+  background-color: white;
+  padding: 16px;
 }
 
 .clickable {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 // this was getting applied globally when it was in the collection-info.scss file
 // which means other components now rely on it, so I'm just going move it here
 // so that it's explicitly setting these styles globally.
 pre {
-    background-color: #f8f8f8;
-    border: 1px solid #e6e9e9;
-    font-family: var(--pf-global--FontFamily--monospace);
-    display: block;
-    padding: 10px;
+  background-color: #f8f8f8;
+  border: 1px solid #e6e9e9;
+  font-family: var(--pf-global--FontFamily--monospace);
+  display: block;
+  padding: 10px;
 
-    // Patternfly does something that makes it so that fonts don't get inherited
-    // from the parent so it has to be overridden at every level.
-    code {
-        font-family: var(--pf-global--FontFamily--monospace);
-    }
+  // Patternfly does something that makes it so that fonts don't get inherited
+  // from the parent so it has to be overridden at every level.
+  code {
+    font-family: var(--pf-global--FontFamily--monospace);
+  }
 }
 
 // Patternfly expects the root Page component to be the height of the browser window
 body,
 #root {
-    height: 100%;
+  height: 100%;
 }

--- a/src/loaders/standalone-loader.tsx
+++ b/src/loaders/standalone-loader.tsx
@@ -5,13 +5,13 @@ import { withRouter, Link } from 'react-router-dom';
 
 import '@patternfly/patternfly/patternfly.scss';
 import {
-    Page,
-    PageHeader,
-    PageSidebar,
-    Nav,
-    NavList,
-    NavItem,
-    PageSection,
+  Page,
+  PageHeader,
+  PageSidebar,
+  Nav,
+  NavList,
+  NavItem,
+  PageSection,
 } from '@patternfly/react-core';
 
 import { Routes } from '../Routes';
@@ -19,67 +19,61 @@ import RageTater from '../../static/images/awx-spud.gif';
 import { Paths } from '../paths';
 
 interface IProps {
-    history: any;
+  history: any;
 }
 
 class App extends React.Component<IProps> {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            currentUser: true,
-        };
-    }
+    this.state = {
+      currentUser: true,
+    };
+  }
 
-    componentDidMount() {}
+  componentDidMount() {}
 
-    render() {
-        const Header = (
-            <PageHeader
-                logo={
-                    <React.Fragment>
-                        <img
-                            style={{ height: '50px' }}
-                            src={RageTater}
-                            alt='AWX Spud'
-                        />
-                        Automation Hub
-                    </React.Fragment>
-                }
-                toolbar='Toolbar'
-                avatar=' | Avatar'
-                showNavToggle
-            />
-        );
-        const Sidebar = (
-            <PageSidebar
-                theme='dark'
-                nav={
-                    <Nav theme='dark'>
-                        <NavList>
-                            <NavItem>
-                                <Link to={Paths.search}>Collections</Link>
-                            </NavItem>
-                            <NavItem>
-                                <Link to={Paths.partners}>Namespaces</Link>
-                            </NavItem>
-                            <NavItem>
-                                <Link to={Paths.myNamespaces}>
-                                    My Namespaces
-                                </Link>
-                            </NavItem>
-                        </NavList>
-                    </Nav>
-                }
-            />
-        );
+  render() {
+    const Header = (
+      <PageHeader
+        logo={
+          <React.Fragment>
+            <img style={{ height: '50px' }} src={RageTater} alt='AWX Spud' />
+            Automation Hub
+          </React.Fragment>
+        }
+        toolbar='Toolbar'
+        avatar=' | Avatar'
+        showNavToggle
+      />
+    );
+    const Sidebar = (
+      <PageSidebar
+        theme='dark'
+        nav={
+          <Nav theme='dark'>
+            <NavList>
+              <NavItem>
+                <Link to={Paths.search}>Collections</Link>
+              </NavItem>
+              <NavItem>
+                <Link to={Paths.partners}>Namespaces</Link>
+              </NavItem>
+              <NavItem>
+                <Link to={Paths.myNamespaces}>My Namespaces</Link>
+              </NavItem>
+            </NavList>
+          </Nav>
+        }
+      />
+    );
 
-        return (
-            <Page isManagedSidebar={true} header={Header} sidebar={Sidebar}>
-                <Routes childProps={this.props} />
-            </Page>
-        );
-    }
+    return (
+      <Page isManagedSidebar={true} header={Header} sidebar={Sidebar}>
+        <Routes childProps={this.props} />
+      </Page>
+    );
+  }
 }
 
 /**

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,34 +1,34 @@
 import { ParamHelper } from './utilities/param-helper';
 
 export function formatPath(path: Paths, data: any, params?: object) {
-    let url = path as string;
+  let url = path as string;
 
-    for (const k of Object.keys(data)) {
-        url = url.replace(':' + k, data[k]);
-    }
+  for (const k of Object.keys(data)) {
+    url = url.replace(':' + k, data[k]);
+  }
 
-    if (params) {
-        return `${url}?${ParamHelper.getQueryString(params)}`;
-    } else {
-        return url;
-    }
+  if (params) {
+    return `${url}?${ParamHelper.getQueryString(params)}`;
+  } else {
+    return url;
+  }
 }
 
 export enum Paths {
-    myCollections = '/my-namespaces/:namespace',
-    myNamespaces = '/my-namespaces',
-    editNamespace = '/my-namespaces/edit/:namespace',
-    myImports = '/my-imports',
-    search = '/',
-    collectionDocsPage = '/:namespace/:collection/docs/:page',
-    collectionDocsIndex = '/:namespace/:collection/docs',
-    collectionContentDocs = '/:namespace/:collection/content/:type/:name',
-    collectionContentList = '/:namespace/:collection/content',
-    collectionImportLog = '/:namespace/:collection/import-log',
-    collection = '/:namespace/:collection',
-    namespace = '/:namespace',
-    partners = '/partners',
-    notFound = '/not-found',
-    token = '/token',
-    certificationDashboard = '/certification-dashboard',
+  myCollections = '/my-namespaces/:namespace',
+  myNamespaces = '/my-namespaces',
+  editNamespace = '/my-namespaces/edit/:namespace',
+  myImports = '/my-imports',
+  search = '/',
+  collectionDocsPage = '/:namespace/:collection/docs/:page',
+  collectionDocsIndex = '/:namespace/:collection/docs',
+  collectionContentDocs = '/:namespace/:collection/content/:type/:name',
+  collectionContentList = '/:namespace/:collection/content',
+  collectionImportLog = '/:namespace/:collection/import-log',
+  collection = '/:namespace/:collection',
+  namespace = '/:namespace',
+  partners = '/partners',
+  notFound = '/not-found',
+  token = '/token',
+  certificationDashboard = '/certification-dashboard',
 }

--- a/src/utilities/content-summary.ts
+++ b/src/utilities/content-summary.ts
@@ -1,32 +1,32 @@
 import { ContentSummaryType } from '../api';
 
 class Summary {
-    total_count: number;
-    contents: {
-        module: number;
-        role: number;
-        plugin: number;
-        // playbook: number;
-    };
+  total_count: number;
+  contents: {
+    module: number;
+    role: number;
+    plugin: number;
+    // playbook: number;
+  };
 }
 
 export function convertContentSummaryCounts(
-    content: ContentSummaryType[],
+  content: ContentSummaryType[],
 ): Summary {
-    const summary: Summary = {
-        total_count: content.length,
-        contents: { module: 0, role: 0, plugin: 0 },
-    };
+  const summary: Summary = {
+    total_count: content.length,
+    contents: { module: 0, role: 0, plugin: 0 },
+  };
 
-    for (let c of content) {
-        if (c.content_type === 'role') {
-            summary.contents.role++;
-        } else if (c.content_type === 'module') {
-            summary.contents.module++;
-        } else {
-            summary.contents.plugin++;
-        }
+  for (let c of content) {
+    if (c.content_type === 'role') {
+      summary.contents.role++;
+    } else if (c.content_type === 'module') {
+      summary.contents.module++;
+    } else {
+      summary.contents.plugin++;
     }
+  }
 
-    return summary;
+  return summary;
 }

--- a/src/utilities/param-helper.tsx
+++ b/src/utilities/param-helper.tsx
@@ -1,141 +1,139 @@
 import { cloneDeep } from 'lodash';
 
 export class ParamHelper {
-    // Helper class for managing param object.
-    // Param object is just a dictionary where the keys map to
-    // parameter names that contain a value or list of values
+  // Helper class for managing param object.
+  // Param object is just a dictionary where the keys map to
+  // parameter names that contain a value or list of values
 
-    // Convert URLSearchParams object to param object
-    static parseParamString(paramString: string, numericTypes?: string[]) {
-        let params = {};
-        const paramObj = new URLSearchParams(paramString);
-        let v;
+  // Convert URLSearchParams object to param object
+  static parseParamString(paramString: string, numericTypes?: string[]) {
+    let params = {};
+    const paramObj = new URLSearchParams(paramString);
+    let v;
 
-        paramObj.forEach((val, key) => {
-            // Parse value as number if it's included in the list of numeric
-            // types.
-            // It seems like there should be a better way to do this based off
-            // of the interface for the parameters, but I can't figure out if
-            // that's possible or not
-            if (numericTypes && numericTypes.includes(key)) {
-                v = Number(val);
-            } else {
-                v = val;
-            }
+    paramObj.forEach((val, key) => {
+      // Parse value as number if it's included in the list of numeric
+      // types.
+      // It seems like there should be a better way to do this based off
+      // of the interface for the parameters, but I can't figure out if
+      // that's possible or not
+      if (numericTypes && numericTypes.includes(key)) {
+        v = Number(val);
+      } else {
+        v = val;
+      }
 
-            params = ParamHelper.appendParam(params, key, v);
-        });
+      params = ParamHelper.appendParam(params, key, v);
+    });
 
-        return params;
+    return params;
+  }
+
+  // Replaces specified parameter with speficied value
+  static setParam(
+    p: Object,
+    key: string,
+    value: number | string | string[] | number[],
+  ) {
+    const params = cloneDeep(p);
+    params[key] = value;
+
+    return params;
+  }
+
+  // Appends parameter to existing value
+  static appendParam(p: Object, key: string, value: number | string) {
+    const params = cloneDeep(p);
+    if (params[key]) {
+      if (Array.isArray(params[key])) {
+        params[key].push(value);
+      } else {
+        params[key] = [params[key], value];
+      }
+    } else {
+      params[key] = value;
     }
 
-    // Replaces specified parameter with speficied value
-    static setParam(
-        p: Object,
-        key: string,
-        value: number | string | string[] | number[],
-    ) {
-        const params = cloneDeep(p);
-        params[key] = value;
+    return params;
+  }
 
-        return params;
+  // Returns a reduced set of parameters. Useful when not all params should
+  // be passed to the API
+  static getReduced(p: Object, keys: string[]) {
+    const params = cloneDeep(p);
+    for (let k of keys) {
+      delete params[k];
     }
 
-    // Appends parameter to existing value
-    static appendParam(p: Object, key: string, value: number | string) {
-        const params = cloneDeep(p);
-        if (params[key]) {
-            if (Array.isArray(params[key])) {
-                params[key].push(value);
-            } else {
-                params[key] = [params[key], value];
-            }
-        } else {
-            params[key] = value;
+    return params;
+  }
+
+  // Removes a parameter, or a specific key value pair from a parameter object
+  static deleteParam(p: any, key: string, value?: string | number) {
+    const params = cloneDeep(p);
+    if (value && Array.isArray(params[key]) && params[key].length > 1) {
+      const i = params[key].indexOf(value);
+      if (i !== -1) {
+        params[key].splice(i, 1);
+      }
+    } else {
+      delete params[key];
+    }
+
+    return params;
+  }
+
+  // Checks to see if a specific key value pair exists
+  static paramExists(params: Object, key: string, value: string | number) {
+    const param = params[key];
+
+    if (param) {
+      if (Array.isArray(param)) {
+        return param.includes(value);
+      } else {
+        return param === value;
+      }
+    } else {
+      return false;
+    }
+  }
+
+  // Returns the query string for the set of parameters
+  static getQueryString(params: Object, ignoreParams?: string[]) {
+    let paramString = '';
+    for (const key of Object.keys(params)) {
+      // skip the param if its in the list of ignored params
+      if (ignoreParams && ignoreParams.includes(key)) {
+        continue;
+      }
+      if (Array.isArray(params[key])) {
+        for (const val of params[key]) {
+          paramString += key + '=' + encodeURIComponent(val) + '&';
         }
-
-        return params;
+      } else {
+        paramString += key + '=' + params[key] + '&';
+      }
     }
 
-    // Returns a reduced set of parameters. Useful when not all params should
-    // be passed to the API
-    static getReduced(p: Object, keys: string[]) {
-        const params = cloneDeep(p);
-        for (let k of keys) {
-            delete params[k];
-        }
+    // Remove trailing '&'
+    paramString = paramString.substring(0, paramString.length - 1);
+    return paramString;
+  }
 
-        return params;
-    }
-
-    // Removes a parameter, or a specific key value pair from a parameter object
-    static deleteParam(p: any, key: string, value?: string | number) {
-        const params = cloneDeep(p);
-        if (value && Array.isArray(params[key]) && params[key].length > 1) {
-            const i = params[key].indexOf(value);
-            if (i !== -1) {
-                params[key].splice(i, 1);
-            }
-        } else {
-            delete params[key];
-        }
-
-        return params;
-    }
-
-    // Checks to see if a specific key value pair exists
-    static paramExists(params: Object, key: string, value: string | number) {
-        const param = params[key];
-
-        if (param) {
-            if (Array.isArray(param)) {
-                return param.includes(value);
-            } else {
-                return param === value;
-            }
-        } else {
-            return false;
-        }
-    }
-
-    // Returns the query string for the set of parameters
-    static getQueryString(params: Object, ignoreParams?: string[]) {
-        let paramString = '';
-        for (const key of Object.keys(params)) {
-            // skip the param if its in the list of ignored params
-            if (ignoreParams && ignoreParams.includes(key)) {
-                continue;
-            }
-            if (Array.isArray(params[key])) {
-                for (const val of params[key]) {
-                    paramString += key + '=' + encodeURIComponent(val) + '&';
-                }
-            } else {
-                paramString += key + '=' + params[key] + '&';
-            }
-        }
-
-        // Remove trailing '&'
-        paramString = paramString.substring(0, paramString.length - 1);
-        return paramString;
-    }
-
-    // Reusable function that can be included in a component to update it's
-    // internal state and page params at the same time
-    static updateParamsMixin(ignoreParams?: string[]) {
-        return function(params: object, callback?) {
-            // Note. In the callback, make sure to reference the state as
-            // this.state instead of const { foo } = this.state.
-            // In the example above, foo only gets set to the latest state after
-            // the component re-runs render() and the callback typically gets
-            // executed before that happens
-            this.setState({ params: params }, callback);
-            this.props.history.push({
-                pathname: this.props.location.pathname,
-                search:
-                    '?' +
-                    ParamHelper.getQueryString(params, ignoreParams || []),
-            });
-        };
-    }
+  // Reusable function that can be included in a component to update it's
+  // internal state and page params at the same time
+  static updateParamsMixin(ignoreParams?: string[]) {
+    return function(params: object, callback?) {
+      // Note. In the callback, make sure to reference the state as
+      // this.state instead of const { foo } = this.state.
+      // In the example above, foo only gets set to the latest state after
+      // the component re-runs render() and the callback typically gets
+      // executed before that happens
+      this.setState({ params: params }, callback);
+      this.props.history.push({
+        pathname: this.props.location.pathname,
+        search: '?' + ParamHelper.getQueryString(params, ignoreParams || []),
+      });
+    };
+  }
 }

--- a/src/utilities/sanitize-docs-urls.ts
+++ b/src/utilities/sanitize-docs-urls.ts
@@ -1,5 +1,5 @@
 // insights crashes when you give it a .md page.
 
 export function sanitizeDocsUrls(url) {
-    return url.replace('.md', '');
+  return url.replace('.md', '');
 }


### PR DESCRIPTION
Even though there does not seem to be a set standard for React/TypeScript code, I would still like to suggest to take back changes done in commit 39e0f8369690331522e4917018805c34c19751f9 and use two spaces instead of four to indent our TypeScript code.

Using two spaces seems to be the most common style, and also helps to read code as the longer lines are breaked in less cases. Especially reading the code on vertical monitor would be much easier.