### PR TITLE
Add tooltips to user's password field and fixes namespace's to PF version

### DIFF
--- a/src/components/helper-text/helper-text.scss
+++ b/src/components/helper-text/helper-text.scss
@@ -1,0 +1,3 @@
+.helper {
+  padding: 0px;
+}

--- a/src/components/helper-text/helper-text.tsx
+++ b/src/components/helper-text/helper-text.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { Popover, PopoverPosition, Button } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import './helper-text.scss';
 
 interface IProps {
   /** Value to display in the tag */
@@ -15,7 +16,7 @@ export class HelperText extends React.Component<IProps, {}> {
         position={PopoverPosition.top}
         bodyContent={this.props.content}
       >
-        <Button iconPosition={'left'} variant={'plain'} padding={'0px'}>
+        <Button iconPosition={'left'} variant={'plain'} className={'helper'}>
           <OutlinedQuestionCircleIcon />
         </Button>
       </Popover>

--- a/src/components/helper-text/helper-text.tsx
+++ b/src/components/helper-text/helper-text.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { Popover, PopoverPosition, Button } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+
+interface IProps {
+  /** Value to display in the tag */
+  content: string;
+}
+
+export class HelperText extends React.Component<IProps, {}> {
+  render() {
+    return (
+      <Popover
+        aria-label='popover example'
+        position={PopoverPosition.top}
+        bodyContent={this.props.content}
+      >
+        <Button iconPosition={'left'} variant={'plain'} padding={'0px'}>
+          <OutlinedQuestionCircleIcon />
+        </Button>
+      </Popover>
+    );
+  }
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -47,3 +47,4 @@ export { RemoteForm } from './repositories/remote-form';
 export { RemoteRepositoryTable } from './repositories/remote-repository-table';
 export { LocalRepositoryTable } from './repositories/local-repository-table';
 export { StatusIndicator } from './status/status-indicator';
+export { HelperText } from './helper-text/helper-text';

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -5,7 +5,7 @@ import { Button, InputGroup, TextInput } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { NamespaceAPI, GroupObjectPermissionType } from '../../api';
 
-import { ObjectPermissionField } from '../../components';
+import { HelperText, ObjectPermissionField } from '../../components';
 
 interface IProps {
   isOpen: boolean;
@@ -116,14 +116,11 @@ export class NamespaceModal extends React.Component<IProps, IState> {
             helperTextInvalid={this.state.errorMessages['name']}
             validated={this.toError(this.state.newNamespaceNameValid)}
             labelIcon={
-              <Tooltip
-                position='top'
+              <HelperText
                 content={
-                  'Namespace names are limited to lowercase word characters ([a-zA-Z0-9_]), must have a minimum length of 2 characters and cannot start with an ‘_’.'
+                  'Namespace names are limited to alphanumeric characters and underscores, must have a minimum length of 2 characters and cannot start with an ‘_’.'
                 }
-              >
-                <OutlinedQuestionCircleIcon />
-              </Tooltip>
+              />
             }
           >
             <InputGroup>

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -1,15 +1,8 @@
 import * as React from 'react';
-import { Modal } from '@patternfly/react-core';
-import { Form, FormGroup, ActionGroup } from '@patternfly/react-core';
-import {
-  Button,
-  ButtonVariant,
-  InputGroup,
-  Popover,
-  PopoverPosition,
-  TextInput,
-} from '@patternfly/react-core';
-import { QuestionCircleIcon } from '@patternfly/react-icons';
+import { Modal, Tooltip } from '@patternfly/react-core';
+import { Form, FormGroup } from '@patternfly/react-core';
+import { Button, InputGroup, TextInput } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { NamespaceAPI, GroupObjectPermissionType } from '../../api';
 
 import { ObjectPermissionField } from '../../components';
@@ -122,6 +115,16 @@ export class NamespaceModal extends React.Component<IProps, IState> {
             helperText='Please, provide the namespace name'
             helperTextInvalid={this.state.errorMessages['name']}
             validated={this.toError(this.state.newNamespaceNameValid)}
+            labelIcon={
+              <Tooltip
+                position='top'
+                content={
+                  'Namespace names are limited to lowercase word characters ([a-zA-Z0-9_]), must have a minimum length of 2 characters and cannot start with an ‘_’.'
+                }
+              >
+                <OutlinedQuestionCircleIcon />
+              </Tooltip>
+            }
           >
             <InputGroup>
               <TextInput
@@ -137,18 +140,6 @@ export class NamespaceModal extends React.Component<IProps, IState> {
                   });
                 }}
               />
-              <Popover
-                aria-label='popover example'
-                position={PopoverPosition.top}
-                bodyContent='Namespace names are limited to lowercase word characters ([a-zA-Z0-9_]), must have a minimum length of 2 characters and cannot start with an ‘_’.'
-              >
-                <Button
-                  variant={ButtonVariant.control}
-                  aria-label='popover for input'
-                >
-                  <QuestionCircleIcon />
-                </Button>
-              </Popover>
             </InputGroup>
           </FormGroup>
           <FormGroup

--- a/src/components/repositories/remote-repository-table.tsx
+++ b/src/components/repositories/remote-repository-table.tsx
@@ -20,7 +20,7 @@ import {
 } from '@patternfly/react-icons';
 
 import { RemoteType, UserType, PulpStatus } from '../../api';
-import { SortTable, StatefulDropdown } from '..';
+import { HelperText, SortTable, StatefulDropdown } from '..';
 import { StatusIndicator } from '../../components';
 
 import { Constants } from '../../constants';
@@ -204,11 +204,7 @@ export class RemoteRepositoryTable extends React.Component<IProps> {
     let errorMessage = null;
     if (remote['last_sync_task']['error']) {
       errorMessage = (
-        <Popover bodyContent={remote.last_sync_task.error['description']}>
-          <Button variant='plain'>
-            <QuestionCircleIcon />
-          </Button>
-        </Popover>
+        <HelperText content={remote.last_sync_task.error['description']} />
       );
     }
 

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -99,6 +99,23 @@ export class UserForm extends React.Component<IProps, IState> {
             label={v.title}
             validated={this.toError(!(v.id in errorMessages))}
             helperTextInvalid={errorMessages[v.id]}
+            labelIcon={
+              v.id === 'password' && (
+                <Tooltip
+                  position='top'
+                  content={
+                    <div>
+                      Password must contain at least 9 characters. Password
+                      cannot contain a user's attributes such as a name,
+                      username, etc. Password cannot be too common like
+                      "password123" Password cannot be just numbers.
+                    </div>
+                  }
+                >
+                  <OutlinedQuestionCircleIcon />
+                </Tooltip>
+              )
+            }
           >
             <TextInput
               validated={this.toError(!(v.id in errorMessages))}

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -12,7 +12,7 @@ import {
 
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
-import { APISearchTypeAhead } from '../../components';
+import { APISearchTypeAhead, HelperText } from '../../components';
 
 import { UserType, GroupAPI } from '../../api';
 
@@ -101,19 +101,11 @@ export class UserForm extends React.Component<IProps, IState> {
             helperTextInvalid={errorMessages[v.id]}
             labelIcon={
               v.id === 'password' && (
-                <Tooltip
-                  position='top'
+                <HelperText
                   content={
-                    <div>
-                      Password must contain at least 9 characters. Password
-                      cannot contain a user's attributes such as a name,
-                      username, etc. Password cannot be too common like
-                      "password123" Password cannot be just numbers.
-                    </div>
+                    'Password must contain at least 9 characters. Password cannot contain a user\'s attributes such as a name, username, etc. Password cannot be too common like"password123" Password cannot be just numbers.'
                   }
-                >
-                  <OutlinedQuestionCircleIcon />
-                </Tooltip>
+                />
               )
             }
           >
@@ -172,14 +164,12 @@ export class UserForm extends React.Component<IProps, IState> {
           fieldId='is_superuser'
           label='Super user'
           labelIcon={
-            <Tooltip
+            <HelperText
               content={
                 'Super users have all system permissions regardless of' +
                 ' their group. Adding new super users is not permitted.'
               }
-            >
-              <OutlinedQuestionCircleIcon size='sm' />
-            </Tooltip>
+            />
           }
         >
           <Checkbox

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -103,7 +103,7 @@ export class UserForm extends React.Component<IProps, IState> {
               v.id === 'password' && (
                 <HelperText
                   content={
-                    'Password must contain at least 9 characters. Password cannot contain a user\'s attributes such as a name, username, etc. Password cannot be too common like"password123" Password cannot be just numbers.'
+                    'Create a password using at least 9 characters, including special characters , ex <!@$%>. Avoid using common names or expressions.'
                   }
                 />
               )


### PR DESCRIPTION
Closes-Issue: AAH-159

**NAMESPACE CREATE FORM**
Before:
<img width="1250" alt="Screenshot 2020-12-01 at 15 09 27" src="https://user-images.githubusercontent.com/9210860/100751108-397eb800-33e7-11eb-84e6-3c3d450e550e.png">

After:
<img width="407" alt="Screenshot 2020-12-02 at 14 20 49" src="https://user-images.githubusercontent.com/9210860/100877850-a8bce080-34a9-11eb-984f-29032a7a835b.png">



**USER CREATE FORM**
Before:
<img width="245" alt="Screenshot 2020-12-01 at 15 08 30" src="https://user-images.githubusercontent.com/9210860/100751005-181dcc00-33e7-11eb-9649-990b83d7c0c4.png">

After:
<img width="374" alt="Screenshot 2020-12-02 at 14 20 40" src="https://user-images.githubusercontent.com/9210860/100877843-a5c1f000-34a9-11eb-9ec5-12bebfea25b4.png">

**REMOTE REPO TABLE**
Before:
<img width="414" alt="Screenshot 2020-12-03 at 16 15 06" src="https://user-images.githubusercontent.com/9210860/101049236-9fa04200-3583-11eb-85e2-dac8b7cc8f95.png">

After:
<img width="445" alt="Screenshot 2020-12-03 at 15 59 10" src="https://user-images.githubusercontent.com/9210860/101045779-d2950680-3580-11eb-9ffe-919849fe54d8.png">


Used password validators:
```
class MinimumLengthValidator(min_length=8)¶
Validates whether the password meets a minimum length. The minimum length can be customized with the min_length parameter.

class UserAttributeSimilarityValidator(user_attributes=DEFAULT_USER_ATTRIBUTES, max_similarity=0.7)¶
Validates whether the password is sufficiently different from certain attributes of the user.

The user_attributes parameter should be an iterable of names of user attributes to compare to. If this argument is not provided, the default is used: 'username', 'first_name', 'last_name', 'email'. Attributes that don’t exist are ignored.

The minimum similarity of a rejected password can be set on a scale of 0 to 1 with the max_similarity parameter. A setting of 0 rejects all passwords, whereas a setting of 1 rejects only passwords that are identical to an attribute’s value.

class CommonPasswordValidator(password_list_path=DEFAULT_PASSWORD_LIST_PATH)¶
Validates whether the password is not a common password. This converts the password to lowercase (to do a case-insensitive comparison) and checks it against a list of 20,000 common password created by Royce Williams.

The password_list_path can be set to the path of a custom file of common passwords. This file should contain one lowercase password per line and may be plain text or gzipped.

class NumericPasswordValidator¶
Validates whether the password is not entirely numeric.
```
from https://docs.djangoproject.com/en/3.1/topics/auth/passwords/