### PR TITLE
Improve sync UX

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -17,9 +17,9 @@ export {
 export {
   ImportListType,
   ImportDetailType,
-  PulpStatus,
   ImportMessageCodes,
 } from './response-types/import';
+export { PulpStatus } from './response-types/pulp';
 export { ImportAPI } from './import';
 export { ActiveUserAPI } from './active-user';
 export { UserType, MeType } from './response-types/user';

--- a/src/api/response-types/import.ts
+++ b/src/api/response-types/import.ts
@@ -1,11 +1,4 @@
-export enum PulpStatus {
-  waiting = 'waiting',
-  skipped = 'skipped',
-  running = 'running',
-  completed = 'completed',
-  failed = 'failed',
-  canceled = 'canceled',
-}
+import { PulpStatus } from './pulp';
 
 export enum ImportMessageCodes {
   error = 'error',

--- a/src/api/response-types/pulp.ts
+++ b/src/api/response-types/pulp.ts
@@ -1,0 +1,8 @@
+export enum PulpStatus {
+  waiting = 'waiting',
+  skipped = 'skipped',
+  running = 'running',
+  completed = 'completed',
+  failed = 'failed',
+  canceled = 'canceled',
+}

--- a/src/api/response-types/remote.tsx
+++ b/src/api/response-types/remote.tsx
@@ -1,5 +1,7 @@
+import { PulpStatus } from './pulp';
+
 class LastSyncType {
-  state: string;
+  state: PulpStatus;
   started_at: string;
   finished_at: string;
   error: {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -46,3 +46,4 @@ export { GroupModal } from './group-management/group-modal';
 export { RemoteForm } from './repositories/remote-form';
 export { RemoteRepositoryTable } from './repositories/remote-repository-table';
 export { LocalRepositoryTable } from './repositories/local-repository-table';
+export { StatusIndicator } from './status/status-indicator';

--- a/src/components/my-imports/import-console.tsx
+++ b/src/components/my-imports/import-console.tsx
@@ -14,6 +14,8 @@ import {
   CollectionVersion,
 } from '../../api';
 
+import { StatusIndicator } from '../../components';
+
 import { Constants } from '../../constants';
 
 interface IProps {
@@ -173,7 +175,7 @@ export class ImportConsole extends React.Component<IProps, {}> {
         <div className='title-bar'>
           <div>
             <span className='data-title'>Status: </span>
-            {selectedImport.state}
+            <StatusIndicator type='secondary' status={selectedImport.state} />
           </div>
           <div>
             <span className='data-title'>Approval status: </span>

--- a/src/components/status/status-indicator.tsx
+++ b/src/components/status/status-indicator.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+
+import { Label } from '@patternfly/react-core';
+import {
+  OutlinedClockIcon,
+  ExclamationIcon,
+  SyncAltIcon,
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+} from '@patternfly/react-icons';
+
+import { PulpStatus } from '../../api';
+
+interface IProps {
+  status: PulpStatus;
+}
+
+interface LabelPropType {
+  color: string;
+  icon: any;
+  text: string;
+}
+
+export class StatusIndicator extends React.Component<IProps, {}> {
+  render() {
+    let labelProps: LabelPropType;
+    switch (this.props.status) {
+      case PulpStatus.waiting:
+        labelProps = {
+          color: 'blue',
+          text: 'Pending',
+          icon: <OutlinedClockIcon />,
+        };
+        break;
+
+      // TODO: what does skipped mean in pulp
+      case PulpStatus.skipped:
+      case PulpStatus.canceled:
+        labelProps = {
+          color: 'orange',
+          text: 'Canceled',
+          icon: <ExclamationIcon />,
+        };
+        break;
+
+      case PulpStatus.running:
+        labelProps = { color: 'blue', text: 'Running', icon: <SyncAltIcon /> };
+        break;
+
+      case PulpStatus.completed:
+        labelProps = {
+          color: 'green',
+          text: 'Completed',
+          icon: <CheckCircleIcon />,
+        };
+        break;
+
+      case PulpStatus.failed:
+        labelProps = {
+          color: 'red',
+          text: 'Failed',
+          icon: <ExclamationCircleIcon />,
+        };
+        break;
+      default:
+        return '---';
+    }
+
+    return (
+      <Label
+        variant='outline'
+        color={labelProps.color as any}
+        icon={labelProps.icon}
+      >
+        {labelProps.text}
+      </Label>
+    );
+  }
+}

--- a/src/components/status/status-indicator.tsx
+++ b/src/components/status/status-indicator.tsx
@@ -13,6 +13,7 @@ import { PulpStatus } from '../../api';
 
 interface IProps {
   status: PulpStatus;
+  type?: 'primary' | 'secondary';
 }
 
 interface LabelPropType {
@@ -22,9 +23,20 @@ interface LabelPropType {
 }
 
 export class StatusIndicator extends React.Component<IProps, {}> {
+  static defaultProps = {
+    type: 'primary',
+  };
+
+  typeToVariantMap = {
+    primary: 'outline',
+    secondary: 'filled',
+  };
+
   render() {
     let labelProps: LabelPropType;
-    switch (this.props.status) {
+    const { status, type } = this.props;
+
+    switch (status) {
       case PulpStatus.waiting:
         labelProps = {
           color: 'blue',
@@ -68,7 +80,7 @@ export class StatusIndicator extends React.Component<IProps, {}> {
 
     return (
       <Label
-        variant='outline'
+        variant={this.typeToVariantMap[type] as any}
         color={labelProps.color as any}
         icon={labelProps.icon}
       >

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -199,7 +199,7 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
             <LoadingPageSpinner />
           ) : (
             <RemoteRepositoryTable
-              repositories={content}
+              remotes={content}
               updateParams={this.updateParams}
               editRemote={(remote: RemoteType) => {
                 this.setState({
@@ -211,6 +211,7 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
                 RemoteAPI.sync(distro).then(result => this.loadContent())
               }
               user={user}
+              refreshRemotes={this.refreshContent}
             />
           )}
         </div>
@@ -218,9 +219,13 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
     }
   }
 
-  private loadContent() {
+  private refreshContent = () => {
+    this.loadContent(false);
+  };
+
+  private loadContent = (showLoading = true) => {
     const { params } = this.state;
-    this.setState({ loading: true }, () => {
+    this.setState({ loading: showLoading }, () => {
       if (params['tab'] == 'remote') {
         RemoteAPI.list(
           ParamHelper.getReduced(params, this.nonQueryStringParams),
@@ -247,7 +252,7 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
         });
       }
     });
-  }
+  };
 
   private get updateParams() {
     return ParamHelper.updateParamsMixin(this.nonQueryStringParams);


### PR DESCRIPTION
Changes:
- Adds new `StatusIndicator` component to translate pulp worker statuses into platform status components.
- Updates the remotes page to poll the API when a sync is happening to automatically reload sync progress
- Updates remotes page and imports to use new status indicator

![Screen Shot 2020-11-10 at 11 49 56-fullpage](https://user-images.githubusercontent.com/6063371/98704829-1bbfb500-234b-11eb-8f8b-c0d522e269c8.png)
![Screen Shot 2020-11-10 at 11 49 47-fullpage](https://user-images.githubusercontent.com/6063371/98704902-2da15800-234b-11eb-9f9f-1e94ec576bc0.png)

