### PR TITLE
Allow all users to see Repositories

### DIFF
--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -344,11 +344,9 @@ class App extends React.Component<RouteComponentProps, IState> {
                   <Link to={Paths.approvalDashboard}>Approval</Link>
                 </NavItem>
               )}
-              {!!user && user.model_permissions.view_distribution && (
-                <NavItem>
-                  <Link to={Paths.repositories}>Repo Management</Link>
-                </NavItem>
-              )}
+              <NavItem>
+                <Link to={Paths.repositories}>Repo Management</Link>
+              </NavItem>
             </NavList>
           </Nav>
         }


### PR DESCRIPTION
Closes-Issue: AHH-107

Notes:
1) All users should be able to view Repo Management
2) Only Administrators should be able to modify remote repositories and start a Sync.