### PR TITLE
Update my namespaces to work with inbound repos

### DIFF
--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -34,6 +34,7 @@ export class API extends BaseAPI {
   }
 
   upload(
+    repositoryPath: String,
     data: CollectionUploadType,
     progressCallback: (e) => void,
     cancelToken?: any,
@@ -52,8 +53,11 @@ export class API extends BaseAPI {
     if (cancelToken) {
       config['cancelToken'] = cancelToken.token;
     }
-
-    return this.http.post('v3/artifacts/collections/', formData, config);
+    return this.http.post(
+      'content/' + repositoryPath + '/v3/artifacts/collections/',
+      formData,
+      config,
+    );
   }
 
   getCancelToken() {

--- a/src/containers/namespace-detail/import-modal/import-modal.tsx
+++ b/src/containers/namespace-detail/import-modal/import-modal.tsx
@@ -192,6 +192,7 @@ export class ImportModal extends React.Component<IProps, IState> {
     this.cancelToken = CollectionAPI.getCancelToken();
 
     CollectionAPI.upload(
+      'inbound-' + this.props.namespace,
       artifact,
       e => {
         this.setState({

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -7,6 +7,7 @@ import {
   DropdownItem,
   Alert,
   AlertActionCloseButton,
+  ClipboardCopy,
 } from '@patternfly/react-core';
 
 import * as ReactMarkdown from 'react-markdown';
@@ -111,7 +112,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    const tabs = ['Collections', 'Configuration'];
+    const tabs = ['Collections', 'CLI Configuration'];
 
     const tab = params['tab'] || 'collections';
 
@@ -188,8 +189,14 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             ) : (
               this.renderResources(namespace)
             )}
-            {tab.toLowerCase() === 'configuration' ? (
-              <div>{repositoryUrl}</div>
+            {tab.toLowerCase() === 'cli configuration' ? (
+              <div>
+                <ClipboardCopy isReadOnly>{repositoryUrl}</ClipboardCopy>
+                <div>
+                  <b>Note:</b> Use this URL to configure ansible-galaxy to
+                  upload collections to.
+                </div>
+              </div>
             ) : (
               this.renderResources(namespace)
             )}

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -7,6 +7,11 @@ import {
   DropdownItem,
   Alert,
   AlertActionCloseButton,
+  ButtonVariant,
+  TextInput,
+  Form,
+  FormGroup,
+  ActionGroup,
 } from '@patternfly/react-core';
 
 import * as ReactMarkdown from 'react-markdown';
@@ -111,13 +116,15 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    const tabs = ['Collections'];
+    const tabs = ['Collections', 'Configuration'];
 
     const tab = params['tab'] || 'collections';
 
     if (namespace.resources) {
       tabs.push('Resources');
     }
+
+    const repositoryUrl = 'inbound-' + namespace.name;
 
     return (
       <React.Fragment>
@@ -179,6 +186,11 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                   this.handleCollectionAction(id, action)
                 }
               />
+            ) : (
+              this.renderResources(namespace)
+            )}
+            {tab.toLowerCase() === 'configuration' ? (
+              <div>{repositoryUrl}</div>
             ) : (
               this.renderResources(namespace)
             )}

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -129,7 +129,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
         API_BASE_PATH +
         'content/inbound-' +
         namespace.name +
-        '/v3/collections/';
+        '/';
 
     return (
       <React.Fragment>

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -119,7 +119,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       tabs.push('Resources');
     }
 
-    const repositoryUrl = 'inbound-' + namespace.name;
+    const repositoryUrl = 'content/inbound-' + namespace.name;
 
     return (
       <React.Fragment>

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -123,12 +123,13 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       tabs.push('Resources');
     }
 
-    const repositoryUrl =
-      window.location.href.split('/ui')[0].replace('8002', '5001') +
-      CollectionAPI.apiBaseURL +
-      'content/inbound-' +
-      namespace.name +
-      '/v3/collections';
+    const repositoryUrl = !!API_HOST
+      ? API_HOST
+      : window.location.origin +
+        API_BASE_PATH +
+        'content/inbound-' +
+        namespace.name +
+        '/v3/collections/';
 
     return (
       <React.Fragment>
@@ -198,7 +199,15 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                 <ClipboardCopy isReadOnly>{repositoryUrl}</ClipboardCopy>
                 <div>
                   <b>Note:</b> Use this URL to configure ansible-galaxy to
-                  upload collections to.
+                  upload collections to this namespace. More information on
+                  ansible-galaxy configurations can be found{' '}
+                  <a
+                    href='https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client'
+                    target='_blank'
+                  >
+                    here
+                  </a>
+                  .
                 </div>
               </div>
             ) : (

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -122,7 +122,8 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
     const repositoryUrl =
       window.location.href.split('/ui')[0].replace('8002', '5001') +
-      '/api/automation-hub/content/inbound-' +
+      CollectionAPI.apiBaseURL +
+      'content/inbound-' +
       namespace.name +
       '/v3/collections';
 

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -7,11 +7,6 @@ import {
   DropdownItem,
   Alert,
   AlertActionCloseButton,
-  ButtonVariant,
-  TextInput,
-  Form,
-  FormGroup,
-  ActionGroup,
 } from '@patternfly/react-core';
 
 import * as ReactMarkdown from 'react-markdown';

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -112,8 +112,11 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    const tabs = ['Collections', 'CLI Configuration'];
+    const tabs = ['Collections'];
 
+    if (this.props.showControls) {
+      tabs.push('CLI Configuration');
+    }
     const tab = params['tab'] || 'collections';
 
     if (namespace.resources) {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -119,7 +119,11 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       tabs.push('Resources');
     }
 
-    const repositoryUrl = 'content/inbound-' + namespace.name;
+    const repositoryUrl =
+      window.location.href.split('/ui')[0].replace('8002', '5001') +
+      '/api/automation-hub/content/inbound-' +
+      namespace.name +
+      '/v3/collections';
 
     return (
       <React.Fragment>


### PR DESCRIPTION
Fixes https://github.com/ansible/galaxy_ng/issues/290

Steps to test:
- if https://github.com/ansible/galaxy_ng/pull/272 not merged create an inbound repo `inbound-[namespace.name]` 
```python
>>> from pulp_ansible.app.models import AnsibleRepository, AnsibleDistribution
>>> repo = AnsibleRepository.objects.create(name='inbound-[namespace.name]')
>>> AnsibleDistribution.objects.create(name='inbound-[namespace.name]', base_path='inbound-[namespace.name]', repository=repo)
<AnsibleDistribution: automation-hub>
>>> # Press <CTRL+D> to exit.
```

   else create a namespace
- upload collection
- `/content/inbound-[namespace.name]/v3/artifacts/collection` is called instead of `automation-hub/v3/artifacts/collection`


*Add a new view where the user can copy the repository URL for the purpose of configuring the ansible-galaxy cli:*

This shows only in My Namespaces.

<img width="1383" alt="Screenshot 2020-08-03 at 16 33 35" src="https://user-images.githubusercontent.com/9210860/89194023-1c57eb00-d5a7-11ea-8e69-0cecca0ff03f.png">


