### PR TITLE
Add write only field

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -39,3 +39,4 @@ export { MyDistributionAPI } from './my-distribution';
 export { DistributionType } from './response-types/distribution';
 export { ExecutionEnvironmentAPI } from './execution-environment';
 export { ExecutionEnvironmentType } from './response-types/execution-environment';
+export { WriteOnlyFieldType } from './response-types/write-only-field';

--- a/src/api/response-types/remote.ts
+++ b/src/api/response-types/remote.ts
@@ -1,4 +1,5 @@
 import { PulpStatus } from './pulp';
+import { WriteOnlyFieldType } from './write-only-field';
 
 class LastSyncType {
   state: PulpStatus;
@@ -26,6 +27,8 @@ export class RemoteType {
   client_key: string;
   client_cert: string;
   ca_cert: string;
+
+  write_only_fields: WriteOnlyFieldType[];
 
   repositories: {
     name: string;

--- a/src/api/response-types/remote.ts
+++ b/src/api/response-types/remote.ts
@@ -15,18 +15,20 @@ export class RemoteType {
   name: string;
   url: string;
   auth_url: string;
-  token: string;
+  token?: string;
   policy: string;
   requirements_file: string;
   updated_at: string;
   created_at: string;
   username: string;
-  password: string;
-  proxy_url: string;
-  tls_validation: boolean;
-  client_key: string;
-  client_cert: string;
-  ca_cert: string;
+  password?: string;
+  proxy_url?: string;
+  proxy_password?: string;
+  proxy_username?: string;
+  tls_validation?: boolean;
+  client_key?: string;
+  client_cert?: string;
+  ca_cert?: string;
 
   write_only_fields: WriteOnlyFieldType[];
 

--- a/src/api/response-types/write-only-field.ts
+++ b/src/api/response-types/write-only-field.ts
@@ -1,0 +1,4 @@
+export class WriteOnlyFieldType {
+  name: string;
+  is_set: boolean;
+}

--- a/src/components/helper-text/helper-text.tsx
+++ b/src/components/helper-text/helper-text.tsx
@@ -5,7 +5,7 @@ import './helper-text.scss';
 
 interface IProps {
   /** Value to display in the tag */
-  content: string;
+  content: React.ReactNode;
 }
 
 export class HelperText extends React.Component<IProps, {}> {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -48,3 +48,4 @@ export { RemoteRepositoryTable } from './repositories/remote-repository-table';
 export { LocalRepositoryTable } from './repositories/local-repository-table';
 export { StatusIndicator } from './status/status-indicator';
 export { HelperText } from './helper-text/helper-text';
+export { WriteOnlyField } from './patternfly-wrappers/write-only-field';

--- a/src/components/patternfly-wrappers/write-only-field.tsx
+++ b/src/components/patternfly-wrappers/write-only-field.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { Button, InputGroup, TextInput } from '@patternfly/react-core';
+
+interface IProps {
+  /** Specify if the value is set on the backend already */
+  isValueSet: boolean;
+
+  /** Function to set the value to null */
+  onClear: () => void;
+
+  /**
+    Component to display when the user is allowed to update this field.
+   */
+  children: any;
+}
+
+export class WriteOnlyField extends React.Component<IProps> {
+  render() {
+    const { onClear, isValueSet, children } = this.props;
+
+    if (!isValueSet) {
+      return children;
+    }
+
+    return (
+      <InputGroup>
+        <TextInput
+          aria-label='hidden value'
+          placeholder='••••••••••••••••••••••'
+          type='password'
+          isDisabled={isValueSet}
+        />
+        {isValueSet && (
+          <Button onClick={() => onClear()} variant='control'>
+            Clear
+          </Button>
+        )}
+      </InputGroup>
+    );
+  }
+}

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -14,7 +14,7 @@ import {
   ExpandableSection,
 } from '@patternfly/react-core';
 
-import { WriteOnlyField } from '../../components';
+import { WriteOnlyField, HelperText } from '../../components';
 
 import { DownloadIcon } from '@patternfly/react-icons';
 
@@ -139,6 +139,9 @@ export class RemoteForm extends React.Component<IProps, IState> {
         <FormGroup
           fieldId={'url'}
           label={'URL'}
+          labelIcon={
+            <HelperText content='The URL of an external content source.' />
+          }
           isRequired={requiredFields.includes('url')}
           validated={this.toError(!('url' in errorMessages))}
           helperTextInvalid={errorMessages['url']}
@@ -157,6 +160,9 @@ export class RemoteForm extends React.Component<IProps, IState> {
           <FormGroup
             fieldId={'token'}
             label={'Token'}
+            labelIcon={
+              <HelperText content='Token for authenticating to the server URL.' />
+            }
             isRequired={requiredFields.includes('token')}
             validated={this.toError(!('token' in errorMessages))}
             helperTextInvalid={errorMessages['token']}
@@ -181,6 +187,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
           <FormGroup
             fieldId={'auth_url'}
             label={'SSO URL'}
+            labelIcon={<HelperText content='Single sign on URL.' />}
             isRequired={requiredFields.includes('auth_url')}
             validated={this.toError(!('auth_url' in errorMessages))}
             helperTextInvalid={errorMessages['auth_url']}
@@ -200,6 +207,23 @@ export class RemoteForm extends React.Component<IProps, IState> {
           <FormGroup
             fieldId={'yaml'}
             label={'YAML requirements'}
+            labelIcon={
+              <HelperText
+                content={
+                  <>
+                    This uses the same{' '}
+                    <a
+                      target='_blank'
+                      href='https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#install-multiple-collections-with-a-requirements-file'
+                    >
+                      requirements.yml
+                    </a>{' '}
+                    format as the ansible-galaxy CLI with the caveat that roles
+                    aren't supported and the source parameter is not supported.
+                  </>
+                }
+              />
+            }
             isRequired={requiredFields.includes('requirements_file')}
             validated={this.toError(!('requirements_file' in errorMessages))}
             helperTextInvalid={errorMessages['requirements_file']}
@@ -251,6 +275,9 @@ export class RemoteForm extends React.Component<IProps, IState> {
           <FormGroup
             fieldId={'username'}
             label={'Username'}
+            labelIcon={
+              <HelperText content='The username to be used for authentication when syncing. This is not required when using a token.' />
+            }
             isRequired={requiredFields.includes('username')}
             validated={this.toError(!('username' in errorMessages))}
             helperTextInvalid={errorMessages['username']}
@@ -268,6 +295,9 @@ export class RemoteForm extends React.Component<IProps, IState> {
           <FormGroup
             fieldId={'password'}
             label={'Password'}
+            labelIcon={
+              <HelperText content='The password to be used for authentication when syncing. This is not required when using a token.' />
+            }
             isRequired={requiredFields.includes('password')}
             validated={this.toError(!('password' in errorMessages))}
             helperTextInvalid={errorMessages['password']}
@@ -304,9 +334,57 @@ export class RemoteForm extends React.Component<IProps, IState> {
               onChange={value => this.updateRemote(value, 'proxy_url')}
             />
           </FormGroup>
+
+          <FormGroup
+            fieldId={'proxy_username'}
+            label={'Proxy username'}
+            isRequired={requiredFields.includes('proxy_username')}
+            validated={this.toError(!('proxy_username' in errorMessages))}
+            helperTextInvalid={errorMessages['proxy_username']}
+          >
+            <TextInput
+              validated={this.toError(!('proxy_username' in errorMessages))}
+              isRequired={requiredFields.includes('proxy_username')}
+              isDisabled={disabledFields.includes('proxy_username')}
+              id='proxy_username'
+              type='text'
+              value={remote.proxy_username || ''}
+              onChange={value => this.updateRemote(value, 'proxy_username')}
+            />
+          </FormGroup>
+
+          <FormGroup
+            fieldId={'proxy_password'}
+            label={'Proxy password'}
+            isRequired={requiredFields.includes('proxy_password')}
+            validated={this.toError(!('proxy_password' in errorMessages))}
+            helperTextInvalid={errorMessages['proxy_password']}
+          >
+            <WriteOnlyField
+              isValueSet={isFieldSet(
+                'proxy_password',
+                remote.write_only_fields,
+              )}
+              onClear={() => this.updateIsSet('proxy_password', false)}
+            >
+              <TextInput
+                validated={this.toError(!('proxy_password' in errorMessages))}
+                isRequired={requiredFields.includes('proxy_password')}
+                isDisabled={disabledFields.includes('proxy_password')}
+                id='proxy_password'
+                type='text'
+                value={remote.proxy_password || ''}
+                onChange={value => this.updateRemote(value, 'proxy_password')}
+              />
+            </WriteOnlyField>
+          </FormGroup>
+
           <FormGroup
             fieldId={'tls_validation'}
             label={'TLS validation'}
+            labelIcon={
+              <HelperText content='If selected, TLS peer validation must be performed.' />
+            }
             isRequired={requiredFields.includes('tls_validation')}
             validated={this.toError(!('tls_validation' in errorMessages))}
             helperTextInvalid={errorMessages['tls_validation']}
@@ -320,6 +398,9 @@ export class RemoteForm extends React.Component<IProps, IState> {
           <FormGroup
             fieldId={'client_key'}
             label={'Client key'}
+            labelIcon={
+              <HelperText content='A PEM encoded private key used for authentication.' />
+            }
             isRequired={requiredFields.includes('client_key')}
             validated={this.toError(!('client_key' in errorMessages))}
             helperTextInvalid={errorMessages['client_key']}
@@ -346,7 +427,10 @@ export class RemoteForm extends React.Component<IProps, IState> {
           </FormGroup>
           <FormGroup
             fieldId={'client_cert'}
-            label={'Client certification'}
+            label={'Client certificate'}
+            labelIcon={
+              <HelperText content='A PEM encoded client certificate used for authentication.' />
+            }
             isRequired={requiredFields.includes('client_cert')}
             validated={this.toError(!('client_cert' in errorMessages))}
             helperTextInvalid={errorMessages['client_cert']}
@@ -390,7 +474,10 @@ export class RemoteForm extends React.Component<IProps, IState> {
           </FormGroup>
           <FormGroup
             fieldId={'ca_cert'}
-            label={'CA certification'}
+            label={'CA certificate'}
+            labelIcon={
+              <HelperText content='A PEM encoded client certificate used for authentication.' />
+            }
             isRequired={requiredFields.includes('ca_cert')}
             validated={this.toError(!('ca_cert' in errorMessages))}
             helperTextInvalid={errorMessages['ca_cert']}
@@ -434,6 +521,9 @@ export class RemoteForm extends React.Component<IProps, IState> {
           <FormGroup
             fieldId={'download_concurrency'}
             label={'Download concurrency'}
+            labelIcon={
+              <HelperText content='Total number of simultaneous connections.' />
+            }
             validated={remote.download_concurrency > 0 ? 'default' : 'error'}
             helperTextInvalid={'Number must be greater than 0'}
           >

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -48,7 +48,10 @@ interface IState {
 }
 
 class RepositoryList extends React.Component<RouteComponentProps, IState> {
-  nonQueryStringParams = ['repository'];
+  nonQueryStringParams = ['repository', 'tab'];
+  // Used to save a copy of the remote before it's edited. This can be used to determine
+  // which fields were changed when a user hits save.
+  unModifiedRemote: RemoteType;
 
   constructor(props) {
     super(props);
@@ -113,12 +116,11 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
                 const distro_path =
                   remoteToEdit.repositories[0].distributions[0].base_path;
 
-                // Pulp complains about auth_url = null, so make sure the auth_url
-                // property is unset if its null or empty.
-                if (!remoteToEdit['auth_url']) {
-                  delete remoteToEdit['auth_url'];
-                }
-                RemoteAPI.update(distro_path, remoteToEdit)
+                RemoteAPI.smartUpdate(
+                  distro_path,
+                  remoteToEdit,
+                  this.unModifiedRemote,
+                )
                   .then(r => {
                     this.setState(
                       {
@@ -207,12 +209,7 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
             <RemoteRepositoryTable
               remotes={content}
               updateParams={this.updateParams}
-              editRemote={(remote: RemoteType) => {
-                this.setState({
-                  remoteToEdit: remote,
-                  showRemoteFormModal: true,
-                });
-              }}
+              editRemote={this.selectRemoteToEdit}
               syncRemote={distro =>
                 RemoteAPI.sync(distro).then(result => this.loadContent())
               }
@@ -224,6 +221,18 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
       );
     }
   }
+
+  private selectRemoteToEdit = (remote: RemoteType) => {
+    // save a copy of the remote to diff against
+    this.unModifiedRemote = { ...remote };
+
+    this.setState({
+      // create a copy of the remote to pass to the edit form, so that the
+      // list of remotes doesn't get updated by accident.
+      remoteToEdit: { ...remote },
+      showRemoteFormModal: true,
+    });
+  };
 
   private refreshContent = () => {
     this.loadContent(false);

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -48,7 +48,7 @@ interface IState {
 }
 
 class RepositoryList extends React.Component<RouteComponentProps, IState> {
-  nonQueryStringParams = ['repository', 'tab'];
+  nonQueryStringParams = ['repository'];
   // Used to save a copy of the remote before it's edited. This can be used to determine
   // which fields were changed when a user hits save.
   unModifiedRemote: RemoteType;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -4,3 +4,4 @@ export { sanitizeDocsUrls } from './sanitize-docs-urls';
 export { mapErrorMessages } from './map-error-messages';
 export { getRepoUrl } from './get-repo-url';
 export { twoWayMapper } from './two-way-mapper';
+export { isFieldSet, clearSetFieldsFromRequest } from './write-only-fields';

--- a/src/utilities/write-only-fields.ts
+++ b/src/utilities/write-only-fields.ts
@@ -1,0 +1,31 @@
+import { WriteOnlyFieldType } from '../api';
+
+export function isFieldSet(
+  name: string,
+  writeOnlyFields: WriteOnlyFieldType[],
+) {
+  const field = writeOnlyFields.find(el => el.name === name);
+  if (field) {
+    console.log(field);
+    return field.is_set;
+  } else {
+    throw `Field ${name} is not in writeOnlyFields`;
+  }
+}
+
+// Deletes any write only fields from the object so that they don't
+// get sent to the API
+export function clearSetFieldsFromRequest(
+  data: any,
+  writeOnlyFields: WriteOnlyFieldType[],
+): object {
+  const newObj = { ...data };
+
+  for (const field of writeOnlyFields) {
+    if (field.is_set) {
+      delete newObj[field.name];
+    }
+  }
+
+  return newObj;
+}


### PR DESCRIPTION
Waiting for the following to merged/fixed:
- [x] https://github.com/ansible/galaxy_ng/pull/630
- [x] https://github.com/ansible/galaxy_ng/pull/626

Fixes: https://issues.redhat.com/browse/AAH-120

Adds a WriteOnlyField component and uses it on the remotes form to make it clearer when a user is resetting their password.

![Screen Shot 2021-02-02 at 3 31 27 PM](https://user-images.githubusercontent.com/6063371/106659567-ebb03880-656c-11eb-96ed-4842831cd6cb.png)
![Screen Shot 2021-02-02 at 3 31 35 PM](https://user-images.githubusercontent.com/6063371/106659568-ec48cf00-656c-11eb-8d4e-8fa7f9336294.png)

