### PR TITLE
Add missing default sort to Groups

### DIFF
--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -72,6 +72,10 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
       params['page_size'] = 10;
     }
 
+    if (!params['sort']) {
+      params['sort'] = 'name';
+    }
+
     this.state = {
       params: params,
       loading: true,


### PR DESCRIPTION
Before:
<img width="659" alt="Screenshot 2020-12-11 at 15 28 47" src="https://user-images.githubusercontent.com/9210860/101915199-950a2c00-3bc5-11eb-8f77-14c1010d0369.png">

After:
<img width="646" alt="Screenshot 2020-12-11 at 15 26 04" src="https://user-images.githubusercontent.com/9210860/101915123-799f2100-3bc5-11eb-8c6b-5c3fe8762625.png">
