### PR TITLE
Delete modal - create a shared delete modal, use for all deletions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 # ide config
 .idea/
 
+# vim swap
+.*.sw[po]
+
 # dependencies
 node_modules
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 src/index.html
 *.json
+.*.sw[po]

--- a/src/components/delete-modal/delete-modal.tsx
+++ b/src/components/delete-modal/delete-modal.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Button, Modal, Spinner } from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 interface IProps {
   cancelAction: () => void;

--- a/src/components/delete-modal/delete-modal.tsx
+++ b/src/components/delete-modal/delete-modal.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { Button, Modal, Spinner } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+
+interface IProps {
+  cancelAction: () => void;
+  children?: any;
+  deleteAction: () => void;
+  isDisabled?: boolean;
+  title: string;
+  spinner?: boolean;
+}
+
+export class DeleteModal extends React.Component<IProps> {
+  render() {
+    const {
+      cancelAction,
+      children,
+      deleteAction,
+      isDisabled,
+      title,
+      spinner,
+    } = this.props;
+
+    return (
+      <Modal
+        actions={[
+          <Button
+            key='delete'
+            onClick={deleteAction}
+            variant='danger'
+            isDisabled={isDisabled}
+          >
+            Delete
+            {spinner && <Spinner size='sm'></Spinner>}
+          </Button>,
+          <Button key='cancel' onClick={cancelAction} variant='link'>
+            Cancel
+          </Button>,
+        ]}
+        isOpen={true}
+        onClose={cancelAction}
+        title={title}
+        titleIconVariant='warning'
+        variant='small'
+      >
+        {children}
+      </Modal>
+    );
+  }
+}

--- a/src/containers/group-management/delete-group-modal.tsx
+++ b/src/containers/group-management/delete-group-modal.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { List, ListItem, Spinner } from '@patternfly/react-core';
+import { DeleteModal } from '../../components/delete-modal/delete-modal';
+
+interface IProps {
+  count?: number;
+  cancelAction: () => void;
+  deleteAction: () => void;
+  name: string;
+  users?: any[];
+}
+
+export class DeleteGroupModal extends React.Component<IProps> {
+  render() {
+    const { cancelAction, count, deleteAction, name, users } = this.props;
+
+    return (
+      <DeleteModal
+        cancelAction={cancelAction}
+        deleteAction={deleteAction}
+        title='Delete group?'
+      >
+        <b>{name}</b> will be permanently deleted.
+        <p>&nbsp;</p>
+        <div>
+          {users && count > 10 && (
+            <p>Deleting this group will affect {count} users.</p>
+          )}
+          {users && count > 0 && count <= 10 && (
+            <>
+              <p>These users will lose access to the group content:</p>
+              <List>
+                {users.map(u => (
+                  <ListItem key={u.username}>
+                    <b>{u.username}</b>
+                  </ListItem>
+                ))}
+              </List>
+            </>
+          )}
+          {users && !count && <p>No users will be affected.</p>}
+          {!users && (
+            <p>
+              Checking for affected users... <Spinner size='sm' />
+            </p>
+          )}
+        </div>
+      </DeleteModal>
+    );
+  }
+}

--- a/src/containers/group-management/delete-group-modal.tsx
+++ b/src/containers/group-management/delete-group-modal.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { List, ListItem, Spinner } from '@patternfly/react-core';
 import { DeleteModal } from '../../components/delete-modal/delete-modal';
+import { UserType } from '../../api';
 
 interface IProps {
   count?: number;
   cancelAction: () => void;
   deleteAction: () => void;
   name: string;
-  users?: any[];
+  users?: UserType[];
 }
 
 export class DeleteGroupModal extends React.Component<IProps> {

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -30,10 +30,7 @@ import {
   DropdownItem,
   Flex,
   FlexItem,
-  List,
-  ListItem,
   Modal,
-  Spinner,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
@@ -43,6 +40,7 @@ import { Constants } from '../../constants';
 import * as moment from 'moment';
 import { InsightsUserType } from '../../api/response-types/user';
 import { AppContext } from '../../loaders/app-context';
+import { DeleteGroupModal } from './delete-group-modal';
 import { DeleteModal } from '../../components/delete-modal/delete-modal';
 
 interface IState {
@@ -485,37 +483,13 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     }
 
     return (
-      <DeleteModal
+      <DeleteGroupModal
+        count={itemCount}
         cancelAction={() => this.setState({ showDeleteModal: false })}
         deleteAction={deleteAction}
-        title='Delete group?'
-      >
-        <b>{group.name}</b> will be permanently deleted.
-        <p>&nbsp;</p>
-        <div>
-          {users && itemCount > 10 && (
-            <p>Deleting this group will affect {itemCount} users.</p>
-          )}
-          {users && itemCount > 0 && itemCount <= 10 && (
-            <>
-              <p>These users will lose access to the group content:</p>
-              <List>
-                {users.map(u => (
-                  <ListItem key={u.username}>
-                    <b>{u.username}</b>
-                  </ListItem>
-                ))}
-              </List>
-            </>
-          )}
-          {users && !itemCount && <p>No users will be affected.</p>}
-          {!users && (
-            <p>
-              Checking for affected users... <Spinner size='sm' />
-            </p>
-          )}
-        </div>
-      </DeleteModal>
+        name={group.name}
+        users={users}
+      />
     );
   }
 

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -493,7 +493,10 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         <b>{group.name}</b> will be permanently deleted.
         <p>&nbsp;</p>
         <div>
-          {users && itemCount > 0 && (
+          {users && itemCount > 10 && (
+            <p>Deleting this group will affect {itemCount} users.</p>
+          )}
+          {users && itemCount > 0 && itemCount <= 10 && (
             <>
               <p>These users will lose access to the group content:</p>
               <List>

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -47,7 +47,13 @@ import { DeleteModal } from '../../components/delete-modal/delete-modal';
 
 interface IState {
   group: any;
-  params: { id: string; tab: string; page?: number; page_size?: number };
+  params: {
+    id: string;
+    page?: number;
+    page_size?: number;
+    sort?: string;
+    tab: string;
+  };
   users: UserType[];
   allUsers: UserType[];
   itemCount: number;
@@ -76,23 +82,16 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
       'page_size',
     ]);
 
-    if (!params['page_size']) {
-      params['page_size'] = 10;
-    }
-
-    if (!params['tab']) {
-      params['tab'] = 'permissions';
-    }
-
     this.state = {
       group: null,
       users: null,
       allUsers: null,
       params: {
         id: id,
-        tab: params['tab'],
         page: 0,
-        page_size: params['page_size'],
+        page_size: params['page_size'] || 10,
+        sort: params['sort'] || 'username',
+        tab: params['tab'] || 'permissions',
       },
       itemCount: 0,
       alerts: [],
@@ -565,9 +564,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     const noData =
       itemCount === 0 &&
       !filterIsSet(params, ['username', 'first_name', 'last_name', 'email']);
-    if (!params['sort']) {
-      params['sort'] = 'username';
-    }
+
     if (noData) {
       return (
         <EmptyStateNoData
@@ -584,6 +581,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         />
       );
     }
+
     return (
       <Section className='body'>
         <div className='toolbar'>
@@ -749,7 +747,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     }).then(result =>
       this.setState({
         users: result.data.data,
-        itemCount: result.data.data.length,
+        itemCount: result.data.meta.count,
         addModalVisible: false,
         loading: false,
       }),

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -30,7 +30,10 @@ import {
   DropdownItem,
   Flex,
   FlexItem,
+  List,
+  ListItem,
   Modal,
+  Spinner,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
@@ -446,7 +449,8 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
   }
 
   private renderGroupDeleteModal() {
-    const group = this.state.group;
+    const { group, users, itemCount } = this.state;
+
     const deleteAction = () => {
       GroupAPI.delete(group.id)
         .then(() => {
@@ -477,6 +481,10 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         );
     };
 
+    if (!users) {
+      this.queryUsers();
+    }
+
     return (
       <DeleteModal
         cancelAction={() => this.setState({ showDeleteModal: false })}
@@ -484,6 +492,27 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         title='Delete group?'
       >
         <b>{group.name}</b> will be permanently deleted.
+        <p>&nbsp;</p>
+        <div>
+          {users && itemCount > 0 && (
+            <>
+              <p>These users will lose access to the group content:</p>
+              <List>
+                {users.map(u => (
+                  <ListItem key={u.username}>
+                    <b>{u.username}</b>
+                  </ListItem>
+                ))}
+              </List>
+            </>
+          )}
+          {users && !itemCount && <p>No users will be affected.</p>}
+          {!users && (
+            <p>
+              Checking for affected users... <Spinner size='sm' />
+            </p>
+          )}
+        </div>
       </DeleteModal>
     );
   }

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -7,7 +7,7 @@ import {
   Redirect,
 } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
-import { GroupAPI, UserAPI } from '../../api';
+import { GroupAPI, UserAPI, UserType } from '../../api';
 import { DeleteGroupModal } from './delete-group-modal';
 import { filterIsSet, mapErrorMessages, ParamHelper } from '../../utilities';
 import {
@@ -48,7 +48,7 @@ interface IState {
   groups: any[];
   createModalVisible: boolean;
   deleteModalCount?: number;
-  deleteModalUsers?: any[];
+  deleteModalUsers?: UserType[];
   deleteModalVisible: boolean;
   editModalVisible: boolean;
   selectedGroup: any;

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import { GroupAPI } from '../../api';
+import { DeleteModal } from '../../components/delete-modal/delete-modal';
 import { filterIsSet, mapErrorMessages, ParamHelper } from '../../utilities';
 import {
   AlertList,
@@ -27,13 +28,11 @@ import {
 } from '../../components';
 import {
   Button,
-  Modal,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { formatPath, Paths } from '../../paths';
 import { AppContext } from '../../loaders/app-context';
 
@@ -242,41 +241,16 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
   }
 
   private renderDeleteModal() {
+    const name = this.state.selectedGroup && this.state.selectedGroup.name;
+
     return (
-      <Modal
-        variant='small'
-        onClose={() => this.setState({ deleteModalVisible: false })}
-        isOpen={true}
-        title={''}
-        children={null}
-        header={
-          <span className='pf-c-content'>
-            <h2>
-              <ExclamationTriangleIcon
-                size='sm'
-                style={{ color: 'var(--pf-global--warning-color--100)' }}
-              />{' '}
-              Delete Group?
-            </h2>{' '}
-          </span>
-        }
-        actions={[
-          <Button
-            key='delete'
-            variant='danger'
-            onClick={() => this.selectedGroup(this.state.selectedGroup)}
-          >
-            Delete
-          </Button>,
-          <Button
-            key='cancel'
-            variant='link'
-            onClick={() => this.setState({ deleteModalVisible: false })}
-          >
-            Cancel
-          </Button>,
-        ]}
-      ></Modal>
+      <DeleteModal
+        cancelAction={() => this.setState({ deleteModalVisible: false })}
+        deleteAction={() => this.selectedGroup(this.state.selectedGroup)}
+        title='Delete group?'
+      >
+        <b>{name}</b> will be permanently deleted.
+      </DeleteModal>
     );
   }
 

--- a/src/containers/user-management/delete-user-modal.tsx
+++ b/src/containers/user-management/delete-user-modal.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { Modal, Button, Spinner } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { UserType, UserAPI } from '../../api';
 import { mapErrorMessages } from '../../utilities';
 import { AppContext } from '../../loaders/app-context';
+import { DeleteModal } from '../../components/delete-modal/delete-modal';
 
 interface IState {
   isWaitingForResponse: boolean;
@@ -28,43 +28,20 @@ export class DeleteUserModal extends React.Component<IProps, IState> {
   render() {
     const { isOpen, user, closeModal } = this.props;
     const { isWaitingForResponse } = this.state;
-    if (!user) {
+    if (!user || !isOpen) {
       return null;
     }
+
     return (
-      <Modal
-        variant='small'
-        onClose={() => closeModal(false)}
-        isOpen={isOpen}
-        title={''}
-        aria-label='delete-user-confirmation'
-        header={
-          <span className='pf-c-content'>
-            <h2>
-              <ExclamationTriangleIcon
-                size='sm'
-                style={{ color: 'var(--pf-global--warning-color--100)' }}
-              />{' '}
-              Delete user?
-            </h2>{' '}
-          </span>
-        }
-        actions={[
-          <Button
-            isDisabled={isWaitingForResponse || this.isUserSelfOrAdmin(user)}
-            key='delete'
-            variant='danger'
-            onClick={() => this.deleteUser()}
-          >
-            Delete {isWaitingForResponse && <Spinner size='sm'></Spinner>}
-          </Button>,
-          <Button key='cancel' variant='link' onClick={() => closeModal(false)}>
-            Cancel
-          </Button>,
-        ]}
+      <DeleteModal
+        cancelAction={() => closeModal(false)}
+        deleteAction={() => this.deleteUser()}
+        isDisabled={isWaitingForResponse || this.isUserSelfOrAdmin(user)}
+        spinner={isWaitingForResponse}
+        title='Delete user?'
       >
         {this.getActionDescription(user)}
-      </Modal>
+      </DeleteModal>
     );
   }
 
@@ -75,7 +52,11 @@ export class DeleteUserModal extends React.Component<IProps, IState> {
       return 'Deleting yourself is not allowed.';
     }
 
-    return `${user.username} will be permanently deleted.`;
+    return (
+      <>
+        <b>{user.username}</b> will be permanently deleted.
+      </>
+    );
   }
 
   private isUserSelfOrAdmin = (user: UserType): boolean => {

--- a/src/containers/user-management/delete-user-modal.tsx
+++ b/src/containers/user-management/delete-user-modal.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { UserType, UserAPI } from '../../api';
 import { mapErrorMessages } from '../../utilities';
 import { AppContext } from '../../loaders/app-context';

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -163,15 +163,16 @@ class App extends React.Component<RouteComponentProps, IState> {
 
     const Header = (
       <PageHeader
-        logo={
+        logo={<SmallLogo alt={APPLICATION_NAME}></SmallLogo>}
+        logoComponent={({ children }) => (
           <Link
             to={formatPath(Paths.searchByRepo, {
               repo: this.state.selectedRepo,
             })}
           >
-            <SmallLogo alt={APPLICATION_NAME}></SmallLogo>
+            {children}
           </Link>
-        }
+        )}
         headerTools={
           <PageHeaderTools>
             {!user ? (


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-358

This unifies the confirmation modal for all deletions/removals in the app so that we're:

* using a confirmation modal,
* using patternfly title with `titleVariant='warning'` to fix the icon alignment in the header
* the title has the second word lowercased (Delete user => Delete group)
* there's a description, with the name of the deleted item in bold

It also adds a missing Delete button to the group detail screen (user detail has it),
tweaks `.gitignore` and `.prettierignore` to ignore vim swap files,
fixes a logo console warning,
and updates the Users tab in Group detail to work with 10+ users.
(I can split these off if needed :).)


**Before**:

Users > kebab Delete - icon alignment, missing bold

![usersb](https://user-images.githubusercontent.com/289743/109717579-24f4bc00-7b9e-11eb-8397-058cc89d7b88.png)

Users > detail > Delete - icon alignment, missing bold

![userdb](https://user-images.githubusercontent.com/289743/109717591-2a520680-7b9e-11eb-953e-43c9b03a09c8.png)

Groups > Delete - icon alignment, missing description

![groupsb](https://user-images.githubusercontent.com/289743/109717607-2faf5100-7b9e-11eb-9a59-3a3b4f2fefa3.png)

Groups > detail > Delete - no such button

![groupdetb](https://user-images.githubusercontent.com/289743/109717633-3938b900-7b9e-11eb-9aa9-51d25ff659f1.png)

Groups > detail > tab Users > kebab Remove - no confirmation modal, removed directly

![](https://i.imgur.com/DKUR9Tk.png)

---

**After**:

Users > kebab Delete

![users](https://user-images.githubusercontent.com/289743/109718001-b06e4d00-7b9e-11eb-8fd8-f9917c295e8f.png)

Users > detail > Delete

![userd](https://user-images.githubusercontent.com/289743/109718026-b6fcc480-7b9e-11eb-89ea-c1bd7b05863e.png)

Groups > Delete

![groups](https://user-images.githubusercontent.com/289743/109718050-bf54ff80-7b9e-11eb-9184-52dbc832476b.png)

(see comments for a version with a list/count of users)

Groups > detail > Delete

![groupdet](https://user-images.githubusercontent.com/289743/109718094-cbd95800-7b9e-11eb-9bd7-5270725aaa90.png)
![groupd](https://user-images.githubusercontent.com/289743/109718070-c67c0d80-7b9e-11eb-8970-597fafa4ec9f.png)

(see comments for a version with a list/count of users)

Groups > detail > tab Users > kebab Remove

![groupuser](https://user-images.githubusercontent.com/289743/109718121-d398fc80-7b9e-11eb-9e3b-904770e704ec.png)

---

~~Question: right now, a group can be deleted even if it has users assigned to it. Should that be possible? Warning at least?~~
Resolved by showing a list of affected users.