### PR TITLE
Use new UI API endpoint for Container List View

### DIFF
--- a/src/api/execution-environment.ts
+++ b/src/api/execution-environment.ts
@@ -1,31 +1,10 @@
-import { PulpAPI } from './pulp';
+import { HubAPI } from './hub';
 
-class API extends PulpAPI {
-  apiPath = 'repositories/container/container-push/';
+class API extends HubAPI {
+  apiPath = this.getUIPath('execution-environments/repositories/');
 
   constructor() {
     super();
-  }
-
-  list(params?: object, apiPath?: string) {
-    // Pulp specific: replace sort with ordering
-    let modifiedParams = this.mapPageToOffset(params);
-    modifiedParams['ordering'] = params['sort'];
-    delete modifiedParams['sort'];
-
-    return this.http
-      .get(this.getPath(apiPath), {
-        params: modifiedParams,
-      })
-      .then(results =>
-        Promise.all(
-          results.data.results.map(result =>
-            this.http
-              .get(result.latest_version_href.replace('/pulp/api/v3/', ''), {})
-              .then(data => (result['last_modified'] = data.data.pulp_created)),
-          ),
-        ).then(() => results),
-      );
   }
 }
 

--- a/src/api/response-types/execution-environment.ts
+++ b/src/api/response-types/execution-environment.ts
@@ -1,6 +1,6 @@
 export class ExecutionEnvironmentType {
-  pulp_created: string;
+  created: string;
   name: string;
   description: string;
-  latest_version_href: string;
+  updated: string;
 }

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -175,12 +175,12 @@ class ExecutionEnvironmentList extends React.Component<
         {
           title: 'Created',
           type: 'numeric',
-          id: 'pulp_created',
+          id: 'created',
         },
         {
           title: 'Last modified',
-          type: 'none',
-          id: 'pulp_modified',
+          type: 'alpha',
+          id: 'updated',
         },
       ],
     };
@@ -211,8 +211,8 @@ class ExecutionEnvironmentList extends React.Component<
         ) : (
           <td></td>
         )}
-        <td>{moment(item.pulp_created).fromNow()}</td>
-        <td>{moment(item.last_modified).fromNow()}</td>
+        <td>{moment(item.created).fromNow()}</td>
+        <td>{moment(item.updated).fromNow()}</td>
       </tr>
     );
   }
@@ -221,8 +221,8 @@ class ExecutionEnvironmentList extends React.Component<
     this.setState({ loading: true }, () =>
       ExecutionEnvironmentAPI.list(this.state.params).then(result =>
         this.setState({
-          items: result.data.results,
-          itemCount: result.data.count,
+          items: result.data.data,
+          itemCount: result.data.meta.count,
           loading: false,
         }),
       ),


### PR DESCRIPTION
Fixes: AAH-366

Before:
`http://localhost:8002/pulp/api/v3/repositories/container/container-push/{id}/versions/{version number}/` returns 404
<img width="1678" alt="Screenshot 2021-02-22 at 14 15 33" src="https://user-images.githubusercontent.com/9210860/108713413-79ea5f80-7518-11eb-875d-3222f07e72b7.png">
After:
<img width="1646" alt="Screenshot 2021-02-22 at 14 13 00" src="https://user-images.githubusercontent.com/9210860/108713401-7656d880-7518-11eb-9181-82cbde062853.png">

