### PR TITLE
Fix repo selector.

### DIFF
--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -55,12 +55,11 @@ class App extends React.Component<RouteComponentProps, IState> {
   }
 
   componentDidUpdate(prevProps) {
-    const match = this.isRepoURL(this.props.location.pathname);
-    if (match) {
-      if (match.params['repo'] !== this.state.selectedRepo) {
-        this.setState({ selectedRepo: match.params['repo'] });
-      }
-    }
+    this.setRepoToURL();
+  }
+
+  componentDidMount() {
+    this.setRepoToURL();
   }
 
   render() {
@@ -304,6 +303,15 @@ class App extends React.Component<RouteComponentProps, IState> {
         <Routes selectedRepo={this.state.selectedRepo} />
       </Page>,
     );
+  }
+
+  private setRepoToURL() {
+    const match = this.isRepoURL(this.props.location.pathname);
+    if (match) {
+      if (match.params['repo'] !== this.state.selectedRepo) {
+        this.setState({ selectedRepo: match.params['repo'] });
+      }
+    }
   }
 
   private isRepoURL(location) {


### PR DESCRIPTION
I noticed that the repo selector was showing a blank screen whenever a repo other than the default was selected.

As it turns out the standalone loader was relying on `componentDidMount` to trigger the function which double checked that the URL and page state were in sync. `componentDidMount` got removed in #254, so this broke without anyone realizing. Adding the URL check to `componentDidMount` seems to have fixed this issue.