### PR TITLE
Revert "Update setDeprecation API call to use repo name of a collecti…

### DIFF
--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -20,16 +20,14 @@ export class API extends BaseAPI {
     return super.list(params, path);
   }
 
-  setDeprecation(
-    collection: CollectionListType,
-    isDeprecated: boolean,
-    repo: string,
-  ) {
-    const path = `content/${repo}/v3/collections/`;
+  setDeprecation(collection: CollectionListType, isDeprecated: boolean) {
+    const path = 'v3/collections/';
 
-    return this.patch(
+    return this.update(
       `${collection.namespace.name}/${collection.name}`,
       {
+        name: collection.name,
+        namespace: collection.namespace.name,
         deprecated: isDeprecated,
       },
       path,

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -223,11 +223,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
         });
         break;
       case 'deprecate':
-        CollectionAPI.setDeprecation(
-          collection,
-          !collection.deprecated,
-          this.context.selectedRepo,
-        )
+        CollectionAPI.setDeprecation(collection, !collection.deprecated)
           .then(() => this.loadCollections())
           .catch(error => {
             this.setState({


### PR DESCRIPTION
…on (#222)"

This reverts commit 1b37b13b0778c77672b6f3a326d7fdee14513c41.

Temporarily reverting deprecation on the stable branch so that deprecation will work during phase one of our cloud release next week. This commit can be re-added after the phase 2 deployment.