### PR TITLE
Prevent user to enter namespace editation after he disowns it

### DIFF
--- a/src/containers/edit-namespace/namespace-form.tsx
+++ b/src/containers/edit-namespace/namespace-form.tsx
@@ -221,6 +221,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
                                     `Not possible to proceed with the action.` +
                                     `Plese contact the administrator of the namespace`,
                             }),
+                            saving: false,
                         });
                     }
                 });

--- a/src/containers/edit-namespace/namespace-form.tsx
+++ b/src/containers/edit-namespace/namespace-form.tsx
@@ -217,9 +217,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
                             alerts: this.state.alerts.concat({
                                 variant: 'danger',
                                 title: `API Error: ${error.response.status}`,
-                                description:
-                                    `Not possible to proceed with the action.` +
-                                    `Plese contact the administrator of the namespace`,
+                                description: `You don't have permissions to update this namespace.`,
                             }),
                             saving: false,
                         });

--- a/src/containers/edit-namespace/namespace-form.tsx
+++ b/src/containers/edit-namespace/namespace-form.tsx
@@ -203,6 +203,12 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
                             errorMessages: messages,
                             saving: false,
                         });
+                    } else if (result.status === 403) {
+                        this.setState({
+                            redirect: formatPath(Paths.myNamespaces, {
+                                namespace: '',
+                            }),
+                        });
                     }
                 });
         });

--- a/src/containers/edit-namespace/namespace-form.tsx
+++ b/src/containers/edit-namespace/namespace-form.tsx
@@ -7,6 +7,9 @@ import {
     PartnerHeader,
     NamespaceForm,
     ResourcesForm,
+    AlertList,
+    closeAlertMixin,
+    AlertType,
     Main,
 } from '../../components';
 import { MyNamespaceAPI, NamespaceType } from '../../api';
@@ -25,6 +28,7 @@ interface IState {
     saving: boolean;
     redirect: string;
     unsavedData: boolean;
+    alerts: AlertType[];
     params: {
         tab?: string;
     };
@@ -43,6 +47,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
         }
 
         this.state = {
+            alerts: [],
             namespace: null,
             newLinkURL: '',
             newLinkName: '',
@@ -92,6 +97,10 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
                     params={params}
                     updateParams={p => this.updateParams(p)}
                 ></PartnerHeader>
+                <AlertList
+                    alerts={this.state.alerts}
+                    closeAlert={i => this.closeAlert(i)}
+                />
                 <Main>
                     <Section className='body'>
                         {params.tab.toLowerCase() === 'edit details' ? (
@@ -203,15 +212,22 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
                             errorMessages: messages,
                             saving: false,
                         });
-                    } else if (result.status === 403) {
+                    } else if (result.status === 404) {
                         this.setState({
-                            redirect: formatPath(Paths.myNamespaces, {
-                                namespace: '',
+                            alerts: this.state.alerts.concat({
+                                variant: 'danger',
+                                title: `API Error: ${error.response.status}`,
+                                description:
+                                    `Not possible to proceed with the action.` +
+                                    `Plese contact the administrator of the namespace`,
                             }),
                         });
                     }
                 });
         });
+    }
+    private get closeAlert() {
+        return closeAlertMixin('alerts');
     }
 
     private cancel() {


### PR DESCRIPTION
This PR corrects the situation where error 403 is received after user attempts to save change after loosing access. After the action, user is redirected back on home screen.

The PR also fixes the situation where the user tries to open edit page even though he is not an owner.

Links
----------------

* https://github.com/ansible/galaxy-dev/issues/253#issue-561867562

Steps for Testing/QA
-------------------------------

Prevent to enter the edit page:
1. navigate to namespace edit page (`https://ci.foo.redhat.com:1337/beta/ansible/automation-hub/my-namespaces/edit/<namespace_name>`)
2. remove the user as owner
3. try to access the edit page again

Forward away on attempt to save after loosing access:
1. Open edit namespace page logged as User1
2. Remove User1 as namespace owner
3. Try to save changes

