### PR TITLE
Add npm run build-standalone command.

### DIFF
--- a/config/standalone.prod.webpack.config.js
+++ b/config/standalone.prod.webpack.config.js
@@ -1,0 +1,12 @@
+const webpackBase = require('./webpack.base.config');
+
+// Compile configuration for stnadalone mode
+module.exports = webpackBase({
+  API_HOST: '',
+  API_BASE_PATH: '/api/automation-hub/',
+  UI_BASE_PATH: '',
+  DEPLOYMENT_MODE: 'standalone',
+  UI_USE_HTTPS: false,
+  UI_DEBUG: false,
+  TARGET_ENVIRONMENT: 'prod',
+});

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     },
     "scripts": {
         "build": "webpack --config config/insights.prod.webpack.config.js",
+        "build-standalone": "NODE_ENV=production webpack --config config/standalone.prod.webpack.config.js",
         "test": "jest --verbose",
         "lint": "npm-run-all lint:*",
         "lint:js": "eslint config src",


### PR DESCRIPTION
Adds `npm run build-standalone command` which builds the ui for production standalone mode.