### PR TITLE
Add support for alphabetical sort icon.

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,7 +9,7 @@ export { CollectionList } from './collection-list/collection-list';
 export { CollectionListItem } from './collection-list/collection-list-item';
 export { NamespaceCard } from './cards/namespace-card';
 export { Breadcrumbs } from './patternfly-wrappers/breadcrumbs';
-export { Sort } from './patternfly-wrappers/sort';
+export { Sort, SortFieldType } from './patternfly-wrappers/sort';
 export { Tabs } from './patternfly-wrappers/tabs';
 export { StatefulDropdown } from './patternfly-wrappers/stateful-dropdown';
 export { Toolbar } from './patternfly-wrappers/toolbar';

--- a/src/components/patternfly-wrappers/sort.tsx
+++ b/src/components/patternfly-wrappers/sort.tsx
@@ -1,23 +1,24 @@
 import * as React from 'react';
 import './sort.scss';
 
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import {
-    Select,
-    SelectOption,
-    SelectVariant,
-    Tooltip,
-} from '@patternfly/react-core';
-import { SortAmountDownIcon, SortAmountUpIcon } from '@patternfly/react-icons';
+    SortAmountDownIcon,
+    SortAmountUpIcon,
+    SortAlphaDownIcon,
+    SortAlphaUpIcon,
+} from '@patternfly/react-icons';
 
 import { ParamHelper } from '../../utilities/param-helper';
 
-export class SortFieldOption {
+export class SortFieldType {
     id: string;
     title: string;
+    type: 'numeric' | 'alpha';
 }
 
 interface IProps {
-    options: SortFieldOption[];
+    options: SortFieldType[];
     params: object;
     updateParams: (params) => void;
     sortParamName?: string;
@@ -48,8 +49,16 @@ export class Sort extends React.Component<IProps, IState> {
     }
 
     private onSelect(name) {
-        const desc = this.getIsDescending(this.props.params) ? '-' : '';
+        let isDescending = this.getIsDescending(this.props.params);
+
         const option = this.props.options.find(i => i.title === name);
+
+        // Alphabetical sorting is inverted in Django, so flip it here to make
+        // things match up with the UI.
+        if (option.type === 'alpha') {
+            isDescending = !isDescending;
+        }
+        const desc = isDescending ? '-' : '';
 
         this.setState({ isExpanded: false }, () =>
             this.props.updateParams(
@@ -106,6 +115,20 @@ export class Sort extends React.Component<IProps, IState> {
     render() {
         const { options, params } = this.props;
         const { isExpanded } = this.state;
+
+        const selectedOption = this.getSelected(params);
+
+        let IconDesc;
+        let IconAsc;
+
+        if (selectedOption.type === 'alpha') {
+            IconAsc = SortAlphaDownIcon;
+            IconDesc = SortAlphaUpIcon;
+        } else {
+            IconDesc = SortAmountDownIcon;
+            IconAsc = SortAmountUpIcon;
+        }
+
         return (
             <div className='sort-wrapper'>
                 {options.length > 1 ? (
@@ -114,7 +137,7 @@ export class Sort extends React.Component<IProps, IState> {
                         aria-label='Select input'
                         onToggle={e => this.onToggle(e)}
                         onSelect={(_, name) => this.onSelect(name)}
-                        selections={this.getSelected(params).title}
+                        selections={selectedOption.title}
                         isExpanded={isExpanded}
                         ariaLabelledBy='Sort results'
                     >
@@ -128,13 +151,13 @@ export class Sort extends React.Component<IProps, IState> {
                 ) : null}
 
                 {this.getIsDescending(params) ? (
-                    <SortAmountDownIcon
+                    <IconDesc
                         className='clickable asc-button'
                         size='md'
                         onClick={() => this.setDescending()}
                     />
                 ) : (
-                    <SortAmountUpIcon
+                    <IconAsc
                         className='clickable asc-button'
                         size='md'
                         onClick={() => this.setDescending()}

--- a/src/components/patternfly-wrappers/toolbar.tsx
+++ b/src/components/patternfly-wrappers/toolbar.tsx
@@ -15,16 +15,15 @@ import { SearchIcon } from '@patternfly/react-icons';
 import { ParamHelper } from '../../utilities/param-helper';
 import { Sort } from '../../components';
 
+import { SortFieldType } from './sort';
+
 interface IProps {
     params: {
         sort?: string;
         keywords?: string;
     };
 
-    sortOptions?: {
-        id: string;
-        title: string;
-    }[];
+    sortOptions?: SortFieldType[];
 
     updateParams: (params) => void;
     searchPlaceholder: string;

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -49,6 +49,7 @@ import {
     AlertList,
     closeAlertMixin,
     AlertType,
+    SortFieldType,
 } from '../../components';
 import { Paths, formatPath } from '../../paths';
 
@@ -121,14 +122,15 @@ class CertificationDashboard extends React.Component<
             return <Redirect to={redirect}></Redirect>;
         }
 
-        const sortOptions = [
+        const sortOptions: SortFieldType[] = [
             {
                 id: 'pulp_created',
                 title: 'Date created',
+                type: 'numeric',
             },
-            { id: 'namespace', title: 'Namespace name' },
-            { id: 'version', title: 'Version number' },
-            { id: 'name', title: 'Collection name' },
+            { id: 'namespace', title: 'Namespace name', type: 'alpha' },
+            { id: 'version', title: 'Version number', type: 'numeric' },
+            { id: 'name', title: 'Collection name', type: 'alpha' },
         ];
 
         if (!versions) {

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -71,6 +71,10 @@ export class NamespaceList extends React.Component<IProps, IState> {
             params['page_size'] = 24;
         }
 
+        if (!params['sort']) {
+            params['sort'] = 'name';
+        }
+
         this.state = {
             namespaces: undefined,
             itemCount: 0,
@@ -136,7 +140,9 @@ export class NamespaceList extends React.Component<IProps, IState> {
                     <div className='toolbar'>
                         <Toolbar
                             params={params}
-                            sortOptions={[{ title: 'Name', id: 'name' }]}
+                            sortOptions={[
+                                { title: 'Name', id: 'name', type: 'alpha' },
+                            ]}
                             searchPlaceholder={'Search ' + title}
                             updateParams={p =>
                                 this.updateParams(p, () =>


### PR DESCRIPTION
Adds support for alphabetical sort icons. Set sort on namespaces by default.

![Screen Shot 2020-02-25 at 2 51 14 PM](https://user-images.githubusercontent.com/6063371/75282154-868d8800-57de-11ea-8622-f2acf68741e2.png)
![Screen Shot 2020-02-25 at 2 51 21 PM](https://user-images.githubusercontent.com/6063371/75282156-87261e80-57de-11ea-908f-7443f951764a.png)
![Screen Shot 2020-02-25 at 2 51 36 PM](https://user-images.githubusercontent.com/6063371/75282157-87261e80-57de-11ea-90fb-a50af815c860.png)

Fixes: https://github.com/ansible/galaxy-dev/issues/272