### PR TITLE
Add test to ensure 'download_concurrency' config is surfaced.

### DIFF
--- a/test/cypress/integration/remote_options.js
+++ b/test/cypress/integration/remote_options.js
@@ -1,0 +1,19 @@
+describe('Hub Menu Tests', () => {
+    let host = Cypress.env('host');
+    let adminUsername = Cypress.env('username');
+    let adminPassword = Cypress.env('password');
+
+    beforeEach(() => {
+        cy.visit(host)
+    });
+
+    it('admin user sees download_concurrency in remote config', () => {
+       cy.login(adminUsername, adminPassword);
+        cy.contains('#page-sidebar a', 'Repo Management').click();
+        cy.get('div[class=tabs]>div>ul>li:last-child').click(); // click the 'remote' tab
+        cy.get('tbody>tr>td>span:first').click(); // click the kebab menu on the 'community' repo
+        cy.get('.pf-c-dropdown__menu-item').click(); // click on 'edit' in the dropdown
+        cy.get('.pf-c-expandable-section__toggle-text').click(); // click 'advanced options' in the modal
+        cy.get('#download_concurrency').should('exist');
+    });
+});

--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -10,9 +10,9 @@ describe('Repo Management tests', () => {
     it('admin user sees download_concurrency in remote config', () => {
         cy.login(adminUsername, adminPassword);
         cy.visit(host + 'ui/repositories?page_size=10&tab=remote');
-        cy.get('tbody>tr>td>span:first').click(); // click the kebab menu on the 'community' repo
-        cy.get('.pf-c-dropdown__menu-item').click(); // click on 'edit' in the dropdown
-        cy.get('.pf-c-expandable-section__toggle-text').click(); // click 'advanced options' in the modal
+        cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+        cy.contains('Edit').click();
+        cy.contains('Show advanced options').click();
         cy.get('#download_concurrency').should('exist');
     });
 });

--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -8,9 +8,8 @@ describe('Repo Management tests', () => {
     });
 
     it('admin user sees download_concurrency in remote config', () => {
-       cy.login(adminUsername, adminPassword);
-        cy.contains('#page-sidebar a', 'Repo Management').click();
-        cy.get('div[class=tabs]>div>ul>li:last-child').click(); // click the 'remote' tab
+        cy.login(adminUsername, adminPassword);
+        cy.visit(host + 'ui/repositories?page_size=10&tab=remote');
         cy.get('tbody>tr>td>span:first').click(); // click the kebab menu on the 'community' repo
         cy.get('.pf-c-dropdown__menu-item').click(); // click on 'edit' in the dropdown
         cy.get('.pf-c-expandable-section__toggle-text').click(); // click 'advanced options' in the modal

--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -1,4 +1,4 @@
-describe('Hub Menu Tests', () => {
+describe('Repo Management tests', () => {
     let host = Cypress.env('host');
     let adminUsername = Cypress.env('username');
     let adminPassword = Cypress.env('password');


### PR DESCRIPTION
This test just verifies that the option exists in the UI - I think that's all the coverage required in the UI tests. Thoughts/opinions/reviews/etcetera from @ZitaNemeckova and @ironfroggy are greatly appreciated.