### PR TITLE
Verify 'nopermissions' user can't see stuff they shouldn't.

### DIFF
--- a/test/cypress/integration/menu.js
+++ b/test/cypress/integration/menu.js
@@ -25,10 +25,12 @@ describe('Hub Menu Tests', () => {
             cy.deleteUser(username);
         });
         it('a user without permissions sees limited menu', () => {
-            let menuItems = [ 'Collections', 'Namespaces', 'API Token', 'Repo Management' ];
+            let menuItems = [ 'Collections', 'Namespaces', 'My Namespaces', 'API Token', 'Repo Management' ];
+            let menuMissingItems = [ 'Users', 'Groups', 'Approval' ];
             cy.logout();
             cy.login(username, password);
             menuItems.forEach(item => cy.menuItem(item));
+            menuMissingItems.forEach(item => cy.menuItem(item).should('not.exist'));
         });
     });
 });


### PR DESCRIPTION
The current test for how permissions interact with what appears on the sidebar only verifies that users without permissions **can** see what they **should** see. i.e. that they can see all the ordinary things like 'Collections', 'Namespaces', 'API Token', etc.

This PR extends that test to verify that users without permissions **cannot** see things that they *shouldn't** see, i.e. that they can't see 'Users', 'Groups', and 'Approval'.
