### PR TITLE
Disable namespace owners to remove themselves

### DIFF
--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -32,7 +32,9 @@ export class NamespaceForm extends React.Component<IProps, IState> {
             newLinkName: '',
             newNamespaceGroup: '',
         };
+    }
 
+    componentDidMount() {
         this.userPermissions();
     }
 

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -16,6 +16,7 @@ interface IProps {
 }
 
 interface IState {
+    userId: string;
     newLinkName: string;
     newLinkURL: string;
     newNamespaceGroup: string;
@@ -26,10 +27,13 @@ export class NamespaceForm extends React.Component<IProps, IState> {
         super(props);
 
         this.state = {
+            userId: '',
             newLinkURL: '',
             newLinkName: '',
             newNamespaceGroup: '',
         };
+
+        this.userPermissions();
     }
 
     render() {
@@ -90,7 +94,8 @@ export class NamespaceForm extends React.Component<IProps, IState> {
                                 key={group}
                                 onClick={() => this.deleteItem(group)}
                                 isReadOnly={
-                                    group === 'system:partner-engineers'
+                                    group === 'system:partner-engineers' ||
+                                    this.state.userId == group
                                 }
                             >
                                 {group}
@@ -222,6 +227,14 @@ export class NamespaceForm extends React.Component<IProps, IState> {
                 </FormGroup>
             </Form>
         );
+    }
+
+    private userPermissions() {
+        (window as any).insights.chrome.auth.getUser().then(currentUser => {
+            this.setState({
+                userId: currentUser.identity.account_number,
+            });
+        });
     }
 
     private updateField(value, event) {


### PR DESCRIPTION
These changes should prevent the user to remove himself from the group of namespace owners.

If the user id matches the owner ID of namespace, the UI does not allow the chip to be removed from the list of owners.

I've tested with two accounts - one was a part of `system:partner-engineer` group. 

The possible scenario to avoid is 
- User1, who has permissions to edit namespace, adds User2 as owner
- User2 can not remove himself, but can remove User1 from the list
- User1 looses access unless he has

Links
----------------

* https://github.com/ansible/galaxy-dev/issues/253#issue-561867562

Steps for Testing/QA
-------------------------------

1. have two users: one can edit namespace (User1), one can not (User2)
2. navigate to namespace edit page (`https://ci.foo.redhat.com:1337/beta/ansible/automation-hub/my-namespaces/edit/<namespace_name>`)
3. add User2's ID to the list of owners
4. User2 now can edit the namespace, but the option to remove himself is disabled
