### PR TITLE
Add tests for super-user and self deletion, refactor user-dashboard.js

### DIFF
--- a/test/cypress/integration/user_dashboard.js
+++ b/test/cypress/integration/user_dashboard.js
@@ -1,32 +1,44 @@
 describe('Hub User Management Tests', () => {
-    var host = Cypress.env('host');
-    var adminUsername = Cypress.env('username');
-    var adminPassword = Cypress.env('password');
+    let host = Cypress.env('host');
+    let adminUsername = Cypress.env('username');
+    let adminPassword = Cypress.env('password');
+    let username = 'test';
+    let password = 'p@ssword1';
 
-    beforeEach(() => {
+    before(() => {
         cy.visit(host);
-
         cy.login(adminUsername, adminPassword);
 
-        cy.contains('#page-sidebar a', 'Users').click();
+        cy.createUser(username, password, 'Test F', 'Test L', 'test@example.com');
+        cy.contains('[aria-labelledby=test]', 'Test F');
+
+        cy.createGroup('delete-user');
+        cy.addPermissions('delete-user', [{group: 'users', permissions: ['View user', 'Delete user']}]);
+        cy.addUserToGroup('delete-user', username);
+        cy.logout();
     });
 
-    it('User table lists users', () => {
-        cy.contains('[aria-label="User list"] [aria-labelledby=admin]', 'admin');
+    describe('basic check of user page', () => {
+        beforeEach(() => {
+            cy.visit(host);
+            cy.login(adminUsername, adminPassword);
+            cy.contains('#page-sidebar a', 'Users').click();
+        });
+
+        it('User table lists users', () => {
+            cy.contains('[aria-label="User list"] [aria-labelledby=admin]', 'admin');
+        });
     });
 
     describe('Creation and management of users', () => {
-        var username = 'test';
-        var password = 'p@ssword1';
         beforeEach(() => {
-            cy.createUser(username, password, 'Test F', 'Test L', 'test@example.com');
-            cy.contains('[aria-labelledby=test]', 'Test F');
+            cy.visit(host);
+            cy.login(adminUsername, adminPassword);
+            cy.contains('#page-sidebar a', 'Users').click();
         });
 
         afterEach(() => {
             cy.logout();
-            cy.login(adminUsername, adminPassword);
-            cy.deleteUser('test');
         });
 
         it('Can create new users', () => {
@@ -36,5 +48,42 @@ describe('Hub User Management Tests', () => {
 
             cy.contains('.body', 'Test F').not();
         });
+    });
+
+    describe('prevents super-user and self deletion', () => {
+        beforeEach(() => {
+            cy.visit(host);
+        });
+        afterEach(() => {
+            cy.logout();
+        });
+
+        function attemptToDelete(toDelete) {
+            cy.contains('#page-sidebar a', 'Users').click();
+            cy.get(`[aria-labelledby=${toDelete}] [aria-label=Actions]`).click();
+            cy.containsnear(`[aria-labelledby=${toDelete}] [aria-label=Actions]`, 'Delete').click();
+            cy.get('footer > button:contains("Delete")').should('be.disabled');
+            cy.get('footer > button:contains("Cancel")').click();
+        }
+
+        it('an ordinary user can\'t delete themselves', () => {
+            cy.login(username, password);
+            attemptToDelete(username);
+        });
+        it('an ordinary user can\'t delete the super-user', () => {
+            cy.login(username, password);
+            attemptToDelete(adminUsername);
+        });
+
+        it('the super-user can\'t delete themselves', () => {
+            cy.login(adminUsername, adminPassword);
+            attemptToDelete(adminUsername);
+        });
+    });
+    
+    after(() => {
+        cy.login(adminUsername, adminPassword);
+        cy.deleteUser(username);
+        cy.deleteGroup('delete-user');
     });
 });


### PR DESCRIPTION
The tests are fairly straightforward and verify the fix for AAH-329. The refactor consisted of moving the user and group creation to a 'before' step, rather than creating and deleting the test user at the start and end of each test. This shortens the test run by a tiny bit and also makes it easier to understand what's going on where.