### PR TITLE
Return 404 when users try to access namespace for on namespaces they don't own

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -21,3 +21,4 @@ export { ImportAPI } from './import';
 export { UserAPI } from './user';
 export { UserAuthType, MeType } from './response-types/user';
 export { CollectionVersionAPI } from './collection-version';
+export { MyNamespaceAPI } from './my-namespace';

--- a/src/api/my-namespace.ts
+++ b/src/api/my-namespace.ts
@@ -1,0 +1,11 @@
+import { BaseAPI } from './base';
+
+class API extends BaseAPI {
+    apiPath = 'v3/_ui/my-namespaces/';
+
+    constructor() {
+        super();
+    }
+}
+
+export const MyNamespaceAPI = new API();

--- a/src/api/namespace.ts
+++ b/src/api/namespace.ts
@@ -11,10 +11,6 @@ class API extends BaseAPI {
         // mocked responses will be removed when a real API is available
         // new MockNamespace(this.http, this.apiPath);
     }
-
-    getMyNamespaces(params: object) {
-        return this.list(params, 'v3/_ui/my-namespaces/');
-    }
 }
 
 export const NamespaceAPI = new API();

--- a/src/containers/edit-namespace/namespace-form.tsx
+++ b/src/containers/edit-namespace/namespace-form.tsx
@@ -9,7 +9,7 @@ import {
     ResourcesForm,
     Main,
 } from '../../components';
-import { NamespaceAPI, NamespaceType } from '../../api';
+import { MyNamespaceAPI, NamespaceType } from '../../api';
 
 import { Form, ActionGroup, Button } from '@patternfly/react-core';
 
@@ -162,7 +162,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
     }
 
     private loadNamespace() {
-        NamespaceAPI.get(this.props.match.params['namespace'])
+        MyNamespaceAPI.get(this.props.match.params['namespace'])
             .then(response => {
                 response.data.groups = this.removeGroupsPrefix(
                     response.data.groups,
@@ -176,7 +176,10 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
 
     private saveNamespace() {
         this.setState({ saving: true }, () => {
-            NamespaceAPI.update(this.state.namespace.name, this.state.namespace)
+            MyNamespaceAPI.update(
+                this.state.namespace.name,
+                this.state.namespace,
+            )
                 .then(result => {
                     this.setState({
                         namespace: result.data,

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -3,7 +3,6 @@ import './my-imports.scss';
 
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
-import { Button } from '@patternfly/react-core';
 import { cloneDeep } from 'lodash';
 
 import { BaseHeader, ImportConsole, ImportList, Main } from '../../components';
@@ -12,9 +11,9 @@ import {
     ImportAPI,
     ImportDetailType,
     ImportListType,
-    NamespaceAPI,
     NamespaceType,
     PulpStatus,
+    MyNamespaceAPI,
 } from '../../api';
 
 import { ParamHelper } from '../../utilities/param-helper';
@@ -221,7 +220,7 @@ class MyImports extends React.Component<RouteComponentProps, IState> {
         // TODO: filter by namespaces by current user
         // TODO: We don't currently have a good way to display namespaces for
         // users that have a lot of namespaces (such as admins).
-        NamespaceAPI.getMyNamespaces({ page_size: 1000 })
+        MyNamespaceAPI.list({ page_size: 1000 })
             .then(result => {
                 const namespaces = result.data.data;
                 let selectedNS;

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Modal } from '@patternfly/react-core';
 import './namespace-list.scss';
 
 import { RouteComponentProps, Link } from 'react-router-dom';
@@ -25,10 +24,15 @@ import {
 } from '../../components';
 import { Button } from '@patternfly/react-core';
 import { DataToolbarItem } from '@patternfly/react-core/dist/esm/experimental';
-import { NamespaceAPI, NamespaceListType } from '../../api';
+import {
+    NamespaceAPI,
+    NamespaceListType,
+    UserAPI,
+    MeType,
+    MyNamespaceAPI,
+} from '../../api';
 import { Paths, formatPath } from '../../paths';
 import { Constants } from '../../constants';
-import { UserAPI, MeType } from '../../api';
 
 interface IState {
     namespaces: NamespaceListType[];
@@ -88,7 +92,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
         if (this.props.filterOwner) {
             // Make a query with no params and see if it returns results to tell
             // if the user can edit namespaces
-            NamespaceAPI.getMyNamespaces({}).then(results => {
+            MyNamespaceAPI.list({}).then(results => {
                 if (results.data.meta.count !== 0) {
                     this.loadNamespaces();
                 } else {
@@ -216,7 +220,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
         let apiFunc: any;
 
         if (this.props.filterOwner) {
-            apiFunc = p => NamespaceAPI.getMyNamespaces(p);
+            apiFunc = p => MyNamespaceAPI.list(p);
         } else {
             apiFunc = p => NamespaceAPI.list(p);
         }


### PR DESCRIPTION
Use the `my-namespaces` endpoint for the edit namespace form. This automatically filters out namespaces that the user doesn't have access to.