### PR TITLE
Remove or convert TODO comments into issues.

### DIFF
--- a/config/webpack-ts-overrides.js
+++ b/config/webpack-ts-overrides.js
@@ -10,11 +10,6 @@ module.exports = {
                 use: [
                     { loader: 'source-map-loader' },
                     { loader: 'babel-loader' },
-                    // eslint really hates some of the things prettier does,
-                    // so we're disabling it here
-                    // TODO: Figure out how to disable the rules that prettier
-                    // breaks
-                    // { loader: 'eslint-loader' },
                 ],
             },
             {

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -21,7 +21,6 @@ class API extends BaseAPI {
             });
         } else if (DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE) {
             return new Promise((resolve, reject) => {
-                // TODO: add user data when that's available in the api
                 resolve({} as UserAuthType);
             });
         }

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -28,15 +28,6 @@ export class NamespaceCard extends React.Component<IProps, {}> {
                 <div>
                     <div className='title'>{company}</div>
                     <div className='ns-name'>{name}</div>
-                    {
-                        // TODO: current API doesn't provide collection count for namespaces
-                        // <div>
-                        //     <NumericLabel
-                        //         number={num_collections}
-                        //         label='Collection'
-                        //     />
-                        // </div>
-                    }
                 </div>
             </Card>
         );

--- a/src/components/collection-detail/render-plugin-doc.tsx
+++ b/src/components/collection-detail/render-plugin-doc.tsx
@@ -373,8 +373,6 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
                         );
 
                         if (module) {
-                            // TODO: figure out how to make this use the Link
-                            // component so it doesn't reload the whole app
                             return (
                                 <Link
                                     to={formatPath(
@@ -533,11 +531,6 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
                             ) : null}
                             <th>Comments</th>
                         </tr>
-                        {
-                            // TODO: add support for sub options. Example:
-                            //https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/network/fortios/fortios_dlp_fp_doc_source.py#L93}
-                            // TODO: do we need to display version added?
-                        }
                         {paramEntries}
                     </tbody>
                 </table>

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -71,8 +71,6 @@ class MyImports extends React.Component<RouteComponentProps, IState> {
             this.loadImportList(() => this.loadTaskDetails()),
         );
 
-        // TODO: setting polling to 10 sec for fest because it's hammering
-        // pulp
         this.polling = setInterval(() => {
             if (
                 this.state.selectedImportDetails &&
@@ -217,9 +215,6 @@ class MyImports extends React.Component<RouteComponentProps, IState> {
     }
 
     private loadNamespaces(callback?: () => void) {
-        // TODO: filter by namespaces by current user
-        // TODO: We don't currently have a good way to display namespaces for
-        // users that have a lot of namespaces (such as admins).
         MyNamespaceAPI.list({ page_size: 1000 })
             .then(result => {
                 const namespaces = result.data.data;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,5 @@
 // Fool TypeScript into thinking that we actually have typings for these components.
 // This will tell typescript that anything from this module is of type any.
-// TODO: Add actual typings to the upstream project
 
 declare module '@redhat-cloud-services/frontend-components';
 declare module 'axios-mock-adapter';

--- a/src/utilities/sanitize-docs-urls.ts
+++ b/src/utilities/sanitize-docs-urls.ts
@@ -1,5 +1,4 @@
-// TODO: insights crashes when you give it a .md page. Need to find
-// a more elegant solution to this problem
+// insights crashes when you give it a .md page.
 
 export function sanitizeDocsUrls(url) {
     return url.replace('.md', '');


### PR DESCRIPTION
Removes most of the inline TODO comments. I've left all of the comments for the plugin documentation renderer because that's going to eventually get moved into a separate repo.

Issues created from TODO comments:
- https://github.com/ansible/galaxy-dev/issues/280

Fixes: https://github.com/ansible/galaxy-dev/issues/74