### PR TITLE
Update groups on My profile to be a Label not an input

### DIFF
--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -145,9 +145,7 @@ export class UserForm extends React.Component<IProps, IState> {
         </FormGroup>
         {isMe ? (
           <FormGroup fieldId={'groups'} label={'Groups'}>
-            {user.groups.length === 0 ? (
-              'No groups'
-            ) : (
+            {user.groups.length !== 0 && (
               <ChipGroup>
                 {' '}
                 {user.groups.map(group => (

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -6,11 +6,10 @@ import {
   TextInput,
   ActionGroup,
   Button,
-  Tooltip,
+  Label,
   Checkbox,
+  LabelGroup,
 } from '@patternfly/react-core';
-
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 import { APISearchTypeAhead, HelperText } from '../../components';
 
@@ -142,24 +141,33 @@ export class UserForm extends React.Component<IProps, IState> {
             type='password'
           />
         </FormGroup>
-        <FormGroup
-          fieldId='groups'
-          label='Groups'
-          helperTextInvalid={errorMessages['groups']}
-          validated={this.toError(!('groups' in errorMessages))}
-        >
-          <APISearchTypeAhead
-            results={this.state.searchGroups}
-            loadResults={this.loadGroups}
-            onSelect={this.onSelectGroup}
-            placeholderText='Select groups'
-            selections={user.groups}
-            multiple={true}
-            onClear={this.clearGroups}
-            isDisabled={isReadonly || isMe}
-          />
-        </FormGroup>
-
+        {isMe ? (
+          <FormGroup fieldId={'groups'} label={'Groups'}>
+            {user.groups.length === 0 ? (
+              <Label> No groups</Label>
+            ) : (
+              user.groups.map(group => <Label>{group.name}</Label>)
+            )}
+          </FormGroup>
+        ) : (
+          <FormGroup
+            fieldId='groups'
+            label='Groups'
+            helperTextInvalid={errorMessages['groups']}
+            validated={this.toError(!('groups' in errorMessages))}
+          >
+            <APISearchTypeAhead
+              results={this.state.searchGroups}
+              loadResults={this.loadGroups}
+              onSelect={this.onSelectGroup}
+              placeholderText='Select groups'
+              selections={user.groups}
+              multiple={true}
+              onClear={this.clearGroups}
+              isDisabled={isReadonly}
+            />
+          </FormGroup>
+        )}
         <FormGroup
           fieldId='is_superuser'
           label='Super user'

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -6,9 +6,9 @@ import {
   TextInput,
   ActionGroup,
   Button,
-  Label,
+  Chip,
   Checkbox,
-  LabelGroup,
+  ChipGroup,
 } from '@patternfly/react-core';
 
 import { APISearchTypeAhead, HelperText } from '../../components';
@@ -144,9 +144,16 @@ export class UserForm extends React.Component<IProps, IState> {
         {isMe ? (
           <FormGroup fieldId={'groups'} label={'Groups'}>
             {user.groups.length === 0 ? (
-              <Label> No groups</Label>
+              'No groups'
             ) : (
-              user.groups.map(group => <Label>{group.name}</Label>)
+              <ChipGroup>
+                {' '}
+                {user.groups.map(group => (
+                  <Chip isReadOnly cellPadding={'1px'}>
+                    {group.name}
+                  </Chip>
+                ))}{' '}
+              </ChipGroup>
             )}
           </FormGroup>
         ) : (
@@ -168,26 +175,27 @@ export class UserForm extends React.Component<IProps, IState> {
             />
           </FormGroup>
         )}
-        <FormGroup
-          fieldId='is_superuser'
-          label='Super user'
-          labelIcon={
-            <HelperText
-              content={
-                'Super users have all system permissions regardless of' +
-                ' their group. Adding new super users is not permitted.'
-              }
+        {user.is_superuser && (
+          <FormGroup
+            fieldId='is_superuser'
+            label='Super user'
+            labelIcon={
+              <HelperText
+                content={
+                  'Super users have all system permissions regardless of' +
+                  ' their group. Adding new super users is not permitted.'
+                }
+              />
+            }
+          >
+            <Checkbox
+              id='is_superuser'
+              isDisabled
+              isChecked={user.is_superuser}
+              label='Is super user'
             />
-          }
-        >
-          <Checkbox
-            id='is_superuser'
-            isDisabled
-            isChecked={user.is_superuser}
-            label='Is super user'
-          />
-        </FormGroup>
-
+          </FormGroup>
+        )}
         {!isReadonly && (
           <ActionGroup>
             <Button

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -7,9 +7,11 @@ import {
   ActionGroup,
   Button,
   Chip,
-  Checkbox,
   ChipGroup,
+  Label,
+  Tooltip,
 } from '@patternfly/react-core';
+import { UserPlusIcon } from '@patternfly/react-icons';
 
 import { APISearchTypeAhead, HelperText } from '../../components';
 
@@ -176,24 +178,12 @@ export class UserForm extends React.Component<IProps, IState> {
           </FormGroup>
         )}
         {user.is_superuser && (
-          <FormGroup
-            fieldId='is_superuser'
-            label='Super user'
-            labelIcon={
-              <HelperText
-                content={
-                  'Super users have all system permissions regardless of' +
-                  ' their group. Adding new super users is not permitted.'
-                }
-              />
-            }
-          >
-            <Checkbox
-              id='is_superuser'
-              isDisabled
-              isChecked={user.is_superuser}
-              label='Is super user'
-            />
+          <FormGroup fieldId='is_superuser' label='Super user'>
+            <Tooltip content='Super users have all system permissions regardless of what groups they are in.'>
+              <Label icon={<UserPlusIcon />} color='orange'>
+                Super user
+              </Label>
+            </Tooltip>
           </FormGroup>
         )}
         {!isReadonly && (

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -178,7 +178,7 @@ export class UserForm extends React.Component<IProps, IState> {
           </FormGroup>
         )}
         {user.is_superuser && (
-          <FormGroup fieldId='is_superuser' label='Super user'>
+          <FormGroup fieldId='is_superuser' label='User type'>
             <Tooltip content='Super users have all system permissions regardless of what groups they are in.'>
               <Label icon={<UserPlusIcon />} color='orange'>
                 Super user


### PR DESCRIPTION
Fixes-Issue: AAH-160

**Before:**

User is in groups:


<img width="1352" alt="Screenshot 2020-12-15 at 14 24 31" src="https://user-images.githubusercontent.com/9210860/102220671-6fd92e80-3ee1-11eb-85a3-e342f8da4887.png">
<img width="1318" alt="Screenshot 2020-12-15 at 14 25 34" src="https://user-images.githubusercontent.com/9210860/102220697-77003c80-3ee1-11eb-9e21-fa519a0156ba.png">


User is not in a group:

<img width="1334" alt="Screenshot 2020-12-15 at 14 24 55" src="https://user-images.githubusercontent.com/9210860/102220663-6cde3e00-3ee1-11eb-8655-46ee2ddaff15.png">
<img width="1343" alt="Screenshot 2020-12-15 at 14 25 10" src="https://user-images.githubusercontent.com/9210860/102220685-749de280-3ee1-11eb-9fb5-13f01ec97341.png">


**After:**

User is in groups:

<img width="1344" alt="Screenshot 2020-12-15 at 14 06 14" src="https://user-images.githubusercontent.com/9210860/102220102-a82c3d00-3ee0-11eb-9a0d-c05de4f5fd9c.png">
<img width="1346" alt="Screenshot 2020-12-15 at 14 06 24" src="https://user-images.githubusercontent.com/9210860/102220110-ab272d80-3ee0-11eb-829f-f248f6baa4c0.png">

User is not in a group
<img width="1363" alt="Screenshot 2020-12-15 at 14 08 54" src="https://user-images.githubusercontent.com/9210860/102220118-ae221e00-3ee0-11eb-906d-2033fc980017.png">
<img width="1316" alt="Screenshot 2020-12-15 at 14 09 09" src="https://user-images.githubusercontent.com/9210860/102220129-b11d0e80-3ee0-11eb-9696-fa842975fbc6.png">

@sbuenafe-rh @fionayhlin What do you think? I'm not sure `No groups` looks good.
