### PR TITLE
Update namespace form user ID check to work in standalone mode.

### DIFF
--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -12,12 +12,12 @@ import { NamespaceType } from '../../api';
 interface IProps {
     namespace: NamespaceType;
     errorMessages: any;
+    userId: string;
 
     updateNamespace: (namespace) => void;
 }
 
 interface IState {
-    userId: string;
     newLinkName: string;
     newLinkURL: string;
     newNamespaceGroup: string;
@@ -28,19 +28,14 @@ export class NamespaceForm extends React.Component<IProps, IState> {
         super(props);
 
         this.state = {
-            userId: '',
             newLinkURL: '',
             newLinkName: '',
             newNamespaceGroup: '',
         };
     }
 
-    componentDidMount() {
-        this.userPermissions();
-    }
-
     render() {
-        const { namespace, errorMessages } = this.props;
+        const { namespace, errorMessages, userId } = this.props;
 
         if (!namespace) {
             return null;
@@ -98,7 +93,7 @@ export class NamespaceForm extends React.Component<IProps, IState> {
                                 onClick={() => this.deleteItem(group)}
                                 isReadOnly={
                                     group === Constants.ADMIN_GROUP ||
-                                    this.state.userId == group
+                                    userId === group
                                 }
                             >
                                 {group}
@@ -230,14 +225,6 @@ export class NamespaceForm extends React.Component<IProps, IState> {
                 </FormGroup>
             </Form>
         );
-    }
-
-    private userPermissions() {
-        (window as any).insights.chrome.auth.getUser().then(currentUser => {
-            this.setState({
-                userId: currentUser.identity.account_number,
-            });
-        });
     }
 
     private updateField(value, event) {

--- a/src/containers/edit-namespace/namespace-form.tsx
+++ b/src/containers/edit-namespace/namespace-form.tsx
@@ -9,7 +9,7 @@ import {
     ResourcesForm,
     Main,
 } from '../../components';
-import { MyNamespaceAPI, NamespaceType } from '../../api';
+import { MyNamespaceAPI, NamespaceType, UserAPI } from '../../api';
 import { Constants } from '../../constants';
 
 import { Form, ActionGroup, Button } from '@patternfly/react-core';
@@ -28,6 +28,7 @@ interface IState {
     params: {
         tab?: string;
     };
+    userId: string;
 }
 
 class EditNamespace extends React.Component<RouteComponentProps, IState> {
@@ -44,6 +45,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
 
         this.state = {
             namespace: null,
+            userId: '',
             newLinkURL: '',
             newLinkName: '',
             errorMessages: {},
@@ -55,7 +57,11 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
     }
 
     componentDidMount() {
-        this.loadNamespace();
+        UserAPI.getUser().then(result => {
+            this.setState({ userId: result.account_number }, () =>
+                this.loadNamespace(),
+            );
+        });
     }
 
     render() {
@@ -65,6 +71,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
             saving,
             redirect,
             params,
+            userId,
         } = this.state;
 
         if (redirect) {
@@ -96,6 +103,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
                     <Section className='body'>
                         {params.tab.toLowerCase() === 'edit details' ? (
                             <NamespaceForm
+                                userId={userId}
                                 namespace={namespace}
                                 errorMessages={errorMessages}
                                 updateNamespace={namespace =>


### PR DESCRIPTION
- Use the new `UserAPI` created in #92 to call `insights.chrome.auth` so that the namespace form doesn't break in standalone mode.
- Lift the API call out of the form component and into the form container.