### PR TITLE
Refactor and reduce flake

### DIFF
--- a/src/components/patternfly-wrappers/stateful-dropdown.tsx
+++ b/src/components/patternfly-wrappers/stateful-dropdown.tsx
@@ -25,6 +25,8 @@ interface IProps {
 
   /** Toggles between plain and normal patternfly styling */
   isPlain?: boolean;
+
+  ariaLabel?: string;
 }
 
 interface IState {
@@ -48,7 +50,14 @@ export class StatefulDropdown extends React.Component<IProps, IState> {
 
   render() {
     const { isOpen } = this.state;
-    const { items, toggleType, defaultText, position, isPlain } = this.props;
+    const {
+      items,
+      toggleType,
+      defaultText,
+      position,
+      isPlain,
+      ariaLabel,
+    } = this.props;
 
     return (
       <Dropdown
@@ -59,6 +68,7 @@ export class StatefulDropdown extends React.Component<IProps, IState> {
         dropdownItems={items}
         position={position || DropdownPosition.right}
         autoFocus={false}
+        aria-label={ariaLabel}
       />
     );
   }

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -99,6 +99,7 @@ class App extends React.Component<RouteComponentProps, IState> {
 
         <DropdownItem
           key='logout'
+          aria-label={'logout'}
           onClick={() =>
             ActiveUserAPI.logout().then(() => this.setState({ user: null }))
           }
@@ -189,12 +190,14 @@ class App extends React.Component<RouteComponentProps, IState> {
                   items={dropdownItemsCog}
                   defaultText={<QuestionCircleIcon />}
                   toggleType='icon'
+                  ariaLabel={'cog-dropdown'}
                 />
 
                 <StatefulDropdown
                   defaultText={userName}
                   toggleType='dropdown'
                   items={dropdownItems}
+                  ariaLabel={'user-dropdown'}
                 />
               </div>
             )}

--- a/test/cypress/integration/menu.js
+++ b/test/cypress/integration/menu.js
@@ -1,7 +1,7 @@
 describe('Hub Menu Tests', () => {
-    var host = Cypress.env("host");
-    var adminUsername = Cypress.env("username");
-    var adminPassword = Cypress.env("password");
+    let host = Cypress.env('host');
+    let adminUsername = Cypress.env('username');
+    let adminPassword = Cypress.env('password');
 
     beforeEach(() => {
         cy.visit(host);
@@ -9,13 +9,13 @@ describe('Hub Menu Tests', () => {
 
     it('admin user sees complete menu', () => {
         cy.login(adminUsername, adminPassword);
-        var menuItems = [ 'Collections', 'Namespaces', 'My Namespaces', 'API Token', 'Users', 'Groups', 'Approval', 'Repo Management' ];
+        let menuItems = [ 'Collections', 'Namespaces', 'My Namespaces', 'API Token', 'Users', 'Groups', 'Approval', 'Repo Management' ];
         menuItems.forEach(item => cy.menuItem(item));
     });
 
     describe('', () => {
-        var username = 'nopermission';
-        var password = 'n0permissi0n';
+        let username = 'nopermission';
+        let password = 'n0permissi0n';
 
         beforeEach(() => {
             cy.login(adminUsername, adminPassword);
@@ -25,7 +25,7 @@ describe('Hub Menu Tests', () => {
             cy.deleteUser(username);
         });
         it('a user without permissions sees limited menu', () => {
-            var menuItems = [ 'Collections', 'Namespaces', 'API Token', 'Repo Management' ];
+            let menuItems = [ 'Collections', 'Namespaces', 'API Token', 'Repo Management' ];
             cy.logout();
             cy.login(username, password);
             menuItems.forEach(item => cy.menuItem(item));

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -68,7 +68,10 @@ Cypress.Commands.add('createUser', {}, (username, password, firstName = null, la
     cy.contains('div', 'Password').findnear('input').first().type(user.password);
     cy.contains('div', 'Password confirmation').findnear('input').first().type(user.password);
 
+    cy.server();
+    cy.route('POST', Cypress.env('prefix') + '_ui/v1/users/').as('createUser');
     cy.contains('Save').click();
+    cy.wait('@createUser');
 });
 
 Cypress.Commands.add('deleteUser', {}, (username) => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -42,12 +42,12 @@ Cypress.Commands.add('menuItem', {}, (name) => {
 });
 
 Cypress.Commands.add('logout', {}, () => {
-    cy.get('.pf-c-page__header-tools .pf-c-dropdown button').click();
-    cy.contains('Logout').click()}
-);
+    cy.get('[aria-label="user-dropdown"] button').click({ force: true });
+    cy.get('[aria-label="logout"]').click({ force: true });
+});
 Cypress.Commands.add('login', {}, (username, password) => {
-    cy.contains('.pf-c-form__group', 'Username').find('input').first().type(username);
-    cy.contains('.pf-c-form__group', 'Password').find('input').first().type(`${password}{enter}`);
+    cy.get('#pf-login-username-id').type(username);
+    cy.get('#pf-login-password-id').type(`${password}{enter}`);
 });
 
 Cypress.Commands.add('createUser', {}, (username, password, firstName = null, lastName = null, email = null) => {
@@ -68,25 +68,19 @@ Cypress.Commands.add('createUser', {}, (username, password, firstName = null, la
     cy.contains('div', 'Password').findnear('input').first().type(user.password);
     cy.contains('div', 'Password confirmation').findnear('input').first().type(user.password);
 
-    cy.server();
-    cy.route('POST', Cypress.env('prefix') + '_ui/v1/users/').as('createUser');
     cy.contains('Save').click();
-    cy.wait('@createUser');
 });
 
 Cypress.Commands.add('deleteUser', {}, (username) => {
-    var adminUsername = Cypress.env('username');
-    var adminPassword = Cypress.env('password');
+    let adminUsername = Cypress.env('username');
+    let adminPassword = Cypress.env('password');
 
-    cy.get('.pf-c-page__header-tools .pf-c-dropdown button').click();
-    cy.contains('Logout').click();
-
-    cy.contains('.pf-c-form__group', 'Username').find('input').first().type(adminUsername);
-    cy.contains('.pf-c-form__group', 'Password').find('input').first().type(`${adminPassword}{enter}`);
+    cy.logout();
+    cy.login(adminUsername, adminPassword);
 
     cy.contains('#page-sidebar a', 'Users').click();
 
-    cy.get(`[aria-labelledby=${username}] [aria-label=Actions]`).click({'force': true});
-    cy.containsnear(`[aria-labelledby=${username}] [aria-label=Actions]`, 'Delete').click({'force': true});
-    cy.contains('[role=dialog] button', 'Delete').click({'force': true});
+    cy.get(`[aria-labelledby=${username}] [aria-label=Actions]`).click({ force: true });
+    cy.containsnear(`[aria-labelledby=${username}] [aria-label=Actions]`, 'Delete').click({ force: true });
+    cy.contains('[role=dialog] button', 'Delete').click({ force: true });
 });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -42,8 +42,8 @@ Cypress.Commands.add('menuItem', {}, (name) => {
 });
 
 Cypress.Commands.add('logout', {}, () => {
-    cy.get('[aria-label="user-dropdown"] button').click({ force: true });
-    cy.get('[aria-label="logout"]').click({ force: true });
+    cy.get('[aria-label="user-dropdown"] button').click();
+    cy.get('[aria-label="logout"]').click();
 });
 Cypress.Commands.add('login', {}, (username, password) => {
     cy.get('#pf-login-username-id').type(username);
@@ -59,19 +59,16 @@ Cypress.Commands.add('createUser', {}, (username, password, firstName = null, la
         username: username,
         email: email || 'firstName@example.com',
         password: password,
-    }
+    };
     cy.contains('Create user').click();
-    cy.contains('div', 'First name').findnear('input').first().type(user.firstName);
-    cy.contains('div', 'Last name').findnear('input').first().type(user.lastName);
-    cy.contains('div', 'Email').findnear('input').first().type(user.email);
-    cy.contains('div', 'Username').findnear('input').first().type(user.username);
-    cy.contains('div', 'Password').findnear('input').first().type(user.password);
-    cy.contains('div', 'Password confirmation').findnear('input').first().type(user.password);
+    cy.get('#first_name').type(user.firstName);
+    cy.get('#last_name').type(user.lastName);
+    cy.get('#email').type(user.email);
+    cy.get('#username').type(user.username);
+    cy.get('#password').type(user.password);
+    cy.get('#password-confirm').type(user.password);
 
-    cy.server();
-    cy.route('POST', Cypress.env('prefix') + '_ui/v1/users/').as('createUser');
     cy.contains('Save').click();
-    cy.wait('@createUser');
 });
 
 Cypress.Commands.add('deleteUser', {}, (username) => {
@@ -83,7 +80,7 @@ Cypress.Commands.add('deleteUser', {}, (username) => {
 
     cy.contains('#page-sidebar a', 'Users').click();
 
-    cy.get(`[aria-labelledby=${username}] [aria-label=Actions]`).click({ force: true });
-    cy.containsnear(`[aria-labelledby=${username}] [aria-label=Actions]`, 'Delete').click({ force: true });
-    cy.contains('[role=dialog] button', 'Delete').click({ force: true });
+    cy.get(`[aria-labelledby=${username}] [aria-label=Actions]`).click();
+    cy.containsnear(`[aria-labelledby=${username}] [aria-label=Actions]`, 'Delete').click();
+    cy.contains('[role=dialog] button', 'Delete').click();
 });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -42,12 +42,21 @@ Cypress.Commands.add('menuItem', {}, (name) => {
 });
 
 Cypress.Commands.add('logout', {}, () => {
+    cy.server();
+    cy.route('GET', Cypress.env('prefix') + '_ui/v1/me/').as('me');
     cy.get('[aria-label="user-dropdown"] button').click();
     cy.get('[aria-label="logout"]').click();
+    cy.wait('@me');
 });
+
 Cypress.Commands.add('login', {}, (username, password) => {
+    cy.server();
+    cy.route('POST', Cypress.env('prefix') + '_ui/v1/auth/login/').as('login');
+    cy.route('GET', Cypress.env('prefix') + '_ui/v1/me/').as('me');
     cy.get('#pf-login-username-id').type(username);
     cy.get('#pf-login-password-id').type(`${password}{enter}`);
+    cy.wait('@login');
+    cy.wait('@me');
 });
 
 Cypress.Commands.add('createUser', {}, (username, password, firstName = null, lastName = null, email = null) => {

--- a/test/package.json
+++ b/test/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "cypress:headless":"cypress run --browser chrome --headless",
+    "cypress:chrome":"cypress run --browser chrome --headless",
+    "cypress:chromium":"cypress run --browser chromium-browser --headless",
+    "cypress:firefox":"cypress run --browser firefox --headless",
     "cypress":"cypress open"
   },
   "author": "",


### PR DESCRIPTION
Summary
-------------

This PR encompasses a number of minor refactorings I developed while getting the Cypress tests to run properly on my machine.

These are:

* minor fixes recommended by ESLint (`let` instead of `var` and quoting recommendations mostly.)
* improved readability of the login, logout, and createUser commands (done with the help of the https://github.com/KabaLabs/Cypress-Recorder Chrome plugin.)
* Removed waiting based on request completion. This seemed to introduce issues - once I stripped that out, things started to work fine.
* added additional options in package.json for running headless cypress against different browsers.

Steps for Testing/QA 
----------------------------
If @ZitaNemeckova can verify that I haven't broken the tests on _her_ end, that'd be great - these changes work on my end.

**note:** these changes are based on the work Zita did in #239. I plan to rebase before merging, so this means that her PR should be merged before this one.