### PR TITLE
classNames: prefer classnames over string manipulation

### DIFF
--- a/src/components/card-list-switcher/card-list-switcher.tsx
+++ b/src/components/card-list-switcher/card-list-switcher.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cx from 'classnames';
 import './switcher.scss';
 
 import { ListIcon, ThLargeIcon } from '@patternfly/react-icons';
@@ -27,20 +28,20 @@ export class CardListSwitcher extends React.Component<IProps> {
       disp = 'card';
     }
 
-    const iconClasses = 'icon clickable ';
+    const iconClasses = ['icon', 'clickable'];
 
     return (
       <div className={className}>
         <ThLargeIcon
           size={size}
-          className={iconClasses + (disp === 'card' ? 'selected' : '')}
+          className={cx(iconClasses, { selected: disp === 'card' })}
           onClick={() =>
             updateParams(ParamHelper.setParam(params, 'view_type', 'card'))
           }
         />
         <ListIcon
           size={size}
-          className={iconClasses + (disp === 'list' ? 'selected' : '')}
+          className={cx(iconClasses, { selected: disp === 'list' })}
           onClick={() =>
             updateParams(ParamHelper.setParam(params, 'view_type', 'list'))
           }

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cx from 'classnames';
 import {
   Card,
   CardHead,
@@ -32,7 +33,7 @@ export class CollectionCard extends React.Component<IProps> {
     const contentSummary = convertContentSummaryCounts(latest_version.contents);
 
     return (
-      <Card className={'collection-card-container ' + className}>
+      <Card className={cx('collection-card-container', className)}>
         <CardHead className='logo-row'>
           <Logo
             image={namespace.avatar_url}

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cx from 'classnames';
 import './collection-content-list.scss';
 
 import { Link } from 'react-router-dom';
@@ -77,10 +78,11 @@ export class CollectionContentList extends React.Component<IProps> {
               {Object.keys(summary).map(key => (
                 <ToolbarItem
                   key={key}
-                  className={
-                    'clickable type-selector' +
-                    (key === showing ? ' selected-item' : '')
-                  }
+                  className={cx({
+                    clickable: true,
+                    'selected-item': key === showing,
+                    'type-selector': true,
+                  })}
                   onClick={() =>
                     updateParams(ParamHelper.setParam(params, 'showing', key))
                   }

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cx from 'classnames';
 import './header.scss';
 
 import { PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
@@ -25,7 +26,7 @@ export class BaseHeader extends React.Component<IProps, {}> {
       className,
     } = this.props;
     return (
-      <div className={'background ' + className}>
+      <div className={cx('background', className)}>
         {breadcrumbs ? (
           <div className='breadcrumb-container'>{breadcrumbs}</div>
         ) : (

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cx from 'classnames';
 import './header.scss';
 
 import { Link } from 'react-router-dom';
@@ -127,9 +128,10 @@ export class CollectionHeader extends React.Component<IProps> {
       <div className='pf-c-tabs' id='primary'>
         <ul className='pf-c-tabs__list'>
           <li
-            className={
-              'pf-c-tabs__item' + (active === 'details' ? ' pf-m-current' : '')
-            }
+            className={cx({
+              'pf-c-tabs__item': true,
+              'pf-m-current': active === 'details',
+            })}
           >
             <Link
               to={formatPath(
@@ -147,10 +149,10 @@ export class CollectionHeader extends React.Component<IProps> {
             </Link>
           </li>
           <li
-            className={
-              'pf-c-tabs__item' +
-              (active === 'documentation' ? ' pf-m-current' : '')
-            }
+            className={cx({
+              'pf-c-tabs__item': true,
+              'pf-m-current': active === 'documentation',
+            })}
           >
             <Link
               to={formatPath(
@@ -168,9 +170,10 @@ export class CollectionHeader extends React.Component<IProps> {
             </Link>
           </li>
           <li
-            className={
-              'pf-c-tabs__item' + (active === 'contents' ? ' pf-m-current' : '')
-            }
+            className={cx({
+              'pf-c-tabs__item': true,
+              'pf-m-current': active === 'contents',
+            })}
           >
             <Link
               to={formatPath(
@@ -188,10 +191,10 @@ export class CollectionHeader extends React.Component<IProps> {
             </Link>
           </li>
           <li
-            className={
-              'pf-c-tabs__item' +
-              (active === 'import-log' ? ' pf-m-current' : '')
-            }
+            className={cx({
+              'pf-c-tabs__item': true,
+              'pf-m-current': active === 'import-log',
+            })}
           >
             <Link
               to={formatPath(

--- a/src/components/my-imports/import-console.tsx
+++ b/src/components/my-imports/import-console.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cx from 'classnames';
 import './my-imports.scss';
 
 import { Tooltip } from '@patternfly/react-core';
@@ -64,11 +65,10 @@ export class ImportConsole extends React.Component<IProps, {}> {
         {this.renderTitle(selectedImport)}
         <div className='message-list'>
           <div
-            className={
-              this.props.followMessages
-                ? 'log-follow-button follow-active'
-                : 'log-follow-button'
-            }
+            className={cx({
+              'follow-active': this.props.followMessages,
+              'log-follow-button': true,
+            })}
           >
             <Tooltip
               position='left'

--- a/src/components/my-imports/import-list.tsx
+++ b/src/components/my-imports/import-list.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import cx from 'classnames';
 import './my-imports.scss';
 
 import * as moment from 'moment';
@@ -153,12 +154,13 @@ export class ImportList extends React.Component<IProps, IState> {
             <div
               onClick={() => selectImport(item)}
               key={item.id}
-              className={
-                item.type === selectedImport.type &&
-                item.id === selectedImport.id
-                  ? 'clickable list-container selected-item'
-                  : 'clickable list-container'
-              }
+              className={cx({
+                clickable: true,
+                'list-container': true,
+                'selected-item':
+                  item.type === selectedImport.type &&
+                  item.id === selectedImport.id,
+              })}
             >
               <div className='left'>
                 <i className={this.getStatusClass(item.state)} />

--- a/src/components/patternfly-wrappers/main.tsx
+++ b/src/components/patternfly-wrappers/main.tsx
@@ -1,13 +1,16 @@
 import * as React from 'react';
+import cx from 'classnames';
 
 export class Main extends React.Component<any> {
   render() {
     const { children, className, ...extra } = this.props;
     return (
       <section
-        className={
-          'pf-l-page__main-section pf-c-page__main-section ' + className
-        }
+        className={cx(
+          'pf-l-page__main-section',
+          'pf-c-page__main-section',
+          className,
+        )}
         {...extra}
       >
         {children}


### PR DESCRIPTION
Fixes a couple of `class="undefined"` in the resulting HTML.

(And `classnames` is already in `package.json`.)