### PR TITLE
Update and add instructions on connect to hub page.

### DIFF
--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -58,7 +58,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
           <Section className='body pf-c-content'>
             <h2>Connect the ansible-galaxy client</h2>
             <p>
-              Documentation how to configure the <code>ansible-galaxy</code>{' '}
+              Documentation on how to configure the <code>ansible-galaxy</code>{' '}
               client can be found{' '}
               <a
                 href='https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.0/html/getting_started_with_red_hat_ansible_automation_hub/proc-configure-automation-hub-server'

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -61,7 +61,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
               Documentation on how to configure the <code>ansible-galaxy</code>{' '}
               client can be found{' '}
               <a
-                href='https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.0/html/getting_started_with_red_hat_ansible_automation_hub/proc-configure-automation-hub-server'
+                href='https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/'
                 target='_blank'
               >
                 here
@@ -100,6 +100,11 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
               download content from Automation Hub.
             </p>
             <ClipboardCopy isReadOnly>{getRepoUrl('')}</ClipboardCopy>
+            <p>
+              Note: this URL contains all collections in Hub. To connect to your
+              organization's sync repository use the URL found on{' '}
+              <Link to={Paths.repositories}>Repostory Management</Link>.
+            </p>
           </Section>
           <Section className='body pf-c-content'>
             <h2>SSO URL</h2>

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 
-import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import { ClipboardCopy, Button } from '@patternfly/react-core';
 
+import { Paths } from '../../paths';
 import { BaseHeader, Main } from '../../components';
 import { getRepoUrl } from '../../utilities';
 
@@ -46,8 +47,9 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
           <Section className='body pf-c-content'>
             <h2>Offline token</h2>
             <p>
-              Use this token to authenticate the <code>ansible-galaxy</code>{' '}
-              client.
+              Use this token to authenticate clients that need to download
+              content from Automation Hub. This token grants the user access to
+              all apps on cloud.redhat.com, so keep it safe.
             </p>
             {tokenData ? (
               <div>
@@ -69,20 +71,32 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
           <Section className='body pf-c-content'>
             <h2>Server URL</h2>
             <p>
-              Use this URL to configure Galaxy server in your the{' '}
-              <code>ansible-galaxy</code> client.
+              Use this URL to configure the API endpoints that clients need to
+              download content from Automation Hub.
             </p>
             <ClipboardCopy isReadOnly>{getRepoUrl('')}</ClipboardCopy>
           </Section>
           <Section className='body pf-c-content'>
             <h2>SSO URL</h2>
             <p>
-              Use this URL to authenticate the <code>ansible-galaxy</code>{' '}
-              client.{' '}
+              Use this URL to configure the authentication URLs that clients
+              need to download content from Automation Hub.
             </p>
             <ClipboardCopy isReadOnly>
               https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
             </ClipboardCopy>
+          </Section>
+          <Section className='body pf-c-content'>
+            <h2>Connect Private Automation Hub</h2>
+            <p>
+              The repository provided on the{' '}
+              <Link to={Paths.repositories}>Repostory Management</Link> page can
+              be used to sync collections into the Red Hat certified repository
+              in private Automation Hub. Users with the correct permissions can
+              use the sync toggles on the{' '}
+              <Link to={Paths.search}>Collections</Link> page to control which
+              collections are added to their organization's sync repository.
+            </p>
           </Section>
         </Main>
       </React.Fragment>

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -45,6 +45,31 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
         <BaseHeader title='Connect to Hub'></BaseHeader>
         <Main>
           <Section className='body pf-c-content'>
+            <h2>Connect Private Automation Hub</h2>
+            <p>
+              Use the <Link to={Paths.repositories}>Repostory Management</Link>{' '}
+              page to sync collections curated by your organization to the Red
+              Hat Certified repository in your private Automation Hub. Users
+              with the correct permissions can use the sync toggles on the{' '}
+              <Link to={Paths.search}>Collections</Link> page to control which
+              collections are added to their organization's sync repository.
+            </p>
+          </Section>
+          <Section className='body pf-c-content'>
+            <h2>Connect the ansible-galaxy client</h2>
+            <p>
+              Documentation how to configure the <code>ansible-galaxy</code>{' '}
+              client can be found{' '}
+              <a
+                href='https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.0/html/getting_started_with_red_hat_ansible_automation_hub/proc-configure-automation-hub-server'
+                target='_blank'
+              >
+                here
+              </a>
+              . Use the following parameters to configure the client.
+            </p>
+          </Section>
+          <Section className='body pf-c-content'>
             <h2>Offline token</h2>
             <p>
               Use this token to authenticate clients that need to download
@@ -85,17 +110,6 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
             <ClipboardCopy isReadOnly>
               https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
             </ClipboardCopy>
-          </Section>
-          <Section className='body pf-c-content'>
-            <h2>Connect Private Automation Hub</h2>
-            <p>
-              Use the <Link to={Paths.repositories}>Repostory Management</Link>{' '}
-              page to sync collections curated by your organization to the Red
-              Hat Certified repository in your private Automation Hub. Users
-              with the correct permissions can use the sync toggles on the{' '}
-              <Link to={Paths.search}>Collections</Link> page to control which
-              collections are added to their organization's sync repository.
-            </p>
           </Section>
         </Main>
       </React.Fragment>

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -48,8 +48,8 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
             <h2>Offline token</h2>
             <p>
               Use this token to authenticate clients that need to download
-              content from Automation Hub. This token grants the user access to
-              all apps on cloud.redhat.com, so keep it safe.
+              content from Automation Hub. This is a secret token used to
+              protect your content. Store your API token in a secure location.
             </p>
             {tokenData ? (
               <div>
@@ -89,11 +89,10 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
           <Section className='body pf-c-content'>
             <h2>Connect Private Automation Hub</h2>
             <p>
-              The repository provided on the{' '}
-              <Link to={Paths.repositories}>Repostory Management</Link> page can
-              be used to sync collections into the Red Hat certified repository
-              in private Automation Hub. Users with the correct permissions can
-              use the sync toggles on the{' '}
+              Use the <Link to={Paths.repositories}>Repostory Management</Link>{' '}
+              page to sync collections curated by your organization to the Red
+              Hat Certified repository in your private Automation Hub. Users
+              with the correct permissions can use the sync toggles on the{' '}
               <Link to={Paths.search}>Collections</Link> page to control which
               collections are added to their organization's sync repository.
             </p>


### PR DESCRIPTION
- Rephrase some of the descriptions to not be specific to the `ansible-galaxy` client.
- Connect Private Automation Hub section

![Screen Shot 2020-11-16 at 15 22 23-fullpage](https://user-images.githubusercontent.com/6063371/99303899-a1e26c80-281f-11eb-98f1-36eee7e8b5f7.png)
