### PR TITLE
Fix namespace links

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,10 @@
 export { CollectionAPI } from './collection';
 export { NamespaceAPI } from './namespace';
-export { NamespaceType, NamespaceListType } from './response-types/namespace';
+export {
+  NamespaceType,
+  NamespaceListType,
+  NamespaceLinkType,
+} from './response-types/namespace';
 export {
   CollectionListType,
   CollectionDetailType,

--- a/src/api/response-types/namespace.ts
+++ b/src/api/response-types/namespace.ts
@@ -1,6 +1,6 @@
 import { GroupObjectPermissionType } from './permissions';
 
-export class NamespaceLink {
+export class NamespaceLinkType {
   name: string;
   url: string;
 }
@@ -19,5 +19,5 @@ export class NamespaceType extends NamespaceListType {
   groups: GroupObjectPermissionType[];
   resources: string;
   owners: any[];
-  links: NamespaceLink[];
+  links: NamespaceLinkType[];
 }

--- a/src/components/namespace-form/namespace-form.scss
+++ b/src/components/namespace-form/namespace-form.scss
@@ -68,6 +68,9 @@
     display: flex;
     align-items: center;
     margin-left: 10px;
+    .link-container {
+      width: 20px;
+    }
   }
 }
 

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -123,17 +123,23 @@ export class NamespaceForm extends React.Component<IProps, IState> {
           />
         </FormGroup>
 
-        {namespace.links.length > 0 ? (
-          <FormGroup
-            fieldId='links'
-            label='Useful links'
-            helperTextInvalid={errorMessages['name'] || errorMessages['url']}
-          >
-            {namespace.links.map((link, index) =>
-              this.renderLinkGroup(link, index),
-            )}
-          </FormGroup>
-        ) : null}
+        <FormGroup
+          fieldId='links'
+          label='Useful links'
+          helperTextInvalid={errorMessages['name'] || errorMessages['url']}
+        >
+          {namespace.links.map((link, index) =>
+            this.renderLinkGroup(link, index),
+          )}
+
+          {namespace.links.length === 0 && (
+            <PlusCircleIcon
+              className='clickable'
+              onClick={() => this.addLink()}
+              size='sm'
+            />
+          )}
+        </FormGroup>
       </Form>
     );
   }

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -126,7 +126,10 @@ export class NamespaceForm extends React.Component<IProps, IState> {
         <FormGroup
           fieldId='links'
           label='Useful links'
-          helperTextInvalid={errorMessages['name'] || errorMessages['url']}
+          helperTextInvalid={this.getLinksErrorText(errorMessages)}
+          validated={this.toError(
+            !('links__url' in errorMessages || 'links__name' in errorMessages),
+          )}
         >
           {namespace.links.map((link, index) =>
             this.renderLinkGroup(link, index),
@@ -142,6 +145,18 @@ export class NamespaceForm extends React.Component<IProps, IState> {
         </FormGroup>
       </Form>
     );
+  }
+
+  private getLinksErrorText(errorMessages): string {
+    const msg: string[] = [];
+    if ('links__name' in errorMessages) {
+      msg.push('Text: ' + errorMessages['links__name']);
+    }
+    if ('links__url' in errorMessages) {
+      msg.push('URL: ' + errorMessages['links__url']);
+    }
+
+    return msg.join(' ');
   }
 
   private toError(validated: boolean) {

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import './namespace-form.scss';
 
 import { Form, FormGroup, TextInput, TextArea } from '@patternfly/react-core';
-import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 
 import { NamespaceCard, ObjectPermissionField } from '../../components';
 import { NamespaceType } from '../../api';
@@ -16,8 +16,6 @@ interface IProps {
 }
 
 interface IState {
-  newLinkName: string;
-  newLinkURL: string;
   newNamespaceGroup: string;
 }
 
@@ -26,8 +24,6 @@ export class NamespaceForm extends React.Component<IProps, IState> {
     super(props);
 
     this.state = {
-      newLinkURL: '',
-      newLinkName: '',
       newNamespaceGroup: '',
     };
   }
@@ -138,45 +134,6 @@ export class NamespaceForm extends React.Component<IProps, IState> {
             )}
           </FormGroup>
         ) : null}
-
-        <FormGroup fieldId='add_link' label='Add link'>
-          <div className='useful-links'>
-            <div className='link-name'>
-              <TextInput
-                id='name'
-                type='text'
-                placeholder='Link text'
-                value={this.state.newLinkName}
-                onChange={value => {
-                  this.setState({
-                    newLinkName: value,
-                  });
-                }}
-              />
-            </div>
-            <div className='link-url'>
-              <TextInput
-                id='url'
-                type='text'
-                placeholder='Link URL'
-                value={this.state.newLinkURL}
-                onChange={value =>
-                  this.setState({
-                    newLinkURL: value,
-                  })
-                }
-                onKeyDown={e => {
-                  if (e.key === 'Enter') {
-                    this.addLink();
-                  }
-                }}
-              />
-            </div>
-            <div className='clickable link-button'>
-              <PlusCircleIcon onClick={() => this.addLink()} size='md' />
-            </div>
-          </div>
-        </FormGroup>
       </Form>
     );
   }
@@ -210,19 +167,15 @@ export class NamespaceForm extends React.Component<IProps, IState> {
   private addLink() {
     const update = { ...this.props.namespace };
     update.links.push({
-      name: this.state.newLinkName,
-      url: this.state.newLinkURL,
+      name: '',
+      url: '',
     });
-    this.setState(
-      {
-        newLinkURL: '',
-        newLinkName: '',
-      },
-      () => this.props.updateNamespace(update),
-    );
+
+    this.props.updateNamespace(update);
   }
 
   private renderLinkGroup(link, index) {
+    const last = index === this.props.namespace.links.length - 1;
     return (
       <div className='useful-links' key={index}>
         <div className='link-name'>
@@ -244,11 +197,23 @@ export class NamespaceForm extends React.Component<IProps, IState> {
           />
         </div>
         <div className='link-button'>
-          <MinusCircleIcon
-            className='clickable'
-            onClick={() => this.removeLink(index)}
-            size='md'
-          />
+          <div className='link-container'>
+            <TrashIcon
+              className='clickable'
+              onClick={() => this.removeLink(index)}
+              size='sm'
+            />
+          </div>
+
+          <div className='link-container'>
+            {last && (
+              <PlusCircleIcon
+                className='clickable'
+                onClick={() => this.addLink()}
+                size='sm'
+              />
+            )}
+          </div>
         </div>
       </div>
     );

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -188,8 +188,6 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
         }
       }
 
-      console.log(setLinks);
-
       namespace.links = setLinks;
 
       MyNamespaceAPI.update(this.state.namespace.name, namespace)

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -12,8 +12,12 @@ import {
   AlertType,
   Main,
 } from '../../components';
-import { MyNamespaceAPI, NamespaceType, ActiveUserAPI } from '../../api';
-import { Constants } from '../../constants';
+import {
+  MyNamespaceAPI,
+  NamespaceType,
+  ActiveUserAPI,
+  NamespaceLinkType,
+} from '../../api';
 
 import { Form, ActionGroup, Button } from '@patternfly/react-core';
 
@@ -161,6 +165,10 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
   private loadNamespace() {
     MyNamespaceAPI.get(this.props.match.params['namespace'])
       .then(response => {
+        // Add an empty link to the end of the links array to create an empty field
+        // on the link edit form for adding new links
+        const emptyLink: NamespaceLinkType = { name: '', url: '' };
+        response.data.links.push(emptyLink);
         this.setState({ namespace: response.data });
       })
       .catch(response => {
@@ -170,7 +178,21 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
 
   private saveNamespace() {
     this.setState({ saving: true }, () => {
-      MyNamespaceAPI.update(this.state.namespace.name, this.state.namespace)
+      const namespace = { ...this.state.namespace };
+      const setLinks: NamespaceLinkType[] = [];
+
+      // remove any empty links from the list before saving
+      for (const link of namespace.links) {
+        if (link.url !== '' || link.name !== '') {
+          setLinks.push(link);
+        }
+      }
+
+      console.log(setLinks);
+
+      namespace.links = setLinks;
+
+      MyNamespaceAPI.update(this.state.namespace.name, namespace)
         .then(result => {
           this.setState({
             namespace: result.data,


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/AAH-18

Updates namespace links to do the following:
- Use the new field names introduced in https://github.com/ansible/galaxy_ng/pull/531
- The fields for adding links now automatically add links when the user starts typing rather than requiring the user to hit the plus icon first.

It's currently impossible to associate an error message with a specific link, but the error messages have been updated to to provide the name of the invalid URL as well as the field name that the error is from.