### PR TITLE
Fix issue in webpack base where setting variables to false would fail.

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -37,7 +37,12 @@ module.exports = inputConfigs => {
   const globals = {};
 
   defaultConfigs.forEach((item, i) => {
-    customConfigs[item.name] = inputConfigs[item.name] || item.default;
+    // == will match null and undefined, but not false
+    if (inputConfigs[item.name] == null) {
+      customConfigs[item.name] = item.default;
+    } else {
+      customConfigs[item.name] = inputConfigs[item.name];
+    }
     if (item.scope === 'global') {
       globals[item.name] = JSON.stringify(
         inputConfigs[item.name] || item.default,


### PR DESCRIPTION
Previously if a config value default was `true` and the value was set to `false`, the end value would always be `true`