### PR TITLE
[WIP] Toggle buttons for content sync

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -22,3 +22,4 @@ export { UserAPI } from './user';
 export { UserAuthType, MeType } from './response-types/user';
 export { CollectionVersionAPI } from './collection-version';
 export { MyNamespaceAPI } from './my-namespace';
+export { SyncListAPI } from './synclist';

--- a/src/api/synclist.ts
+++ b/src/api/synclist.ts
@@ -1,0 +1,27 @@
+import { BaseAPI } from './base';
+
+class API extends BaseAPI {
+  apiPath = 'v3/_ui/synclists/';
+
+  constructor() {
+    super();
+
+    // Comment this out to make an actual API request
+    // mocked responses will be removed when a real API is available
+    // new MockNamespace(this.http, this.apiPath);
+  }
+
+  list() {
+    return super.list();
+  }
+
+  get(id) {
+    return super.get(id);
+  }
+
+  update(id, data) {
+    return super.update(id, data);
+  }
+}
+
+export const SyncListAPI = new API();

--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -24,7 +24,7 @@
 
 .collection-card-container {
   width: 280px;
-  height: 280px;
+  height: 340px;
 
   // For some reason the PF Card components overrides all the defaults for
   // divs

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -12,7 +12,7 @@ import {
 
 import { Link } from 'react-router-dom';
 
-import { NumericLabel, Logo } from '../../components';
+import { NumericLabel, Logo, Sync } from '../../components';
 import { CollectionListType, CertificationStatus } from '../../api';
 import { formatPath, Paths } from '../../paths';
 import { convertContentSummaryCounts } from '../../utilities';
@@ -66,10 +66,13 @@ export class CollectionCard extends React.Component<IProps> {
         <CardBody className='description'>
           {this.getDescription(latest_version.metadata.description)}
         </CardBody>
-        <CardFooter className='type-container'>
+        <CardBody className='type-container'>
           {Object.keys(contentSummary.contents).map(k =>
             this.renderTypeCount(k, contentSummary.contents[k]),
           )}
+        </CardBody>
+        <CardFooter className='sync-switch-card'>
+          <Sync collection={name} namespace={namespace.name} />
         </CardFooter>
       </Card>
     );

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  Badge,
   Card,
   CardHead,
   CardBody,
@@ -10,8 +11,6 @@ import {
 } from '@patternfly/react-core';
 
 import { Link } from 'react-router-dom';
-
-import { CertificateIcon } from '@patternfly/react-icons';
 
 import { NumericLabel, Logo } from '../../components';
 import { CollectionListType, CertificationStatus } from '../../api';
@@ -42,7 +41,7 @@ export class CollectionCard extends React.Component<IProps> {
           <TextContent>
             {latest_version.certification === CertificationStatus.certified && (
               <Text component={TextVariants.small}>
-                <CertificateIcon className='icon' /> Certified
+                <Badge isRead>Certified</Badge>
               </Text>
             )}
           </TextContent>

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -15,7 +15,7 @@ import { Link } from 'react-router-dom';
 import * as moment from 'moment';
 
 import { Paths, formatPath } from '../../paths';
-import { NumericLabel, Tag, Logo, DeprecatedTag } from '../../components';
+import { NumericLabel, Tag, Logo, Sync, DeprecatedTag } from '../../components';
 import { CollectionListType } from '../../api';
 import { convertContentSummaryCounts } from '../../utilities';
 
@@ -90,6 +90,7 @@ export class CollectionListItem extends React.Component<IProps, {}> {
 
     cells.push(
       <DataListCell isFilled={false} alignRight key='stats'>
+        <Sync collection={name} namespace={namespace.name} />
         {controls ? <div className='entry'>{controls}</div> : null}
         {
           // <div className='right-col entry'>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,6 +19,7 @@ export { CollectionCard } from './cards/collection-card';
 export { TagFilter } from './tags/tag-filter';
 export { CardListSwitcher } from './card-list-switcher/card-list-switcher';
 export { Logo } from './logo/logo';
+export { Sync } from './sync/sync-toggle';
 export { Pagination } from './patternfly-wrappers/pagination';
 export { CollectionInfo } from './collection-detail/collection-info';
 export { CollectionHeader } from './headers/collection-header';

--- a/src/components/sync/sync-toggle.tsx
+++ b/src/components/sync/sync-toggle.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+
+import { Switch } from '@patternfly/react-core';
+
+interface IProps {
+  collection: string;
+  namespace: string;
+}
+
+interface IState {
+  syncOn: boolean;
+}
+
+export class Sync extends React.Component<IProps, IState> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      syncOn: true,
+    };
+
+    this.whitelisted();
+  }
+
+  render() {
+    const { syncOn } = this.state;
+
+    return (
+      <Switch
+        id='sync-status'
+        className='sync-toggle'
+        label='Sync'
+        isChecked={syncOn}
+        onChange={this.syncToggle}
+      />
+    );
+  }
+
+  private whitelisted = () => {
+    // GET /synclists/(id)
+    console.log('GET /synclists/{id}/');
+    // FIXME: result of API request
+    const whitelistedCollection = this.state.syncOn;
+
+    if (!whitelistedCollection) {
+      this.setState({ syncOn: whitelistedCollection });
+    }
+
+    return whitelistedCollection;
+  };
+
+  private whitelist = () => {
+    console.log('PUT /synclists/{id}/, body');
+    const api_success = true;
+
+    if (api_success) {
+      this.setState({ syncOn: true });
+    }
+  };
+
+  private blacklist = () => {
+    const api_success = true;
+
+    if (api_success) {
+      this.setState({ syncOn: false });
+    }
+  };
+
+  private syncToggle = isChecked => {
+    if (this.whitelisted()) {
+      this.blacklist();
+    } else {
+      this.whitelist();
+    }
+  };
+}


### PR DESCRIPTION
This PR is adding a new component to toggle content sync. Using changes in https://github.com/ansible/galaxy_ng/pull/68 it communicates to the API to list synclists, and update them.

Links
----------------

* dependent on https://github.com/ansible/galaxy_ng/pull/68
* story: ansible/galaxy_ng#17
* subtask ansible/galaxy_ng#19
* [ux mockup - grid](https://marvelapp.com/4dijjai/screen/66854698)
* [ux mockup - list](https://marvelapp.com/4dijjai/screen/67538192)

Steps for Testing/QA
-------------------------------

1. [Create a synclist](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/alikins/galaxy_ng/sync_model_46/openapi/openapi.yaml#/SyncLists/createSyncList)
2. Go to collections page
3. Toggle "Sync" buttons
