### PR TITLE
Show Users tab in Group detail when a user has permission to see users

### DIFF
--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -122,8 +122,12 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
 
   render() {
     const { group, params, alerts, addModalVisible, loading } = this.state;
+    const { user } = this.context;
 
-    const tabs = ['Permissions', 'Users'];
+    const tabs = ['Permissions'];
+    if (!!user && user.model_permissions.view_user) {
+      tabs.push('Users');
+    }
 
     if (!group || loading) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;


### PR DESCRIPTION
For a user with permission to Groups but not to view Users:

**Before:**
<img width="1361" alt="Screenshot 2020-11-02 at 15 40 09" src="https://user-images.githubusercontent.com/9210860/97880983-1e565500-1d22-11eb-902d-6dab7f7b95f5.png">

after clicking Users tab
<img width="1371" alt="Screenshot 2020-11-02 at 15 39 51" src="https://user-images.githubusercontent.com/9210860/97880973-1ac2ce00-1d22-11eb-9951-cc726c281d37.png">

**After:**
<img width="1367" alt="Screenshot 2020-11-02 at 15 38 45" src="https://user-images.githubusercontent.com/9210860/97880950-11396600-1d22-11eb-934f-7fe3b537c36b.png">
