### PR TITLE
Add test for adding and removing remote repository credentials AAH-120.

### DIFF
--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -30,7 +30,7 @@ describe('Repo Management tests', () => {
         cy.get('input[id="proxy_password"]').type('test');
         cy.route('PUT', Cypress.env('prefix') + 'content/community/v3/sync/config/').as('saveConfig');
         cy.contains('Save').click();
-        cy.wait('@saveConfig');
+        cy.wait('@saveConfig').its('status').should('eq', 200);
 
         // verify values have been saved properly.
         cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
@@ -47,7 +47,7 @@ describe('Repo Management tests', () => {
         cy.get('input[id="proxy_username"]').clear();
         cy.route('PUT', Cypress.env('prefix') + 'content/community/v3/sync/config/').as('saveConfig');
         cy.contains('Save').click();
-        cy.wait('@saveConfig');
+        cy.wait('@saveConfig').its('status').should('eq', 200);
 
         // verify the values have been deleted
         cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo

--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -15,4 +15,47 @@ describe('Repo Management tests', () => {
         cy.contains('Show advanced options').click();
         cy.get('#download_concurrency').should('exist');
     });
+    it('remote proxy config can be saved and deleted.', () => {
+        cy.login(adminUsername, adminPassword);
+        cy.visit(host + 'ui/repositories?page_size=10&tab=remote');
+        cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+        cy.contains('Edit').click();
+        cy.contains('Show advanced options').click();
+
+        // first fill it up with data
+        cy.get('input[id="username"]').type('test');
+        cy.get('input[id="password"]').type('test');
+        cy.get('input[id="proxy_url"]').type('https://example.org');
+        cy.get('input[id="proxy_username"]').type('test');
+        cy.get('input[id="proxy_password"]').type('test');
+        cy.route('PUT', Cypress.env('prefix') + 'content/community/v3/sync/config/').as('saveConfig');
+        cy.contains('Save').click();
+        cy.wait('@saveConfig');
+
+        // verify values have been saved properly.
+        cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+        cy.contains('Edit').click();
+        cy.contains('Show advanced options').click();
+        cy.get('input[id="username"]').should('have.value', 'test');
+        cy.get('input[id="proxy_url"]').should('have.value', 'https://example.org');
+        cy.get('input[id="proxy_username"]').should('have.value', 'test');
+
+        // clear the values
+        cy.get('input[id="username"]').clear();
+        cy.get('input[type="password"]').siblings('button').click({ multiple: true });
+        cy.get('input[id="proxy_url"]').clear();
+        cy.get('input[id="proxy_username"]').clear();
+        cy.route('PUT', Cypress.env('prefix') + 'content/community/v3/sync/config/').as('saveConfig');
+        cy.contains('Save').click();
+        cy.wait('@saveConfig');
+
+        // verify the values have been deleted
+        cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+        cy.contains('Edit').click();
+        cy.contains('Show advanced options').click();
+        cy.get('input[id="username"]').should('have.value', '');
+        cy.get('input[id="password"]').should('have.value', '');
+        cy.get('input[id="proxy_url"]').should('have.value', '');
+        cy.get('input[id="proxy_password"]').should('have.value', '');
+    });
 });


### PR DESCRIPTION
I debated adding a command to handle setting and verifying the configuration options, but as it's currently just 1 test I think it's good the way it is. When we come back to this however, it's probably a good idea to clean up the test interface for setting remote repository config.

These tests pass currently, so feel free to merge as soon as you've reviewed.