### PR TITLE
Clarify approval messaging. Misc spelling and phrasing fixes.

### DIFF
--- a/src/components/my-imports/import-console.tsx
+++ b/src/components/my-imports/import-console.tsx
@@ -130,7 +130,7 @@ export class ImportConsole extends React.Component<IProps, {}> {
     const { task, hideCollectionName, collectionVersion } = this.props;
 
     let collectionHead: any = `${selectedImport.namespace}.${selectedImport.name}`;
-    let approvalStatus = 'waiting for approval';
+    let approvalStatus = 'waiting for import to finish';
 
     if (collectionVersion) {
       const rlist = collectionVersion.repository_list;
@@ -138,8 +138,10 @@ export class ImportConsole extends React.Component<IProps, {}> {
         approvalStatus = 'rejected';
       } else if (rlist.includes(Constants.NEEDSREVIEW)) {
         approvalStatus = 'waiting for approval';
-      } else {
+      } else if (rlist.includes(Constants.PUBLISHED)) {
         approvalStatus = 'approved';
+      } else {
+        approvalStatus = 'could not be determined';
       }
 
       collectionHead = (

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -384,7 +384,7 @@ class CertificationDashboard extends React.Component<
         isDisabled={isDisabled}
         key='certify'
       >
-        Certify
+        Approve
       </DropdownItem>
     );
 
@@ -443,7 +443,7 @@ class CertificationDashboard extends React.Component<
               )
             }
           >
-            <span>Certify</span>
+            <span>Approve</span>
           </Button>
           <StatefulDropdown
             items={[rejectDropDown(false, Constants.NEEDSREVIEW), importsLink]}

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -61,7 +61,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
               href='https://sso.redhat.com/auth/realms/redhat-external/account/'
               target='_blank'
             >
-              Red Hat SSO account managment
+              Red Hat SSO account management
             </a>
             .
           </Section>


### PR DESCRIPTION
- Rename "Certify" button to "Approve"
- Clarify approval status on imports page
- Fix typo on token page