### PR TITLE
Deduplicate Resources tab content

### DIFF
--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -191,9 +191,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                   this.handleCollectionAction(id, action)
                 }
               />
-            ) : (
-              this.renderResources(namespace)
-            )}
+            ) : null}
             {tab.toLowerCase() === 'cli configuration' ? (
               <div>
                 <ClipboardCopy isReadOnly>{repositoryUrl}</ClipboardCopy>
@@ -210,9 +208,10 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                   .
                 </div>
               </div>
-            ) : (
-              this.renderResources(namespace)
-            )}
+            ) : null}
+            {tab.toLowerCase() === 'resources'
+              ? this.renderResources(namespace)
+              : null}
           </Section>
         </Main>
       </React.Fragment>


### PR DESCRIPTION
Before:
<img width="1380" alt="Screenshot 2020-08-27 at 09 55 02" src="https://user-images.githubusercontent.com/9210860/91415353-3a370980-e84e-11ea-96b3-8689900b7426.png">

After:
<img width="1367" alt="Screenshot 2020-08-27 at 10 13 27" src="https://user-images.githubusercontent.com/9210860/91415346-36a38280-e84e-11ea-9e45-5864d876e2ea.png">
