### PR TITLE
Add CLI config page

### DIFF
--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -10,6 +10,8 @@ import {
   EmptyStateVariant,
   Title,
   ClipboardCopy,
+  Button,
+  Popover,
 } from '@patternfly/react-core';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 import { SortTable, StatefulDropdown } from '..';
@@ -81,6 +83,11 @@ export class LocalRepositoryTable extends React.Component<IProps> {
           id: 'ansible_cli_url',
         },
         {
+          title: 'CLI configuration',
+          type: 'none',
+          id: 'cli_config',
+        },
+        {
           title: '',
           type: 'none',
           id: 'kebab',
@@ -133,6 +140,18 @@ export class LocalRepositoryTable extends React.Component<IProps> {
           <ClipboardCopy isReadOnly>
             {getRepoUrl(distribution.base_path)}
           </ClipboardCopy>
+        </td>
+        <td>
+          <Popover
+            bodyContent={
+              <ClipboardCopy isReadOnly>
+                galaxy] server_list = published "[galaxy_server"published]
+                url=/content/published token=&lt;put your token here&gt;
+              </ClipboardCopy>
+            }
+          >
+            <Button>CLI Config</Button>
+          </Popover>
         </td>
         <td>
           <span>

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -71,11 +71,6 @@ export class LocalRepositoryTable extends React.Component<IProps> {
           id: 'updated_at',
         },
         {
-          title: 'Sync URL',
-          type: 'none',
-          id: 'pulp_url',
-        },
-        {
           title: 'Ansible CLI URL',
           type: 'none',
           id: 'ansible_cli_url',
@@ -95,7 +90,7 @@ export class LocalRepositoryTable extends React.Component<IProps> {
 
     if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
       sortTableOptions.headers = sortTableOptions.headers.filter(object => {
-        return object.id !== 'updated_at';
+        return object.id !== 'updated_at' && object.id !== 'cli_config';
       });
     }
 
@@ -131,22 +126,19 @@ export class LocalRepositoryTable extends React.Component<IProps> {
         )}
         <td>
           <ClipboardCopy isReadOnly>
-            {getRepoUrl(distribution.base_path) + 'v3/collections'}
-          </ClipboardCopy>
-        </td>
-        <td>
-          <ClipboardCopy isReadOnly>
             {getRepoUrl(distribution.base_path)}
           </ClipboardCopy>
         </td>
-        <td>
-          <ClipboardCopy isCode isReadOnly variant={'expansion'}>
-            [galaxy]&#13;&#10; server_list = {distribution.repository.name}
-            &#13;&#10; "[galaxy_server"{distribution.repository.name}]&#13;&#10;
-            url={getRepoUrl(distribution.base_path)}content/published&#13;&#10;
-            token=&lt;put your token here&gt;
-          </ClipboardCopy>
-        </td>
+        {DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE ? null : (
+          <td>
+            <ClipboardCopy isCode isReadOnly variant={'expansion'}>
+              [galaxy]&#13;&#10; server_list = {distribution.repository.name}
+              &#13;&#10; [galaxy_server_{distribution.repository.name}
+              ]&#13;&#10; url={getRepoUrl(distribution.base_path)}
+              content/published&#13;&#10; token=&lt;put your token here&gt;
+            </ClipboardCopy>
+          </td>
+        )}
         <td>
           <span>
             <StatefulDropdown

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -71,7 +71,7 @@ export class LocalRepositoryTable extends React.Component<IProps> {
           id: 'updated_at',
         },
         {
-          title: 'Ansible CLI URL',
+          title: 'Repo URL',
           type: 'none',
           id: 'ansible_cli_url',
         },
@@ -112,6 +112,15 @@ export class LocalRepositoryTable extends React.Component<IProps> {
   }
 
   private renderRow(distribution) {
+    const cliConfig = [
+      '[galaxy]',
+      `server_list = ${distribution.repository.name}_repo`,
+      '',
+      `[galaxy_server.${distribution.repository.name}_repo]`,
+      `url=${getRepoUrl(distribution.base_path)}`,
+      'token=<put your token here>',
+    ];
+
     return (
       <tr key={distribution.name}>
         <td>{distribution.name}</td>
@@ -132,10 +141,7 @@ export class LocalRepositoryTable extends React.Component<IProps> {
         {DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE ? null : (
           <td>
             <ClipboardCopy isCode isReadOnly variant={'expansion'}>
-              [galaxy]&#13;&#10; server_list = {distribution.repository.name}
-              &#13;&#10; [galaxy_server_{distribution.repository.name}
-              ]&#13;&#10; url={getRepoUrl(distribution.base_path)}
-              content/published&#13;&#10; token=&lt;put your token here&gt;
+              {cliConfig.join('\n')}
             </ClipboardCopy>
           </td>
         )}

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -10,8 +10,6 @@ import {
   EmptyStateVariant,
   Title,
   ClipboardCopy,
-  Button,
-  Popover,
 } from '@patternfly/react-core';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
 import { SortTable, StatefulDropdown } from '..';
@@ -142,16 +140,12 @@ export class LocalRepositoryTable extends React.Component<IProps> {
           </ClipboardCopy>
         </td>
         <td>
-          <Popover
-            bodyContent={
-              <ClipboardCopy isReadOnly>
-                galaxy] server_list = published "[galaxy_server"published]
-                url=/content/published token=&lt;put your token here&gt;
-              </ClipboardCopy>
-            }
-          >
-            <Button>CLI Config</Button>
-          </Popover>
+          <ClipboardCopy isCode isReadOnly variant={'expansion'}>
+            [galaxy]&#13;&#10; server_list = {distribution.repository.name}
+            &#13;&#10; "[galaxy_server"{distribution.repository.name}]&#13;&#10;
+            url={getRepoUrl(distribution.base_path)}content/published&#13;&#10;
+            token=&lt;put your token here&gt;
+          </ClipboardCopy>
         </td>
         <td>
           <span>

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -5,6 +5,7 @@ import { Section } from '@redhat-cloud-services/frontend-components';
 import { ClipboardCopy, Button } from '@patternfly/react-core';
 
 import { BaseHeader, Main } from '../../components';
+import { getRepoUrl } from '../../utilities';
 
 interface IState {
   tokenData: {
@@ -40,7 +41,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
 
     return (
       <React.Fragment>
-        <BaseHeader title='Token management'></BaseHeader>
+        <BaseHeader title='Connect to Hub'></BaseHeader>
         <Main>
           <Section className='body pf-c-content'>
             <h2>Offline token</h2>
@@ -61,9 +62,19 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
               href='https://sso.redhat.com/auth/realms/redhat-external/account/'
               target='_blank'
             >
-              Red Hat SSO account managment
+              Red Hat SSO account management
             </a>
             .
+          </Section>
+          <Section className='body pf-c-content'>
+            <h2>Server URL</h2>
+            <p>Use this URL to do something.</p>
+            <ClipboardCopy isReadOnly>{getRepoUrl('')}</ClipboardCopy>
+          </Section>
+          <Section className='body pf-c-content'>
+            <h2>SSO URL</h2>
+            <p>Use this URL to do something.</p>
+            <ClipboardCopy isReadOnly>{getRepoUrl('')}</ClipboardCopy>
           </Section>
         </Main>
       </React.Fragment>

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -68,14 +68,20 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
           </Section>
           <Section className='body pf-c-content'>
             <h2>Server URL</h2>
-            <p>Use this URL to do something.</p>
+            <p>
+              Use this URL to configure Galaxy server in your the{' '}
+              <code>ansible-galaxy</code> client.
+            </p>
             <ClipboardCopy isReadOnly>
               {getRepoUrl('').replace('//', '')}
             </ClipboardCopy>
           </Section>
           <Section className='body pf-c-content'>
             <h2>SSO URL</h2>
-            <p>Use this URL to do something.</p>
+            <p>
+              Use this URL to authenticate the <code>ansible-galaxy</code>{' '}
+              client.{' '}
+            </p>
             <ClipboardCopy isReadOnly>
               https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
             </ClipboardCopy>

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -74,7 +74,9 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
           <Section className='body pf-c-content'>
             <h2>SSO URL</h2>
             <p>Use this URL to do something.</p>
-            <ClipboardCopy isReadOnly>{getRepoUrl('')}</ClipboardCopy>
+            <ClipboardCopy isReadOnly>
+              https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+            </ClipboardCopy>
           </Section>
         </Main>
       </React.Fragment>

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -72,9 +72,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
               Use this URL to configure Galaxy server in your the{' '}
               <code>ansible-galaxy</code> client.
             </p>
-            <ClipboardCopy isReadOnly>
-              {getRepoUrl('').replace('//', '')}
-            </ClipboardCopy>
+            <ClipboardCopy isReadOnly>{getRepoUrl('')}</ClipboardCopy>
           </Section>
           <Section className='body pf-c-content'>
             <h2>SSO URL</h2>

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -69,7 +69,9 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
           <Section className='body pf-c-content'>
             <h2>Server URL</h2>
             <p>Use this URL to do something.</p>
-            <ClipboardCopy isReadOnly>{getRepoUrl('')}</ClipboardCopy>
+            <ClipboardCopy isReadOnly>
+              {getRepoUrl('').replace('//', '')}
+            </ClipboardCopy>
           </Section>
           <Section className='body pf-c-content'>
             <h2>SSO URL</h2>

--- a/src/utilities/get-repo-url.ts
+++ b/src/utilities/get-repo-url.ts
@@ -4,5 +4,7 @@ export function getRepoUrl(distributionPath: string) {
   // Otherwise use the host that the UI is served from
   const host = !!API_HOST ? API_HOST : window.location.origin;
 
-  return `${host}${API_BASE_PATH}content/${distributionPath}/`;
+  return !!distributionPath
+    ? `${host}${API_BASE_PATH}content/${distributionPath}/`
+    : `${host}${API_BASE_PATH}`;
 }


### PR DESCRIPTION
Closes-Issue: AHH-11

Standalone:
<img width="1370" alt="Screenshot 2020-11-09 at 17 05 59" src="https://user-images.githubusercontent.com/9210860/98565676-29732d00-22ae-11eb-889a-48c044ce05e9.png">
<img width="1349" alt="Screenshot 2020-11-10 at 09 50 38" src="https://user-images.githubusercontent.com/9210860/98651312-608f2000-233a-11eb-824c-20be41d87a69.png">




Insights:
<img width="1382" alt="Screenshot 2020-11-06 at 13 24 23" src="https://user-images.githubusercontent.com/9210860/98367385-d131f600-2035-11eb-808a-6e4bd1ee008f.png">

<img width="1364" alt="Screenshot 2020-11-10 at 10 27 03" src="https://user-images.githubusercontent.com/9210860/98655038-51f73780-233f-11eb-9c7c-0061e5db8dab.png">



TODO:
- [x] server URL
- [x] hide snippet for insights
- [x] expand the snippet? Is it needed?