### PR TITLE
Group detail - Permission tab UX changes

### DIFF
--- a/src/components/headers/header.scss
+++ b/src/components/headers/header.scss
@@ -47,6 +47,11 @@
     flex-grow: 0;
   }
 
+  // Tabs isDisabled
+  .pf-c-tabs__item.disabled .pf-c-tabs__link {
+    cursor: not-allowed;
+  }
+
   .links {
     @media (min-width: $breakpoint-md) {
       justify-content: flex-end;

--- a/src/components/patternfly-wrappers/tabs.tsx
+++ b/src/components/patternfly-wrappers/tabs.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Tab, Tabs as PFTabs } from '@patternfly/react-core';
+import { Tab, Tabs as PFTabs, TabTitleText } from '@patternfly/react-core';
 
 import { ParamHelper } from '../../utilities/param-helper';
 
@@ -16,11 +16,18 @@ interface IProps {
 
   /** Disables tab controls */
   isDisabled?: boolean;
+  disabledTitle?: string;
 }
 
 export class Tabs extends React.Component<IProps> {
   render() {
-    const { tabs, params, updateParams, isDisabled } = this.props;
+    const {
+      tabs,
+      params,
+      updateParams,
+      isDisabled,
+      disabledTitle,
+    } = this.props;
     return (
       <PFTabs
         activeKey={this.getActiveTab()}
@@ -35,7 +42,11 @@ export class Tabs extends React.Component<IProps> {
           <Tab
             key={i}
             eventKey={i}
-            title={tab}
+            title={
+              <TabTitleText title={isDisabled ? disabledTitle : null}>
+                {tab}
+              </TabTitleText>
+            }
             className={isDisabled ? 'disabled' : null}
           />
         ))}

--- a/src/components/patternfly-wrappers/tabs.tsx
+++ b/src/components/patternfly-wrappers/tabs.tsx
@@ -13,22 +13,31 @@ interface IProps {
 
   /** Sets the current page params to p */
   updateParams: (params) => void;
+
+  /** Disables tab controls */
+  isDisabled?: boolean;
 }
 
 export class Tabs extends React.Component<IProps> {
   render() {
-    const { tabs, params, updateParams } = this.props;
+    const { tabs, params, updateParams, isDisabled } = this.props;
     return (
       <PFTabs
         activeKey={this.getActiveTab()}
         onSelect={(_, key) =>
+          !isDisabled &&
           updateParams(
             ParamHelper.setParam(params, 'tab', tabs[key].toLowerCase()),
           )
         }
       >
         {tabs.map((tab, i) => (
-          <Tab key={i} eventKey={i} title={tab} />
+          <Tab
+            key={i}
+            eventKey={i}
+            title={tab}
+            className={isDisabled ? 'disabled' : null}
+          />
         ))}
       </PFTabs>
     );

--- a/src/components/permissions/permission-chip-selector.tsx
+++ b/src/components/permissions/permission-chip-selector.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import {
-  List,
-  ListItem,
-  ListVariant,
+  Label,
+  LabelGroup,
   Select,
   SelectOption,
   SelectVariant,
@@ -35,11 +34,11 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
         ? this.props.selectedPermissions
         : [this.placeholderText()];
       return (
-        <List variant={ListVariant.inline}>
+        <LabelGroup>
           {items.map(text => (
-            <ListItem key={text}>{text}</ListItem>
+            <Label key={text}>{text}</Label>
           ))}
-        </List>
+        </LabelGroup>
       );
     }
 

--- a/src/components/permissions/permission-chip-selector.tsx
+++ b/src/components/permissions/permission-chip-selector.tsx
@@ -1,11 +1,19 @@
 import * as React from 'react';
-import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import {
+  List,
+  ListItem,
+  ListVariant,
+  Select,
+  SelectOption,
+  SelectVariant,
+} from '@patternfly/react-core';
 
 interface IProps {
   availablePermissions: string[];
   selectedPermissions: string[];
   setSelected: (selected: string[]) => void;
   isDisabled?: boolean;
+  isViewOnly?: boolean;
   onSelect?: (event, selection) => void;
   onClear?: () => void;
   menuAppendTo?: 'parent' | 'inline';
@@ -22,6 +30,19 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
   }
 
   render() {
+    if (this.props.isViewOnly) {
+      const items = this.props.selectedPermissions.length
+        ? this.props.selectedPermissions
+        : [this.placeholderText()];
+      return (
+        <List variant={ListVariant.inline}>
+          {items.map(text => (
+            <ListItem key={text}>{text}</ListItem>
+          ))}
+        </List>
+      );
+    }
+
     return (
       <Select
         menuAppendTo={this.props.menuAppendTo}
@@ -53,7 +74,7 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
   }
 
   private placeholderText() {
-    if (!this.props.isDisabled) {
+    if (!this.props.isDisabled && !this.props.isViewOnly) {
       return 'Select permissions';
     }
     return this.props.selectedPermissions.length === 0 ? 'No permission' : '';

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -301,7 +301,8 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
                     )
                     .map(value =>
                       twoWayMapper(value, Constants.HUMAN_PERMISSIONS),
-                    )}
+                    )
+                    .sort()}
                   selectedPermissions={selectedPermissions
                     .filter(selected =>
                       group.object_permissions.find(perm => selected === perm),

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -194,41 +194,23 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
 
   private renderControls() {
     const { user } = this.context;
+    const { editPermissions } = this.state;
 
-    if (this.state.params.tab == 'users') {
+    if (!user || !user.model_permissions.delete_group) {
       return null;
     }
-    return this.state.editPermissions ? (
+
+    return (
       <ToolbarItem>
         <Button
-          onClick={this.actionSavePermissions}
+          isDisabled={editPermissions}
+          onClick={() => this.setState({ showDeleteModal: true })}
+          variant='secondary'
         >
-          Save
-        </Button>
-        <Button
-          variant='link'
-          onClick={() => this.setState({ editPermissions: false })}
-        >
-          Cancel
+          Delete
         </Button>
       </ToolbarItem>
-    ) : !!user ? (
-      <ToolbarItem>
-        {user.model_permissions.change_group ? (
-          <Button onClick={() => this.setState({ editPermissions: true })}>
-            Edit
-          </Button>
-        ) : null}{' '}
-        {user.model_permissions.delete_group ? (
-          <Button
-            onClick={() => this.setState({ showDeleteModal: true })}
-            variant='secondary'
-          >
-            Delete
-          </Button>
-        ) : null}
-      </ToolbarItem>
-    ) : null;
+    );
   }
 
   private actionSavePermissions() {
@@ -277,9 +259,29 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
 
   private renderPermissions() {
     const groups = Constants.PERMISSIONS;
-    const selectedPermissions = this.state.permissions;
+    const { editPermissions, permissions: selectedPermissions } = this.state;
+    const { user } = this.context;
+
     return (
       <Section className='body'>
+        <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          {!editPermissions && user.model_permissions.change_group && (
+            <Button onClick={() => this.setState({ editPermissions: true })}>
+              Edit
+            </Button>
+          )}
+          {editPermissions && (
+            <>
+              <Button onClick={() => this.actionSavePermissions()}>Save</Button>
+              <Button
+                variant='link'
+                onClick={() => this.setState({ editPermissions: false })}
+              >
+                Cancel
+              </Button>
+            </>
+          )}
+        </div>
         <div>
           {groups.map(group => (
             <Flex
@@ -310,7 +312,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
                     )}
                   setSelected={perms => this.setState({ permissions: perms })}
                   menuAppendTo='inline'
-                  isDisabled={!this.state.editPermissions}
+                  isDisabled={!editPermissions}
                   onClear={() => {
                     const clearedPerms = group.object_permissions;
                     this.setState({

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -125,11 +125,13 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     const {
       addModalVisible,
       alerts,
+      editPermissions,
       group,
       loading,
       params,
       showDeleteModal,
       showUserRemoveModal,
+      users,
     } = this.state;
     const { user } = this.context;
 
@@ -141,7 +143,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     if (!group || loading) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
-    if (this.state.params.tab == 'users' && !this.state.users) {
+    if (params.tab == 'users' && !users) {
       this.queryUsers();
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
@@ -156,7 +158,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         {showUserRemoveModal ? this.renderUserRemoveModal() : null}
         <BaseHeader
           title={
-            this.state.editPermissions && this.state.params.tab == 'permissions'
+            editPermissions && params.tab == 'permissions'
               ? 'Edit group permissions'
               : group.name
           }
@@ -181,12 +183,8 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
           </div>
         </BaseHeader>
         <Main>
-          {this.state.params.tab == 'permissions'
-            ? this.renderPermissions()
-            : null}
-          {this.state.params.tab == 'users'
-            ? this.renderUsers(this.state.users)
-            : null}
+          {params.tab == 'permissions' ? this.renderPermissions() : null}
+          {params.tab == 'users' ? this.renderUsers(users) : null}
         </Main>
       </React.Fragment>
     );

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -26,10 +26,12 @@ import { GroupAPI, UserAPI, UserType } from '../../api';
 import { filterIsSet, ParamHelper, twoWayMapper } from '../../utilities';
 import { formatPath, Paths } from '../../paths';
 import {
+  ActionGroup,
   Button,
   DropdownItem,
   Flex,
   FlexItem,
+  Form,
   Modal,
   Toolbar,
   ToolbarContent,
@@ -270,17 +272,6 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
               Edit
             </Button>
           )}
-          {editPermissions && (
-            <>
-              <Button onClick={() => this.actionSavePermissions()}>Save</Button>
-              <Button
-                variant='link'
-                onClick={() => this.setState({ editPermissions: false })}
-              >
-                Cancel
-              </Button>
-            </>
-          )}
         </div>
         <div>
           {groups.map(group => (
@@ -344,6 +335,24 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
             </Flex>
           ))}
         </div>
+        {editPermissions && (
+          <Form>
+            <ActionGroup>
+              <Button
+                variant='primary'
+                onClick={() => this.actionSavePermissions()}
+              >
+                Save
+              </Button>
+              <Button
+                variant='secondary'
+                onClick={() => this.setState({ editPermissions: false })}
+              >
+                Cancel
+              </Button>
+            </ActionGroup>
+          </Form>
+        )}
       </Section>
     );
   }

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -201,52 +201,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     return this.state.editPermissions ? (
       <ToolbarItem>
         <Button
-          onClick={() => {
-            // Add permissions
-            this.state.permissions.forEach(permission => {
-              if (
-                !this.state.originalPermissions.find(p => p.name === permission)
-              ) {
-                GroupAPI.addPermission(this.state.group.id, {
-                  permission: permission,
-                }).catch(() =>
-                  this.setState({
-                    alerts: [
-                      ...this.state.alerts,
-                      {
-                        variant: 'danger',
-                        title: null,
-                        description:
-                          'Permission ' + permission + ' was not added',
-                      },
-                    ],
-                  }),
-                );
-              }
-            });
-            //Remove permissions
-            this.state.originalPermissions.forEach(original => {
-              if (!this.state.permissions.includes(original.name)) {
-                GroupAPI.removePermission(
-                  this.state.group.id,
-                  original.id,
-                ).catch(() =>
-                  this.setState({
-                    alerts: [
-                      ...this.state.alerts,
-                      {
-                        variant: 'danger',
-                        title: null,
-                        description:
-                          'Permission ' + original.name + ' was not removed.',
-                      },
-                    ],
-                  }),
-                );
-              }
-            });
-            this.setState({ editPermissions: false });
-          }}
+          onClick={this.actionSavePermissions}
         >
           Save
         </Button>
@@ -275,6 +230,51 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
       </ToolbarItem>
     ) : null;
   }
+
+  private actionSavePermissions() {
+    const { group, originalPermissions, permissions } = this.state;
+
+    // Add permissions
+    permissions.forEach(permission => {
+      if (!originalPermissions.find(p => p.name === permission)) {
+        GroupAPI.addPermission(group.id, {
+          permission: permission,
+        }).catch(() =>
+          this.setState({
+            alerts: [
+              ...this.state.alerts,
+              {
+                variant: 'danger',
+                title: null,
+                description: `Permission ${permission} was not added`,
+              },
+            ],
+          }),
+        );
+      }
+    });
+
+    // Remove permissions
+    originalPermissions.forEach(original => {
+      if (!permissions.includes(original.name)) {
+        GroupAPI.removePermission(group.id, original.id).catch(() =>
+          this.setState({
+            alerts: [
+              ...this.state.alerts,
+              {
+                variant: 'danger',
+                title: null,
+                description: `Permission ${original.name} was not removed.`,
+              },
+            ],
+          }),
+        );
+      }
+    });
+
+    this.setState({ editPermissions: false });
+  }
+
   private renderPermissions() {
     const groups = Constants.PERMISSIONS;
     const selectedPermissions = this.state.permissions;

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -181,16 +181,17 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
           </div>
         </BaseHeader>
         <Main>
-          {this.state.params.tab == 'users'
-            ? this.renderUsers(this.state.users)
-            : null}
           {this.state.params.tab == 'permissions'
             ? this.renderPermissions()
+            : null}
+          {this.state.params.tab == 'users'
+            ? this.renderUsers(this.state.users)
             : null}
         </Main>
       </React.Fragment>
     );
   }
+
   private renderControls() {
     const { user } = this.context;
 

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -176,6 +176,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
             <div className='tabs'>
               <Tabs
                 isDisabled={editPermissions}
+                disabledTitle='Please finish editing permissions first.'
                 tabs={tabs}
                 params={params}
                 updateParams={p => this.updateParams(p)}

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -175,6 +175,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
           <div className='tab-link-container'>
             <div className='tabs'>
               <Tabs
+                isDisabled={editPermissions}
                 tabs={tabs}
                 params={params}
                 updateParams={p => this.updateParams(p)}

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -312,7 +312,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
                     )}
                   setSelected={perms => this.setState({ permissions: perms })}
                   menuAppendTo='inline'
-                  isDisabled={!editPermissions}
+                  isViewOnly={!editPermissions}
                   onClear={() => {
                     const clearedPerms = group.object_permissions;
                     this.setState({


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-364

This contains multiple UX changes to the Group detail screen, mostly in the Permissions tab:

* moved the Edit, Save and Cancel buttons from page header to tab header, as these are only related to the tab
* keeps the Delete button as is, but disables it when editing a group, and no longer hides it on the users tab
* makes the tabs appear disabled (cursor + no action on click) when editing Permissions
* sorts the list of available permissions in the Permission selects (note this makes the order unstable between translations once we have i18n)
* use plain text styling (remove gray blocks behind input text) unless in edit mode (this is from https://issues.redhat.com/browse/AAH-360 but consistency)

Cc @ZitaNemeckova, @sbuenafe-rh, this should be ready for review :)

---

Permissions tab in view mode (before and after):

![perm false before](https://user-images.githubusercontent.com/289743/110563428-36f8d080-8143-11eb-95b0-471967ff695c.png)
![perm false after](https://user-images.githubusercontent.com/289743/110563432-38c29400-8143-11eb-8426-b962fe75d554.png)


Permissions tab in edit mode (before and after):

![perm true before](https://user-images.githubusercontent.com/289743/110563486-4c6dfa80-8143-11eb-8bc7-f0d6bd3bc49a.png)
![perm true after](https://user-images.githubusercontent.com/289743/110563476-48da7380-8143-11eb-8747-8b81ee7a2e36.png)

(the tab header also switches to the `not-allowed` cursor when hovering in edit mode)


List of group permissions when editing (before and after):

![perm true2 before](https://user-images.githubusercontent.com/289743/110563589-73c4c780-8143-11eb-8a31-837f7e3b7a61.png)
![perm true2 after](https://user-images.githubusercontent.com/289743/110563597-76bfb800-8143-11eb-9304-c04d6d345347.png)


Users tab (before and after):

![user before](https://user-images.githubusercontent.com/289743/110563628-7cb59900-8143-11eb-8b24-61a38709e734.png)
![user after](https://user-images.githubusercontent.com/289743/110563636-7e7f5c80-8143-11eb-8a20-bb5870b8787c.png)


