### PR TITLE
user-form: only show "Passwords do not match" when there is confirmation password; make required when password

### DIFF
--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -27,9 +27,6 @@ interface IProps {
   /** List of errors from the API */
   errorMessages: object;
 
-  /** List of fields to mark as required */
-  requiredFields?: string[];
-
   /** Disables the form */
   isReadonly?: boolean;
 
@@ -50,7 +47,6 @@ interface IState {
 export class UserForm extends React.Component<IProps, IState> {
   public static defaultProps = {
     isReadonly: false,
-    requiredFields: ['username', 'password'],
   };
 
   constructor(props) {
@@ -73,7 +69,6 @@ export class UserForm extends React.Component<IProps, IState> {
       isReadonly,
       saveUser,
       onCancel,
-      requiredFields,
       isNewUser,
       isMe,
     } = this.props;
@@ -90,6 +85,8 @@ export class UserForm extends React.Component<IProps, IState> {
         placeholder: isNewUser ? '' : '••••••••••••••••••••••',
       },
     ];
+    const requiredFields = ['username', ...(isNewUser ? ['password'] : [])];
+
     return (
       <Form>
         {formFields.map(v => (
@@ -125,6 +122,7 @@ export class UserForm extends React.Component<IProps, IState> {
           fieldId={'password-confirm'}
           label={'Password confirmation'}
           helperTextInvalid={'Passwords do not match'}
+          isRequired={isNewUser || !!user.password}
           validated={this.toError(
             this.isPassSame(user.password, passwordConfirm),
           )}
@@ -188,7 +186,7 @@ export class UserForm extends React.Component<IProps, IState> {
           <ActionGroup>
             <Button
               isDisabled={
-                !this.isPassSame(user.password, passwordConfirm) ||
+                !this.isPassValid(user.password, passwordConfirm) ||
                 !this.requiredFilled(user)
               }
               onClick={() => saveUser()}
@@ -242,8 +240,14 @@ export class UserForm extends React.Component<IProps, IState> {
     }
   }
 
+  // confirm is empty, or matches password
   private isPassSame(pass, confirm) {
-    return !pass || pass === '' || pass === confirm;
+    return !confirm || pass === confirm;
+  }
+
+  // both passwords missing, or both match
+  private isPassValid(pass, confirm) {
+    return !(pass || confirm) || pass === confirm;
   }
 
   private requiredFilled(user) {


### PR DESCRIPTION
This fixes part of https://issues.redhat.com/browse/AAH-362 ...
> "Passwords do not match" alert under password confirmation appears when user types in the "password" field 

... and part of https://issues.redhat.com/browse/AAH-360
> Password confirmation field should be mandatory

@sbuenafe-rh , @ZitaNemeckova I don't see any patternfly guidelines on how the password field + confirm password field combo *should* behave, so this is my best guess based on the assumption that the "Passwords do not match" message is not supposed to appear without any password there. (Which could be wrong given some of the effects below.)

So, this describes the create user/edit user form behaviour with this change in, in all the variants, I'm pretty sure the Save button is correct, not necessarily the rest :) .. I've added a question mark where I think something may be wrong, but if we make the field invalid when there is a password but no confirmation password, it implies that the message would appear when the user types in the password field.

* Create new user:
  * empty password:
    * empty confirm:
      Username, Password, Confirm are required
      Save is disabled
      no message, no invalid fields
    * nonempty confirm:
      Username, Password, Confirm are required
      Save is disabled
      yes message, confirm invalid
  * nonempty password:
    * empty confirm:
      Username, Password, Confirm are required
      Save is disabled
      no message, no invalid fields :question: 
    * nonempty bad confirm:
      Username, Password, Confirm are required
      Save is disabled
      yes message, confirm invalid
    * nonempty good confirm:
      Username, Password, Confirm are required
      Save is enabled
      no message, confirm invalid

* Edit user:
  * placeholder password:
    * placeholder confirm:
      only Username required
      Save is enabled
      no message, no invalid fields
    * nonempty confirm:
      only Username required
      Save is disabled
      yes message, confirm invalid
  * nonempty password:
    * placeholder confirm:
      Username and Confirm are required
      Save is disabled
      no message, no invalid fields :question: 
      maybe there should not be a placeholder confirm with nonempty password and appear empty :question: 
    * nonempty bad confirm:
      Username and Confirm are required
      Save is disabled
      yes message, confirm invalid
    * nonempty good confirm:
      Username and Confirm are required
      Save is enabled
      no message, confirm invalid

As for the mandatory confirmation field, I've made it mandatory only when the password is required (new user), or already entered (edit user, *after* changing the password), hope that makes sense :).

---

https://issues.redhat.com/browse/AAH-362 also contains...
> ~~All fields should be mandatory(double check it's needed)~~

As far as the api/model is concerned, only username/username+password is required.
So the question is: *should* we require First name, Last name, and Email as well? (If so, I'll add it, it's a trivial change.)