### PR TITLE
When field changes remove its error messages

### DIFF
--- a/src/components/user-form/user-form-page.tsx
+++ b/src/components/user-form/user-form-page.tsx
@@ -12,7 +12,7 @@ interface IProps {
   errorMessages: object;
   isReadonly?: boolean;
 
-  updateUser: (user: UserType) => void;
+  updateUser: (user: UserType, errorMessages: object) => void;
   saveUser?: () => void;
   extraControls?: React.ReactNode;
   onCancel?: () => void;

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -15,7 +15,7 @@ interface IProps {
   user: UserType;
 
   /** Updates the current user object with the new user object */
-  updateUser: (user: UserType) => void;
+  updateUser: (user: UserType, errorMesssages: object) => void;
 
   /** List of errors from the API */
   errorMessages: object;
@@ -147,7 +147,11 @@ export class UserForm extends React.Component<IProps, IState> {
 
   private updateField = (value, event) => {
     const update = { ...this.props.user };
+    const errorMessages = { ...this.props.errorMessages };
     update[event.target.id] = value;
-    this.props.updateUser(update);
+    if (event.target.id in errorMessages) {
+      delete errorMessages[event.target.id];
+    }
+    this.props.updateUser(update, errorMessages);
   };
 }

--- a/src/containers/user-management/user-create.tsx
+++ b/src/containers/user-management/user-create.tsx
@@ -41,7 +41,9 @@ class UserCreate extends React.Component<RouteComponentProps, IState> {
         ]}
         title='Create new user'
         errorMessages={errorMessages}
-        updateUser={user => this.setState({ user: user })}
+        updateUser={(user, errorMessages) =>
+          this.setState({ user: user, errorMessages: errorMessages })
+        }
         saveUser={this.saveUser}
         onCancel={() => this.props.history.push(Paths.userList)}
       ></UserFormPage>

--- a/src/containers/user-management/user-edit.tsx
+++ b/src/containers/user-management/user-edit.tsx
@@ -45,7 +45,9 @@ class UserEdit extends React.Component<RouteComponentProps, IState> {
         ]}
         title='Edit user'
         errorMessages={errorMessages}
-        updateUser={user => this.setState({ user: user })}
+        updateUser={(user, errorMessages) =>
+          this.setState({ user: user, errorMessages: errorMessages })
+        }
         saveUser={this.saveUser}
         onCancel={() => this.props.history.push(Paths.userList)}
       ></UserFormPage>


### PR DESCRIPTION
**Links** 

Fixes https://github.com/ansible/galaxy_ng/issues/179#issuecomment-645418813

**Steps for Testing/QA** 

- Go to User 
- Edit or Create a User
- set Password to `password`
- click Save
- error message appears
- change Password

Before:
Error message stays after changing 
<img width="1366" alt="Screenshot 2020-07-01 at 10 34 12" src="https://user-images.githubusercontent.com/9210860/86222777-f80f8580-bb86-11ea-9eb6-27ea5c09b208.png">

After:
<img width="1359" alt="Screenshot 2020-07-01 at 10 31 23" src="https://user-images.githubusercontent.com/9210860/86222757-f219a480-bb86-11ea-8cff-1ce68fc42408.png">
