### PR TITLE
Update removeUserFromGroup to accomodate changes to removal modal

### DIFF
--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -176,6 +176,7 @@ Cypress.Commands.add('removeUserFromGroup', {}, (groupName, userName) => {
     cy.contains('button', 'Users').click();
     cy.get(`[aria-labelledby=${userName}] [aria-label=Actions]`).click();
     cy.containsnear(`[aria-labelledby=${userName}] [aria-label=Actions]`, 'Remove').click();
+    cy.contains('button', 'Delete').click();
     cy.contains(userName).should('not.exist');
 });
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -176,7 +176,7 @@ Cypress.Commands.add('removeUserFromGroup', {}, (groupName, userName) => {
     cy.contains('button', 'Users').click();
     cy.get(`[aria-labelledby=${userName}] [aria-label=Actions]`).click();
     cy.containsnear(`[aria-labelledby=${userName}] [aria-label=Actions]`, 'Remove').click();
-    cy.contains('button', 'Delete').click();
+    cy.contains('button.pf-m-danger', 'Delete').click();
     cy.contains(userName).should('not.exist');
 });
 


### PR DESCRIPTION
Making the delete modals consistent as described in AAH-358 required a minor change to our custom command for removing a user from a group.

That fix has been added and all tests are passing on master :smile: