### PR TITLE
Get token in local repos redirects to new tab

### DIFF
--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -152,7 +152,9 @@ export class LocalRepositoryTable extends React.Component<IProps> {
                 <DropdownItem
                   key='2'
                   component={
-                    <Link to={formatPath(Paths.token, {})}>Get token</Link>
+                    <Link to={formatPath(Paths.token, {})} target='_blank'>
+                      Get token
+                    </Link>
                   }
                 />,
               ]}


### PR DESCRIPTION
Fix-Issue: AAH-164

Before:
when clicking Get token in local repo kebab it redirected in the current tab
After:
when clicking Get token in local repo kebab it redirects to a new tab
