### PR TITLE
Surface missing remote config

### DIFF
--- a/src/api/remotes.ts
+++ b/src/api/remotes.ts
@@ -16,12 +16,33 @@ class API extends BaseAPI {
       'auth_url',
       'token',
       'requirements_file',
+      'tls_validation',
     ]) {
       reducedData[field] = remote[field];
     }
+    for (const field of [
+      'username',
+      'password',
+      'proxy_url',
+      'tls_validation',
+      'client_key',
+      'client_cert',
+      'ca_cert',
+    ]) {
+      if (!!remote[field]) {
+        reducedData[field] = remote[field];
+      }
+    }
 
-    if (reducedData['requirements_file'] === '') {
-      reducedData['requirements_file'] = null;
+    for (const field of [
+      'requirements_file',
+      'client_key',
+      'client_cert',
+      'ca_cert',
+    ]) {
+      if (reducedData[field] === '') {
+        reducedData[field] = null;
+      }
     }
 
     return this.http.put(

--- a/src/api/response-types/remote.tsx
+++ b/src/api/response-types/remote.tsx
@@ -17,6 +17,13 @@ export class RemoteType {
   requirements_file: string;
   updated_at: string;
   created_at: string;
+  username: string;
+  password: string;
+  proxy_url: string;
+  tls_validation: boolean;
+  client_key: string;
+  client_cert: string;
+  ca_cert: string;
 
   repositories: {
     name: string;

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -220,6 +220,125 @@ export class RemoteForm extends React.Component<IProps, IState> {
             </Flex>
           </FormGroup>
         )}
+        <FormGroup
+          fieldId={'username'}
+          label={'Username'}
+          isRequired={requiredFields.includes('username')}
+          validated={this.toError(!('username' in errorMessages))}
+          helperTextInvalid={errorMessages['username']}
+        >
+          <TextInput
+            validated={this.toError(!('username' in errorMessages))}
+            isRequired={requiredFields.includes('username')}
+            isDisabled={disabledFields.includes('username')}
+            id='username'
+            type='text'
+            value={'remote.username' || ''}
+            onChange={(value, event) => console.log('TODO username')}
+          />
+        </FormGroup>
+        <FormGroup
+          fieldId={'password'}
+          label={'Password'}
+          isRequired={requiredFields.includes('password')}
+          validated={this.toError(!('password' in errorMessages))}
+          helperTextInvalid={errorMessages['password']}
+        >
+          <TextInput
+            validated={this.toError(!('password' in errorMessages))}
+            isRequired={requiredFields.includes('password')}
+            isDisabled={disabledFields.includes('password')}
+            id='password'
+            type='text'
+            value={'remote.password' || ''}
+            onChange={(value, event) => console.log('TODO password')}
+          />
+        </FormGroup>
+        <FormGroup
+          fieldId={'proxy_url'}
+          label={'Proxy URL'}
+          isRequired={requiredFields.includes('proxy_url')}
+          validated={this.toError(!('proxy_url' in errorMessages))}
+          helperTextInvalid={errorMessages['proxy_url']}
+        >
+          <TextInput
+            validated={this.toError(!('proxy_url' in errorMessages))}
+            isRequired={requiredFields.includes('proxy_url')}
+            isDisabled={disabledFields.includes('proxy_url')}
+            id='proxy_url'
+            type='text'
+            value={'remote.proxy_url' || ''}
+            onChange={(value, event) => console.log('TODO proxy_url')}
+          />
+        </FormGroup>
+        <FormGroup
+          fieldId={'tls_validation'}
+          label={'TLS validation'}
+          isRequired={requiredFields.includes('tls_validation')}
+          validated={this.toError(!('tls_validation' in errorMessages))}
+          helperTextInvalid={errorMessages['tls_validation']}
+        >
+          <TextInput
+            validated={this.toError(!('tls_validation' in errorMessages))}
+            isRequired={requiredFields.includes('tls_validation')}
+            isDisabled={disabledFields.includes('tls_validation')}
+            id='tls_validation'
+            type='text'
+            value={'remote.tls_validation' || ''}
+            onChange={(value, event) => console.log('TODO tls_validation')}
+          />
+        </FormGroup>
+        <FormGroup
+          fieldId={'client_key'}
+          label={'Client key'}
+          isRequired={requiredFields.includes('client_key')}
+          validated={this.toError(!('client_key' in errorMessages))}
+          helperTextInvalid={errorMessages['client_key']}
+        >
+          <TextInput
+            validated={this.toError(!('client_key' in errorMessages))}
+            isRequired={requiredFields.includes('client_key')}
+            isDisabled={disabledFields.includes('client_key')}
+            id='client_key'
+            type='text'
+            value={'remote.client_key' || ''}
+            onChange={(value, event) => console.log('TODO client_key')}
+          />
+        </FormGroup>
+        <FormGroup
+          fieldId={'client_cert'}
+          label={'Client certification'}
+          isRequired={requiredFields.includes('client_cert')}
+          validated={this.toError(!('client_cert' in errorMessages))}
+          helperTextInvalid={errorMessages['client_cert']}
+        >
+          <TextInput
+            validated={this.toError(!('client_cert' in errorMessages))}
+            isRequired={requiredFields.includes('client_cert')}
+            isDisabled={disabledFields.includes('client_cert')}
+            id='client_cert'
+            type='text'
+            value={'remote.client_cert' || ''}
+            onChange={(value, event) => console.log('TODO client_cert')}
+          />
+        </FormGroup>
+        <FormGroup
+          fieldId={'ca_cert'}
+          label={'CA certification'}
+          isRequired={requiredFields.includes('ca_cert')}
+          validated={this.toError(!('ca_cert' in errorMessages))}
+          helperTextInvalid={errorMessages['ca_cert']}
+        >
+          <TextInput
+            validated={this.toError(!('ca_cert' in errorMessages))}
+            isRequired={requiredFields.includes('ca_cert')}
+            isDisabled={disabledFields.includes('ca_cert')}
+            id='ca_cert'
+            type='text'
+            value={'remote.ca_cert' || ''}
+            onChange={(value, event) => console.log('TODO ca_cert')}
+          />
+        </FormGroup>
 
         {errorMessages['__nofield'] ? (
           <span

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -29,23 +29,35 @@ interface IProps {
 }
 
 interface IState {
-  uploadedFileName: string;
+  uploadedRequirementFilename: string;
+  uploadedClientKeyFilename: string;
+  uploadedClientCertFilename: string;
+  uploadedCaCertFilename: string;
 }
 
 export class RemoteForm extends React.Component<IProps, IState> {
   constructor(props) {
     super(props);
 
-    let requirementsFilename = '';
+    let requirementsFilename,
+      clientCertFilename,
+      clientKeyFilename,
+      caCertFilename = '';
 
     if (props.remote) {
       requirementsFilename = props.remote.requirements_file
         ? 'requirements.yml'
         : '';
+      clientKeyFilename = props.remote.client_key ? 'client_key.yml' : '';
+      clientCertFilename = props.remote.client_cert ? 'client_cert.yml' : '';
+      caCertFilename = props.remote.ca_cert ? 'ca_cert.yml' : '';
     }
 
     this.state = {
-      uploadedFileName: requirementsFilename,
+      uploadedRequirementFilename: requirementsFilename,
+      uploadedClientKeyFilename: clientKeyFilename,
+      uploadedClientCertFilename: clientCertFilename,
+      uploadedCaCertFilename: caCertFilename,
     };
   }
 
@@ -54,6 +66,8 @@ export class RemoteForm extends React.Component<IProps, IState> {
     if (!remote) {
       return null;
     }
+    console.log('REMOTE');
+    console.log(remote);
     const remoteType = this.getRemoteType(remote.url);
 
     let requiredFields = ['name', 'url'];
@@ -191,12 +205,13 @@ export class RemoteForm extends React.Component<IProps, IState> {
                   isRequired={requiredFields.includes('requirements_file')}
                   id='yaml'
                   type='text'
-                  filename={this.state.uploadedFileName}
+                  filename={this.state.uploadedRequirementFilename}
                   value={this.props.remote.requirements_file || ''}
                   hideDefaultPreview
                   onChange={(value, filename) => {
-                    this.setState({ uploadedFileName: filename }, () =>
-                      this.updateRemote(value, 'requirements_file'),
+                    this.setState(
+                      { uploadedRequirementFilename: filename },
+                      () => this.updateRemote(value, 'requirements_file'),
                     );
                   }}
                 />
@@ -209,7 +224,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
                       new Blob([this.props.remote.requirements_file], {
                         type: 'text/plain;charset=utf-8',
                       }),
-                      this.state.uploadedFileName,
+                      this.state.uploadedRequirementFilename,
                     );
                   }}
                   variant='plain'
@@ -296,15 +311,24 @@ export class RemoteForm extends React.Component<IProps, IState> {
             validated={this.toError(!('client_key' in errorMessages))}
             helperTextInvalid={errorMessages['client_key']}
           >
-            <TextInput
-              validated={this.toError(!('client_key' in errorMessages))}
-              isRequired={requiredFields.includes('client_key')}
-              isDisabled={disabledFields.includes('client_key')}
-              id='client_key'
-              type='text'
-              value={remote.client_key || ''}
-              onChange={value => this.updateRemote(value, 'client_key')}
-            />
+            <Flex>
+              <FlexItem grow={{ default: 'grow' }}>
+                <FileUpload
+                  validated={this.toError(!('client_key' in errorMessages))}
+                  isRequired={requiredFields.includes('client_key')}
+                  id='yaml'
+                  type='text'
+                  filename={this.state.uploadedClientKeyFilename}
+                  value={this.props.remote.client_key || ''}
+                  hideDefaultPreview
+                  onChange={(value, filename) => {
+                    this.setState({ uploadedClientKeyFilename: filename }, () =>
+                      this.updateRemote(value, 'client_key'),
+                    );
+                  }}
+                />
+              </FlexItem>
+            </Flex>
           </FormGroup>
           <FormGroup
             fieldId={'client_cert'}
@@ -313,15 +337,25 @@ export class RemoteForm extends React.Component<IProps, IState> {
             validated={this.toError(!('client_cert' in errorMessages))}
             helperTextInvalid={errorMessages['client_cert']}
           >
-            <TextInput
-              validated={this.toError(!('client_cert' in errorMessages))}
-              isRequired={requiredFields.includes('client_cert')}
-              isDisabled={disabledFields.includes('client_cert')}
-              id='client_cert'
-              type='text'
-              value={remote.client_cert || ''}
-              onChange={value => this.updateRemote(value, 'client_cert')}
-            />
+            <Flex>
+              <FlexItem grow={{ default: 'grow' }}>
+                <FileUpload
+                  validated={this.toError(!('client_cert' in errorMessages))}
+                  isRequired={requiredFields.includes('client_cert')}
+                  id='yaml'
+                  type='text'
+                  filename={this.state.uploadedClientCertFilename}
+                  value={this.props.remote.client_cert || ''}
+                  hideDefaultPreview
+                  onChange={(value, filename) => {
+                    this.setState(
+                      { uploadedClientCertFilename: filename },
+                      () => this.updateRemote(value, 'client_cert'),
+                    );
+                  }}
+                />
+              </FlexItem>
+            </Flex>
           </FormGroup>
           <FormGroup
             fieldId={'ca_cert'}
@@ -330,15 +364,24 @@ export class RemoteForm extends React.Component<IProps, IState> {
             validated={this.toError(!('ca_cert' in errorMessages))}
             helperTextInvalid={errorMessages['ca_cert']}
           >
-            <TextInput
-              validated={this.toError(!('ca_cert' in errorMessages))}
-              isRequired={requiredFields.includes('ca_cert')}
-              isDisabled={disabledFields.includes('ca_cert')}
-              id='ca_cert'
-              type='text'
-              value={remote.ca_cert || ''}
-              onChange={value => this.updateRemote(value, 'ca_cert')}
-            />
+            <Flex>
+              <FlexItem grow={{ default: 'grow' }}>
+                <FileUpload
+                  validated={this.toError(!('ca_cert' in errorMessages))}
+                  isRequired={requiredFields.includes('ca_cert')}
+                  id='yaml'
+                  type='text'
+                  filename={this.state.uploadedCaCertFilename}
+                  value={this.props.remote.ca_cert || ''}
+                  hideDefaultPreview
+                  onChange={(value, filename) => {
+                    this.setState({ uploadedCaCertFilename: filename }, () =>
+                      this.updateRemote(value, 'ca_cert'),
+                    );
+                  }}
+                />
+              </FlexItem>
+            </Flex>
           </FormGroup>
         </ExpandableSection>
         {errorMessages['__nofield'] ? (

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -11,6 +11,7 @@ import {
   Button,
   Modal,
   Checkbox,
+  ExpandableSection,
 } from '@patternfly/react-core';
 
 import { DownloadIcon } from '@patternfly/react-icons';
@@ -200,7 +201,6 @@ export class RemoteForm extends React.Component<IProps, IState> {
                   }}
                 />
               </FlexItem>
-
               <FlexItem>
                 <Button
                   isDisabled={!this.props.remote.requirements_file}
@@ -221,122 +221,126 @@ export class RemoteForm extends React.Component<IProps, IState> {
             </Flex>
           </FormGroup>
         )}
-        <FormGroup
-          fieldId={'username'}
-          label={'Username'}
-          isRequired={requiredFields.includes('username')}
-          validated={this.toError(!('username' in errorMessages))}
-          helperTextInvalid={errorMessages['username']}
+        <ExpandableSection
+          toggleTextExpanded='Show Less'
+          toggleTextCollapsed='Show More'
         >
-          <TextInput
-            validated={this.toError(!('username' in errorMessages))}
+          <FormGroup
+            fieldId={'username'}
+            label={'Username'}
             isRequired={requiredFields.includes('username')}
-            isDisabled={disabledFields.includes('username')}
-            id='username'
-            type='text'
-            value={remote.username || ''}
-            onChange={value => this.updateRemote(value, 'username')}
-          />
-        </FormGroup>
-        <FormGroup
-          fieldId={'password'}
-          label={'Password'}
-          isRequired={requiredFields.includes('password')}
-          validated={this.toError(!('password' in errorMessages))}
-          helperTextInvalid={errorMessages['password']}
-        >
-          <TextInput
-            validated={this.toError(!('password' in errorMessages))}
+            validated={this.toError(!('username' in errorMessages))}
+            helperTextInvalid={errorMessages['username']}
+          >
+            <TextInput
+              validated={this.toError(!('username' in errorMessages))}
+              isRequired={requiredFields.includes('username')}
+              isDisabled={disabledFields.includes('username')}
+              id='username'
+              type='text'
+              value={remote.username || ''}
+              onChange={value => this.updateRemote(value, 'username')}
+            />
+          </FormGroup>
+          <FormGroup
+            fieldId={'password'}
+            label={'Password'}
             isRequired={requiredFields.includes('password')}
-            isDisabled={disabledFields.includes('password')}
-            id='password'
-            type='password'
-            value={remote.password || ''}
-            onChange={value => this.updateRemote(value, 'password')}
-          />
-        </FormGroup>
-        <FormGroup
-          fieldId={'proxy_url'}
-          label={'Proxy URL'}
-          isRequired={requiredFields.includes('proxy_url')}
-          validated={this.toError(!('proxy_url' in errorMessages))}
-          helperTextInvalid={errorMessages['proxy_url']}
-        >
-          <TextInput
-            validated={this.toError(!('proxy_url' in errorMessages))}
+            validated={this.toError(!('password' in errorMessages))}
+            helperTextInvalid={errorMessages['password']}
+          >
+            <TextInput
+              validated={this.toError(!('password' in errorMessages))}
+              isRequired={requiredFields.includes('password')}
+              isDisabled={disabledFields.includes('password')}
+              id='password'
+              type='password'
+              value={remote.password || ''}
+              onChange={value => this.updateRemote(value, 'password')}
+            />
+          </FormGroup>
+          <FormGroup
+            fieldId={'proxy_url'}
+            label={'Proxy URL'}
             isRequired={requiredFields.includes('proxy_url')}
-            isDisabled={disabledFields.includes('proxy_url')}
-            id='proxy_url'
-            type='text'
-            value={remote.proxy_url || ''}
-            onChange={value => this.updateRemote(value, 'proxy_url')}
-          />
-        </FormGroup>
-        <FormGroup
-          fieldId={'tls_validation'}
-          label={'TLS validation'}
-          isRequired={requiredFields.includes('tls_validation')}
-          validated={this.toError(!('tls_validation' in errorMessages))}
-          helperTextInvalid={errorMessages['tls_validation']}
-        >
-          <Checkbox
-            onChange={value => this.updateRemote(value, 'tls_validation')}
-            id='tls_validation'
-            isChecked={remote.tls_validation}
-          />
-        </FormGroup>
-        <FormGroup
-          fieldId={'client_key'}
-          label={'Client key'}
-          isRequired={requiredFields.includes('client_key')}
-          validated={this.toError(!('client_key' in errorMessages))}
-          helperTextInvalid={errorMessages['client_key']}
-        >
-          <TextInput
-            validated={this.toError(!('client_key' in errorMessages))}
+            validated={this.toError(!('proxy_url' in errorMessages))}
+            helperTextInvalid={errorMessages['proxy_url']}
+          >
+            <TextInput
+              validated={this.toError(!('proxy_url' in errorMessages))}
+              isRequired={requiredFields.includes('proxy_url')}
+              isDisabled={disabledFields.includes('proxy_url')}
+              id='proxy_url'
+              type='text'
+              value={remote.proxy_url || ''}
+              onChange={value => this.updateRemote(value, 'proxy_url')}
+            />
+          </FormGroup>
+          <FormGroup
+            fieldId={'tls_validation'}
+            label={'TLS validation'}
+            isRequired={requiredFields.includes('tls_validation')}
+            validated={this.toError(!('tls_validation' in errorMessages))}
+            helperTextInvalid={errorMessages['tls_validation']}
+          >
+            <Checkbox
+              onChange={value => this.updateRemote(value, 'tls_validation')}
+              id='tls_validation'
+              isChecked={remote.tls_validation}
+            />
+          </FormGroup>
+          <FormGroup
+            fieldId={'client_key'}
+            label={'Client key'}
             isRequired={requiredFields.includes('client_key')}
-            isDisabled={disabledFields.includes('client_key')}
-            id='client_key'
-            type='text'
-            value={remote.client_key || ''}
-            onChange={value => this.updateRemote(value, 'client_key')}
-          />
-        </FormGroup>
-        <FormGroup
-          fieldId={'client_cert'}
-          label={'Client certification'}
-          isRequired={requiredFields.includes('client_cert')}
-          validated={this.toError(!('client_cert' in errorMessages))}
-          helperTextInvalid={errorMessages['client_cert']}
-        >
-          <TextInput
-            validated={this.toError(!('client_cert' in errorMessages))}
+            validated={this.toError(!('client_key' in errorMessages))}
+            helperTextInvalid={errorMessages['client_key']}
+          >
+            <TextInput
+              validated={this.toError(!('client_key' in errorMessages))}
+              isRequired={requiredFields.includes('client_key')}
+              isDisabled={disabledFields.includes('client_key')}
+              id='client_key'
+              type='text'
+              value={remote.client_key || ''}
+              onChange={value => this.updateRemote(value, 'client_key')}
+            />
+          </FormGroup>
+          <FormGroup
+            fieldId={'client_cert'}
+            label={'Client certification'}
             isRequired={requiredFields.includes('client_cert')}
-            isDisabled={disabledFields.includes('client_cert')}
-            id='client_cert'
-            type='text'
-            value={remote.client_cert || ''}
-            onChange={value => this.updateRemote(value, 'client_cert')}
-          />
-        </FormGroup>
-        <FormGroup
-          fieldId={'ca_cert'}
-          label={'CA certification'}
-          isRequired={requiredFields.includes('ca_cert')}
-          validated={this.toError(!('ca_cert' in errorMessages))}
-          helperTextInvalid={errorMessages['ca_cert']}
-        >
-          <TextInput
-            validated={this.toError(!('ca_cert' in errorMessages))}
+            validated={this.toError(!('client_cert' in errorMessages))}
+            helperTextInvalid={errorMessages['client_cert']}
+          >
+            <TextInput
+              validated={this.toError(!('client_cert' in errorMessages))}
+              isRequired={requiredFields.includes('client_cert')}
+              isDisabled={disabledFields.includes('client_cert')}
+              id='client_cert'
+              type='text'
+              value={remote.client_cert || ''}
+              onChange={value => this.updateRemote(value, 'client_cert')}
+            />
+          </FormGroup>
+          <FormGroup
+            fieldId={'ca_cert'}
+            label={'CA certification'}
             isRequired={requiredFields.includes('ca_cert')}
-            isDisabled={disabledFields.includes('ca_cert')}
-            id='ca_cert'
-            type='text'
-            value={remote.ca_cert || ''}
-            onChange={value => this.updateRemote(value, 'ca_cert')}
-          />
-        </FormGroup>
-
+            validated={this.toError(!('ca_cert' in errorMessages))}
+            helperTextInvalid={errorMessages['ca_cert']}
+          >
+            <TextInput
+              validated={this.toError(!('ca_cert' in errorMessages))}
+              isRequired={requiredFields.includes('ca_cert')}
+              isDisabled={disabledFields.includes('ca_cert')}
+              id='ca_cert'
+              type='text'
+              value={remote.ca_cert || ''}
+              onChange={value => this.updateRemote(value, 'ca_cert')}
+            />
+          </FormGroup>
+        </ExpandableSection>
         {errorMessages['__nofield'] ? (
           <span
             style={{

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -328,6 +328,23 @@ export class RemoteForm extends React.Component<IProps, IState> {
                   }}
                 />
               </FlexItem>
+              <FlexItem>
+                <Button
+                  isDisabled={!this.props.remote.client_key}
+                  onClick={() => {
+                    FileSaver.saveAs(
+                      new Blob([this.props.remote.client_key], {
+                        type: 'text/plain;charset=utf-8',
+                      }),
+                      this.state.uploadedClientKeyFilename,
+                    );
+                  }}
+                  variant='plain'
+                  aria-label='Download client key file'
+                >
+                  <DownloadIcon />
+                </Button>
+              </FlexItem>
             </Flex>
           </FormGroup>
           <FormGroup
@@ -355,6 +372,23 @@ export class RemoteForm extends React.Component<IProps, IState> {
                   }}
                 />
               </FlexItem>
+              <FlexItem>
+                <Button
+                  isDisabled={!this.props.remote.client_cert}
+                  onClick={() => {
+                    FileSaver.saveAs(
+                      new Blob([this.props.remote.client_cert], {
+                        type: 'text/plain;charset=utf-8',
+                      }),
+                      this.state.uploadedClientCertFilename,
+                    );
+                  }}
+                  variant='plain'
+                  aria-label='Download client certification file'
+                >
+                  <DownloadIcon />
+                </Button>
+              </FlexItem>
             </Flex>
           </FormGroup>
           <FormGroup
@@ -380,6 +414,23 @@ export class RemoteForm extends React.Component<IProps, IState> {
                     );
                   }}
                 />
+              </FlexItem>
+              <FlexItem>
+                <Button
+                  isDisabled={!this.props.remote.ca_cert}
+                  onClick={() => {
+                    FileSaver.saveAs(
+                      new Blob([this.props.remote.ca_cert], {
+                        type: 'text/plain;charset=utf-8',
+                      }),
+                      this.state.uploadedCaCertFilename,
+                    );
+                  }}
+                  variant='plain'
+                  aria-label='Download CA certification file'
+                >
+                  <DownloadIcon />
+                </Button>
               </FlexItem>
             </Flex>
           </FormGroup>

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -10,6 +10,7 @@ import {
   FlexItem,
   Button,
   Modal,
+  Checkbox,
 } from '@patternfly/react-core';
 
 import { DownloadIcon } from '@patternfly/react-icons';
@@ -113,7 +114,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
             id='name'
             type='text'
             value={remote.name || ''}
-            onChange={(value, event) => this.updateRemote(value, 'name')}
+            onChange={value => this.updateRemote(value, 'name')}
           />
         </FormGroup>
         <FormGroup
@@ -130,7 +131,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
             id='url'
             type='text'
             value={remote.url || ''}
-            onChange={(value, event) => this.updateRemote(value, 'url')}
+            onChange={value => this.updateRemote(value, 'url')}
           />
         </FormGroup>
         {!disabledFields.includes('token') && (
@@ -148,7 +149,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
               type='password'
               id='token'
               value={remote.token || ''}
-              onChange={(value, event) => this.updateRemote(value, 'token')}
+              onChange={value => this.updateRemote(value, 'token')}
             />
           </FormGroup>
         )}
@@ -167,7 +168,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
               id='ssoUrl'
               type='text'
               value={this.props.remote.auth_url || ''}
-              onChange={(value, event) => this.updateRemote(value, 'auth_url')}
+              onChange={value => this.updateRemote(value, 'auth_url')}
             />
           </FormGroup>
         )}
@@ -192,7 +193,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
                   filename={this.state.uploadedFileName}
                   value={this.props.remote.requirements_file || ''}
                   hideDefaultPreview
-                  onChange={(value, filename, event) => {
+                  onChange={(value, filename) => {
                     this.setState({ uploadedFileName: filename }, () =>
                       this.updateRemote(value, 'requirements_file'),
                     );
@@ -233,8 +234,8 @@ export class RemoteForm extends React.Component<IProps, IState> {
             isDisabled={disabledFields.includes('username')}
             id='username'
             type='text'
-            value={'remote.username' || ''}
-            onChange={(value, event) => console.log('TODO username')}
+            value={remote.username || ''}
+            onChange={value => this.updateRemote(value, 'username')}
           />
         </FormGroup>
         <FormGroup
@@ -249,9 +250,9 @@ export class RemoteForm extends React.Component<IProps, IState> {
             isRequired={requiredFields.includes('password')}
             isDisabled={disabledFields.includes('password')}
             id='password'
-            type='text'
-            value={'remote.password' || ''}
-            onChange={(value, event) => console.log('TODO password')}
+            type='password'
+            value={remote.password || ''}
+            onChange={value => this.updateRemote(value, 'password')}
           />
         </FormGroup>
         <FormGroup
@@ -267,8 +268,8 @@ export class RemoteForm extends React.Component<IProps, IState> {
             isDisabled={disabledFields.includes('proxy_url')}
             id='proxy_url'
             type='text'
-            value={'remote.proxy_url' || ''}
-            onChange={(value, event) => console.log('TODO proxy_url')}
+            value={remote.proxy_url || ''}
+            onChange={value => this.updateRemote(value, 'proxy_url')}
           />
         </FormGroup>
         <FormGroup
@@ -278,14 +279,10 @@ export class RemoteForm extends React.Component<IProps, IState> {
           validated={this.toError(!('tls_validation' in errorMessages))}
           helperTextInvalid={errorMessages['tls_validation']}
         >
-          <TextInput
-            validated={this.toError(!('tls_validation' in errorMessages))}
-            isRequired={requiredFields.includes('tls_validation')}
-            isDisabled={disabledFields.includes('tls_validation')}
+          <Checkbox
+            onChange={value => this.updateRemote(value, 'tls_validation')}
             id='tls_validation'
-            type='text'
-            value={'remote.tls_validation' || ''}
-            onChange={(value, event) => console.log('TODO tls_validation')}
+            isChecked={remote.tls_validation}
           />
         </FormGroup>
         <FormGroup
@@ -301,8 +298,8 @@ export class RemoteForm extends React.Component<IProps, IState> {
             isDisabled={disabledFields.includes('client_key')}
             id='client_key'
             type='text'
-            value={'remote.client_key' || ''}
-            onChange={(value, event) => console.log('TODO client_key')}
+            value={remote.client_key || ''}
+            onChange={value => this.updateRemote(value, 'client_key')}
           />
         </FormGroup>
         <FormGroup
@@ -318,8 +315,8 @@ export class RemoteForm extends React.Component<IProps, IState> {
             isDisabled={disabledFields.includes('client_cert')}
             id='client_cert'
             type='text'
-            value={'remote.client_cert' || ''}
-            onChange={(value, event) => console.log('TODO client_cert')}
+            value={remote.client_cert || ''}
+            onChange={value => this.updateRemote(value, 'client_cert')}
           />
         </FormGroup>
         <FormGroup
@@ -335,8 +332,8 @@ export class RemoteForm extends React.Component<IProps, IState> {
             isDisabled={disabledFields.includes('ca_cert')}
             id='ca_cert'
             type='text'
-            value={'remote.ca_cert' || ''}
-            onChange={(value, event) => console.log('TODO ca_cert')}
+            value={remote.ca_cert || ''}
+            onChange={value => this.updateRemote(value, 'ca_cert')}
           />
         </FormGroup>
 

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -238,8 +238,8 @@ export class RemoteForm extends React.Component<IProps, IState> {
           </FormGroup>
         )}
         <ExpandableSection
-          toggleTextExpanded='Show Less'
-          toggleTextCollapsed='Show More'
+          toggleTextExpanded='Hide advanced options'
+          toggleTextCollapsed='Show advanced options'
         >
           <FormGroup
             fieldId={'username'}

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -38,19 +38,22 @@ interface IState {
 export class RemoteForm extends React.Component<IProps, IState> {
   constructor(props) {
     super(props);
-
-    let requirementsFilename,
+    let [
+      requirementsFilename,
       clientCertFilename,
       clientKeyFilename,
-      caCertFilename = '';
+      caCertFilename,
+    ] = Array(4).fill('');
 
-    if (props.remote) {
-      requirementsFilename = props.remote.requirements_file
+    if (!!props.remote) {
+      requirementsFilename = this.props.remote.requirements_file
         ? 'requirements.yml'
         : '';
-      clientKeyFilename = props.remote.client_key ? 'client_key.yml' : '';
-      clientCertFilename = props.remote.client_cert ? 'client_cert.yml' : '';
-      caCertFilename = props.remote.ca_cert ? 'ca_cert.yml' : '';
+      clientKeyFilename = this.props.remote.client_key ? 'client_key.yml' : '';
+      clientCertFilename = this.props.remote.client_cert
+        ? 'client_cert.yml'
+        : '';
+      caCertFilename = this.props.remote.ca_cert ? 'ca_cert.yml' : '';
     }
 
     this.state = {
@@ -66,8 +69,6 @@ export class RemoteForm extends React.Component<IProps, IState> {
     if (!remote) {
       return null;
     }
-    console.log('REMOTE');
-    console.log(remote);
     const remoteType = this.getRemoteType(remote.url);
 
     let requiredFields = ['name', 'url'];

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -105,44 +105,46 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
     const tabs = ['Local', 'Remote'];
     return (
       <React.Fragment>
-        <RemoteForm
-          remote={remoteToEdit}
-          updateRemote={(r: RemoteType) => this.setState({ remoteToEdit: r })}
-          saveRemote={() => {
-            const { remoteToEdit } = this.state;
+        {remoteToEdit && showRemoteFormModal && (
+          <RemoteForm
+            remote={remoteToEdit}
+            updateRemote={(r: RemoteType) => this.setState({ remoteToEdit: r })}
+            saveRemote={() => {
+              const { remoteToEdit } = this.state;
 
-            try {
-              const distro_path =
-                remoteToEdit.repositories[0].distributions[0].base_path;
-              RemoteAPI.update(distro_path, remoteToEdit)
-                .then(r => {
-                  this.setState(
-                    {
-                      errorMessages: {},
-                      showRemoteFormModal: false,
-                      remoteToEdit: undefined,
-                    },
-                    () => this.loadContent(),
+              try {
+                const distro_path =
+                  remoteToEdit.repositories[0].distributions[0].base_path;
+                RemoteAPI.update(distro_path, remoteToEdit)
+                  .then(r => {
+                    this.setState(
+                      {
+                        errorMessages: {},
+                        showRemoteFormModal: false,
+                        remoteToEdit: undefined,
+                      },
+                      () => this.loadContent(),
+                    );
+                  })
+                  .catch(err =>
+                    this.setState({ errorMessages: mapErrorMessages(err) }),
                   );
-                })
-                .catch(err =>
-                  this.setState({ errorMessages: mapErrorMessages(err) }),
-                );
-            } catch {
-              this.setState({
-                errorMessages: {
-                  __nofield:
-                    "Can't update remote without a distribution attached to it.",
-                },
-              });
+              } catch {
+                this.setState({
+                  errorMessages: {
+                    __nofield:
+                      "Can't update remote without a distribution attached to it.",
+                  },
+                });
+              }
+            }}
+            errorMessages={errorMessages}
+            showModal={showRemoteFormModal}
+            closeModal={() =>
+              this.setState({ showRemoteFormModal: false, errorMessages: {} })
             }
-          }}
-          errorMessages={errorMessages}
-          showModal={showRemoteFormModal}
-          closeModal={() =>
-            this.setState({ showRemoteFormModal: false, errorMessages: {} })
-          }
-        />
+          />
+        )}
         <BaseHeader title='Repo Management'>
           {DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE ? (
             <div className='header-bottom'>


### PR DESCRIPTION
UI: surface missing remote config

Depends on https://github.com/ansible/galaxy_ng/pull/520 (merged)

<img width="586" alt="Screenshot 2020-10-22 at 14 45 47" src="https://user-images.githubusercontent.com/9210860/96873796-b0827180-1475-11eb-88dd-2824117abe20.png">
<img width="584" alt="Screenshot 2020-10-23 at 15 04 46" src="https://user-images.githubusercontent.com/9210860/97007077-1daf0900-1541-11eb-984e-17e7da9a2ddb.png">


Create new remote repo
```
>>> from pulp_ansible.app.models import AnsibleRepository, CollectionRemote
>>> remote = CollectionRemote.objects.create(name='automation hub', url='', policy='imidiate', auth_url='')
>>> repo = AnsibleRepository.objects.get(name='automation-hub')
>>> repo.remote = remote
>>> repo.save()
```

TODO:
- [x] Add download button