### PR TITLE
Update js packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19217,9 +19217,9 @@
       "dev": true
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-gyp": {
@@ -23709,12 +23709,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18166,11 +18166,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
-    "lodash-es": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
-      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
-    },
     "lodash-webpack-plugin": {
       "version": "0.11.5",
       "resolved": "https://registry.npmjs.org/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.5.tgz",
@@ -22863,14 +22858,22 @@
       }
     },
     "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.5.tgz",
+      "integrity": "sha512-VSz1uMAH24DM6MF72vcojpYPtrTUu3ByVWfPL1nPfVRb5mZVTve5GnNCUV53QM/BZ66xfWrm0CTWoM+Xlz8V1w==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
-        "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
+      },
+      "dependencies": {
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        }
       }
     },
     "redux-logger": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "react-redux": "^5.1.2",
         "react-router-dom": "^4.2.2",
         "react-router-hash-link": "^1.2.2",
-        "redux": "^3.7.2",
+        "redux": "^4.0.5",
         "redux-logger": "^3.0.6",
         "redux-promise-middleware": "^5.1.1"
     },


### PR DESCRIPTION
Needs double check that everything (especially storybook) still works!

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1857566 and https://bugzilla.redhat.com/show_bug.cgi?id=1875401 

Note:

We have all lodash packages in 4.17.20.

Following lodash.* packages with lower version aren't using zipObjectDeep function.

`find node_modules/ -name lodash\* -a -type d | while read foo; do grep -H version.: $foo/package.json ; done | grep -v 4.17.20`

```
node_modules//lodash/package.json:  "version": "4.17.15"
node_modules//lodash.memoize/package.json:  "version": "4.1.2"
node_modules//lodash.flattendeep/package.json:  "version": "4.4.0"
node_modules//lodash.debounce/package.json:  "version": "4.0.8"
node_modules//lodash.throttle/package.json:  "version": "4.1.1"
node_modules//@patternfly/react-table/node_modules/lodash/package.json:  "version": "4.17.19"
node_modules//lodash.sortby/package.json:  "version": "4.7.0"
node_modules//lodash.camelcase/package.json:  "version": "4.3.0"
node_modules//lodash-webpack-plugin/package.json:  "version": "0.11.5"
node_modules//lodash.escape/package.json:  "version": "4.0.1"
node_modules//@babel/helper-split-export-declaration/node_modules/lodash/package.json:  "version": "4.17.15"
node_modules//@babel/template/node_modules/lodash/package.json:  "version": "4.17.15"
node_modules//@babel/generator/node_modules/lodash/package.json:  "version": "4.17.15"
node_modules//@babel/traverse/node_modules/lodash/package.json:  "version": "4.17.15"
node_modules//istanbul-lib-instrument/node_modules/lodash/package.json:  "version": "4.17.15"
node_modules//lodash.isequal/package.json:  "version": "4.5.0"
node_modules//inquirer/node_modules/lodash/package.json:  "version": "4.17.15"
```