### PR TITLE
Save null  when proxy_url is undefined(deleted)

### DIFF
--- a/src/api/remotes.ts
+++ b/src/api/remotes.ts
@@ -41,8 +41,9 @@ class API extends BaseAPI {
       'client_key',
       'client_cert',
       'ca_cert',
+      'proxy_url',
     ]) {
-      if (reducedData[field] === '') {
+      if (reducedData[field] === '' || reducedData[field] === undefined) {
         reducedData[field] = null;
       }
     }


### PR DESCRIPTION
Fixes-Issue: AAH-174

Details:
If a proxy URL has been configured for a remote, it is not possible to remove it. Emptying the field and saving simply leaves the previous value in place. You can change the value, just not remove it.
