### PR TITLE
Remove unsupported sort parameter from namespace collection listing

### DIFF
--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -62,13 +62,6 @@ export class CollectionList extends React.Component<IProps, IState> {
                 <div className='controls top'>
                     <Toolbar
                         searchPlaceholder='Find collection by name'
-                        sortOptions={[
-                            { title: 'Name', id: 'name' },
-                            {
-                                title: 'Last updated',
-                                id: 'created',
-                            },
-                        ]}
                         updateParams={updateParams}
                         params={params}
                     />


### PR DESCRIPTION
Removes the sort option from the UI while backend support is corrected per issue https://github.com/ansible/galaxy-dev/issues/248.