### PR TITLE
Add default sort to Users table

### DIFF
--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -71,6 +71,10 @@ class UserList extends React.Component<RouteComponentProps, IState> {
       params['page_size'] = 10;
     }
 
+    if (!params['sort']) {
+      params['sort'] = 'username';
+    }
+
     this.state = {
       deleteUser: undefined,
       showDeleteModal: false,


### PR DESCRIPTION
Fixing inconsistency found by UX.

Before:
<img width="1649" alt="Screenshot 2020-10-22 at 13 47 54" src="https://user-images.githubusercontent.com/9210860/96867592-35b55880-146d-11eb-9158-4fff2e2f6b11.png">

After:
<img width="1664" alt="Screenshot 2020-10-22 at 13 44 26" src="https://user-images.githubusercontent.com/9210860/96867555-29310000-146d-11eb-8827-650a5a4b9e21.png">
