### PR TITLE
Certification-dashboard uses new viewset and promotion for accept/reject API endpoints

### DIFF
--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -15,8 +15,7 @@ export class API extends BaseAPI {
     destinationRepo: string,
   ) {
     const path = `v3/collections/${namespace}/${name}/versions/${version}/move/${originalRepo}/${destinationRepo}/`;
-    const data = {};
-    return this.create(data, path);
+    return this.create({}, path);
   }
 }
 

--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -1,27 +1,10 @@
 import { BaseAPI } from './base';
-import { CertificationStatus } from '../api';
 
 export class API extends BaseAPI {
   apiPath = 'v3/_ui/collection-versions/';
 
   constructor() {
     super();
-  }
-
-  setCertifiation(
-    namespace: string,
-    collection: string,
-    version: string,
-    certification: CertificationStatus,
-  ) {
-    const id = `${namespace}/${collection}/${version}/certified`;
-
-    return this.update(id, {
-      namespace: namespace,
-      name: collection,
-      version: version,
-      certification: certification,
-    });
   }
 
   setRepository(

--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -23,6 +23,18 @@ export class API extends BaseAPI {
       certification: certification,
     });
   }
+
+  setRepository(
+    namespace: string,
+    name: string,
+    version: string,
+    originalRepo: string,
+    destinationRepo: string,
+  ) {
+    const path = `v3/collections/${namespace}/${name}/versions/${version}/move/${originalRepo}/${destinationRepo}/`;
+    const data = {};
+    return this.create(data, path);
+  }
 }
 
 export const CollectionVersionAPI = new API();

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -25,3 +25,4 @@ export { MyNamespaceAPI } from './my-namespace';
 export { UserAPI } from './user';
 export { MySyncListAPI } from './my-synclist';
 export { SyncListType } from './response-types/synclists';
+export { TaskAPI } from './task';

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,7 +10,6 @@ export {
   ContentSummaryType,
   CollectionVersion,
   CertificationStatus,
-  RepositoryStatus,
 } from './response-types/collection';
 export {
   ImportListType,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,6 +10,7 @@ export {
   ContentSummaryType,
   CollectionVersion,
   CertificationStatus,
+  RepositoryStatus,
 } from './response-types/collection';
 export {
   ImportListType,

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -16,12 +16,19 @@ export class CollectionVersion {
   certification: CertificationStatus;
   namespace: string;
   name: string;
+  repository_list: string[];
 }
 
 export enum CertificationStatus {
   certified = 'certified',
   notCertified = 'not_certified',
   needsReview = 'needs_review',
+}
+
+export enum RepositoryStatus {
+  certified = 'automation-hub',
+  notCertified = 'rejected',
+  needsReview = 'staging',
 }
 
 class RenderedFile {

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -25,12 +25,6 @@ export enum CertificationStatus {
   needsReview = 'needs_review',
 }
 
-export enum RepositoryStatus {
-  certified = 'automation-hub',
-  notCertified = 'rejected',
-  needsReview = 'staging',
-}
-
 class RenderedFile {
   name: string;
   html: string;

--- a/src/api/task.ts
+++ b/src/api/task.ts
@@ -1,0 +1,11 @@
+import { BaseAPI } from './base';
+
+export class API extends BaseAPI {
+  apiPath = 'v3/tasks/';
+
+  constructor() {
+    super();
+  }
+}
+
+export const TaskAPI = new API();

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -9,4 +9,10 @@ export class Constants {
   static readonly STANDALONE_DEPLOYMENT_MODE = 'standalone';
 
   static readonly ADMIN_GROUP = 'system:partner-engineers';
+  static CERTIFIED =
+    DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
+      ? 'automation-hub'
+      : 'published';
+  static NOTCERTIFIED = 'rejected';
+  static NEEDSREVIEW = 'staging';
 }

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -23,7 +23,12 @@ import {
   EmptyStateVariant,
 } from '@patternfly/react-core';
 
-import { WarningTriangleIcon } from '@patternfly/react-icons';
+import {
+  InfoCircleIcon,
+  ExclamationCircleIcon,
+  CheckCircleIcon,
+  WarningTriangleIcon,
+} from '@patternfly/react-icons';
 
 import {
   CollectionVersionAPI,
@@ -254,6 +259,11 @@ class CertificationDashboard extends React.Component<
           id: 'pulp_created',
         },
         {
+          title: 'Status',
+          type: 'none',
+          id: 'status',
+        },
+        {
           title: 'Repository',
           type: 'none',
           id: 'repository',
@@ -285,6 +295,39 @@ class CertificationDashboard extends React.Component<
     );
   }
 
+  private renderStatus(version: CollectionVersion) {
+    if (version.repository_list.includes(this.certified)) {
+      return (
+        <span>
+          <CheckCircleIcon
+            style={{ color: 'var(--pf-global--success-color--100)' }}
+          />{' '}
+          Certified
+        </span>
+      );
+    }
+    if (version.repository_list.includes(this.notCertified)) {
+      return (
+        <span>
+          <ExclamationCircleIcon
+            style={{ color: 'var(--pf-global--danger-color--100)' }}
+          />{' '}
+          Rejected
+        </span>
+      );
+    }
+    if (version.repository_list.includes(this.needsReview)) {
+      return (
+        <span>
+          <InfoCircleIcon
+            style={{ color: 'var(--pf-global--info-color--100)' }}
+          />{' '}
+          Needs Review
+        </span>
+      );
+    }
+  }
+
   private renderRow(version: CollectionVersion, index) {
     return (
       <tr
@@ -310,6 +353,7 @@ class CertificationDashboard extends React.Component<
           </Link>
         </td>
         <td>{moment(version.created_at).fromNow()}</td>
+        <td>{this.renderStatus(version)}</td>
         <td>{version.repository_list}</td>
         <td>
           <div className='control-column'>

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -23,12 +23,7 @@ import {
   EmptyStateVariant,
 } from '@patternfly/react-core';
 
-import {
-  InfoCircleIcon,
-  ExclamationCircleIcon,
-  CheckCircleIcon,
-  WarningTriangleIcon,
-} from '@patternfly/react-icons';
+import { WarningTriangleIcon } from '@patternfly/react-icons';
 
 import {
   CollectionVersionAPI,

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -264,11 +264,6 @@ class CertificationDashboard extends React.Component<
           id: 'status',
         },
         {
-          title: 'Repository',
-          type: 'none',
-          id: 'repository',
-        },
-        {
           title: '',
           type: 'none',
           id: 'certify',
@@ -354,7 +349,6 @@ class CertificationDashboard extends React.Component<
         </td>
         <td>{moment(version.created_at).fromNow()}</td>
         <td>{this.renderStatus(version)}</td>
-        <td>{version.repository_list}</td>
         <td>
           <div className='control-column'>
             <div>{this.renderButtons(version)}</div>

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -28,7 +28,6 @@ import { WarningTriangleIcon } from '@patternfly/react-icons';
 import {
   CollectionVersionAPI,
   CollectionVersion,
-  RepositoryStatus,
   ActiveUserAPI,
   MeType,
 } from '../../api';
@@ -46,6 +45,7 @@ import {
   SortTable,
 } from '../../components';
 import { Paths, formatPath } from '../../paths';
+import { Constants } from '../../constants';
 
 interface IState {
   params: {
@@ -67,6 +67,13 @@ class CertificationDashboard extends React.Component<
   RouteComponentProps,
   IState
 > {
+  certified =
+    DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
+      ? 'automation-hub'
+      : 'published';
+  notCertified = 'rejected';
+  needsReview = 'staging';
+
   constructor(props) {
     super(props);
 
@@ -152,15 +159,15 @@ class CertificationDashboard extends React.Component<
                           inputType: 'select',
                           options: [
                             {
-                              id: RepositoryStatus.notCertified,
+                              id: this.notCertified,
                               title: 'Rejected',
                             },
                             {
-                              id: RepositoryStatus.needsReview,
+                              id: this.needsReview,
                               title: 'Needs Review',
                             },
                             {
-                              id: RepositoryStatus.certified,
+                              id: this.certified,
                               title: 'Certified',
                             },
                           ],
@@ -338,11 +345,7 @@ class CertificationDashboard extends React.Component<
     const certifyDropDown = (isDisabled: boolean, originalRepo) => (
       <DropdownItem
         onClick={() =>
-          this.updateCertification(
-            version,
-            originalRepo,
-            RepositoryStatus.certified,
-          )
+          this.updateCertification(version, originalRepo, this.certified)
         }
         isDisabled={isDisabled}
         key='certify'
@@ -354,11 +357,7 @@ class CertificationDashboard extends React.Component<
     const rejectDropDown = (isDisabled: boolean, originalRepo) => (
       <DropdownItem
         onClick={() =>
-          this.updateCertification(
-            version,
-            originalRepo,
-            RepositoryStatus.notCertified,
-          )
+          this.updateCertification(version, originalRepo, this.notCertified)
         }
         isDisabled={isDisabled}
         className='rejected-icon'
@@ -368,51 +367,48 @@ class CertificationDashboard extends React.Component<
       </DropdownItem>
     );
 
-    if (version.repository_list.includes(RepositoryStatus.certified)) {
+    if (version.repository_list.includes(this.certified)) {
       return (
         <span>
           <StatefulDropdown
             items={[
-              certifyDropDown(true, RepositoryStatus.certified),
-              rejectDropDown(false, RepositoryStatus.certified),
+              certifyDropDown(true, this.certified),
+              rejectDropDown(false, this.certified),
               importsLink,
             ]}
           />
         </span>
       );
     }
-    if (version.repository_list.includes(RepositoryStatus.notCertified)) {
+    if (version.repository_list.includes(this.notCertified)) {
       return (
         <span>
           <StatefulDropdown
             items={[
-              certifyDropDown(false, RepositoryStatus.notCertified),
-              rejectDropDown(true, RepositoryStatus.notCertified),
+              certifyDropDown(false, this.notCertified),
+              rejectDropDown(true, this.notCertified),
               importsLink,
             ]}
           />
         </span>
       );
     }
-    if (version.repository_list.includes(RepositoryStatus.needsReview)) {
+    if (version.repository_list.includes(this.needsReview)) {
       return (
         <span>
           <Button
             onClick={() =>
               this.updateCertification(
                 version,
-                RepositoryStatus.needsReview,
-                RepositoryStatus.certified,
+                this.needsReview,
+                this.certified,
               )
             }
           >
             <span>Certify</span>
           </Button>
           <StatefulDropdown
-            items={[
-              rejectDropDown(false, RepositoryStatus.needsReview),
-              importsLink,
-            ]}
+            items={[rejectDropDown(false, this.needsReview), importsLink]}
           />
         </span>
       );

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -310,7 +310,7 @@ class CertificationDashboard extends React.Component<
     const certifyDropDown = (isDisabled: boolean) => (
       <DropdownItem
         onClick={() =>
-          this.updateCertification(version, CertificationStatus.certified)
+          this.updateCertification(version, 'rejected', 'automation-hub')
         }
         isDisabled={isDisabled}
         key='certify'
@@ -322,7 +322,7 @@ class CertificationDashboard extends React.Component<
     const rejectDropDown = (isDisabled: boolean) => (
       <DropdownItem
         onClick={() =>
-          this.updateCertification(version, CertificationStatus.notCertified)
+          this.updateCertification(version, 'automation-hub', 'rejected')
         }
         isDisabled={isDisabled}
         className='rejected-icon'
@@ -362,7 +362,7 @@ class CertificationDashboard extends React.Component<
           <span>
             <Button
               onClick={() =>
-                this.updateCertification(version, CertificationStatus.certified)
+                this.updateCertification(version, 'staging', 'automation-hub')
               }
             >
               <span>Certify</span>
@@ -373,19 +373,20 @@ class CertificationDashboard extends React.Component<
     }
   }
 
-  private updateCertification(version, certification) {
+  private updateCertification(version, originalRepo, destinationRepo) {
+    debugger;
     // Set the selected version to loading
     this.setState(
       {
         updatingVersions: this.state.updatingVersions.concat([version.id]),
       },
       () =>
-        // Perform the PUT request
-        CollectionVersionAPI.setCertifiation(
+        CollectionVersionAPI.setRepository(
           version.namespace,
           version.name,
           version.version,
-          certification,
+          'automation-hub',
+          'rejected',
         )
           .then(() =>
             // Since pulp doesn't reply with the new object, perform a

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -146,6 +146,25 @@ class CertificationDashboard extends React.Component<
                           id: 'name',
                           title: 'Collection Name',
                         },
+                        {
+                          id: 'repository',
+                          title: 'Repository',
+                          inputType: 'select',
+                          options: [
+                            {
+                              id: 'rejected',
+                              title: 'Rejected',
+                            },
+                            {
+                              id: 'staging',
+                              title: 'Needs Review',
+                            },
+                            {
+                              id: 'automation-hub',
+                              title: 'Certified',
+                            },
+                          ],
+                        },
                       ]}
                     />
                   </ToolbarItem>

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -463,7 +463,7 @@ class CertificationDashboard extends React.Component<
     // Set the selected version to loading
     this.setState(
       {
-        updatingVersions: this.state.updatingVersions.concat([version.id]),
+        updatingVersions: [],
       },
       () =>
         CollectionVersionAPI.setRepository(
@@ -484,9 +484,7 @@ class CertificationDashboard extends React.Component<
           )
           .catch(error => {
             this.setState({
-              updatingVersions: this.state.updatingVersions.filter(
-                v => v != version.id,
-              ),
+              updatingVersions: [],
               alerts: this.state.alerts.concat({
                 variant: 'danger',
                 title: `API Error: ${error.response.status}`,

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -420,7 +420,6 @@ class CertificationDashboard extends React.Component<
   }
 
   private updateCertification(version, originalRepo, destinationRepo) {
-    debugger;
     // Set the selected version to loading
     this.setState(
       {
@@ -437,23 +436,9 @@ class CertificationDashboard extends React.Component<
           .then(() =>
             // Since pulp doesn't reply with the new object, perform a
             // second query to get the updated data
-            CollectionVersionAPI.list({
-              namespace: version.namespace,
-              name: version.name,
-              version: version.version,
-            }).then(result => {
-              const updatedVersion = result.data.data[0];
-              const newVersionList = [...this.state.versions];
-              const ind = newVersionList.findIndex(
-                x => x.id === updatedVersion.id,
-              );
-              newVersionList[ind] = updatedVersion;
-
+            CollectionVersionAPI.list(this.state.params).then(result => {
               this.setState({
-                versions: newVersionList,
-                updatingVersions: this.state.updatingVersions.filter(
-                  v => v != updatedVersion.id,
-                ),
+                versions: result.data.data,
               });
             }),
           )

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -89,10 +89,6 @@ class CertificationDashboard extends React.Component<
       params['sort'] = '-pulp_created';
     }
 
-    if (!params['certification']) {
-      params['certification'] = CertificationStatus.needsReview;
-    }
-
     this.state = {
       versions: undefined,
       itemCount: 0,
@@ -151,25 +147,6 @@ class CertificationDashboard extends React.Component<
                         {
                           id: 'name',
                           title: 'Collection Name',
-                        },
-                        {
-                          id: 'certification',
-                          title: 'Certification Status',
-                          inputType: 'select',
-                          options: [
-                            {
-                              id: 'not_certified',
-                              title: 'Rejected',
-                            },
-                            {
-                              id: 'needs_review',
-                              title: 'Needs Review',
-                            },
-                            {
-                              id: 'certified',
-                              title: 'Certified',
-                            },
-                          ],
                         },
                       ]}
                     />
@@ -253,11 +230,6 @@ class CertificationDashboard extends React.Component<
           id: 'pulp_created',
         },
         {
-          title: 'Status',
-          type: 'none',
-          id: 'status',
-        },
-        {
           title: '',
           type: 'none',
           id: 'certify',
@@ -282,41 +254,6 @@ class CertificationDashboard extends React.Component<
         </tbody>
       </table>
     );
-  }
-
-  private renderStatus(version: CollectionVersion) {
-    if (this.state.updatingVersions.includes(version.id)) {
-      return <span className='fa fa-lg fa-spin fa-spinner' />;
-    }
-    switch (version.certification) {
-      case CertificationStatus.certified:
-        return (
-          <span>
-            <CheckCircleIcon
-              style={{ color: 'var(--pf-global--success-color--100)' }}
-            />{' '}
-            Certified
-          </span>
-        );
-      case CertificationStatus.notCertified:
-        return (
-          <span>
-            <ExclamationCircleIcon
-              style={{ color: 'var(--pf-global--danger-color--100)' }}
-            />{' '}
-            Rejected
-          </span>
-        );
-      case CertificationStatus.needsReview:
-        return (
-          <span>
-            <InfoCircleIcon
-              style={{ color: 'var(--pf-global--info-color--100)' }}
-            />{' '}
-            Needs Review
-          </span>
-        );
-    }
   }
 
   private renderRow(version: CollectionVersion, index) {
@@ -344,7 +281,6 @@ class CertificationDashboard extends React.Component<
           </Link>
         </td>
         <td>{moment(version.created_at).fromNow()}</td>
-        <td>{this.renderStatus(version)}</td>
         <td>
           <div className='control-column'>
             <div>{this.renderButtons(version)}</div>
@@ -499,14 +435,15 @@ class CertificationDashboard extends React.Component<
 
   private queryCollections() {
     this.setState({ loading: true }, () =>
-      CollectionVersionAPI.list(this.state.params).then(result =>
+      CollectionVersionAPI.list(this.state.params).then(result => {
+        debugger;
         this.setState({
           versions: result.data.data,
           itemCount: result.data.meta.count,
           loading: false,
           updatingVersions: [],
-        }),
-      ),
+        });
+      }),
     );
   }
 

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -72,13 +72,6 @@ class CertificationDashboard extends React.Component<
   RouteComponentProps,
   IState
 > {
-  certified =
-    DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-      ? 'automation-hub'
-      : 'published';
-  notCertified = 'rejected';
-  needsReview = 'staging';
-
   constructor(props) {
     super(props);
 
@@ -164,15 +157,15 @@ class CertificationDashboard extends React.Component<
                           inputType: 'select',
                           options: [
                             {
-                              id: this.notCertified,
+                              id: Constants.NOTCERTIFIED,
                               title: 'Rejected',
                             },
                             {
-                              id: this.needsReview,
+                              id: Constants.NEEDSREVIEW,
                               title: 'Needs Review',
                             },
                             {
-                              id: this.certified,
+                              id: Constants.CERTIFIED,
                               title: 'Certified',
                             },
                           ],
@@ -291,7 +284,7 @@ class CertificationDashboard extends React.Component<
   }
 
   private renderStatus(version: CollectionVersion) {
-    if (version.repository_list.includes(this.certified)) {
+    if (version.repository_list.includes(Constants.CERTIFIED)) {
       return (
         <span>
           <CheckCircleIcon
@@ -301,7 +294,7 @@ class CertificationDashboard extends React.Component<
         </span>
       );
     }
-    if (version.repository_list.includes(this.notCertified)) {
+    if (version.repository_list.includes(Constants.NOTCERTIFIED)) {
       return (
         <span>
           <ExclamationCircleIcon
@@ -311,7 +304,7 @@ class CertificationDashboard extends React.Component<
         </span>
       );
     }
-    if (version.repository_list.includes(this.needsReview)) {
+    if (version.repository_list.includes(Constants.NEEDSREVIEW)) {
       return (
         <span>
           <InfoCircleIcon
@@ -383,7 +376,7 @@ class CertificationDashboard extends React.Component<
     const certifyDropDown = (isDisabled: boolean, originalRepo) => (
       <DropdownItem
         onClick={() =>
-          this.updateCertification(version, originalRepo, this.certified)
+          this.updateCertification(version, originalRepo, Constants.CERTIFIED)
         }
         isDisabled={isDisabled}
         key='certify'
@@ -395,7 +388,11 @@ class CertificationDashboard extends React.Component<
     const rejectDropDown = (isDisabled: boolean, originalRepo) => (
       <DropdownItem
         onClick={() =>
-          this.updateCertification(version, originalRepo, this.notCertified)
+          this.updateCertification(
+            version,
+            originalRepo,
+            Constants.NOTCERTIFIED,
+          )
         }
         isDisabled={isDisabled}
         className='rejected-icon'
@@ -405,48 +402,48 @@ class CertificationDashboard extends React.Component<
       </DropdownItem>
     );
 
-    if (version.repository_list.includes(this.certified)) {
+    if (version.repository_list.includes(Constants.CERTIFIED)) {
       return (
         <span>
           <StatefulDropdown
             items={[
-              certifyDropDown(true, this.certified),
-              rejectDropDown(false, this.certified),
+              certifyDropDown(true, Constants.CERTIFIED),
+              rejectDropDown(false, Constants.CERTIFIED),
               importsLink,
             ]}
           />
         </span>
       );
     }
-    if (version.repository_list.includes(this.notCertified)) {
+    if (version.repository_list.includes(Constants.NOTCERTIFIED)) {
       return (
         <span>
           <StatefulDropdown
             items={[
-              certifyDropDown(false, this.notCertified),
-              rejectDropDown(true, this.notCertified),
+              certifyDropDown(false, Constants.NOTCERTIFIED),
+              rejectDropDown(true, Constants.NOTCERTIFIED),
               importsLink,
             ]}
           />
         </span>
       );
     }
-    if (version.repository_list.includes(this.needsReview)) {
+    if (version.repository_list.includes(Constants.NEEDSREVIEW)) {
       return (
         <span>
           <Button
             onClick={() =>
               this.updateCertification(
                 version,
-                this.needsReview,
-                this.certified,
+                Constants.NEEDSREVIEW,
+                Constants.CERTIFIED,
               )
             }
           >
             <span>Certify</span>
           </Button>
           <StatefulDropdown
-            items={[rejectDropDown(false, this.needsReview), importsLink]}
+            items={[rejectDropDown(false, Constants.NEEDSREVIEW), importsLink]}
           />
         </span>
       );

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -503,8 +503,7 @@ class CertificationDashboard extends React.Component<
       if (result.data.state === 'waiting' || result.data.state === 'running') {
         await new Promise(r => setTimeout(r, 500));
         this.waitForUpdate(taskId, version);
-      }
-      if (result.data.state === 'completed') {
+      } else if (result.data.state === 'completed') {
         return CollectionVersionAPI.list(this.state.params).then(
           async result => {
             this.setState({

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -43,7 +43,6 @@ import {
   AlertList,
   closeAlertMixin,
   AlertType,
-  SortFieldType,
   SortTable,
 } from '../../components';
 import { Paths, formatPath } from '../../paths';

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -83,6 +83,10 @@ class CertificationDashboard extends React.Component<
       params['sort'] = '-pulp_created';
     }
 
+    if (!params['repository']) {
+      params['repository'] = 'staging';
+    }
+
     this.state = {
       versions: undefined,
       itemCount: 0,


### PR DESCRIPTION
Issue: https://github.com/ansible/galaxy_ng/issues/119

Depends on https://github.com/ansible/galaxy_ng/pull/284 (merged) and https://github.com/ansible/galaxy_ng/pull/311 (merged)

You have to create `published`(for standalone mode), `rejected` and `staging` as following
```python
>>> from pulp_ansible.app.models import AnsibleRepository, AnsibleDistribution
>>> repo = AnsibleRepository.objects.create(name='automation-hub')
>>> AnsibleDistribution.objects.create(name='automation-hub', base_path='automation-hub', repository=repo)
<AnsibleDistribution: automation-hub>
>>> # Press <CTRL+D> to exit.
```
TODO:
- [x] remove all certification related things like search and so on
- [x] repo search and default settings
- [x] use new API to certify/reject 
- [x] UX details like should we show repo like `automation-hub` or `certified` -> NOPE -> Remove Repository column
- [x] Use API `\tasks` to wait till `\move` is done before updating UI - tobe done in follow up PR

Before:
<img width="1345" alt="Screenshot 2020-07-09 at 13 00 17" src="https://user-images.githubusercontent.com/9210860/87031968-28d56780-c1e4-11ea-8a41-fba6f89908b4.png">
Bugs: after Reject/Certify from Dropdown the CollectionVersion is double. See `sindhuparvathi_gopi` in the pic above

After:
<img width="1344" alt="Screenshot 2020-07-09 at 15 36 23" src="https://user-images.githubusercontent.com/9210860/87055510-bb85fe80-c204-11ea-8880-9a68ed0ad8e6.png">


