### PR TITLE
Disable Create button if there's name related error

### DIFF
--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -93,7 +93,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
   };
 
   render() {
-    const { newNamespaceName, newGroups } = this.state;
+    const { newNamespaceName, newGroups, newNamespaceNameValid } = this.state;
     return (
       <Modal
         variant='large'
@@ -105,7 +105,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
             key='confirm'
             variant='primary'
             onClick={this.handleSubmit}
-            isDisabled={!newNamespaceName}
+            isDisabled={!newNamespaceName || !newNamespaceNameValid}
           >
             Create
           </Button>,


### PR DESCRIPTION
Fixes-Issue: AAH-151

Disables Create button when name is not filled or not correct. Shown on `Name must be longer than 2 characters` error as it's better visible than whitespace one mentioned in the issue.

Before:
<img width="1110" alt="Screenshot 2020-11-16 at 13 12 10" src="https://user-images.githubusercontent.com/9210860/99251345-72c2ff80-280d-11eb-8668-89f33390cc03.png">

After:
<img width="1115" alt="Screenshot 2020-11-16 at 13 10 11" src="https://user-images.githubusercontent.com/9210860/99251352-76ef1d00-280d-11eb-9eec-03cd7c75cd82.png">

