### PR TITLE
Use constants for admin user group.

### DIFF
--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -2,8 +2,9 @@ import * as React from 'react';
 import './namespace-form.scss';
 
 import { Form, FormGroup, TextInput, TextArea } from '@patternfly/react-core';
-import { Chip, ChipGroup, ChipGroupToolbarItem } from '@patternfly/react-core';
+import { Chip, ChipGroup } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { Constants } from '../../constants';
 
 import { NamespaceCard } from '../../components';
 import { NamespaceType } from '../../api';
@@ -96,7 +97,7 @@ export class NamespaceForm extends React.Component<IProps, IState> {
                                 key={group}
                                 onClick={() => this.deleteItem(group)}
                                 isReadOnly={
-                                    group === 'system:partner-engineers' ||
+                                    group === Constants.ADMIN_GROUP ||
                                     this.state.userId == group
                                 }
                             >

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -11,6 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { NamespaceAPI } from '../../api';
+import { Constants } from '../../constants';
 
 interface IProps {
     isOpen: boolean;
@@ -92,7 +93,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
 
     private handleSubmit = event => {
         const groups = this.namespaceOwners();
-        groups.push('system:partner-engineers');
+        groups.push(Constants.ADMIN_GROUP);
         const data: any = {
             name: this.state.newNamespaceName,
             groups: groups,

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -7,4 +7,6 @@ export class Constants {
     static readonly CARD_DEFAULT_PAGINATION_OPTIONS = [12, 24, 60, 120];
     static readonly INSIGHTS_DEPLOYMENT_MODE = 'insights';
     static readonly STANDALONE_DEPLOYMENT_MODE = 'standalone';
+
+    static readonly ADMIN_GROUP = 'system:partner-engineers';
 }

--- a/src/containers/edit-namespace/namespace-form.tsx
+++ b/src/containers/edit-namespace/namespace-form.tsx
@@ -10,6 +10,7 @@ import {
     Main,
 } from '../../components';
 import { MyNamespaceAPI, NamespaceType } from '../../api';
+import { Constants } from '../../constants';
 
 import { Form, ActionGroup, Button } from '@patternfly/react-core';
 
@@ -149,7 +150,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
     }
 
     private removeGroupsPrefix(groups) {
-        const partnerEngineerOwner = 'system:partner-engineers';
+        const partnerEngineerOwner = Constants.ADMIN_GROUP;
         let unprefixedGroupOwners = [partnerEngineerOwner];
         for (const owner of groups) {
             if (owner == partnerEngineerOwner) {

--- a/src/containers/edit-namespace/namespace-form.tsx
+++ b/src/containers/edit-namespace/namespace-form.tsx
@@ -150,10 +150,9 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
     }
 
     private removeGroupsPrefix(groups) {
-        const partnerEngineerOwner = Constants.ADMIN_GROUP;
-        let unprefixedGroupOwners = [partnerEngineerOwner];
+        let unprefixedGroupOwners = [Constants.ADMIN_GROUP];
         for (const owner of groups) {
-            if (owner == partnerEngineerOwner) {
+            if (owner == Constants.ADMIN_GROUP) {
                 continue;
             }
             // 'rh-identity-account', '<id>'


### PR DESCRIPTION
Adds `ADMIN_GROUP` constant that's set to `system:partner-engineers` to make it a little easier to update the system if we ever need to change the name name of the partner engineer group.