### PR TITLE
Add Empty state components and use them

### DIFF
--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -1,18 +1,7 @@
 import * as React from 'react';
 import './list.scss';
 
-import {
-  TextInput,
-  Button,
-  DropdownItem,
-  DataList,
-  EmptyState,
-  EmptyStateIcon,
-  Title,
-  EmptyStateVariant,
-  EmptyStateBody,
-} from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
+import { Button, DropdownItem, DataList } from '@patternfly/react-core';
 
 import { CollectionListType } from '../../api';
 import {
@@ -20,6 +9,7 @@ import {
   Toolbar,
   Pagination,
   StatefulDropdown,
+  EmptyStateFilter,
 } from '../../components';
 import { ParamHelper } from '../../utilities/param-helper';
 
@@ -91,19 +81,7 @@ export class CollectionList extends React.Component<IProps, IState> {
               />
             ))
           ) : (
-            <EmptyState className='empty' variant={EmptyStateVariant.full}>
-              <EmptyStateIcon icon={SearchIcon} />
-              <Title headingLevel='h2' size='lg'>
-                No results found
-              </Title>
-              <EmptyStateBody>
-                No results match the filter criteria. Remove all filters or
-                clear all filters to show results.
-              </EmptyStateBody>
-              <Button variant='link' onClick={() => updateParams({})}>
-                Clear all filters
-              </Button>
-            </EmptyState>
+            <EmptyStateFilter />
           )}
         </DataList>
 

--- a/src/components/empty-state/empty-state-custom.tsx
+++ b/src/components/empty-state/empty-state-custom.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Title,
+} from '@patternfly/react-core';
+import { ComponentClass } from 'react';
+
+interface IProps {
+  icon?: ComponentClass;
+  title: string;
+  description: string;
+}
+
+export class EmptyStateCustom extends React.Component<IProps> {
+  render() {
+    return (
+      <EmptyState variant={EmptyStateVariant.small}>
+        <EmptyStateIcon icon={this.props.icon} />
+        <Title headingLevel='h4' size='lg'>
+          {this.props.title}
+        </Title>
+        <EmptyStateBody>{this.props.description}</EmptyStateBody>
+      </EmptyState>
+    );
+  }
+}

--- a/src/components/empty-state/empty-state-custom.tsx
+++ b/src/components/empty-state/empty-state-custom.tsx
@@ -3,15 +3,18 @@ import {
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
+  EmptyStatePrimary,
   EmptyStateVariant,
   Title,
 } from '@patternfly/react-core';
 import { ComponentClass } from 'react';
+import { ReactElement } from 'react';
 
 interface IProps {
   icon?: ComponentClass;
   title: string;
   description: string;
+  button?: ReactElement;
 }
 
 export class EmptyStateCustom extends React.Component<IProps> {
@@ -23,6 +26,9 @@ export class EmptyStateCustom extends React.Component<IProps> {
           {this.props.title}
         </Title>
         <EmptyStateBody>{this.props.description}</EmptyStateBody>
+        {this.props.button && (
+          <EmptyStatePrimary>{this.props.button}</EmptyStatePrimary>
+        )}
       </EmptyState>
     );
   }

--- a/src/components/empty-state/empty-state-filter.tsx
+++ b/src/components/empty-state/empty-state-filter.tsx
@@ -1,27 +1,18 @@
 import * as React from 'react';
-import {
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  EmptyStateVariant,
-  Title,
-} from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
+import { EmptyStateCustom } from './empty-state-custom';
 interface IProps {}
 
 export class EmptyStateFilter extends React.Component<IProps> {
   render() {
     return (
-      <EmptyState variant={EmptyStateVariant.small}>
-        <EmptyStateIcon icon={SearchIcon} />
-        <Title headingLevel='h4' size='lg'>
-          No results found
-        </Title>
-        <EmptyStateBody>
-          No results match the filter criteria. Remove all filters or clear all
-          filters to show results.
-        </EmptyStateBody>
-      </EmptyState>
+      <EmptyStateCustom
+        title={'No results found'}
+        description={
+          'No results match the filter criteria. Remove all filters or clear all filters to show results.'
+        }
+        icon={SearchIcon}
+      />
     );
   }
 }

--- a/src/components/empty-state/empty-state-filter.tsx
+++ b/src/components/empty-state/empty-state-filter.tsx
@@ -5,11 +5,8 @@ import {
   EmptyStateIcon,
   EmptyStateVariant,
   Title,
-  EmptyStatePrimary,
-  Button,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-
 interface IProps {}
 
 export class EmptyStateFilter extends React.Component<IProps> {
@@ -24,14 +21,6 @@ export class EmptyStateFilter extends React.Component<IProps> {
           No results match the filter criteria. Remove all filters or clear all
           filters to show results.
         </EmptyStateBody>
-        <EmptyStatePrimary>
-          <Button
-            variant='link'
-            onClick={() => console.log('TODO clear search')}
-          >
-            Clear all filters
-          </Button>
-        </EmptyStatePrimary>
       </EmptyState>
     );
   }

--- a/src/components/empty-state/empty-state-filter.tsx
+++ b/src/components/empty-state/empty-state-filter.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Title,
+  EmptyStatePrimary,
+  Button,
+} from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+
+interface IProps {}
+
+export class EmptyStateFilter extends React.Component<IProps> {
+  render() {
+    return (
+      <EmptyState variant={EmptyStateVariant.small}>
+        <EmptyStateIcon icon={SearchIcon} />
+        <Title headingLevel='h4' size='lg'>
+          No results found
+        </Title>
+        <EmptyStateBody>
+          No results match the filter criteria. Remove all filters or clear all
+          filters to show results.
+        </EmptyStateBody>
+        <EmptyStatePrimary>
+          <Button
+            variant='link'
+            onClick={() => console.log('TODO clear search')}
+          >
+            Clear all filters
+          </Button>
+        </EmptyStatePrimary>
+      </EmptyState>
+    );
+  }
+}

--- a/src/components/empty-state/empty-state-no-data.tsx
+++ b/src/components/empty-state/empty-state-no-data.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-  Button,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
@@ -8,27 +7,33 @@ import {
   EmptyStateVariant,
   Title,
 } from '@patternfly/react-core';
-import { AddCircleOIcon } from '@patternfly/react-icons';
+import { AddCircleOIcon, SearchIcon } from '@patternfly/react-icons';
+import { ReactElement } from 'react';
 
-interface IProps {}
+interface IProps {
+  button?: ReactElement;
+  title?: string;
+  description?: string;
+}
 
 export class EmptyStateNoData extends React.Component<IProps> {
   render() {
     return (
       <EmptyState variant={EmptyStateVariant.small}>
-        <EmptyStateIcon icon={AddCircleOIcon} />
+        <EmptyStateIcon
+          icon={this.props.button ? AddCircleOIcon : SearchIcon}
+        />
         <Title headingLevel='h4' size='lg'>
-          No stuff yet
+          {this.props.title ? this.props.title : 'No stuff yet'}
         </Title>
-        <EmptyStateBody>Specific message?</EmptyStateBody>
-        <EmptyStatePrimary>
-          <Button
-            variant='primary'
-            onClick={() => console.log('TODO redirect to previous page')}
-          >
-            Specific? Add/Upload
-          </Button>
-        </EmptyStatePrimary>
+        <EmptyStateBody>
+          {this.props.description
+            ? this.props.description
+            : 'Specific message?'}
+        </EmptyStateBody>
+        {this.props.button && (
+          <EmptyStatePrimary>{this.props.button}</EmptyStatePrimary>
+        )}
       </EmptyState>
     );
   }

--- a/src/components/empty-state/empty-state-no-data.tsx
+++ b/src/components/empty-state/empty-state-no-data.tsx
@@ -7,7 +7,7 @@ import {
   EmptyStateVariant,
   Title,
 } from '@patternfly/react-core';
-import { AddCircleOIcon, SearchIcon } from '@patternfly/react-icons';
+import { PlusCircleIcon, SearchIcon } from '@patternfly/react-icons';
 import { ReactElement } from 'react';
 
 interface IProps {
@@ -21,7 +21,7 @@ export class EmptyStateNoData extends React.Component<IProps> {
     return (
       <EmptyState variant={EmptyStateVariant.small}>
         <EmptyStateIcon
-          icon={this.props.button ? AddCircleOIcon : SearchIcon}
+          icon={this.props.button ? PlusCircleIcon : SearchIcon}
         />
         <Title headingLevel='h4' size='lg'>
           {this.props.title ? this.props.title : 'No stuff yet'}

--- a/src/components/empty-state/empty-state-no-data.tsx
+++ b/src/components/empty-state/empty-state-no-data.tsx
@@ -1,14 +1,7 @@
 import * as React from 'react';
-import {
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  EmptyStatePrimary,
-  EmptyStateVariant,
-  Title,
-} from '@patternfly/react-core';
 import { PlusCircleIcon, SearchIcon } from '@patternfly/react-icons';
 import { ReactElement } from 'react';
+import { EmptyStateCustom } from './empty-state-custom';
 
 interface IProps {
   button?: ReactElement;
@@ -19,18 +12,12 @@ interface IProps {
 export class EmptyStateNoData extends React.Component<IProps> {
   render() {
     return (
-      <EmptyState variant={EmptyStateVariant.small}>
-        <EmptyStateIcon
-          icon={this.props.button ? PlusCircleIcon : SearchIcon}
-        />
-        <Title headingLevel='h4' size='lg'>
-          {this.props.title}
-        </Title>
-        <EmptyStateBody>{this.props.description}</EmptyStateBody>
-        {this.props.button && (
-          <EmptyStatePrimary>{this.props.button}</EmptyStatePrimary>
-        )}
-      </EmptyState>
+      <EmptyStateCustom
+        icon={this.props.button ? PlusCircleIcon : SearchIcon}
+        title={this.props.title}
+        description={this.props.description}
+        button={this.props.button}
+      />
     );
   }
 }

--- a/src/components/empty-state/empty-state-no-data.tsx
+++ b/src/components/empty-state/empty-state-no-data.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  EmptyStatePrimary,
+  EmptyStateVariant,
+  Title,
+} from '@patternfly/react-core';
+import { AddCircleOIcon } from '@patternfly/react-icons';
+
+interface IProps {}
+
+export class EmptyStateNoData extends React.Component<IProps> {
+  render() {
+    return (
+      <EmptyState variant={EmptyStateVariant.small}>
+        <EmptyStateIcon icon={AddCircleOIcon} />
+        <Title headingLevel='h4' size='lg'>
+          No stuff yet
+        </Title>
+        <EmptyStateBody>Specific message?</EmptyStateBody>
+        <EmptyStatePrimary>
+          <Button
+            variant='primary'
+            onClick={() => console.log('TODO redirect to previous page')}
+          >
+            Specific? Add/Upload
+          </Button>
+        </EmptyStatePrimary>
+      </EmptyState>
+    );
+  }
+}

--- a/src/components/empty-state/empty-state-no-data.tsx
+++ b/src/components/empty-state/empty-state-no-data.tsx
@@ -12,8 +12,8 @@ import { ReactElement } from 'react';
 
 interface IProps {
   button?: ReactElement;
-  title?: string;
-  description?: string;
+  title: string;
+  description: string;
 }
 
 export class EmptyStateNoData extends React.Component<IProps> {
@@ -24,13 +24,9 @@ export class EmptyStateNoData extends React.Component<IProps> {
           icon={this.props.button ? PlusCircleIcon : SearchIcon}
         />
         <Title headingLevel='h4' size='lg'>
-          {this.props.title ? this.props.title : 'No stuff yet'}
+          {this.props.title}
         </Title>
-        <EmptyStateBody>
-          {this.props.description
-            ? this.props.description
-            : 'Specific message?'}
-        </EmptyStateBody>
+        <EmptyStateBody>{this.props.description}</EmptyStateBody>
         {this.props.button && (
           <EmptyStatePrimary>{this.props.button}</EmptyStatePrimary>
         )}

--- a/src/components/empty-state/empty-state-unauthorised.tsx
+++ b/src/components/empty-state/empty-state-unauthorised.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import {
+  Button,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Title,
+  EmptyStateBody,
+  EmptyStatePrimary,
+} from '@patternfly/react-core';
+import { LockedIcon } from '@patternfly/react-icons';
+
+interface IProps {}
+
+export class EmptyStateUnauthorised extends React.Component<IProps> {
+  render() {
+    return (
+      <EmptyState variant={EmptyStateVariant.small}>
+        <EmptyStateIcon icon={LockedIcon} />
+        <Title headingLevel='h4' size='lg'>
+          You do not have have access to TODO: get correct name
+        </Title>
+        <EmptyStateBody>
+          Contact you organization administrator for more information.
+        </EmptyStateBody>
+        <EmptyStatePrimary>
+          <Button
+            variant='primary'
+            onClick={() => console.log('TODO redirect to previous page')}
+          >
+            Return to previous page
+          </Button>
+        </EmptyStatePrimary>
+      </EmptyState>
+    );
+  }
+}

--- a/src/components/empty-state/empty-state-unauthorised.tsx
+++ b/src/components/empty-state/empty-state-unauthorised.tsx
@@ -8,29 +8,21 @@ import {
   EmptyStateBody,
   EmptyStatePrimary,
 } from '@patternfly/react-core';
-import { LockedIcon } from '@patternfly/react-icons';
+import { LockIcon } from '@patternfly/react-icons';
 
 interface IProps {}
 
 export class EmptyStateUnauthorised extends React.Component<IProps> {
   render() {
     return (
-      <EmptyState variant={EmptyStateVariant.small}>
-        <EmptyStateIcon icon={LockedIcon} />
-        <Title headingLevel='h4' size='lg'>
-          You do not have have access to TODO: get correct name
+      <EmptyState variant={EmptyStateVariant.xs}>
+        <EmptyStateIcon icon={LockIcon} />
+        <Title headingLevel='h4'>
+          You do not have have access to Automation Hub
         </Title>
         <EmptyStateBody>
           Contact you organization administrator for more information.
         </EmptyStateBody>
-        <EmptyStatePrimary>
-          <Button
-            variant='primary'
-            onClick={() => console.log('TODO redirect to previous page')}
-          >
-            Return to previous page
-          </Button>
-        </EmptyStatePrimary>
       </EmptyState>
     );
   }

--- a/src/components/empty-state/empty-state-unauthorized.tsx
+++ b/src/components/empty-state/empty-state-unauthorized.tsx
@@ -1,13 +1,5 @@
 import * as React from 'react';
-import {
-  Button,
-  EmptyState,
-  EmptyStateIcon,
-  EmptyStateVariant,
-  Title,
-  EmptyStateBody,
-  EmptyStatePrimary,
-} from '@patternfly/react-core';
+import { EmptyStateCustom } from './empty-state-custom';
 import { LockIcon } from '@patternfly/react-icons';
 
 interface IProps {}
@@ -15,15 +7,13 @@ interface IProps {}
 export class EmptyStateUnauthorized extends React.Component<IProps> {
   render() {
     return (
-      <EmptyState variant={EmptyStateVariant.xs}>
-        <EmptyStateIcon icon={LockIcon} />
-        <Title headingLevel='h4'>
-          You do not have have access to Automation Hub
-        </Title>
-        <EmptyStateBody>
-          Contact you organization administrator for more information.
-        </EmptyStateBody>
-      </EmptyState>
+      <EmptyStateCustom
+        icon={LockIcon}
+        title={'You do not have have access to Automation Hub'}
+        description={
+          'Contact you organization administrator for more information.'
+        }
+      />
     );
   }
 }

--- a/src/components/empty-state/empty-state-unauthorized.tsx
+++ b/src/components/empty-state/empty-state-unauthorized.tsx
@@ -12,7 +12,7 @@ import { LockIcon } from '@patternfly/react-icons';
 
 interface IProps {}
 
-export class EmptyStateUnauthorised extends React.Component<IProps> {
+export class EmptyStateUnauthorized extends React.Component<IProps> {
   render() {
     return (
       <EmptyState variant={EmptyStateVariant.xs}>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -52,3 +52,4 @@ export { WriteOnlyField } from './patternfly-wrappers/write-only-field';
 export { EmptyStateFilter } from './empty-state/empty-state-filter';
 export { EmptyStateUnauthorised } from './empty-state/empty-state-unauthorised';
 export { EmptyStateNoData } from './empty-state/empty-state-no-data';
+export { EmptyStateCustom } from './empty-state/empty-state-custom';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -49,3 +49,6 @@ export { LocalRepositoryTable } from './repositories/local-repository-table';
 export { StatusIndicator } from './status/status-indicator';
 export { HelperText } from './helper-text/helper-text';
 export { WriteOnlyField } from './patternfly-wrappers/write-only-field';
+export { EmptyStateFilter } from './empty-state/empty-state-filter';
+export { EmptyStateUnauthorised } from './empty-state/empty-state-unauthorised';
+export { EmptyStateNoData } from './empty-state/empty-state-no-data';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -50,6 +50,6 @@ export { StatusIndicator } from './status/status-indicator';
 export { HelperText } from './helper-text/helper-text';
 export { WriteOnlyField } from './patternfly-wrappers/write-only-field';
 export { EmptyStateFilter } from './empty-state/empty-state-filter';
-export { EmptyStateUnauthorised } from './empty-state/empty-state-unauthorised';
+export { EmptyStateUnauthorized } from './empty-state/empty-state-unauthorized';
 export { EmptyStateNoData } from './empty-state/empty-state-no-data';
 export { EmptyStateCustom } from './empty-state/empty-state-custom';

--- a/src/components/my-imports/import-list.tsx
+++ b/src/components/my-imports/import-list.tsx
@@ -130,7 +130,12 @@ export class ImportList extends React.Component<IProps, IState> {
       );
     }
     if (importList.length === 0) {
-      return <EmptyStateNoData />;
+      return (
+        <EmptyStateNoData
+          title={'No imports'}
+          description={'There have not been any imports on this namespace.'}
+        />
+      );
     }
 
     return (

--- a/src/components/my-imports/import-list.tsx
+++ b/src/components/my-imports/import-list.tsx
@@ -6,10 +6,6 @@ import * as moment from 'moment';
 import { cloneDeep } from 'lodash';
 
 import {
-  EmptyState,
-  EmptyStateIcon,
-  EmptyStateBody,
-  Title,
   TextInput,
   Pagination,
   FormSelect,
@@ -18,12 +14,13 @@ import {
   Button,
   ButtonVariant,
 } from '@patternfly/react-core';
-import { InfoIcon, SearchIcon } from '@patternfly/react-icons';
+import { SearchIcon } from '@patternfly/react-icons';
 import { Spinner } from '@redhat-cloud-services/frontend-components';
 
 import { PulpStatus, NamespaceType, ImportListType } from '../../api';
 import { ParamHelper } from '../../utilities/param-helper';
 import { Constants } from '../../constants';
+import { EmptyStateNoData } from '..';
 
 interface IProps {
   namespaces: NamespaceType[];
@@ -133,18 +130,7 @@ export class ImportList extends React.Component<IProps, IState> {
       );
     }
     if (importList.length === 0) {
-      return (
-        <EmptyState>
-          <EmptyStateIcon icon={InfoIcon} />
-          <Title size='lg' headingLevel='h5'>
-            No imports
-          </Title>
-
-          <EmptyStateBody>
-            There have not been any imports on this namespace.
-          </EmptyStateBody>
-        </EmptyState>
-      );
+      return <EmptyStateNoData />;
     }
 
     return (

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -2,17 +2,8 @@ import * as React from 'react';
 
 import { Link } from 'react-router-dom';
 
-import {
-  DropdownItem,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  EmptyStateVariant,
-  Title,
-  ClipboardCopy,
-} from '@patternfly/react-core';
-import { WarningTriangleIcon } from '@patternfly/react-icons';
-import { EmptyStateFilter, SortTable, StatefulDropdown } from '..';
+import { DropdownItem, ClipboardCopy } from '@patternfly/react-core';
+import { EmptyStateNoData, SortTable, StatefulDropdown } from '..';
 import * as moment from 'moment';
 import { Constants } from '../../constants';
 import { getRepoUrl } from '../../utilities';
@@ -31,7 +22,7 @@ export class LocalRepositoryTable extends React.Component<IProps> {
   render() {
     const { repositories } = this.props;
     if (repositories.length === 0) {
-      return <EmptyStateFilter />;
+      return <EmptyStateNoData />;
     }
     return this.renderTable(repositories);
   }

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -22,7 +22,12 @@ export class LocalRepositoryTable extends React.Component<IProps> {
   render() {
     const { repositories } = this.props;
     if (repositories.length === 0) {
-      return <EmptyStateNoData />;
+      return (
+        <EmptyStateNoData
+          title={'No local repositories yet'}
+          description={''}
+        />
+      );
     }
     return this.renderTable(repositories);
   }

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -12,7 +12,7 @@ import {
   ClipboardCopy,
 } from '@patternfly/react-core';
 import { WarningTriangleIcon } from '@patternfly/react-icons';
-import { SortTable, StatefulDropdown } from '..';
+import { EmptyStateFilter, SortTable, StatefulDropdown } from '..';
 import * as moment from 'moment';
 import { Constants } from '../../constants';
 import { getRepoUrl } from '../../utilities';
@@ -31,17 +31,7 @@ export class LocalRepositoryTable extends React.Component<IProps> {
   render() {
     const { repositories } = this.props;
     if (repositories.length === 0) {
-      return (
-        <EmptyState className='empty' variant={EmptyStateVariant.full}>
-          <EmptyStateIcon icon={WarningTriangleIcon} />
-          <Title headingLevel='h2' size='lg'>
-            No matches
-          </Title>
-          <EmptyStateBody>
-            Please try adjusting your search query.
-          </EmptyStateBody>
-        </EmptyState>
-      );
+      return <EmptyStateFilter />;
     }
     return this.renderTable(repositories);
   }

--- a/src/components/repositories/remote-repository-table.tsx
+++ b/src/components/repositories/remote-repository-table.tsx
@@ -5,7 +5,7 @@ import { Button, DropdownItem, Tooltip } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import { RemoteType, UserType, PulpStatus } from '../../api';
-import { EmptyStateNoData, HelperText, SortTable, StatefulDropdown } from '..';
+import { HelperText, SortTable, StatefulDropdown } from '..';
 import { StatusIndicator } from '../../components';
 
 import { Constants } from '../../constants';
@@ -55,14 +55,6 @@ export class RemoteRepositoryTable extends React.Component<IProps> {
 
   render() {
     const { remotes } = this.props;
-    if (remotes.length !== 0) {
-      return (
-        <EmptyStateNoData
-          title={'No remote repositories yet'}
-          description={''}
-        />
-      );
-    }
     return this.renderTable(remotes);
   }
 

--- a/src/components/repositories/remote-repository-table.tsx
+++ b/src/components/repositories/remote-repository-table.tsx
@@ -1,19 +1,11 @@
 import * as React from 'react';
 import * as moment from 'moment';
 
-import {
-  Button,
-  DropdownItem,
-  EmptyState,
-  EmptyStateIcon,
-  EmptyStateVariant,
-  Title,
-  Tooltip,
-} from '@patternfly/react-core';
-import { WrenchIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { Button, DropdownItem, Tooltip } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import { RemoteType, UserType, PulpStatus } from '../../api';
-import { EmptyStateFilter, HelperText, SortTable, StatefulDropdown } from '..';
+import { EmptyStateNoData, HelperText, SortTable, StatefulDropdown } from '..';
 import { StatusIndicator } from '../../components';
 
 import { Constants } from '../../constants';
@@ -63,19 +55,8 @@ export class RemoteRepositoryTable extends React.Component<IProps> {
 
   render() {
     const { remotes } = this.props;
-    if (remotes.length == 0) {
-      return (
-        <EmptyState className='empty' variant={EmptyStateVariant.full}>
-          <EmptyStateIcon icon={WrenchIcon} />
-          <Title headingLevel='h2' size='lg'>
-            No remote repos
-          </Title>
-        </EmptyState>
-      );
-    }
-    // TODO only with search
-    if (remotes.length === 0) {
-      return <EmptyStateFilter />;
+    if (remotes.length !== 0) {
+      return <EmptyStateNoData />;
     }
     return this.renderTable(remotes);
   }

--- a/src/components/repositories/remote-repository-table.tsx
+++ b/src/components/repositories/remote-repository-table.tsx
@@ -5,21 +5,15 @@ import {
   Button,
   DropdownItem,
   EmptyState,
-  EmptyStateBody,
   EmptyStateIcon,
   EmptyStateVariant,
   Title,
   Tooltip,
-  Popover,
 } from '@patternfly/react-core';
-import {
-  WarningTriangleIcon,
-  WrenchIcon,
-  ExclamationCircleIcon,
-} from '@patternfly/react-icons';
+import { WrenchIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import { RemoteType, UserType, PulpStatus } from '../../api';
-import { HelperText, SortTable, StatefulDropdown } from '..';
+import { EmptyStateFilter, HelperText, SortTable, StatefulDropdown } from '..';
 import { StatusIndicator } from '../../components';
 
 import { Constants } from '../../constants';
@@ -81,17 +75,7 @@ export class RemoteRepositoryTable extends React.Component<IProps> {
     }
     // TODO only with search
     if (remotes.length === 0) {
-      return (
-        <EmptyState className='empty' variant={EmptyStateVariant.full}>
-          <EmptyStateIcon icon={WarningTriangleIcon} />
-          <Title headingLevel='h2' size='lg'>
-            No matches
-          </Title>
-          <EmptyStateBody>
-            Please try adjusting your search query.
-          </EmptyStateBody>
-        </EmptyState>
-      );
+      return <EmptyStateFilter />;
     }
     return this.renderTable(remotes);
   }

--- a/src/components/repositories/remote-repository-table.tsx
+++ b/src/components/repositories/remote-repository-table.tsx
@@ -56,7 +56,12 @@ export class RemoteRepositoryTable extends React.Component<IProps> {
   render() {
     const { remotes } = this.props;
     if (remotes.length !== 0) {
-      return <EmptyStateNoData />;
+      return (
+        <EmptyStateNoData
+          title={'No remote repositories yet'}
+          description={''}
+        />
+      );
     }
     return this.renderTable(remotes);
   }

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -2,13 +2,13 @@ import * as React from 'react';
 import './certification-dashboard.scss';
 
 import * as moment from 'moment';
+import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import {
-  withRouter,
-  RouteComponentProps,
-  Link,
-  Redirect,
-} from 'react-router-dom';
-import { BaseHeader, EmptyStateFilter, Main } from '../../components';
+  BaseHeader,
+  EmptyStateFilter,
+  EmptyStateUnauthorised,
+  Main,
+} from '../../components';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import {
   Toolbar,
@@ -107,10 +107,6 @@ class CertificationDashboard extends React.Component<
   render() {
     const { versions, params, itemCount, loading, redirect } = this.state;
 
-    if (redirect) {
-      return <Redirect to={redirect}></Redirect>;
-    }
-
     if (!versions) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
@@ -121,86 +117,90 @@ class CertificationDashboard extends React.Component<
           alerts={this.state.alerts}
           closeAlert={i => this.closeAlert(i)}
         />
-        <Main className='certification-dashboard'>
-          <Section className='body'>
-            <div className='toolbar'>
-              <Toolbar>
-                <ToolbarGroup>
-                  <ToolbarItem>
-                    <CompoundFilter
-                      updateParams={p =>
-                        this.updateParams(p, () => this.queryCollections())
-                      }
-                      params={params}
-                      filterConfig={[
-                        {
-                          id: 'namespace',
-                          title: 'Namespace',
-                        },
-                        {
-                          id: 'name',
-                          title: 'Collection Name',
-                        },
-                        {
-                          id: 'repository',
-                          title: 'Repository',
-                          inputType: 'select',
-                          options: [
-                            {
-                              id: Constants.NOTCERTIFIED,
-                              title: 'Rejected',
-                            },
-                            {
-                              id: Constants.NEEDSREVIEW,
-                              title: 'Needs Review',
-                            },
-                            {
-                              id: Constants.PUBLISHED,
-                              title: 'Approved',
-                            },
-                          ],
-                        },
-                      ]}
-                    />
-                  </ToolbarItem>
-                </ToolbarGroup>
-              </Toolbar>
+        {redirect ? (
+          <EmptyStateUnauthorised />
+        ) : (
+          <Main className='certification-dashboard'>
+            <Section className='body'>
+              <div className='toolbar'>
+                <Toolbar>
+                  <ToolbarGroup>
+                    <ToolbarItem>
+                      <CompoundFilter
+                        updateParams={p =>
+                          this.updateParams(p, () => this.queryCollections())
+                        }
+                        params={params}
+                        filterConfig={[
+                          {
+                            id: 'namespace',
+                            title: 'Namespace',
+                          },
+                          {
+                            id: 'name',
+                            title: 'Collection Name',
+                          },
+                          {
+                            id: 'repository',
+                            title: 'Repository',
+                            inputType: 'select',
+                            options: [
+                              {
+                                id: Constants.NOTCERTIFIED,
+                                title: 'Rejected',
+                              },
+                              {
+                                id: Constants.NEEDSREVIEW,
+                                title: 'Needs Review',
+                              },
+                              {
+                                id: Constants.PUBLISHED,
+                                title: 'Approved',
+                              },
+                            ],
+                          },
+                        ]}
+                      />
+                    </ToolbarItem>
+                  </ToolbarGroup>
+                </Toolbar>
 
-              <Pagination
-                params={params}
-                updateParams={p =>
-                  this.updateParams(p, () => this.queryCollections())
-                }
-                count={itemCount}
-                isTop
-              />
-            </div>
-            <div>
-              <AppliedFilters
-                updateParams={p =>
-                  this.updateParams(p, () => this.queryCollections())
-                }
-                params={params}
-                ignoredParams={['page_size', 'page', 'sort']}
-              />
-            </div>
-            {loading ? (
-              <LoadingPageSpinner />
-            ) : (
-              this.renderTable(versions, params)
-            )}
+                <Pagination
+                  params={params}
+                  updateParams={p =>
+                    this.updateParams(p, () => this.queryCollections())
+                  }
+                  count={itemCount}
+                  isTop
+                />
+              </div>
+              <div>
+                <AppliedFilters
+                  updateParams={p =>
+                    this.updateParams(p, () => this.queryCollections())
+                  }
+                  params={params}
+                  ignoredParams={['page_size', 'page', 'sort']}
+                />
+              </div>
+              {loading ? (
+                <LoadingPageSpinner />
+              ) : (
+                this.renderTable(versions, params)
+              )}
 
-            <div className='footer'>
-              <Pagination
-                params={params}
-                updateParams={p =>
-                  this.updateParams(p, () => this.queryCollections())
-                }
-                count={itemCount}
-              />
-            </div>
-          </Section>
-        </Main>
+              <div className='footer'>
+                <Pagination
+                  params={params}
+                  updateParams={p =>
+                    this.updateParams(p, () => this.queryCollections())
+                  }
+                  count={itemCount}
+                />
+              </div>
+            </Section>
+          </Main>
+        )}
       </React.Fragment>
     );
   }

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -7,7 +7,7 @@ import {
   BaseHeader,
   EmptyStateFilter,
   EmptyStateNoData,
-  EmptyStateUnauthorised,
+  EmptyStateUnauthorized,
   Main,
 } from '../../components';
 import { Section } from '@redhat-cloud-services/frontend-components';
@@ -120,7 +120,7 @@ class CertificationDashboard extends React.Component<
           closeAlert={i => this.closeAlert(i)}
         />
         {redirect ? (
-          <EmptyStateUnauthorised />
+          <EmptyStateUnauthorized />
         ) : (
           <Main className='certification-dashboard'>
             <Section className='body'>

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -56,7 +56,7 @@ interface IState {
   itemCount: number;
   loading: boolean;
   updatingVersions: CollectionVersion[];
-  redirect: string;
+  unauthorized: boolean;
 }
 
 class CertificationDashboard extends React.Component<
@@ -89,8 +89,8 @@ class CertificationDashboard extends React.Component<
       params: params,
       loading: true,
       updatingVersions: [],
-      redirect: undefined,
       alerts: [],
+      unauthorized: false,
     };
   }
 
@@ -99,16 +99,16 @@ class CertificationDashboard extends React.Component<
       !this.context.user ||
       !this.context.user.model_permissions.move_collection
     ) {
-      this.setState({ redirect: Paths.notFound });
+      this.setState({ unauthorized: true });
     } else {
       this.queryCollections();
     }
   }
 
   render() {
-    const { versions, params, itemCount, loading, redirect } = this.state;
+    const { versions, params, itemCount, loading, unauthorized } = this.state;
 
-    if (!versions && !redirect) {
+    if (!versions && !unauthorized) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
@@ -119,7 +119,7 @@ class CertificationDashboard extends React.Component<
           alerts={this.state.alerts}
           closeAlert={i => this.closeAlert(i)}
         />
-        {redirect ? (
+        {unauthorized ? (
           <EmptyStateUnauthorized />
         ) : (
           <Main className='certification-dashboard'>

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -8,7 +8,7 @@ import {
   Link,
   Redirect,
 } from 'react-router-dom';
-import { BaseHeader, Main } from '../../components';
+import { BaseHeader, EmptyStateFilter, Main } from '../../components';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import {
   Toolbar,
@@ -16,18 +16,12 @@ import {
   ToolbarItem,
   Button,
   DropdownItem,
-  EmptyState,
-  EmptyStateIcon,
-  Title,
-  EmptyStateBody,
-  EmptyStateVariant,
 } from '@patternfly/react-core';
 
 import {
   InfoCircleIcon,
   ExclamationCircleIcon,
   CheckCircleIcon,
-  WarningTriangleIcon,
 } from '@patternfly/react-icons';
 
 import { CollectionVersionAPI, CollectionVersion, TaskAPI } from '../../api';
@@ -213,17 +207,7 @@ class CertificationDashboard extends React.Component<
 
   private renderTable(versions, params) {
     if (versions.length === 0) {
-      return (
-        <EmptyState className='empty' variant={EmptyStateVariant.full}>
-          <EmptyStateIcon icon={WarningTriangleIcon} />
-          <Title headingLevel='h2' size='lg'>
-            No matches
-          </Title>
-          <EmptyStateBody>
-            Please try adjusting your search query.
-          </EmptyStateBody>
-        </EmptyState>
-      );
+      return <EmptyStateFilter />;
     }
     let sortTableOptions = {
       headers: [

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -211,7 +211,10 @@ class CertificationDashboard extends React.Component<
       return filterIsSet(params, ['namespace', 'name', 'repository']) ? (
         <EmptyStateFilter />
       ) : (
-        <EmptyStateNoData />
+        <EmptyStateNoData
+          title={'No managed collections yet'}
+          description={'Collections will appear once uploaded'}
+        />
       );
     }
     let sortTableOptions = {

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -6,6 +6,7 @@ import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import {
   BaseHeader,
   EmptyStateFilter,
+  EmptyStateNoData,
   EmptyStateUnauthorised,
   Main,
 } from '../../components';
@@ -25,7 +26,7 @@ import {
 } from '@patternfly/react-icons';
 
 import { CollectionVersionAPI, CollectionVersion, TaskAPI } from '../../api';
-import { ParamHelper } from '../../utilities';
+import { filterIsSet, ParamHelper } from '../../utilities';
 import {
   LoadingPageWithHeader,
   StatefulDropdown,
@@ -207,7 +208,11 @@ class CertificationDashboard extends React.Component<
 
   private renderTable(versions, params) {
     if (versions.length === 0) {
-      return <EmptyStateFilter />;
+      return filterIsSet(params, ['namespace', 'name', 'repository']) ? (
+        <EmptyStateFilter />
+      ) : (
+        <EmptyStateNoData />
+      );
     }
     let sortTableOptions = {
       headers: [

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -108,9 +108,10 @@ class CertificationDashboard extends React.Component<
   render() {
     const { versions, params, itemCount, loading, redirect } = this.state;
 
-    if (!versions) {
+    if (!versions && !redirect) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
+
     return (
       <React.Fragment>
         <BaseHeader title='Approval dashboard'></BaseHeader>

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -149,7 +149,7 @@ class CollectionDocs extends React.Component<
               params={params}
             ></TableOfContents>
             <div className='body docs pf-c-content' ref={this.docsRef}>
-              {!(displayHTML || pluginData) ? (
+              {displayHTML || pluginData ? (
                 // if neither variable is set, render not found
                 displayHTML ? (
                   // if displayHTML is set, render it

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -21,6 +21,7 @@ import {
   TableOfContents,
   LoadingPageWithHeader,
   Main,
+  EmptyStateNoData,
 } from '../../components';
 
 import { RenderPluginDoc } from '@ansible/galaxy-doc-builder';
@@ -257,16 +258,13 @@ class CollectionDocs extends React.Component<
 
   private renderNotFound(collectionName) {
     return (
-      <EmptyState className='empty' variant={EmptyStateVariant.full}>
-        <EmptyStateIcon icon={WarningTriangleIcon} />
-        <Title headingLevel='h2' size='lg'>
-          Not found
-        </Title>
-        <EmptyStateBody>
-          The file you're looking for doesn't seem to be available in this
-          version of {collectionName}.
-        </EmptyStateBody>
-      </EmptyState>
+      <EmptyStateNoData
+        title={'Not found'}
+        description={
+          "The file you're looking for doesn't seem to be available in this version of " +
+          collectionName
+        }
+      />
     );
   }
 

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -5,23 +5,14 @@ import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import { HashLink } from 'react-router-hash-link';
 
-import {
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateVariant,
-  Title,
-  EmptyStateIcon,
-  Alert,
-} from '@patternfly/react-core';
-
-import { WarningTriangleIcon } from '@patternfly/react-icons';
+import { Alert } from '@patternfly/react-core';
 
 import {
   CollectionHeader,
   TableOfContents,
   LoadingPageWithHeader,
   Main,
-  EmptyStateNoData,
+  EmptyStateCustom,
 } from '../../components';
 
 import { RenderPluginDoc } from '@ansible/galaxy-doc-builder';
@@ -30,6 +21,8 @@ import { loadCollection, IBaseCollectionState } from './base';
 import { ParamHelper, sanitizeDocsUrls } from '../../utilities';
 import { formatPath, Paths } from '../../paths';
 import { AppContext } from '../../loaders/app-context';
+
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 // renders markdown files in collection docs/ directory
 class CollectionDocs extends React.Component<
@@ -156,7 +149,7 @@ class CollectionDocs extends React.Component<
               params={params}
             ></TableOfContents>
             <div className='body docs pf-c-content' ref={this.docsRef}>
-              {displayHTML || pluginData ? (
+              {!(displayHTML || pluginData) ? (
                 // if neither variable is set, render not found
                 displayHTML ? (
                   // if displayHTML is set, render it
@@ -258,12 +251,12 @@ class CollectionDocs extends React.Component<
 
   private renderNotFound(collectionName) {
     return (
-      <EmptyStateNoData
+      <EmptyStateCustom
         title={'Not found'}
         description={
-          "The file you're looking for doesn't seem to be available in this version of " +
-          collectionName
+          'The file is not available for this version of ' + collectionName
         }
+        icon={ExclamationCircleIcon}
       />
     );
   }

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Section, Spinner } from '@redhat-cloud-services/frontend-components';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import {
   PartnerHeader,
@@ -11,6 +11,7 @@ import {
   closeAlertMixin,
   AlertType,
   Main,
+  EmptyStateUnauthorised,
 } from '../../components';
 import {
   MyNamespaceAPI,
@@ -83,10 +84,6 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
       userId,
     } = this.state;
 
-    if (redirect) {
-      return <Redirect to={redirect} />;
-    }
-
     if (!namespace) {
       return null;
     }
@@ -112,48 +109,55 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
           alerts={this.state.alerts}
           closeAlert={i => this.closeAlert(i)}
         />
-        <Main>
-          <Section className='body'>
-            {params.tab.toLowerCase() === 'edit details' ? (
-              <NamespaceForm
-                userId={userId}
-                namespace={namespace}
-                errorMessages={errorMessages}
-                updateNamespace={namespace =>
-                  this.setState({
-                    namespace: namespace,
-                    unsavedData: true,
-                  })
-                }
-              />
-            ) : (
-              <ResourcesForm
-                updateNamespace={namespace =>
-                  this.setState({
-                    namespace: namespace,
-                    unsavedData: true,
-                  })
-                }
-                namespace={namespace}
-              />
-            )}
-            <Form>
-              <ActionGroup>
-                <Button variant='primary' onClick={() => this.saveNamespace()}>
-                  Save
-                </Button>
-                <Button variant='secondary' onClick={() => this.cancel()}>
-                  Cancel
-                </Button>
+        {redirect ? (
+          <EmptyStateUnauthorised />
+        ) : (
+          <Main>
+            <Section className='body'>
+              {params.tab.toLowerCase() === 'edit details' ? (
+                <NamespaceForm
+                  userId={userId}
+                  namespace={namespace}
+                  errorMessages={errorMessages}
+                  updateNamespace={namespace =>
+                    this.setState({
+                      namespace: namespace,
+                      unsavedData: true,
+                    })
+                  }
+                />
+              ) : (
+                <ResourcesForm
+                  updateNamespace={namespace =>
+                    this.setState({
+                      namespace: namespace,
+                      unsavedData: true,
+                    })
+                  }
+                  namespace={namespace}
+                />
+              )}
+              <Form>
+                <ActionGroup>
+                  <Button
+                    variant='primary'
+                    onClick={() => this.saveNamespace()}
+                  >
+                    Save
+                  </Button>
+                  <Button variant='secondary' onClick={() => this.cancel()}>
+                    Cancel
+                  </Button>
 
-                {saving ? <Spinner></Spinner> : null}
-              </ActionGroup>
-              {this.state.unsavedData ? (
-                <div style={{ color: 'red' }}>You have unsaved changes</div>
-              ) : null}
-            </Form>
-          </Section>
-        </Main>
+                  {saving ? <Spinner></Spinner> : null}
+                </ActionGroup>
+                {this.state.unsavedData ? (
+                  <div style={{ color: 'red' }}>You have unsaved changes</div>
+                ) : null}
+              </Form>
+            </Section>
+          </Main>
+        )}
       </React.Fragment>
     );
   }

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 import { Section, Spinner } from '@redhat-cloud-services/frontend-components';
-import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
 import {
   PartnerHeader,
@@ -86,6 +86,10 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
 
     if (!namespace) {
       return null;
+    }
+
+    if (redirect && redirect !== Paths.notFound) {
+      return <Redirect to={redirect} />;
     }
     return (
       <React.Fragment>

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -11,7 +11,7 @@ import {
   closeAlertMixin,
   AlertType,
   Main,
-  EmptyStateUnauthorised,
+  EmptyStateUnauthorized,
 } from '../../components';
 import {
   MyNamespaceAPI,
@@ -114,7 +114,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
           closeAlert={i => this.closeAlert(i)}
         />
         {redirect ? (
-          <EmptyStateUnauthorised />
+          <EmptyStateUnauthorized />
         ) : (
           <Main>
             <Section className='body'>

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -38,6 +38,7 @@ interface IState {
     tab?: string;
   };
   userId: string;
+  unauthorized: boolean;
 }
 
 class EditNamespace extends React.Component<RouteComponentProps, IState> {
@@ -63,6 +64,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
       redirect: null,
       unsavedData: false,
       params: params,
+      unauthorized: false,
     };
   }
 
@@ -82,13 +84,14 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
       redirect,
       params,
       userId,
+      unauthorized,
     } = this.state;
 
     if (!namespace) {
       return null;
     }
 
-    if (redirect && redirect !== Paths.notFound) {
+    if (redirect) {
       return <Redirect to={redirect} />;
     }
     return (
@@ -113,7 +116,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
           alerts={this.state.alerts}
           closeAlert={i => this.closeAlert(i)}
         />
-        {redirect ? (
+        {unauthorized ? (
           <EmptyStateUnauthorized />
         ) : (
           <Main>
@@ -180,7 +183,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
         this.setState({ namespace: response.data });
       })
       .catch(response => {
-        this.setState({ redirect: Paths.notFound });
+        this.setState({ unauthorized: true });
       });
   }
 

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -537,7 +537,18 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
       ]) ? (
         <EmptyStateFilter />
       ) : (
-        <EmptyStateNoData />
+        <EmptyStateNoData
+          title={'No users added to this group'}
+          description={'Users will appear once added to this group'}
+          button={
+            <Button
+              variant='primary'
+              onClick={() => this.setState({ addModalVisible: true })}
+            >
+              Add
+            </Button>
+          }
+        />
       );
     }
 

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -450,8 +450,27 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
   private renderUsers(users) {
     const { params, itemCount } = this.state;
     const { user } = this.context;
+    const noData =
+      itemCount === 0 &&
+      !filterIsSet(params, ['username', 'first_name', 'last_name', 'email']);
     if (!params['sort']) {
       params['sort'] = 'username';
+    }
+    if (noData) {
+      return (
+        <EmptyStateNoData
+          title={'No users added to this group'}
+          description={'Users will appear once added to this group'}
+          button={
+            <Button
+              variant='primary'
+              onClick={() => this.setState({ addModalVisible: true })}
+            >
+              Add
+            </Button>
+          }
+        />
+      );
     }
     return (
       <Section className='body'>
@@ -529,27 +548,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
   private renderUsersTable(users) {
     const { params } = this.state;
     if (users.length === 0) {
-      return filterIsSet(params, [
-        'username',
-        'first_name',
-        'last_name',
-        'email',
-      ]) ? (
-        <EmptyStateFilter />
-      ) : (
-        <EmptyStateNoData
-          title={'No users added to this group'}
-          description={'Users will appear once added to this group'}
-          button={
-            <Button
-              variant='primary'
-              onClick={() => this.setState({ addModalVisible: true })}
-            >
-              Add
-            </Button>
-          }
-        />
-      );
+      return <EmptyStateFilter />;
     }
 
     let sortTableOptions = {

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -12,6 +12,7 @@ import {
   Breadcrumbs,
   closeAlertMixin,
   CompoundFilter,
+  EmptyStateFilter,
   LoadingPageWithHeader,
   Main,
   Pagination,
@@ -26,14 +27,9 @@ import { formatPath, Paths } from '../../paths';
 import {
   Button,
   DropdownItem,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  EmptyStateVariant,
   Flex,
   FlexItem,
   Modal,
-  Title,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
@@ -41,7 +37,6 @@ import {
 } from '@patternfly/react-core';
 import { Constants } from '../../constants';
 import * as moment from 'moment';
-import { WarningTriangleIcon } from '@patternfly/react-icons';
 import { InsightsUserType } from '../../api/response-types/user';
 import { AppContext } from '../../loaders/app-context';
 
@@ -535,15 +530,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     if (users.length === 0) {
       return (
         <Section className='body'>
-          <EmptyState className='empty' variant={EmptyStateVariant.full}>
-            <EmptyStateIcon icon={WarningTriangleIcon} />
-            <Title headingLevel='h2' size='lg'>
-              No matches
-            </Title>
-            <EmptyStateBody>
-              Please try adjusting your search query.
-            </EmptyStateBody>
-          </EmptyState>
+          <EmptyStateFilter />
         </Section>
       );
     }

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -459,7 +459,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     if (noData) {
       return (
         <EmptyStateNoData
-          title={'No users added to this group'}
+          title={'No users yet'}
           description={'Users will appear once added to this group'}
           button={
             <Button

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -13,6 +13,7 @@ import {
   closeAlertMixin,
   CompoundFilter,
   EmptyStateFilter,
+  EmptyStateNoData,
   LoadingPageWithHeader,
   Main,
   Pagination,
@@ -22,7 +23,7 @@ import {
   Tabs,
 } from '../../components';
 import { GroupAPI, UserAPI, UserType } from '../../api';
-import { ParamHelper, twoWayMapper } from '../../utilities';
+import { filterIsSet, ParamHelper, twoWayMapper } from '../../utilities';
 import { formatPath, Paths } from '../../paths';
 import {
   Button,
@@ -528,10 +529,15 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
   private renderUsersTable(users) {
     const { params } = this.state;
     if (users.length === 0) {
-      return (
-        <Section className='body'>
-          <EmptyStateFilter />
-        </Section>
+      return filterIsSet(params, [
+        'username',
+        'first_name',
+        'last_name',
+        'email',
+      ]) ? (
+        <EmptyStateFilter />
+      ) : (
+        <EmptyStateNoData />
       );
     }
 

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -297,7 +297,18 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
       return filterIsSet(params, ['name']) ? (
         <EmptyStateFilter />
       ) : (
-        <EmptyStateNoData />
+        <EmptyStateNoData
+          title={'No groups yet'}
+          description={'Groups will appear once created'}
+          button={
+            <Button
+              variant='primary'
+              onClick={() => this.setState({ createModalVisible: true })}
+            >
+              Create
+            </Button>
+          }
+        />
       );
     }
 

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -52,6 +52,7 @@ interface IState {
   editModalVisible: boolean;
   selectedGroup: any;
   groupError: any;
+  unauthorized: boolean;
 }
 
 class GroupList extends React.Component<RouteComponentProps, IState> {
@@ -82,12 +83,13 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
       editModalVisible: false,
       selectedGroup: null,
       groupError: null,
+      unauthorized: false,
     };
   }
 
   componentDidMount() {
     if (!this.context.user || !this.context.user.model_permissions.view_group) {
-      this.setState({ redirect: Paths.notFound });
+      this.setState({ unauthorized: true });
     } else {
       this.queryGroups();
     }
@@ -104,12 +106,13 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
       editModalVisible,
       alerts,
       groups,
+      unauthorized,
     } = this.state;
 
     const { user } = this.context;
     const noData = groups.length === 0 && !filterIsSet(params, ['name']);
 
-    if (redirect && redirect !== Paths.notFound) {
+    if (redirect) {
       return <Redirect to={redirect} />;
     }
 
@@ -123,7 +126,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
         {deleteModalVisible ? this.renderDeleteModal() : null}
         {editModalVisible ? this.renderEditModal() : null}
         <BaseHeader title='Groups'></BaseHeader>
-        {redirect ? (
+        {unauthorized ? (
           <EmptyStateUnauthorized />
         ) : noData ? (
           <EmptyStateNoData

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -18,7 +18,7 @@ import {
   CompoundFilter,
   EmptyStateFilter,
   EmptyStateNoData,
-  EmptyStateUnauthorised,
+  EmptyStateUnauthorized,
   GroupModal,
   LoadingPageSpinner,
   Main,
@@ -124,7 +124,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
         {editModalVisible ? this.renderEditModal() : null}
         <BaseHeader title='Groups'></BaseHeader>
         {redirect ? (
-          <EmptyStateUnauthorised />
+          <EmptyStateUnauthorized />
         ) : noData ? (
           <EmptyStateNoData
             title={'No groups yet'}

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -16,6 +16,7 @@ import {
   BaseHeader,
   closeAlertMixin,
   CompoundFilter,
+  EmptyStateFilter,
   GroupModal,
   LoadingPageSpinner,
   Main,
@@ -24,21 +25,13 @@ import {
 } from '../../components';
 import {
   Button,
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  EmptyStateVariant,
   Modal,
-  Title,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import {
-  WarningTriangleIcon,
-  ExclamationTriangleIcon,
-} from '@patternfly/react-icons';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { formatPath, Paths } from '../../paths';
 import { AppContext } from '../../loaders/app-context';
 
@@ -304,17 +297,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
   private renderTable(params) {
     const { groups } = this.state;
     if (groups.length === 0) {
-      return (
-        <EmptyState className='empty' variant={EmptyStateVariant.full}>
-          <EmptyStateIcon icon={WarningTriangleIcon} />
-          <Title headingLevel='h2' size='lg'>
-            No matches
-          </Title>
-          <EmptyStateBody>
-            Please try adjusting your search query.
-          </EmptyStateBody>
-        </EmptyState>
-      );
+      return <EmptyStateFilter />;
     }
 
     let sortTableOptions = {

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -1,11 +1,6 @@
 import * as React from 'react';
 
-import {
-  withRouter,
-  RouteComponentProps,
-  Redirect,
-  Link,
-} from 'react-router-dom';
+import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import { GroupAPI } from '../../api';
 import { mapErrorMessages, ParamHelper } from '../../utilities';
@@ -17,6 +12,7 @@ import {
   closeAlertMixin,
   CompoundFilter,
   EmptyStateFilter,
+  EmptyStateUnauthorised,
   GroupModal,
   LoadingPageSpinner,
   Main,
@@ -101,10 +97,6 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
 
     const { user } = this.context;
 
-    if (redirect) {
-      return <Redirect to={redirect}></Redirect>;
-    }
-
     return (
       <React.Fragment>
         <AlertList
@@ -115,73 +107,77 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
         {deleteModalVisible ? this.renderDeleteModal() : null}
         {editModalVisible ? this.renderEditModal() : null}
         <BaseHeader title='Groups'></BaseHeader>
-        <Main>
-          <Section className='body'>
-            <div className='toolbar'>
-              <Toolbar>
-                <ToolbarContent>
-                  <ToolbarGroup>
-                    <ToolbarItem>
-                      <CompoundFilter
-                        updateParams={p =>
-                          this.updateParams(p, () => this.queryGroups())
-                        }
-                        params={params}
-                        filterConfig={[
-                          {
-                            id: 'name',
-                            title: 'Group',
-                          },
-                        ]}
-                      />
-                    </ToolbarItem>
-                  </ToolbarGroup>
-                  {!!user && user.model_permissions.add_group && (
+        {redirect ? (
+          <EmptyStateUnauthorised />
+        ) : (
+          <Main>
+            <Section className='body'>
+              <div className='toolbar'>
+                <Toolbar>
+                  <ToolbarContent>
                     <ToolbarGroup>
                       <ToolbarItem>
-                        <Button
-                          onClick={() =>
-                            this.setState({ createModalVisible: true })
+                        <CompoundFilter
+                          updateParams={p =>
+                            this.updateParams(p, () => this.queryGroups())
                           }
-                        >
-                          Create
-                        </Button>
+                          params={params}
+                          filterConfig={[
+                            {
+                              id: 'name',
+                              title: 'Group',
+                            },
+                          ]}
+                        />
                       </ToolbarItem>
                     </ToolbarGroup>
-                  )}
-                </ToolbarContent>
-              </Toolbar>
+                    {!!user && user.model_permissions.add_group && (
+                      <ToolbarGroup>
+                        <ToolbarItem>
+                          <Button
+                            onClick={() =>
+                              this.setState({ createModalVisible: true })
+                            }
+                          >
+                            Create
+                          </Button>
+                        </ToolbarItem>
+                      </ToolbarGroup>
+                    )}
+                  </ToolbarContent>
+                </Toolbar>
 
-              <Pagination
-                params={params}
-                updateParams={p =>
-                  this.updateParams(p, () => this.queryGroups())
-                }
-                count={itemCount}
-                isTop
-              />
-            </div>
-            <div>
-              <AppliedFilters
-                updateParams={p =>
-                  this.updateParams(p, () => this.queryGroups())
-                }
-                params={params}
-                ignoredParams={['page_size', 'page', 'sort']}
-              />
-            </div>
-            {loading ? <LoadingPageSpinner /> : this.renderTable(params)}
-            <div style={{ paddingTop: '24px', paddingBottom: '8px' }}>
-              <Pagination
-                params={params}
-                updateParams={p =>
-                  this.updateParams(p, () => this.queryGroups())
-                }
-                count={itemCount}
-              />
-            </div>
-          </Section>
-        </Main>
+                <Pagination
+                  params={params}
+                  updateParams={p =>
+                    this.updateParams(p, () => this.queryGroups())
+                  }
+                  count={itemCount}
+                  isTop
+                />
+              </div>
+              <div>
+                <AppliedFilters
+                  updateParams={p =>
+                    this.updateParams(p, () => this.queryGroups())
+                  }
+                  params={params}
+                  ignoredParams={['page_size', 'page', 'sort']}
+                />
+              </div>
+              {loading ? <LoadingPageSpinner /> : this.renderTable(params)}
+              <div style={{ paddingTop: '24px', paddingBottom: '8px' }}>
+                <Pagination
+                  params={params}
+                  updateParams={p =>
+                    this.updateParams(p, () => this.queryGroups())
+                  }
+                  count={itemCount}
+                />
+              </div>
+            </Section>
+          </Main>
+        )}
       </React.Fragment>
     );
   }

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -94,9 +94,11 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
       deleteModalVisible,
       editModalVisible,
       alerts,
+      groups,
     } = this.state;
 
     const { user } = this.context;
+    const noData = groups.length === 0 && !filterIsSet(params, ['name']);
 
     return (
       <React.Fragment>
@@ -110,6 +112,19 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
         <BaseHeader title='Groups'></BaseHeader>
         {redirect ? (
           <EmptyStateUnauthorised />
+        ) : noData ? (
+          <EmptyStateNoData
+            title={'No groups yet'}
+            description={'Groups will appear once created'}
+            button={
+              <Button
+                variant='primary'
+                onClick={() => this.setState({ createModalVisible: true })}
+              >
+                Create
+              </Button>
+            }
+          />
         ) : (
           <Main>
             <Section className='body'>
@@ -294,22 +309,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
   private renderTable(params) {
     const { groups } = this.state;
     if (groups.length === 0) {
-      return filterIsSet(params, ['name']) ? (
-        <EmptyStateFilter />
-      ) : (
-        <EmptyStateNoData
-          title={'No groups yet'}
-          description={'Groups will appear once created'}
-          button={
-            <Button
-              variant='primary'
-              onClick={() => this.setState({ createModalVisible: true })}
-            >
-              Create
-            </Button>
-          }
-        />
-      );
+      return <EmptyStateFilter />;
     }
 
     let sortTableOptions = {

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -86,7 +86,11 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
   }
 
   componentDidMount() {
-    this.queryGroups();
+    if (!this.context.user || !this.context.user.model_permissions.view_group) {
+      this.setState({ redirect: Paths.notFound });
+    } else {
+      this.queryGroups();
+    }
   }
 
   render() {

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 
-import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
+import {
+  withRouter,
+  RouteComponentProps,
+  Link,
+  Redirect,
+} from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import { GroupAPI } from '../../api';
 import { filterIsSet, mapErrorMessages, ParamHelper } from '../../utilities';
@@ -99,6 +104,10 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
 
     const { user } = this.context;
     const noData = groups.length === 0 && !filterIsSet(params, ['name']);
+
+    if (redirect && redirect !== Paths.notFound) {
+      return <Redirect to={redirect} />;
+    }
 
     return (
       <React.Fragment>

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import { GroupAPI } from '../../api';
-import { mapErrorMessages, ParamHelper } from '../../utilities';
+import { filterIsSet, mapErrorMessages, ParamHelper } from '../../utilities';
 import {
   AlertList,
   AlertType,
@@ -12,6 +12,7 @@ import {
   closeAlertMixin,
   CompoundFilter,
   EmptyStateFilter,
+  EmptyStateNoData,
   EmptyStateUnauthorised,
   GroupModal,
   LoadingPageSpinner,
@@ -293,7 +294,11 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
   private renderTable(params) {
     const { groups } = this.state;
     if (groups.length === 0) {
-      return <EmptyStateFilter />;
+      return filterIsSet(params, ['name']) ? (
+        <EmptyStateFilter />
+      ) : (
+        <EmptyStateNoData />
+      );
     }
 
     let sortTableOptions = {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { RouteComponentProps, Redirect, Link } from 'react-router-dom';
+import { RouteComponentProps, Link } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import {
   Button,
@@ -26,6 +26,7 @@ import {
   LoadingPageWithHeader,
   Main,
   APIButton,
+  EmptyStateUnauthorised,
 } from '../../components';
 
 import { ImportModal } from './import-modal/import-modal';
@@ -103,10 +104,6 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
     const { breadcrumbs } = this.props;
 
-    if (redirect) {
-      return <Redirect to={redirect} />;
-    }
-
     if (!namespace) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
@@ -169,45 +166,49 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           updateParams={p => this.updateParams(p)}
           pageControls={this.renderPageControls()}
         ></PartnerHeader>
-        <Main>
-          <Section className='body'>
-            {tab.toLowerCase() === 'collections' ? (
-              <CollectionList
-                updateParams={params =>
-                  this.updateParams(params, () => this.loadCollections())
-                }
-                params={params}
-                collections={collections}
-                itemCount={itemCount}
-                showControls={this.props.showControls}
-                handleControlClick={(id, action) =>
-                  this.handleCollectionAction(id, action)
-                }
-                repo={this.context.selectedRepo}
-              />
-            ) : null}
-            {tab.toLowerCase() === 'cli configuration' ? (
-              <div>
-                <ClipboardCopy isReadOnly>{repositoryUrl}</ClipboardCopy>
+        {redirect ? (
+          <EmptyStateUnauthorised />
+        ) : (
+          <Main>
+            <Section className='body'>
+              {tab.toLowerCase() === 'collections' ? (
+                <CollectionList
+                  updateParams={params =>
+                    this.updateParams(params, () => this.loadCollections())
+                  }
+                  params={params}
+                  collections={collections}
+                  itemCount={itemCount}
+                  showControls={this.props.showControls}
+                  handleControlClick={(id, action) =>
+                    this.handleCollectionAction(id, action)
+                  }
+                  repo={this.context.selectedRepo}
+                />
+              ) : null}
+              {tab.toLowerCase() === 'cli configuration' ? (
                 <div>
-                  <b>Note:</b> Use this URL to configure ansible-galaxy to
-                  upload collections to this namespace. More information on
-                  ansible-galaxy configurations can be found{' '}
-                  <a
-                    href='https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client'
-                    target='_blank'
-                  >
-                    here
-                  </a>
-                  .
+                  <ClipboardCopy isReadOnly>{repositoryUrl}</ClipboardCopy>
+                  <div>
+                    <b>Note:</b> Use this URL to configure ansible-galaxy to
+                    upload collections to this namespace. More information on
+                    ansible-galaxy configurations can be found{' '}
+                    <a
+                      href='https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client'
+                      target='_blank'
+                    >
+                      here
+                    </a>
+                    .
+                  </div>
                 </div>
-              </div>
-            ) : null}
-            {tab.toLowerCase() === 'resources'
-              ? this.renderResources(namespace)
-              : null}
-          </Section>
-        </Main>
+              ) : null}
+              {tab.toLowerCase() === 'resources'
+                ? this.renderResources(namespace)
+                : null}
+            </Section>
+          </Main>
+        )}
       </React.Fragment>
     );
   }

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -106,12 +106,12 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
     const { breadcrumbs } = this.props;
 
-    if (!namespace) {
-      return <LoadingPageWithHeader></LoadingPageWithHeader>;
+    if (redirect) {
+      return <Redirect to={redirect} />;
     }
 
-    if (redirect && redirect !== Paths.notFound) {
-      return <Redirect to={redirect} />;
+    if (!namespace) {
+      return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
     const tabs = ['Collections'];
@@ -174,67 +174,63 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           updateParams={p => this.updateParams(p)}
           pageControls={this.renderPageControls()}
         ></PartnerHeader>
-        {redirect ? (
-          <EmptyStateUnauthorised />
-        ) : (
-          <Main>
-            {tab.toLowerCase() === 'collections' ? (
-              noData ? (
-                <EmptyStateNoData
-                  title={'No collections yet'}
-                  description={'Collections will appear once uploaded'}
-                  button={
-                    this.props.showControls && (
-                      <Button
-                        onClick={() => this.setState({ showImportModal: true })}
-                      >
-                        Upload collection
-                      </Button>
-                    )
-                  }
-                />
-              ) : (
-                <Section className='body'>
-                  <CollectionList
-                    updateParams={params =>
-                      this.updateParams(params, () => this.loadCollections())
-                    }
-                    params={params}
-                    collections={collections}
-                    itemCount={itemCount}
-                    showControls={this.props.showControls}
-                    handleControlClick={(id, action) =>
-                      this.handleCollectionAction(id, action)
-                    }
-                    repo={this.context.selectedRepo}
-                  />
-                </Section>
-              )
-            ) : null}
-            {tab.toLowerCase() === 'cli configuration' ? (
-              <Section className='body'>
-                <div>
-                  <ClipboardCopy isReadOnly>{repositoryUrl}</ClipboardCopy>
-                  <div>
-                    <b>Note:</b> Use this URL to configure ansible-galaxy to
-                    upload collections to this namespace. More information on
-                    ansible-galaxy configurations can be found{' '}
-                    <a
-                      href='https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client'
-                      target='_blank'
+        <Main>
+          {tab.toLowerCase() === 'collections' ? (
+            noData ? (
+              <EmptyStateNoData
+                title={'No collections yet'}
+                description={'Collections will appear once uploaded'}
+                button={
+                  this.props.showControls && (
+                    <Button
+                      onClick={() => this.setState({ showImportModal: true })}
                     >
-                      here
-                    </a>
-                    .
-                  </div>
-                </div>
+                      Upload collection
+                    </Button>
+                  )
+                }
+              />
+            ) : (
+              <Section className='body'>
+                <CollectionList
+                  updateParams={params =>
+                    this.updateParams(params, () => this.loadCollections())
+                  }
+                  params={params}
+                  collections={collections}
+                  itemCount={itemCount}
+                  showControls={this.props.showControls}
+                  handleControlClick={(id, action) =>
+                    this.handleCollectionAction(id, action)
+                  }
+                  repo={this.context.selectedRepo}
+                />
               </Section>
-            ) : null}
-            {tab.toLowerCase() === 'resources'
-              ? this.renderResources(namespace)
-              : null}
-          </Main>
-        )}
+            )
+          ) : null}
+          {tab.toLowerCase() === 'cli configuration' ? (
+            <Section className='body'>
+              <div>
+                <ClipboardCopy isReadOnly>{repositoryUrl}</ClipboardCopy>
+                <div>
+                  <b>Note:</b> Use this URL to configure ansible-galaxy to
+                  upload collections to this namespace. More information on
+                  ansible-galaxy configurations can be found{' '}
+                  <a
+                    href='https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client'
+                    target='_blank'
+                  >
+                    here
+                  </a>
+                  .
+                </div>
+              </div>
+            </Section>
+          ) : null}
+          {tab.toLowerCase() === 'resources'
+            ? this.renderResources(namespace)
+            : null}
+        </Main>
       </React.Fragment>
     );
   }

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { RouteComponentProps, Link } from 'react-router-dom';
+import { RouteComponentProps, Link, Redirect } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import {
   Button,
@@ -106,6 +106,10 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
     if (!namespace) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
+    }
+
+    if (redirect && redirect !== Paths.notFound) {
+      return <Redirect to={redirect} />;
     }
 
     const tabs = ['Collections'];

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -26,7 +26,7 @@ import {
   LoadingPageWithHeader,
   Main,
   APIButton,
-  EmptyStateUnauthorised,
+  EmptyStateUnauthorized,
   EmptyStateFilter,
   EmptyStateNoData,
 } from '../../components';

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -174,9 +174,19 @@ export class NamespaceList extends React.Component<IProps, IState> {
   }
 
   private renderBody() {
-    const { namespaces, hasPermission } = this.state;
+    const { namespaces, loading } = this.state;
     const { namespacePath } = this.props;
-    const { loading } = this.state;
+    const noDataTitle = Constants.STANDALONE_DEPLOYMENT_MODE
+      ? 'No namespaces yet'
+      : 'No managed namespaces yet';
+    const noDataDescription = Constants.STANDALONE_DEPLOYMENT_MODE
+      ? 'Namespaces will appear once created.'
+      : 'This account is not set up to manage any namespaces. ';
+    const noDataButton = Constants.STANDALONE_DEPLOYMENT_MODE ? (
+      <Button variant='primary' onClick={() => this.handleModalToggle}>
+        Create
+      </Button>
+    ) : null;
 
     if (loading) {
       return (
@@ -192,7 +202,11 @@ export class NamespaceList extends React.Component<IProps, IState> {
           {filterIsSet(this.state.params, ['keywords']) ? (
             <EmptyStateFilter />
           ) : (
-            <EmptyStateNoData />
+            <EmptyStateNoData
+              title={noDataTitle}
+              description={noDataDescription}
+              button={noDataButton}
+            />
           )}
         </Section>
       );

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -104,6 +104,8 @@ export class NamespaceList extends React.Component<IProps, IState> {
     const { namespaces, params, itemCount } = this.state;
     const { title, filterOwner } = this.props;
     const { user } = this.context;
+    const noData =
+      !filterIsSet(this.state.params, ['keywords']) && namespaces.length === 0;
 
     if (!namespaces) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
@@ -135,8 +137,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
           }
         ></NamespaceModal>
         <BaseHeader title={title}>
-          {filterIsSet(this.state.params, ['keywords']) ||
-          namespaces.length !== 0 ? (
+          {noData ? null : (
             <div className='toolbar'>
               <Toolbar
                 params={params}
@@ -159,11 +160,10 @@ export class NamespaceList extends React.Component<IProps, IState> {
                 />
               </div>
             </div>
-          ) : null}
+          )}
         </BaseHeader>
         <Section className='card-area'>{this.renderBody()}</Section>
-        {filterIsSet(this.state.params, ['keywords']) ||
-        namespaces.length !== 0 ? (
+        {noData ? null : (
           <Section className='footer'>
             <Pagination
               params={params}
@@ -174,7 +174,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
               count={itemCount}
             />
           </Section>
-        ) : null}
+        )}
       </div>
     );
   }

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -3,14 +3,6 @@ import './namespace-list.scss';
 
 import { RouteComponentProps } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
-import {
-  EmptyState,
-  EmptyStateIcon,
-  Title,
-  EmptyStateBody,
-  EmptyStateVariant,
-} from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
 
 import { ParamHelper } from '../../utilities/param-helper';
 import {
@@ -21,6 +13,8 @@ import {
   NamespaceModal,
   LoadingPageWithHeader,
   LoadingPageSpinner,
+  EmptyStateFilter,
+  EmptyStateNoData,
 } from '../../components';
 import { Button } from '@patternfly/react-core';
 import { ToolbarItem } from '@patternfly/react-core';
@@ -28,6 +22,7 @@ import { NamespaceAPI, NamespaceListType, MyNamespaceAPI } from '../../api';
 import { Paths, formatPath } from '../../paths';
 import { Constants } from '../../constants';
 import { AppContext } from '../../loaders/app-context';
+import { filterIsSet } from '../../utilities';
 
 interface IState {
   namespaces: NamespaceListType[];
@@ -194,29 +189,11 @@ export class NamespaceList extends React.Component<IProps, IState> {
     if (namespaces.length === 0) {
       return (
         <Section>
-          <EmptyState className='empty' variant={EmptyStateVariant.full}>
-            <EmptyStateIcon icon={SearchIcon} />
-            <Title headingLevel='h2' size='lg'>
-              {hasPermission ? 'No results found' : 'No managed namespaces'}
-            </Title>
-            <EmptyStateBody>
-              {hasPermission
-                ? 'No results match the filter criteria.' +
-                  ' Remove all filters or clear all filters' +
-                  ' to show results.'
-                : 'This account is not set up to manage any namespaces.'}
-            </EmptyStateBody>
-            {hasPermission && (
-              <Button
-                variant='link'
-                onClick={() =>
-                  this.updateParams({}, () => this.loadNamespaces())
-                }
-              >
-                Clear all filters
-              </Button>
-            )}
-          </EmptyState>
+          {filterIsSet(this.state.params, ['keywords']) ? (
+            <EmptyStateFilter />
+          ) : (
+            <EmptyStateNoData />
+          )}
         </Section>
       );
     }

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -105,7 +105,9 @@ export class NamespaceList extends React.Component<IProps, IState> {
     const { title, filterOwner } = this.props;
     const { user } = this.context;
     const noData =
-      !filterIsSet(this.state.params, ['keywords']) && namespaces.length === 0;
+      !filterIsSet(this.state.params, ['keywords']) &&
+      namespaces !== undefined &&
+      namespaces.length === 0;
 
     if (!namespaces) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -135,58 +135,65 @@ export class NamespaceList extends React.Component<IProps, IState> {
           }
         ></NamespaceModal>
         <BaseHeader title={title}>
-          <div className='toolbar'>
-            <Toolbar
-              params={params}
-              sortOptions={[{ title: 'Name', id: 'name', type: 'alpha' }]}
-              searchPlaceholder={'Search ' + title.toLowerCase()}
-              updateParams={p =>
-                this.updateParams(p, () => this.loadNamespaces())
-              }
-              extraInputs={extra}
-            />
-            <div>
-              <Pagination
+          {filterIsSet(this.state.params, ['keywords']) ||
+          namespaces.length !== 0 ? (
+            <div className='toolbar'>
+              <Toolbar
                 params={params}
+                sortOptions={[{ title: 'Name', id: 'name', type: 'alpha' }]}
+                searchPlaceholder={'Search ' + title.toLowerCase()}
                 updateParams={p =>
                   this.updateParams(p, () => this.loadNamespaces())
                 }
-                count={itemCount}
-                isCompact
-                perPageOptions={Constants.CARD_DEFAULT_PAGINATION_OPTIONS}
+                extraInputs={extra}
               />
+              <div>
+                <Pagination
+                  params={params}
+                  updateParams={p =>
+                    this.updateParams(p, () => this.loadNamespaces())
+                  }
+                  count={itemCount}
+                  isCompact
+                  perPageOptions={Constants.CARD_DEFAULT_PAGINATION_OPTIONS}
+                />
+              </div>
             </div>
-          </div>
+          ) : null}
         </BaseHeader>
         <Section className='card-area'>{this.renderBody()}</Section>
-        <Section className='footer'>
-          <Pagination
-            params={params}
-            updateParams={p =>
-              this.updateParams(p, () => this.loadNamespaces())
-            }
-            perPageOptions={Constants.CARD_DEFAULT_PAGINATION_OPTIONS}
-            count={itemCount}
-          />
-        </Section>
+        {filterIsSet(this.state.params, ['keywords']) ||
+        namespaces.length !== 0 ? (
+          <Section className='footer'>
+            <Pagination
+              params={params}
+              updateParams={p =>
+                this.updateParams(p, () => this.loadNamespaces())
+              }
+              perPageOptions={Constants.CARD_DEFAULT_PAGINATION_OPTIONS}
+              count={itemCount}
+            />
+          </Section>
+        ) : null}
       </div>
     );
   }
 
   private renderBody() {
     const { namespaces, loading } = this.state;
-    const { namespacePath } = this.props;
+    const { namespacePath, filterOwner } = this.props;
     const noDataTitle = Constants.STANDALONE_DEPLOYMENT_MODE
       ? 'No namespaces yet'
       : 'No managed namespaces yet';
     const noDataDescription = Constants.STANDALONE_DEPLOYMENT_MODE
-      ? 'Namespaces will appear once created.'
-      : 'This account is not set up to manage any namespaces. ';
-    const noDataButton = Constants.STANDALONE_DEPLOYMENT_MODE ? (
-      <Button variant='primary' onClick={() => this.handleModalToggle}>
-        Create
-      </Button>
-    ) : null;
+      ? 'Namespaces will appear once created'
+      : 'This account is not set up to manage any namespaces';
+    const noDataButton =
+      Constants.STANDALONE_DEPLOYMENT_MODE && filterOwner ? (
+        <Button variant='primary' onClick={() => this.handleModalToggle()}>
+          Create
+        </Button>
+      ) : null;
 
     if (loading) {
       return (

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -10,6 +10,7 @@ import {
   RemoteRepositoryTable,
   LocalRepositoryTable,
   RemoteForm,
+  EmptyStateNoData,
 } from '../../components';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import { ParamHelper, mapErrorMessages } from '../../utilities';
@@ -171,11 +172,7 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
             </div>
           ) : null}
         </BaseHeader>
-        <Main className='repository-list'>
-          <Section className='body'>
-            {this.renderContent(params, loading, itemCount, content)}
-          </Section>
-        </Main>
+        {this.renderContent(params, loading, itemCount, content)}
       </React.Fragment>
     );
   }
@@ -188,36 +185,50 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
       (!!params.tab && params.tab.toLowerCase() === 'local')
     ) {
       return (
-        <div>
-          {loading ? (
-            <LoadingPageSpinner />
-          ) : (
-            <LocalRepositoryTable
-              repositories={content}
-              updateParams={this.updateParams}
-            />
-          )}
-        </div>
+        <Main className='repository-list'>
+          <Section className='body'>
+            {loading ? (
+              <LoadingPageSpinner />
+            ) : (
+              <LocalRepositoryTable
+                repositories={content}
+                updateParams={this.updateParams}
+              />
+            )}
+          </Section>
+        </Main>
       );
     }
     if (!!params.tab && params.tab.toLowerCase() === 'remote') {
-      return (
-        <div>
-          {loading ? (
-            <LoadingPageSpinner />
-          ) : (
-            <RemoteRepositoryTable
-              remotes={content}
-              updateParams={this.updateParams}
-              editRemote={this.selectRemoteToEdit}
-              syncRemote={distro =>
-                RemoteAPI.sync(distro).then(result => this.loadContent())
-              }
-              user={user}
-              refreshRemotes={this.refreshContent}
-            />
-          )}
-        </div>
+      return content.length === 0 ? (
+        <EmptyStateNoData
+          title={'No remote repositories yet'}
+          description={'Remote repositories will appear once added'}
+        />
+      ) : (
+        <Main className='repository-list'>
+          <Section className='body'>
+            {loading ? (
+              <LoadingPageSpinner />
+            ) : (
+              <RemoteRepositoryTable
+                remotes={content}
+                updateParams={this.updateParams}
+                editRemote={(remote: RemoteType) => {
+                  this.setState({
+                    remoteToEdit: remote,
+                    showRemoteFormModal: true,
+                  });
+                }}
+                syncRemote={distro =>
+                  RemoteAPI.sync(distro).then(result => this.loadContent())
+                }
+                user={user}
+                refreshRemotes={this.refreshContent}
+              />
+            )}
+          </Section>
+        </Main>
       );
     }
   }

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -214,12 +214,9 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
               <RemoteRepositoryTable
                 remotes={content}
                 updateParams={this.updateParams}
-                editRemote={(remote: RemoteType) => {
-                  this.setState({
-                    remoteToEdit: remote,
-                    showRemoteFormModal: true,
-                  });
-                }}
+                editRemote={(remote: RemoteType) =>
+                  this.selectRemoteToEdit(remote)
+                }
                 syncRemote={distro =>
                   RemoteAPI.sync(distro).then(result => this.loadContent())
                 }

--- a/src/containers/search/search.scss
+++ b/src/containers/search/search.scss
@@ -4,7 +4,6 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
 
   .toolbar-wrapper {
     .toolbar {

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -5,20 +5,12 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import {
   DataList,
-  EmptyState,
-  EmptyStateIcon,
-  Title,
   Toolbar,
   ToolbarGroup,
   ToolbarItem,
-  EmptyStateBody,
-  EmptyStateVariant,
-  Button,
   ToolbarContent,
   Switch,
 } from '@patternfly/react-core';
-
-import { SearchIcon } from '@patternfly/react-icons';
 
 import {
   BaseHeader,
@@ -29,6 +21,8 @@ import {
   Pagination,
   LoadingPageSpinner,
   AppliedFilters,
+  EmptyStateFilter,
+  EmptyStateNoData,
 } from '../../components';
 import {
   CollectionAPI,
@@ -39,6 +33,7 @@ import {
 import { ParamHelper } from '../../utilities/param-helper';
 import { Constants } from '../../constants';
 import { AppContext } from '../../loaders/app-context';
+import { filterIsSet } from '../../utilities';
 
 interface IState {
   collections: CollectionListType[];
@@ -216,34 +211,17 @@ class Search extends React.Component<RouteComponentProps, IState> {
       return <LoadingPageSpinner></LoadingPageSpinner>;
     }
     if (collections.length === 0) {
-      return this.renderEmpty();
+      return filterIsSet(params, ['keywords', 'tags']) ? (
+        <EmptyStateFilter />
+      ) : (
+        <EmptyStateNoData />
+      );
     }
     if (params.view_type === 'list') {
       return this.renderList(collections);
     } else {
       return this.renderCards(collections);
     }
-  }
-
-  private renderEmpty() {
-    return (
-      <EmptyState className='empty' variant={EmptyStateVariant.full}>
-        <EmptyStateIcon icon={SearchIcon} />
-        <Title headingLevel='h2' size='lg'>
-          No results found
-        </Title>
-        <EmptyStateBody>
-          No results match the search criteria. Remove all filters to show
-          results.
-        </EmptyStateBody>
-        <Button
-          variant='link'
-          onClick={() => this.updateParams({}, () => this.queryCollections())}
-        >
-          Clear search
-        </Button>
-      </EmptyState>
-    );
   }
 
   private renderCards(collections) {

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -214,7 +214,10 @@ class Search extends React.Component<RouteComponentProps, IState> {
       return filterIsSet(params, ['keywords', 'tags']) ? (
         <EmptyStateFilter />
       ) : (
-        <EmptyStateNoData />
+        <EmptyStateNoData
+          title={'No collections yet'}
+          description={'Collections will appear once uploaded'}
+        />
       );
     }
     if (params.view_type === 'list') {

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -90,6 +90,8 @@ class Search extends React.Component<RouteComponentProps, IState> {
 
   render() {
     const { collections, params, numberOfResults } = this.state;
+    const noData =
+      collections.length === 0 && !filterIsSet(params, ['keywords', 'tags']);
 
     const tags = [
       'cloud',
@@ -108,100 +110,113 @@ class Search extends React.Component<RouteComponentProps, IState> {
     return (
       <div className='search-page'>
         <BaseHeader className='header' title='Collections'>
-          <div className='toolbar-wrapper'>
-            <div className='toolbar'>
-              <Toolbar>
-                <ToolbarContent>
-                  <ToolbarGroup>
-                    <ToolbarItem>
-                      <CompoundFilter
-                        updateParams={p =>
-                          this.updateParams(p, () => this.queryCollections())
-                        }
-                        params={params}
-                        filterConfig={[
-                          {
-                            id: 'keywords',
-                            title: 'Keywords',
-                          },
-                          {
-                            id: 'tags',
-                            title: 'Tag',
-                            inputType: 'multiple',
-                            options: tags.map(tag => ({
-                              id: tag,
-                              title: tag,
-                            })),
-                          },
-                        ]}
-                      />
+          {!noData && (
+            <div className='toolbar-wrapper'>
+              <div className='toolbar'>
+                <Toolbar>
+                  <ToolbarContent>
+                    <ToolbarGroup>
                       <ToolbarItem>
-                        <AppliedFilters
-                          style={{ marginTop: '16px' }}
+                        <CompoundFilter
                           updateParams={p =>
                             this.updateParams(p, () => this.queryCollections())
                           }
                           params={params}
-                          ignoredParams={[
-                            'page_size',
-                            'page',
-                            'sort',
-                            'view_type',
+                          filterConfig={[
+                            {
+                              id: 'keywords',
+                              title: 'Keywords',
+                            },
+                            {
+                              id: 'tags',
+                              title: 'Tag',
+                              inputType: 'multiple',
+                              options: tags.map(tag => ({
+                                id: tag,
+                                title: tag,
+                              })),
+                            },
                           ]}
                         />
+                        <ToolbarItem>
+                          <AppliedFilters
+                            style={{ marginTop: '16px' }}
+                            updateParams={p =>
+                              this.updateParams(p, () =>
+                                this.queryCollections(),
+                              )
+                            }
+                            params={params}
+                            ignoredParams={[
+                              'page_size',
+                              'page',
+                              'sort',
+                              'view_type',
+                            ]}
+                          />
+                        </ToolbarItem>
                       </ToolbarItem>
-                    </ToolbarItem>
-                  </ToolbarGroup>
-                </ToolbarContent>
-              </Toolbar>
+                    </ToolbarGroup>
+                  </ToolbarContent>
+                </Toolbar>
 
-              <div className='pagination-container'>
-                <div className='card-list-switcher'>
-                  <CardListSwitcher
-                    size='sm'
+                <div className='pagination-container'>
+                  <div className='card-list-switcher'>
+                    <CardListSwitcher
+                      size='sm'
+                      params={params}
+                      updateParams={p =>
+                        this.updateParams(p, () =>
+                          // Note, we have to use this.state.params instead
+                          // of params in the callback because the callback
+                          // executes before the page can re-run render
+                          // which means params doesn't contain the most
+                          // up to date state
+                          localStorage.setItem(
+                            Constants.SEARCH_VIEW_TYPE_LOCAL_KEY,
+                            this.state.params.view_type,
+                          ),
+                        )
+                      }
+                    />
+                  </div>
+
+                  <Pagination
                     params={params}
                     updateParams={p =>
-                      this.updateParams(p, () =>
-                        // Note, we have to use this.state.params instead
-                        // of params in the callback because the callback
-                        // executes before the page can re-run render
-                        // which means params doesn't contain the most
-                        // up to date state
-                        localStorage.setItem(
-                          Constants.SEARCH_VIEW_TYPE_LOCAL_KEY,
-                          this.state.params.view_type,
-                        ),
-                      )
+                      this.updateParams(p, () => this.queryCollections())
                     }
+                    count={numberOfResults}
+                    perPageOptions={Constants.CARD_DEFAULT_PAGINATION_OPTIONS}
+                    isTop
                   />
                 </div>
-
-                <Pagination
-                  params={params}
-                  updateParams={p =>
-                    this.updateParams(p, () => this.queryCollections())
-                  }
-                  count={numberOfResults}
-                  perPageOptions={Constants.CARD_DEFAULT_PAGINATION_OPTIONS}
-                  isTop
-                />
               </div>
             </div>
-          </div>
+          )}
         </BaseHeader>
-        <Section className='collection-container'>
-          {this.renderCollections(collections, params)}
-        </Section>
-        <Section className='footer'>
-          <Pagination
-            params={params}
-            updateParams={p =>
-              this.updateParams(p, () => this.queryCollections())
-            }
-            perPageOptions={Constants.CARD_DEFAULT_PAGINATION_OPTIONS}
-            count={numberOfResults}
+        {noData ? (
+          <EmptyStateNoData
+            title={'No collections yet'}
+            description={'Collections will appear once uploaded'}
           />
-        </Section>
+        ) : (
+          <React.Fragment>
+            <Section className='collection-container'>
+              {this.renderCollections(collections, params)}
+            </Section>
+            <Section className='footer'>
+              <Pagination
+                params={params}
+                updateParams={p =>
+                  this.updateParams(p, () => this.queryCollections())
+                }
+                perPageOptions={Constants.CARD_DEFAULT_PAGINATION_OPTIONS}
+                count={numberOfResults}
+              />
+            </Section>
+          </React.Fragment>
+        )}
       </div>
     );
   }
@@ -211,14 +226,7 @@ class Search extends React.Component<RouteComponentProps, IState> {
       return <LoadingPageSpinner></LoadingPageSpinner>;
     }
     if (collections.length === 0) {
-      return filterIsSet(params, ['keywords', 'tags']) ? (
-        <EmptyStateFilter />
-      ) : (
-        <EmptyStateNoData
-          title={'No collections yet'}
-          description={'Collections will appear once uploaded'}
-        />
-      );
+      return <EmptyStateFilter />;
     }
     if (params.view_type === 'list') {
       return this.renderList(collections);

--- a/src/containers/user-management/user-create.tsx
+++ b/src/containers/user-management/user-create.tsx
@@ -36,7 +36,7 @@ class UserCreate extends React.Component<RouteComponentProps, IState> {
 
   render() {
     const { user, errorMessages } = this.state;
-    const redirect =
+    const notAutthorised =
       !this.context.user || !this.context.user.model_permissions.add_user;
     const breadcrumbs = [
       { url: Paths.userList, name: 'Users' },
@@ -44,7 +44,7 @@ class UserCreate extends React.Component<RouteComponentProps, IState> {
     ];
     const title = 'Create new user';
 
-    return redirect ? (
+    return notAutthorised ? (
       <React.Fragment>
         <BaseHeader
           breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}

--- a/src/containers/user-management/user-create.tsx
+++ b/src/containers/user-management/user-create.tsx
@@ -36,7 +36,7 @@ class UserCreate extends React.Component<RouteComponentProps, IState> {
 
   render() {
     const { user, errorMessages } = this.state;
-    const notAutthorised =
+    const notAuthorised =
       !this.context.user || !this.context.user.model_permissions.add_user;
     const breadcrumbs = [
       { url: Paths.userList, name: 'Users' },
@@ -44,7 +44,7 @@ class UserCreate extends React.Component<RouteComponentProps, IState> {
     ];
     const title = 'Create new user';
 
-    return notAutthorised ? (
+    return notAuthorised ? (
       <React.Fragment>
         <BaseHeader
           breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}

--- a/src/containers/user-management/user-create.tsx
+++ b/src/containers/user-management/user-create.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 
-import { UserFormPage } from '../../components';
+import {
+  BaseHeader,
+  Breadcrumbs,
+  EmptyStateUnauthorised,
+  UserFormPage,
+} from '../../components';
 import { mapErrorMessages } from '../../utilities';
 import { UserType, UserAPI } from '../../api';
 import { Paths } from '../../paths';
@@ -31,17 +36,27 @@ class UserCreate extends React.Component<RouteComponentProps, IState> {
 
   render() {
     const { user, errorMessages } = this.state;
-    if (!this.context.user || !this.context.user.model_permissions.add_user) {
-      return <Redirect to={Paths.notFound}></Redirect>;
-    }
-    return (
+    const redirect =
+      !this.context.user || !this.context.user.model_permissions.add_user;
+    const breadcrumbs = [
+      { url: Paths.userList, name: 'Users' },
+      { name: 'Create new user' },
+    ];
+    const title = 'Create new user';
+
+    return redirect ? (
+      <React.Fragment>
+        <BaseHeader
+          breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}
+          title={title}
+        ></BaseHeader>
+        <EmptyStateUnauthorised />
+      </React.Fragment>
+    ) : (
       <UserFormPage
         user={user}
-        breadcrumbs={[
-          { url: Paths.userList, name: 'Users' },
-          { name: 'Create new user' },
-        ]}
-        title='Create new user'
+        breadcrumbs={breadcrumbs}
+        title={title}
         errorMessages={errorMessages}
         updateUser={(user, errorMessages) =>
           this.setState({ user: user, errorMessages: errorMessages })

--- a/src/containers/user-management/user-create.tsx
+++ b/src/containers/user-management/user-create.tsx
@@ -4,7 +4,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import {
   BaseHeader,
   Breadcrumbs,
-  EmptyStateUnauthorised,
+  EmptyStateUnauthorized,
   UserFormPage,
 } from '../../components';
 import { mapErrorMessages } from '../../utilities';
@@ -50,7 +50,7 @@ class UserCreate extends React.Component<RouteComponentProps, IState> {
           breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}
           title={title}
         ></BaseHeader>
-        <EmptyStateUnauthorised />
+        <EmptyStateUnauthorized />
       </React.Fragment>
     ) : (
       <UserFormPage

--- a/src/containers/user-management/user-detail.tsx
+++ b/src/containers/user-management/user-detail.tsx
@@ -1,10 +1,5 @@
 import * as React from 'react';
-import {
-  withRouter,
-  RouteComponentProps,
-  Link,
-  Redirect,
-} from 'react-router-dom';
+import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 
 import { Button } from '@patternfly/react-core';
 
@@ -14,6 +9,9 @@ import {
   AlertList,
   closeAlertMixin,
   UserFormPage,
+  EmptyStateUnauthorised,
+  BaseHeader,
+  Breadcrumbs,
 } from '../../components';
 import { UserType, UserAPI } from '../../api';
 import { Paths, formatPath } from '../../paths';
@@ -55,9 +53,12 @@ class UserDetail extends React.Component<RouteComponentProps, IState> {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    if (!!user && !user.model_permissions.view_user) {
-      return <Redirect to={Paths.notFound}></Redirect>;
-    }
+    const redirect = !!user && !user.model_permissions.view_user;
+    const breadcrumbs = [
+      { url: Paths.userList, name: 'Users' },
+      { name: userDetail.username },
+    ];
+    const title = 'User details';
 
     return (
       <>
@@ -77,42 +78,49 @@ class UserDetail extends React.Component<RouteComponentProps, IState> {
             })
           }
         ></DeleteUserModal>
-        <UserFormPage
-          user={userDetail}
-          breadcrumbs={[
-            { url: Paths.userList, name: 'Users' },
-            { name: userDetail.username },
-          ]}
-          title='User details'
-          errorMessages={errorMessages}
-          updateUser={user => this.setState({ userDetail: user })}
-          isReadonly
-          extraControls={
-            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-              {!!user && user.model_permissions.change_user ? (
-                <div>
-                  <Link
-                    to={formatPath(Paths.editUser, {
-                      userID: userDetail.id,
-                    })}
-                  >
-                    <Button>Edit</Button>
-                  </Link>
-                </div>
-              ) : null}
-              {!!user && user.model_permissions.delete_user ? (
-                <div style={{ marginLeft: '8px' }}>
-                  <Button
-                    variant='secondary'
-                    onClick={() => this.setState({ showDeleteModal: true })}
-                  >
-                    Delete
-                  </Button>
-                </div>
-              ) : null}
-            </div>
-          }
-        ></UserFormPage>
+        {redirect ? (
+          <React.Fragment>
+            <BaseHeader
+              breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}
+              title={title}
+            ></BaseHeader>
+            <EmptyStateUnauthorised />{' '}
+          </React.Fragment>
+        ) : (
+          <UserFormPage
+            user={userDetail}
+            breadcrumbs={breadcrumbs}
+            title={title}
+            errorMessages={errorMessages}
+            updateUser={user => this.setState({ userDetail: user })}
+            isReadonly
+            extraControls={
+              <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                {!!user && user.model_permissions.change_user ? (
+                  <div>
+                    <Link
+                      to={formatPath(Paths.editUser, {
+                        userID: userDetail.id,
+                      })}
+                    >
+                      <Button>Edit</Button>
+                    </Link>
+                  </div>
+                ) : null}
+                {!!user && user.model_permissions.delete_user ? (
+                  <div style={{ marginLeft: '8px' }}>
+                    <Button
+                      variant='secondary'
+                      onClick={() => this.setState({ showDeleteModal: true })}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+            }
+          ></UserFormPage>
+        )}
       </>
     );
   }

--- a/src/containers/user-management/user-detail.tsx
+++ b/src/containers/user-management/user-detail.tsx
@@ -53,7 +53,7 @@ class UserDetail extends React.Component<RouteComponentProps, IState> {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    const redirect = !!user && !user.model_permissions.view_user;
+    const notAuthorised = !!user && !user.model_permissions.view_user;
     const breadcrumbs = [
       { url: Paths.userList, name: 'Users' },
       { name: userDetail.username },
@@ -78,7 +78,7 @@ class UserDetail extends React.Component<RouteComponentProps, IState> {
             })
           }
         ></DeleteUserModal>
-        {redirect ? (
+        {notAuthorised ? (
           <React.Fragment>
             <BaseHeader
               breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}

--- a/src/containers/user-management/user-detail.tsx
+++ b/src/containers/user-management/user-detail.tsx
@@ -9,7 +9,7 @@ import {
   AlertList,
   closeAlertMixin,
   UserFormPage,
-  EmptyStateUnauthorised,
+  EmptyStateUnauthorized,
   BaseHeader,
   Breadcrumbs,
 } from '../../components';
@@ -53,7 +53,7 @@ class UserDetail extends React.Component<RouteComponentProps, IState> {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    const notAuthorised = !!user && !user.model_permissions.view_user;
+    const notAuthorized = !!user && !user.model_permissions.view_user;
     const breadcrumbs = [
       { url: Paths.userList, name: 'Users' },
       { name: userDetail.username },
@@ -78,13 +78,13 @@ class UserDetail extends React.Component<RouteComponentProps, IState> {
             })
           }
         ></DeleteUserModal>
-        {notAuthorised ? (
+        {notAuthorized ? (
           <React.Fragment>
             <BaseHeader
               breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}
               title={title}
             ></BaseHeader>
-            <EmptyStateUnauthorised />{' '}
+            <EmptyStateUnauthorized />{' '}
           </React.Fragment>
         ) : (
           <UserFormPage

--- a/src/containers/user-management/user-edit.tsx
+++ b/src/containers/user-management/user-edit.tsx
@@ -39,7 +39,7 @@ class UserEdit extends React.Component<RouteComponentProps, IState> {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    const redirect =
+    const notAuthorised =
       !this.context.user || !this.context.user.model_permissions.change_user;
     const title = 'Edit user';
     const breadcrumbs = [
@@ -51,7 +51,7 @@ class UserEdit extends React.Component<RouteComponentProps, IState> {
       { name: 'Edit' },
     ];
 
-    return redirect ? (
+    return notAuthorised ? (
       <React.Fragment>
         <BaseHeader
           breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}

--- a/src/containers/user-management/user-edit.tsx
+++ b/src/containers/user-management/user-edit.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 
-import { LoadingPageWithHeader, UserFormPage } from '../../components';
+import {
+  BaseHeader,
+  Breadcrumbs,
+  EmptyStateUnauthorised,
+  LoadingPageWithHeader,
+  UserFormPage,
+} from '../../components';
 import { mapErrorMessages } from '../../utilities';
 import { UserType, UserAPI } from '../../api';
 import { Paths, formatPath } from '../../paths';
@@ -33,32 +39,38 @@ class UserEdit extends React.Component<RouteComponentProps, IState> {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    if (
-      !this.context.user ||
-      !this.context.user.model_permissions.change_user
-    ) {
-      return <Redirect to={Paths.notFound}></Redirect>;
-    }
+    const redirect =
+      !this.context.user || !this.context.user.model_permissions.change_user;
+    const title = 'Edit user';
+    const breadcrumbs = [
+      { url: Paths.userList, name: 'Users' },
+      {
+        url: formatPath(Paths.userDetail, { userID: user.id }),
+        name: user.username,
+      },
+      { name: 'Edit' },
+    ];
 
-    return (
+    return redirect ? (
+      <React.Fragment>
+        <BaseHeader
+          breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}
+          title={title}
+        ></BaseHeader>
+        <EmptyStateUnauthorised />
+      </React.Fragment>
+    ) : (
       <UserFormPage
         user={user}
-        breadcrumbs={[
-          { url: Paths.userList, name: 'Users' },
-          {
-            url: formatPath(Paths.userDetail, { userID: user.id }),
-            name: user.username,
-          },
-          { name: 'Edit' },
-        ]}
-        title='Edit user'
+        breadcrumbs={breadcrumbs}
+        title={title}
         errorMessages={errorMessages}
         updateUser={(user, errorMessages) =>
           this.setState({ user: user, errorMessages: errorMessages })
         }
         saveUser={this.saveUser}
         onCancel={() => this.props.history.push(Paths.userList)}
-      ></UserFormPage>
+      />
     );
   }
   private saveUser = () => {

--- a/src/containers/user-management/user-edit.tsx
+++ b/src/containers/user-management/user-edit.tsx
@@ -16,32 +16,41 @@ import { AppContext } from '../../loaders/app-context';
 interface IState {
   user: UserType;
   errorMessages: object;
+  unauthorised: boolean;
 }
 
 class UserEdit extends React.Component<RouteComponentProps, IState> {
   constructor(props) {
     super(props);
 
-    this.state = { user: undefined, errorMessages: {} };
+    this.state = { user: undefined, errorMessages: {}, unauthorised: false };
   }
 
   componentDidMount() {
     const id = this.props.match.params['userID'];
+
     UserAPI.get(id)
-      .then(result => this.setState({ user: result.data }))
-      .catch(() => this.props.history.push(Paths.notFound));
+      .then(result => this.setState({ user: result.data, unauthorised: false }))
+      .catch(() => this.setState({ unauthorised: true }));
   }
 
   render() {
-    const { user, errorMessages } = this.state;
+    const { user, errorMessages, unauthorised } = this.state;
+    const title = 'Edit user';
+
+    if (unauthorised) {
+      return (
+        <React.Fragment>
+          <BaseHeader title={title}></BaseHeader>
+          <EmptyStateUnauthorised />
+        </React.Fragment>
+      );
+    }
 
     if (!user) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    const notAuthorised =
-      !this.context.user || !this.context.user.model_permissions.change_user;
-    const title = 'Edit user';
     const breadcrumbs = [
       { url: Paths.userList, name: 'Users' },
       {
@@ -51,15 +60,7 @@ class UserEdit extends React.Component<RouteComponentProps, IState> {
       { name: 'Edit' },
     ];
 
-    return notAuthorised ? (
-      <React.Fragment>
-        <BaseHeader
-          breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}
-          title={title}
-        ></BaseHeader>
-        <EmptyStateUnauthorised />
-      </React.Fragment>
-    ) : (
+    return (
       <UserFormPage
         user={user}
         breadcrumbs={breadcrumbs}

--- a/src/containers/user-management/user-edit.tsx
+++ b/src/containers/user-management/user-edit.tsx
@@ -4,7 +4,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import {
   BaseHeader,
   Breadcrumbs,
-  EmptyStateUnauthorised,
+  EmptyStateUnauthorized,
   LoadingPageWithHeader,
   UserFormPage,
 } from '../../components';
@@ -16,33 +16,33 @@ import { AppContext } from '../../loaders/app-context';
 interface IState {
   user: UserType;
   errorMessages: object;
-  unauthorised: boolean;
+  unauthorized: boolean;
 }
 
 class UserEdit extends React.Component<RouteComponentProps, IState> {
   constructor(props) {
     super(props);
 
-    this.state = { user: undefined, errorMessages: {}, unauthorised: false };
+    this.state = { user: undefined, errorMessages: {}, unauthorized: false };
   }
 
   componentDidMount() {
     const id = this.props.match.params['userID'];
 
     UserAPI.get(id)
-      .then(result => this.setState({ user: result.data, unauthorised: false }))
-      .catch(() => this.setState({ unauthorised: true }));
+      .then(result => this.setState({ user: result.data, unauthorized: false }))
+      .catch(() => this.setState({ unauthorized: true }));
   }
 
   render() {
-    const { user, errorMessages, unauthorised } = this.state;
+    const { user, errorMessages, unauthorized } = this.state;
     const title = 'Edit user';
 
-    if (unauthorised) {
+    if (unauthorized) {
       return (
         <React.Fragment>
           <BaseHeader title={title}></BaseHeader>
-          <EmptyStateUnauthorised />
+          <EmptyStateUnauthorized />
         </React.Fragment>
       );
     }

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -17,7 +17,7 @@ import {
 import { UserPlusIcon } from '@patternfly/react-icons';
 
 import { UserAPI, UserType } from '../../api';
-import { ParamHelper } from '../../utilities';
+import { ParamHelper, filterIsSet } from '../../utilities';
 import {
   StatefulDropdown,
   CompoundFilter,
@@ -32,6 +32,7 @@ import {
   Main,
   EmptyStateNoData,
   EmptyStateUnauthorised,
+  EmptyStateFilter,
 } from '../../components';
 import { DeleteUserModal } from './delete-user-modal';
 
@@ -207,7 +208,16 @@ class UserList extends React.Component<RouteComponentProps, IState> {
   private renderTable(params) {
     const { users } = this.state;
     if (users.length === 0) {
-      return <EmptyStateNoData />;
+      return filterIsSet(params, [
+        'username',
+        'first_name',
+        'last_name',
+        'email',
+      ]) ? (
+        <EmptyStateFilter />
+      ) : (
+        <EmptyStateNoData />
+      );
     }
 
     let sortTableOptions = {

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react';
 
 import * as moment from 'moment';
-import {
-  withRouter,
-  RouteComponentProps,
-  Link,
-  Redirect,
-} from 'react-router-dom';
+import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import {
   Toolbar,
@@ -35,7 +30,8 @@ import {
   AlertType,
   BaseHeader,
   Main,
-  EmptyStateFilter,
+  EmptyStateNoData,
+  EmptyStateUnauthorised,
 } from '../../components';
 import { DeleteUserModal } from './delete-user-modal';
 
@@ -105,10 +101,6 @@ class UserList extends React.Component<RouteComponentProps, IState> {
 
     const { user } = this.context;
 
-    if (redirect) {
-      return <Redirect to={redirect}></Redirect>;
-    }
-
     return (
       <React.Fragment>
         <AlertList
@@ -128,82 +120,86 @@ class UserList extends React.Component<RouteComponentProps, IState> {
           }
         ></DeleteUserModal>
         <BaseHeader title='Users'></BaseHeader>
-        <Main>
-          <Section className='body'>
-            <div className='toolbar'>
-              <Toolbar>
-                <ToolbarContent>
-                  <ToolbarGroup>
-                    <ToolbarItem>
-                      <CompoundFilter
-                        updateParams={p =>
-                          this.updateParams(p, () => this.queryUsers())
-                        }
-                        params={params}
-                        filterConfig={[
-                          {
-                            id: 'username',
-                            title: 'Username',
-                          },
-                          {
-                            id: 'first_name',
-                            title: 'First name',
-                          },
-                          {
-                            id: 'last_name',
-                            title: 'Last name',
-                          },
-                          {
-                            id: 'email',
-                            title: 'Email',
-                          },
-                        ]}
-                      />
-                    </ToolbarItem>
-                  </ToolbarGroup>
-                  {!!user && user.model_permissions.add_user ? (
+        {redirect ? (
+          <EmptyStateUnauthorised />
+        ) : (
+          <Main>
+            <Section className='body'>
+              <div className='toolbar'>
+                <Toolbar>
+                  <ToolbarContent>
                     <ToolbarGroup>
                       <ToolbarItem>
-                        <Link to={Paths.createUser}>
-                          <Button>Create user</Button>
-                        </Link>
+                        <CompoundFilter
+                          updateParams={p =>
+                            this.updateParams(p, () => this.queryUsers())
+                          }
+                          params={params}
+                          filterConfig={[
+                            {
+                              id: 'username',
+                              title: 'Username',
+                            },
+                            {
+                              id: 'first_name',
+                              title: 'First name',
+                            },
+                            {
+                              id: 'last_name',
+                              title: 'Last name',
+                            },
+                            {
+                              id: 'email',
+                              title: 'Email',
+                            },
+                          ]}
+                        />
                       </ToolbarItem>
                     </ToolbarGroup>
-                  ) : null}
-                </ToolbarContent>
-              </Toolbar>
+                    {!!user && user.model_permissions.add_user ? (
+                      <ToolbarGroup>
+                        <ToolbarItem>
+                          <Link to={Paths.createUser}>
+                            <Button>Create user</Button>
+                          </Link>
+                        </ToolbarItem>
+                      </ToolbarGroup>
+                    ) : null}
+                  </ToolbarContent>
+                </Toolbar>
 
-              <Pagination
-                params={params}
-                updateParams={p =>
-                  this.updateParams(p, () => this.queryUsers())
-                }
-                count={itemCount}
-                isTop
-              />
-            </div>
-            <div>
-              <AppliedFilters
-                updateParams={p =>
-                  this.updateParams(p, () => this.queryUsers())
-                }
-                params={params}
-                ignoredParams={['page_size', 'page', 'sort']}
-              />
-            </div>
-            {loading ? <LoadingPageSpinner /> : this.renderTable(params)}
+                <Pagination
+                  params={params}
+                  updateParams={p =>
+                    this.updateParams(p, () => this.queryUsers())
+                  }
+                  count={itemCount}
+                  isTop
+                />
+              </div>
+              <div>
+                <AppliedFilters
+                  updateParams={p =>
+                    this.updateParams(p, () => this.queryUsers())
+                  }
+                  params={params}
+                  ignoredParams={['page_size', 'page', 'sort']}
+                />
+              </div>
+              {loading ? <LoadingPageSpinner /> : this.renderTable(params)}
 
-            <div style={{ paddingTop: '24px', paddingBottom: '8px' }}>
-              <Pagination
-                params={params}
-                updateParams={p =>
-                  this.updateParams(p, () => this.queryUsers())
-                }
-                count={itemCount}
-              />
-            </div>
-          </Section>
-        </Main>
+              <div style={{ paddingTop: '24px', paddingBottom: '8px' }}>
+                <Pagination
+                  params={params}
+                  updateParams={p =>
+                    this.updateParams(p, () => this.queryUsers())
+                  }
+                  count={itemCount}
+                />
+              </div>
+            </Section>
+          </Main>
+        )}
       </React.Fragment>
     );
   }
@@ -211,7 +207,7 @@ class UserList extends React.Component<RouteComponentProps, IState> {
   private renderTable(params) {
     const { users } = this.state;
     if (users.length === 0) {
-      return <EmptyStateFilter />;
+      return <EmptyStateNoData />;
     }
 
     let sortTableOptions = {

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -56,6 +56,7 @@ interface IState {
   deleteUser: UserType;
   showDeleteModal: boolean;
   alerts: AlertType[];
+  unauthorized: boolean;
 }
 
 class UserList extends React.Component<RouteComponentProps, IState> {
@@ -83,12 +84,13 @@ class UserList extends React.Component<RouteComponentProps, IState> {
       loading: true,
       itemCount: 0,
       alerts: [],
+      unauthorized: false,
     };
   }
 
   componentDidMount() {
     if (!this.context.user || !this.context.user.model_permissions.view_user) {
-      this.setState({ redirect: Paths.notFound });
+      this.setState({ unauthorized: true });
     } else {
       this.queryUsers();
     }
@@ -103,11 +105,12 @@ class UserList extends React.Component<RouteComponentProps, IState> {
       showDeleteModal,
       deleteUser,
       alerts,
+      unauthorized,
     } = this.state;
 
     const { user } = this.context;
 
-    if (redirect && redirect !== Paths.notFound) {
+    if (redirect) {
       return <Redirect to={redirect} />;
     }
 
@@ -130,7 +133,7 @@ class UserList extends React.Component<RouteComponentProps, IState> {
           }
         ></DeleteUserModal>
         <BaseHeader title='Users'></BaseHeader>
-        {redirect ? (
+        {unauthorized ? (
           <EmptyStateUnauthorized />
         ) : (
           <Main>

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -1,7 +1,12 @@
 import * as React from 'react';
 
 import * as moment from 'moment';
-import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
+import {
+  withRouter,
+  RouteComponentProps,
+  Link,
+  Redirect,
+} from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import {
   Toolbar,
@@ -101,6 +106,10 @@ class UserList extends React.Component<RouteComponentProps, IState> {
     } = this.state;
 
     const { user } = this.context;
+
+    if (redirect && redirect !== Paths.notFound) {
+      return <Redirect to={redirect} />;
+    }
 
     return (
       <React.Fragment>

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -15,16 +15,11 @@ import {
   ToolbarContent,
   Button,
   DropdownItem,
-  EmptyState,
-  EmptyStateIcon,
-  Title,
-  EmptyStateBody,
-  EmptyStateVariant,
   Label,
   Tooltip,
 } from '@patternfly/react-core';
 
-import { WarningTriangleIcon, UserPlusIcon } from '@patternfly/react-icons';
+import { UserPlusIcon } from '@patternfly/react-icons';
 
 import { UserAPI, UserType } from '../../api';
 import { ParamHelper } from '../../utilities';
@@ -40,6 +35,7 @@ import {
   AlertType,
   BaseHeader,
   Main,
+  EmptyStateFilter,
 } from '../../components';
 import { DeleteUserModal } from './delete-user-modal';
 
@@ -215,17 +211,7 @@ class UserList extends React.Component<RouteComponentProps, IState> {
   private renderTable(params) {
     const { users } = this.state;
     if (users.length === 0) {
-      return (
-        <EmptyState className='empty' variant={EmptyStateVariant.full}>
-          <EmptyStateIcon icon={WarningTriangleIcon} />
-          <Title headingLevel='h2' size='lg'>
-            No matches
-          </Title>
-          <EmptyStateBody>
-            Please try adjusting your search query.
-          </EmptyStateBody>
-        </EmptyState>
-      );
+      return <EmptyStateFilter />;
     }
 
     let sortTableOptions = {

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -216,7 +216,15 @@ class UserList extends React.Component<RouteComponentProps, IState> {
       ]) ? (
         <EmptyStateFilter />
       ) : (
-        <EmptyStateNoData />
+        <EmptyStateNoData
+          title={'No users yet'}
+          description={'Users will appear once created'}
+          button={
+            <Link to={Paths.createUser}>
+              <Button variant={'primary'}>Create</Button>
+            </Link>
+          }
+        />
       );
     }
 

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -36,7 +36,7 @@ import {
   BaseHeader,
   Main,
   EmptyStateNoData,
-  EmptyStateUnauthorised,
+  EmptyStateUnauthorized,
   EmptyStateFilter,
 } from '../../components';
 import { DeleteUserModal } from './delete-user-modal';
@@ -131,7 +131,7 @@ class UserList extends React.Component<RouteComponentProps, IState> {
         ></DeleteUserModal>
         <BaseHeader title='Users'></BaseHeader>
         {redirect ? (
-          <EmptyStateUnauthorised />
+          <EmptyStateUnauthorized />
         ) : (
           <Main>
             <Section className='body'>

--- a/src/utilities/filter-is-set.ts
+++ b/src/utilities/filter-is-set.ts
@@ -1,0 +1,12 @@
+// Checks that at least one filter is set
+export function filterIsSet(params, filters) {
+  let filterSet = false;
+
+  filters.forEach(filter => {
+    if (filter in params) {
+      filterSet = true;
+    }
+  });
+
+  return filterSet;
+}

--- a/src/utilities/filter-is-set.ts
+++ b/src/utilities/filter-is-set.ts
@@ -1,12 +1,5 @@
 // Checks that at least one filter is set
+import { some } from 'lodash';
 export function filterIsSet(params, filters) {
-  let filterSet = false;
-
-  filters.forEach(filter => {
-    if (filter in params) {
-      filterSet = true;
-    }
-  });
-
-  return filterSet;
+  return some(filters, filter => filter in params);
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -5,3 +5,4 @@ export { mapErrorMessages } from './map-error-messages';
 export { getRepoUrl } from './get-repo-url';
 export { twoWayMapper } from './two-way-mapper';
 export { isFieldSet, clearSetFieldsFromRequest } from './write-only-fields';
+export { filterIsSet } from './filter-is-set';


### PR DESCRIPTION
How it looks so far:
<img width="1666" alt="Screenshot 2021-01-26 at 13 53 44" src="https://user-images.githubusercontent.com/9210860/105847467-efc4df00-5fdd-11eb-9859-d4b0d5b53c91.png">
<img width="1658" alt="Screenshot 2021-01-26 at 13 52 30" src="https://user-images.githubusercontent.com/9210860/105847485-f3f0fc80-5fdd-11eb-8fe5-ace275242e34.png">
<img width="1665" alt="Screenshot 2021-01-26 at 14 49 05" src="https://user-images.githubusercontent.com/9210860/105853211-babc8a80-5fe5-11eb-903e-9c0af4e63a94.png">
<img width="1674" alt="Screenshot 2021-01-26 at 14 51 27" src="https://user-images.githubusercontent.com/9210860/105853477-0838f780-5fe6-11eb-9005-07d88dc541f4.png">

<img width="1670" alt="Screenshot 2021-01-26 at 16 09 37" src="https://user-images.githubusercontent.com/9210860/105863199-ee50e200-5ff0-11eb-90e4-88750cebb0f5.png">

<img width="1659" alt="Screenshot 2021-01-26 at 16 20 05" src="https://user-images.githubusercontent.com/9210860/105864660-72f03000-5ff2-11eb-9caf-daf842728cb8.png">


<img width="1661" alt="Screenshot 2021-01-25 at 15 56 28" src="https://user-images.githubusercontent.com/9210860/105726808-c008cf00-5f2a-11eb-9a1d-73350f9421b6.png">

TODO: 
- [x] add EmptyState component for "filter", "unauthorised" and "no data yet"
- [x] make them fully functional
  - [x] Clear all filters - removed based on UX feedback
  - [x] Add button 
- [x] replace code with components
  - [x] filter
  - [x] unauthorised
  - [x] no data yet
- [x] add check for filter/no data
- [x] src/containers/collection-detail/collection-docs.tsx -> Use EmptyState with red ! icon - followup PR
- [x] EmptyStateNoData -> if possible to add data use "add" icon + primary button else use "search" icon
- [x] "No stuff yet" -> no headers, no footer, no pagination, just title
- [x] fix redirect as it's not always `not-found`
- [x] Exe. Env. needs to use the new nes too.

List of all pages:

Empty state - No data yet:
- Collections
- Namespaces
- My namespaces
- Users (it's there but it shouldn't happen)
- Groups
- Groups - select a group - click on Users tab
- Repo management - Remote tab (it's there but it shouldn't happen)
- Approval 

Empty state - No data for filter:
- Collections
- Namespaces
- My namespaces
- Users
- Groups
- Groups - select a group - click on User tab
- Approval

Empty state - Unauthorised:
- Groups (view and add/edit)
- Users (view and add/edit)
- Approval

Custom "errror" state:
- Collections - select a collection - click documentation tab (it's there but it shouldn't happen)
