### PR TITLE
[WIP] Visualize parsed entry into tokens

### DIFF
--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Modal } from '@patternfly/react-core';
 import { Form, FormGroup, ActionGroup } from '@patternfly/react-core';
+import { Badge } from '@patternfly/react-core';
 import {
     Button,
     ButtonVariant,
@@ -40,6 +41,13 @@ export class NamespaceModal extends React.Component<IProps, IState> {
             newNamespaceGroupIdsValid: true,
             errorMessages: {},
         };
+    }
+
+    private newNamespaceGroups() {
+        const groups = this.state.newNamespaceGroupIds
+            .split(',')
+            .map(group => group.trim());
+        return groups;
     }
 
     private namespaceOwners() {
@@ -199,6 +207,12 @@ export class NamespaceModal extends React.Component<IProps, IState> {
                         helperTextInvalid={this.state.errorMessages['groups']}
                         isValid={this.state.newNamespaceGroupIdsValid}
                     >
+                        &nbsp; &nbsp;
+                        {this.newNamespaceGroups().map(group => (
+                            <Badge key={group} isRead>
+                                {group.trim()}
+                            </Badge>
+                        ))}
                         <TextInput
                             isRequired
                             type='text'


### PR DESCRIPTION
Blocked-by: https://github.com/patternfly/patternfly-react/issues/3707

Proposing this change to make it easier for users to see the parsed input, where comma-separated string is expected.

The badges with id's are updated as the user types.

**Before:**
![Screenshot_2020-02-05 Ansible Automation Hub(1)](https://user-images.githubusercontent.com/1187051/73860160-0b663100-4833-11ea-9131-e6b6e778c93a.png)

**After:**
![Screenshot_2020-02-05 Ansible Automation Hub](https://user-images.githubusercontent.com/1187051/73859846-9dba0500-4832-11ea-9195-3e4153154b23.png)

Steps for Testing/QA
-------------------------------

- create a new namespace button opens up the modal 
