### PR TITLE
Support repo-root-relative import paths

### DIFF
--- a/config/webpack-ts-overrides.js
+++ b/config/webpack-ts-overrides.js
@@ -1,4 +1,5 @@
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { resolve } = require('path');
 
 module.exports = {
   devtool: 'source-map',
@@ -56,5 +57,9 @@ module.exports = {
   resolve: {
     // changed from extensions: [".js", ".jsx"]
     extensions: ['.ts', '.tsx', '.js', '.jsx'],
+    // imports relative to repo root
+    alias: {
+      src: resolve(__dirname, '../src'),
+    },
   },
 };

--- a/src/api/active-user.ts
+++ b/src/api/active-user.ts
@@ -1,4 +1,4 @@
-import { Constants } from '../constants';
+import { Constants } from 'src/constants';
 import { HubAPI } from './hub';
 
 class API extends HubAPI {

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
-import { Constants } from '../constants';
-import { ParamHelper } from '../utilities';
+import { Constants } from 'src/constants';
+import { ParamHelper } from 'src/utilities';
 import * as Cookies from 'js-cookie';
 
 export class BaseAPI {

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -3,7 +3,7 @@ import {
   CollectionDetailType,
   CollectionListType,
   CollectionUploadType,
-} from '../api';
+} from 'src/api';
 import axios from 'axios';
 
 export class API extends HubAPI {

--- a/src/api/hub.ts
+++ b/src/api/hub.ts
@@ -1,4 +1,4 @@
-import { Constants } from '../constants';
+import { Constants } from 'src/constants';
 import { BaseAPI } from './base';
 
 export class HubAPI extends BaseAPI {

--- a/src/api/remotes.ts
+++ b/src/api/remotes.ts
@@ -1,6 +1,6 @@
 import { HubAPI } from './hub';
 import { RemoteType } from '.';
-import { clearSetFieldsFromRequest } from '../utilities';
+import { clearSetFieldsFromRequest } from 'src/utilities';
 
 class API extends HubAPI {
   apiPath = this.getUIPath('remotes/');

--- a/src/components/api-button/api-button.tsx
+++ b/src/components/api-button/api-button.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
-import { Paths } from '../../paths';
+import { Paths } from 'src/paths';
 
 interface IProps {
   style?: Object;

--- a/src/components/card-list-switcher/card-list-switcher.tsx
+++ b/src/components/card-list-switcher/card-list-switcher.tsx
@@ -4,7 +4,7 @@ import './switcher.scss';
 
 import { ListIcon, ThLargeIcon } from '@patternfly/react-icons';
 
-import { ParamHelper } from '../../utilities/param-helper';
+import { ParamHelper } from 'src/utilities/param-helper';
 
 interface IProps {
   params: {

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -13,11 +13,11 @@ import {
 
 import { Link } from 'react-router-dom';
 
-import { NumericLabel, Logo } from '../../components';
-import { CollectionListType } from '../../api';
-import { formatPath, Paths } from '../../paths';
-import { convertContentSummaryCounts } from '../../utilities';
-import { Constants } from '../../constants';
+import { NumericLabel, Logo } from 'src/components';
+import { CollectionListType } from 'src/api';
+import { formatPath, Paths } from 'src/paths';
+import { convertContentSummaryCounts } from 'src/utilities';
+import { Constants } from 'src/constants';
 
 interface IProps extends CollectionListType {
   className?: string;

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -12,7 +12,7 @@ import {
 
 import { Link } from 'react-router-dom';
 
-import { Logo } from '../../components';
+import { Logo } from 'src/components';
 // Use snake case to match field types provided py python API so that the
 // spread operator can be used.
 interface IProps {

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -10,10 +10,10 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 
-import { ContentSummaryType } from '../../api';
-import { Paths, formatPath } from '../../paths';
-import { ParamHelper } from '../../utilities/param-helper';
-import { AppContext } from '../../loaders/app-context';
+import { ContentSummaryType } from 'src/api';
+import { Paths, formatPath } from 'src/paths';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IProps {
   contents: ContentSummaryType[];

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -17,11 +17,11 @@ import {
 
 import { DownloadIcon } from '@patternfly/react-icons';
 
-import { CollectionDetailType, CollectionAPI } from '../../api';
-import { Tag } from '../../components';
-import { Paths, formatPath } from '../../paths';
-import { ParamHelper } from '../../utilities/param-helper';
-import { AppContext } from '../../loaders/app-context';
+import { CollectionDetailType, CollectionAPI } from 'src/api';
+import { Tag } from 'src/components';
+import { Paths, formatPath } from 'src/paths';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IProps extends CollectionDetailType {
   params: {

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -5,10 +5,10 @@ import { Link } from 'react-router-dom';
 
 import { Nav, NavExpandable, NavItem, NavList } from '@patternfly/react-core';
 
-import { DocsBlobType } from '../../api';
-import { Paths, formatPath } from '../../paths';
-import { ParamHelper, sanitizeDocsUrls } from '../../utilities';
-import { AppContext } from '../../loaders/app-context';
+import { DocsBlobType } from 'src/api';
+import { Paths, formatPath } from 'src/paths';
+import { ParamHelper, sanitizeDocsUrls } from 'src/utilities';
+import { AppContext } from 'src/loaders/app-context';
 
 class DocsEntry {
   display: string;

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -14,10 +14,10 @@ import {
 import { Link } from 'react-router-dom';
 import * as moment from 'moment';
 
-import { Paths, formatPath } from '../../paths';
-import { NumericLabel, Tag, Logo, DeprecatedTag } from '../../components';
-import { CollectionListType } from '../../api';
-import { convertContentSummaryCounts } from '../../utilities';
+import { Paths, formatPath } from 'src/paths';
+import { NumericLabel, Tag, Logo, DeprecatedTag } from 'src/components';
+import { CollectionListType } from 'src/api';
+import { convertContentSummaryCounts } from 'src/utilities';
 
 interface IProps extends CollectionListType {
   showNamespace?: boolean;

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -3,15 +3,15 @@ import './list.scss';
 
 import { Button, DropdownItem, DataList } from '@patternfly/react-core';
 
-import { CollectionListType } from '../../api';
+import { CollectionListType } from 'src/api';
 import {
   CollectionListItem,
   Toolbar,
   Pagination,
   StatefulDropdown,
   EmptyStateFilter,
-} from '../../components';
-import { ParamHelper } from '../../utilities/param-helper';
+} from 'src/components';
+import { ParamHelper } from 'src/utilities/param-helper';
 
 interface IProps {
   collections: CollectionListType[];

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -4,7 +4,7 @@ import './header.scss';
 
 import { PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 
-import { Logo } from '../../components';
+import { Logo } from 'src/components';
 
 interface IProps {
   title: string;

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -6,10 +6,10 @@ import { Link } from 'react-router-dom';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { FormSelect, FormSelectOption, Alert } from '@patternfly/react-core';
 
-import { BaseHeader, Breadcrumbs, APIButton } from '../../components';
-import { CollectionDetailType } from '../../api';
-import { Paths, formatPath } from '../../paths';
-import { ParamHelper } from '../../utilities/param-helper';
+import { BaseHeader, Breadcrumbs, APIButton } from 'src/components';
+import { CollectionDetailType } from 'src/api';
+import { Paths, formatPath } from 'src/paths';
+import { ParamHelper } from 'src/utilities/param-helper';
 
 interface IProps {
   collection: CollectionDetailType;

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -3,8 +3,8 @@ import './header.scss';
 
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import { BaseHeader, Tabs, Breadcrumbs } from '../../components';
-import { NamespaceType } from '../../api';
+import { BaseHeader, Tabs, Breadcrumbs } from 'src/components';
+import { NamespaceType } from 'src/api';
 
 interface IProps {
   namespace: NamespaceType;

--- a/src/components/loading/loading-with-header.tsx
+++ b/src/components/loading/loading-with-header.tsx
@@ -7,9 +7,9 @@ import {
   Section,
 } from '@redhat-cloud-services/frontend-components';
 
-import { Main } from '../../components';
+import { Main } from 'src/components';
 
-import { LoadingPageSpinner } from '../../components';
+import { LoadingPageSpinner } from 'src/components';
 
 export class LoadingPageWithHeader extends React.Component<{}> {
   render() {

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // had to declare *.svg in src/index.d.ts
-import DefaultLogo from '../../../static/images/default-logo.svg';
+import DefaultLogo from 'src/../static/images/default-logo.svg';
 
 interface IProps {
   // size should be css length measurment: '100px'

--- a/src/components/logo/small-logo.tsx
+++ b/src/components/logo/small-logo.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import SmallLogoImage from '../../../static/images/logo_small.svg';
+import SmallLogoImage from 'src/../static/images/logo_small.svg';
 
 interface IProps {
   alt: string;

--- a/src/components/my-imports/import-console.tsx
+++ b/src/components/my-imports/import-console.tsx
@@ -6,17 +6,17 @@ import { Tooltip } from '@patternfly/react-core';
 import { Link } from 'react-router-dom';
 import { Spinner } from '@redhat-cloud-services/frontend-components';
 
-import { formatPath, Paths } from '../../paths';
+import { formatPath, Paths } from 'src/paths';
 import {
   ImportListType,
   ImportDetailType,
   PulpStatus,
   CollectionVersion,
-} from '../../api';
+} from 'src/api';
 
-import { StatusIndicator } from '../../components';
+import { StatusIndicator } from 'src/components';
 
-import { Constants } from '../../constants';
+import { Constants } from 'src/constants';
 
 interface IProps {
   task: ImportDetailType;

--- a/src/components/my-imports/import-list.tsx
+++ b/src/components/my-imports/import-list.tsx
@@ -17,9 +17,9 @@ import {
 import { SearchIcon } from '@patternfly/react-icons';
 import { Spinner } from '@redhat-cloud-services/frontend-components';
 
-import { PulpStatus, NamespaceType, ImportListType } from '../../api';
-import { ParamHelper } from '../../utilities/param-helper';
-import { Constants } from '../../constants';
+import { PulpStatus, NamespaceType, ImportListType } from 'src/api';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { Constants } from 'src/constants';
 import { EmptyStateNoData } from '..';
 
 interface IProps {

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -4,8 +4,8 @@ import './namespace-form.scss';
 import { Form, FormGroup, TextInput, TextArea } from '@patternfly/react-core';
 import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 
-import { NamespaceCard, ObjectPermissionField } from '../../components';
-import { NamespaceType } from '../../api';
+import { NamespaceCard, ObjectPermissionField } from 'src/components';
+import { NamespaceType } from 'src/api';
 
 interface IProps {
   namespace: NamespaceType;

--- a/src/components/namespace-form/resources-form.tsx
+++ b/src/components/namespace-form/resources-form.tsx
@@ -4,7 +4,7 @@ import './namespace-form.scss';
 import { Form, FormGroup, TextArea } from '@patternfly/react-core';
 import * as ReactMarkdown from 'react-markdown';
 
-import { NamespaceType } from '../../api';
+import { NamespaceType } from 'src/api';
 
 const placeholder = `## Custom resources
 

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -3,9 +3,9 @@ import { Modal, Tooltip } from '@patternfly/react-core';
 import { Form, FormGroup } from '@patternfly/react-core';
 import { Button, InputGroup, TextInput } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
-import { NamespaceAPI, GroupObjectPermissionType } from '../../api';
+import { NamespaceAPI, GroupObjectPermissionType } from 'src/api';
 
-import { HelperText, ObjectPermissionField } from '../../components';
+import { HelperText, ObjectPermissionField } from 'src/components';
 
 interface IProps {
   isOpen: boolean;

--- a/src/components/patternfly-wrappers/applied-filters.tsx
+++ b/src/components/patternfly-wrappers/applied-filters.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { Chip, ChipGroup, Button } from '@patternfly/react-core';
 
-import { ParamHelper } from '../../utilities';
+import { ParamHelper } from 'src/utilities';
 
 interface IProps {
   /** Sets the current page params to p */

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -14,8 +14,8 @@ import {
 
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 
-import { StatefulDropdown } from '../../components';
-import { ParamHelper } from '../../utilities';
+import { StatefulDropdown } from 'src/components';
+import { ParamHelper } from 'src/utilities';
 
 class FilterOption {
   id: string;

--- a/src/components/patternfly-wrappers/pagination.tsx
+++ b/src/components/patternfly-wrappers/pagination.tsx
@@ -5,8 +5,8 @@ import {
   PaginationVariant,
 } from '@patternfly/react-core';
 
-import { Constants } from '../../constants';
-import { ParamHelper } from '../../utilities/param-helper';
+import { Constants } from 'src/constants';
+import { ParamHelper } from 'src/utilities/param-helper';
 
 interface IProps {
   /** Number of total items returned by the query */

--- a/src/components/patternfly-wrappers/sort.tsx
+++ b/src/components/patternfly-wrappers/sort.tsx
@@ -9,7 +9,7 @@ import {
   SortAlphaUpIcon,
 } from '@patternfly/react-icons';
 
-import { ParamHelper } from '../../utilities/param-helper';
+import { ParamHelper } from 'src/utilities/param-helper';
 
 export class SortFieldType {
   id: string;

--- a/src/components/patternfly-wrappers/tabs.tsx
+++ b/src/components/patternfly-wrappers/tabs.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { Tab, Tabs as PFTabs } from '@patternfly/react-core';
 
-import { ParamHelper } from '../../utilities/param-helper';
+import { ParamHelper } from 'src/utilities/param-helper';
 
 interface IProps {
   /** List of names for tabs */

--- a/src/components/patternfly-wrappers/toolbar.tsx
+++ b/src/components/patternfly-wrappers/toolbar.tsx
@@ -13,8 +13,8 @@ import {
 
 import { SearchIcon } from '@patternfly/react-icons';
 
-import { ParamHelper } from '../../utilities/param-helper';
-import { Sort } from '../../components';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { Sort } from 'src/components';
 
 import { SortFieldType } from './sort';
 

--- a/src/components/permissions/obect-permission-field.tsx
+++ b/src/components/permissions/obect-permission-field.tsx
@@ -3,10 +3,10 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 
 import { TrashIcon } from '@patternfly/react-icons';
 
-import { GroupObjectPermissionType, GroupAPI } from '../../api';
-import { APISearchTypeAhead, PermissionChipSelector } from '../../components';
-import { twoWayMapper } from '../../utilities';
-import { Constants } from '../../constants';
+import { GroupObjectPermissionType, GroupAPI } from 'src/api';
+import { APISearchTypeAhead, PermissionChipSelector } from 'src/components';
+import { twoWayMapper } from 'src/utilities';
+import { Constants } from 'src/constants';
 
 interface IProps {
   groups: GroupObjectPermissionType[];

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -5,9 +5,9 @@ import { Link } from 'react-router-dom';
 import { DropdownItem, ClipboardCopy } from '@patternfly/react-core';
 import { EmptyStateNoData, SortTable, StatefulDropdown } from '..';
 import * as moment from 'moment';
-import { Constants } from '../../constants';
-import { getRepoUrl } from '../../utilities';
-import { Paths, formatPath } from '../../paths';
+import { Constants } from 'src/constants';
+import { getRepoUrl } from 'src/utilities';
+import { Paths, formatPath } from 'src/paths';
 
 interface IProps {
   repositories: {}[];

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -14,13 +14,13 @@ import {
   ExpandableSection,
 } from '@patternfly/react-core';
 
-import { WriteOnlyField, HelperText } from '../../components';
+import { WriteOnlyField, HelperText } from 'src/components';
 
 import { DownloadIcon } from '@patternfly/react-icons';
 
-import { RemoteType, WriteOnlyFieldType } from '../../api';
-import { Constants } from '../../constants';
-import { isFieldSet } from '../../utilities';
+import { RemoteType, WriteOnlyFieldType } from 'src/api';
+import { Constants } from 'src/constants';
+import { isFieldSet } from 'src/utilities';
 
 interface IProps {
   updateRemote: (remote) => void;

--- a/src/components/repositories/remote-repository-table.tsx
+++ b/src/components/repositories/remote-repository-table.tsx
@@ -4,11 +4,11 @@ import * as moment from 'moment';
 import { Button, DropdownItem, Tooltip } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
-import { RemoteType, UserType, PulpStatus } from '../../api';
+import { RemoteType, UserType, PulpStatus } from 'src/api';
 import { HelperText, SortTable, StatefulDropdown } from '..';
-import { StatusIndicator } from '../../components';
+import { StatusIndicator } from 'src/components';
 
-import { Constants } from '../../constants';
+import { Constants } from 'src/constants';
 
 interface IProps {
   remotes: RemoteType[];

--- a/src/components/sort-table/sort-table.tsx
+++ b/src/components/sort-table/sort-table.tsx
@@ -5,7 +5,7 @@ import {
   LongArrowAltDownIcon,
   ArrowsAltVIcon,
 } from '@patternfly/react-icons';
-import { ParamHelper } from '../../utilities';
+import { ParamHelper } from 'src/utilities';
 import './sort-table.scss';
 
 interface IProps {

--- a/src/components/status/status-indicator.tsx
+++ b/src/components/status/status-indicator.tsx
@@ -9,7 +9,7 @@ import {
   ExclamationCircleIcon,
 } from '@patternfly/react-icons';
 
-import { PulpStatus } from '../../api';
+import { PulpStatus } from 'src/api';
 
 interface IProps {
   status: PulpStatus;

--- a/src/components/user-form/user-form-page.tsx
+++ b/src/components/user-form/user-form-page.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 
 import { Section } from '@redhat-cloud-services/frontend-components';
 
-import { BaseHeader, Main, Breadcrumbs, UserForm } from '../../components';
-import { UserType } from '../../api';
+import { BaseHeader, Main, Breadcrumbs, UserForm } from 'src/components';
+import { UserType } from 'src/api';
 
 interface IProps {
   title: string;

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -13,9 +13,9 @@ import {
 } from '@patternfly/react-core';
 import { UserPlusIcon } from '@patternfly/react-icons';
 
-import { APISearchTypeAhead, HelperText } from '../../components';
+import { APISearchTypeAhead, HelperText } from 'src/components';
 
-import { UserType, GroupAPI } from '../../api';
+import { UserType, GroupAPI } from 'src/api';
 
 interface IProps {
   /** User to edit */

--- a/src/containers/about-modal/about-modal.tsx
+++ b/src/containers/about-modal/about-modal.tsx
@@ -7,8 +7,8 @@ import {
   TextListItemVariants,
   TextListVariants,
 } from '@patternfly/react-core';
-import Logo from '../../../static/images/logo_large.svg';
-import { ApplicationInfoAPI, UserType } from '../../api';
+import Logo from 'src/../static/images/logo_large.svg';
+import { ApplicationInfoAPI, UserType } from 'src/api';
 import { detect } from 'detect-browser';
 
 interface IProps {

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -9,7 +9,7 @@ import {
   EmptyStateNoData,
   EmptyStateUnauthorized,
   Main,
-} from '../../components';
+} from 'src/components';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import {
   Toolbar,
@@ -25,8 +25,8 @@ import {
   CheckCircleIcon,
 } from '@patternfly/react-icons';
 
-import { CollectionVersionAPI, CollectionVersion, TaskAPI } from '../../api';
-import { filterIsSet, ParamHelper } from '../../utilities';
+import { CollectionVersionAPI, CollectionVersion, TaskAPI } from 'src/api';
+import { filterIsSet, ParamHelper } from 'src/utilities';
 import {
   LoadingPageWithHeader,
   StatefulDropdown,
@@ -38,10 +38,10 @@ import {
   closeAlertMixin,
   AlertType,
   SortTable,
-} from '../../components';
-import { Paths, formatPath } from '../../paths';
-import { Constants } from '../../constants';
-import { AppContext } from '../../loaders/app-context';
+} from 'src/components';
+import { Paths, formatPath } from 'src/paths';
+import { Constants } from 'src/constants';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   params: {

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -1,5 +1,5 @@
-import { CollectionDetailType, CollectionAPI } from '../../api';
-import { Paths } from '../../paths';
+import { CollectionDetailType, CollectionAPI } from 'src/api';
+import { Paths } from 'src/paths';
 
 export interface IBaseCollectionState {
   params: {

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -8,11 +8,11 @@ import {
   CollectionContentList,
   LoadingPageWithHeader,
   Main,
-} from '../../components';
+} from 'src/components';
 import { loadCollection, IBaseCollectionState } from './base';
-import { ParamHelper } from '../../utilities/param-helper';
-import { formatPath, Paths } from '../../paths';
-import { AppContext } from '../../loaders/app-context';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { formatPath, Paths } from 'src/paths';
+import { AppContext } from 'src/loaders/app-context';
 
 // renders list of contents in a collection
 class CollectionContent extends React.Component<

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -8,11 +8,11 @@ import {
   CollectionInfo,
   LoadingPageWithHeader,
   Main,
-} from '../../components';
+} from 'src/components';
 import { loadCollection, IBaseCollectionState } from './base';
-import { ParamHelper } from '../../utilities/param-helper';
-import { formatPath, Paths } from '../../paths';
-import { AppContext } from '../../loaders/app-context';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { formatPath, Paths } from 'src/paths';
+import { AppContext } from 'src/loaders/app-context';
 
 // renders collection level information
 class CollectionDetail extends React.Component<

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -13,14 +13,14 @@ import {
   LoadingPageWithHeader,
   Main,
   EmptyStateCustom,
-} from '../../components';
+} from 'src/components';
 
 import { RenderPluginDoc } from '@ansible/galaxy-doc-builder';
 
 import { loadCollection, IBaseCollectionState } from './base';
-import { ParamHelper, sanitizeDocsUrls } from '../../utilities';
-import { formatPath, Paths } from '../../paths';
-import { AppContext } from '../../loaders/app-context';
+import { ParamHelper, sanitizeDocsUrls } from 'src/utilities';
+import { formatPath, Paths } from 'src/paths';
+import { AppContext } from 'src/loaders/app-context';
 
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -3,18 +3,18 @@ import * as React from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 
-import { ImportAPI, ImportDetailType, ImportListType } from '../../api';
+import { ImportAPI, ImportDetailType, ImportListType } from 'src/api';
 import {
   CollectionHeader,
   LoadingPageWithHeader,
   ImportConsole,
   Main,
-} from '../../components';
+} from 'src/components';
 
 import { loadCollection, IBaseCollectionState } from './base';
-import { ParamHelper } from '../../utilities/param-helper';
-import { formatPath, Paths } from '../../paths';
-import { AppContext } from '../../loaders/app-context';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { formatPath, Paths } from 'src/paths';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IState extends IBaseCollectionState {
   loadingImports: boolean;

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -12,18 +12,18 @@ import {
   AlertType,
   Main,
   EmptyStateUnauthorized,
-} from '../../components';
+} from 'src/components';
 import {
   MyNamespaceAPI,
   NamespaceType,
   ActiveUserAPI,
   NamespaceLinkType,
-} from '../../api';
+} from 'src/api';
 
 import { Form, ActionGroup, Button } from '@patternfly/react-core';
 
-import { Paths, formatPath } from '../../paths';
-import { ParamHelper, mapErrorMessages } from '../../utilities';
+import { Paths, formatPath } from 'src/paths';
+import { ParamHelper, mapErrorMessages } from 'src/utilities';
 
 interface IState {
   namespace: NamespaceType;

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -9,8 +9,8 @@ import {
   ToolbarContent,
   Tooltip,
 } from '@patternfly/react-core';
-import { ExecutionEnvironmentAPI, ExecutionEnvironmentType } from '../../api';
-import { filterIsSet, ParamHelper } from '../../utilities';
+import { ExecutionEnvironmentAPI, ExecutionEnvironmentType } from 'src/api';
+import { filterIsSet, ParamHelper } from 'src/utilities';
 import {
   CompoundFilter,
   LoadingPageSpinner,
@@ -24,7 +24,7 @@ import {
   Main,
   EmptyStateFilter,
   EmptyStateNoData,
-} from '../../components';
+} from 'src/components';
 
 interface IState {
   params: {

--- a/src/containers/group-management/delete-group-modal.tsx
+++ b/src/containers/group-management/delete-group-modal.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { List, ListItem, Spinner } from '@patternfly/react-core';
-import { DeleteModal } from '../../components/delete-modal/delete-modal';
-import { UserType } from '../../api';
+import { DeleteModal } from 'src/components/delete-modal/delete-modal';
+import { UserType } from 'src/api';
 
 interface IProps {
   count?: number;

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -21,10 +21,10 @@ import {
   SortTable,
   StatefulDropdown,
   Tabs,
-} from '../../components';
-import { GroupAPI, UserAPI, UserType } from '../../api';
-import { filterIsSet, ParamHelper, twoWayMapper } from '../../utilities';
-import { formatPath, Paths } from '../../paths';
+} from 'src/components';
+import { GroupAPI, UserAPI, UserType } from 'src/api';
+import { filterIsSet, ParamHelper, twoWayMapper } from 'src/utilities';
+import { formatPath, Paths } from 'src/paths';
 import {
   Button,
   DropdownItem,
@@ -36,12 +36,12 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { Constants } from '../../constants';
+import { Constants } from 'src/constants';
 import * as moment from 'moment';
-import { InsightsUserType } from '../../api/response-types/user';
-import { AppContext } from '../../loaders/app-context';
+import { InsightsUserType } from 'src/api/response-types/user';
+import { AppContext } from 'src/loaders/app-context';
 import { DeleteGroupModal } from './delete-group-modal';
-import { DeleteModal } from '../../components/delete-modal/delete-modal';
+import { DeleteModal } from 'src/components/delete-modal/delete-modal';
 
 interface IState {
   group: any;

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -7,9 +7,9 @@ import {
   Redirect,
 } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
-import { GroupAPI, UserAPI, UserType } from '../../api';
+import { GroupAPI, UserAPI, UserType } from 'src/api';
 import { DeleteGroupModal } from './delete-group-modal';
-import { filterIsSet, mapErrorMessages, ParamHelper } from '../../utilities';
+import { filterIsSet, mapErrorMessages, ParamHelper } from 'src/utilities';
 import {
   AlertList,
   AlertType,
@@ -25,7 +25,7 @@ import {
   Main,
   Pagination,
   SortTable,
-} from '../../components';
+} from 'src/components';
 import {
   Button,
   Toolbar,
@@ -33,8 +33,8 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { formatPath, Paths } from '../../paths';
-import { AppContext } from '../../loaders/app-context';
+import { formatPath, Paths } from 'src/paths';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   params: {

--- a/src/containers/login/login.tsx
+++ b/src/containers/login/login.tsx
@@ -4,10 +4,10 @@ import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 import { LoginForm, LoginPage as PFLoginPage } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
-import Logo from '../../../static/images/logo_large.svg';
-import { ParamHelper } from '../../utilities/';
-import { Paths } from '../../paths';
-import { ActiveUserAPI } from '../../api';
+import Logo from 'src/../static/images/logo_large.svg';
+import { ParamHelper } from 'src/utilities/';
+import { Paths } from 'src/paths';
+import { ActiveUserAPI } from 'src/api';
 
 interface IState {
   usernameValue: string;

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -5,7 +5,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import { cloneDeep } from 'lodash';
 
-import { BaseHeader, ImportConsole, ImportList, Main } from '../../components';
+import { BaseHeader, ImportConsole, ImportList, Main } from 'src/components';
 
 import {
   ImportAPI,
@@ -16,9 +16,9 @@ import {
   MyNamespaceAPI,
   CollectionVersion,
   CollectionVersionAPI,
-} from '../../api';
+} from 'src/api';
 
-import { ParamHelper } from '../../utilities/param-helper';
+import { ParamHelper } from 'src/utilities/param-helper';
 
 interface IState {
   selectedImport: ImportListType;

--- a/src/containers/namespace-detail/import-modal/import-modal.tsx
+++ b/src/containers/namespace-detail/import-modal/import-modal.tsx
@@ -9,7 +9,7 @@ import {
   CollectionListType,
   CollectionAPI,
   CollectionUploadType,
-} from '../../../api';
+} from 'src/api';
 
 enum Status {
   uploading = 'uploading',

--- a/src/containers/namespace-detail/manage-namespace.tsx
+++ b/src/containers/namespace-detail/manage-namespace.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import { NamespaceDetail } from './namespace-detail';
-import { Paths } from '../../paths';
+import { Paths } from 'src/paths';
 
 interface IProps extends RouteComponentProps {
   selectedRepo: string;

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -17,7 +17,7 @@ import {
   CollectionAPI,
   NamespaceAPI,
   NamespaceType,
-} from '../../api';
+} from 'src/api';
 
 import {
   CollectionList,
@@ -29,13 +29,13 @@ import {
   EmptyStateUnauthorized,
   EmptyStateFilter,
   EmptyStateNoData,
-} from '../../components';
+} from 'src/components';
 
 import { ImportModal } from './import-modal/import-modal';
 
-import { ParamHelper, getRepoUrl, filterIsSet } from '../../utilities';
-import { Paths, formatPath } from '../../paths';
-import { AppContext } from '../../loaders/app-context';
+import { ParamHelper, getRepoUrl, filterIsSet } from 'src/utilities';
+import { Paths, formatPath } from 'src/paths';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   collections: CollectionListType[];

--- a/src/containers/namespace-detail/partner-detail.tsx
+++ b/src/containers/namespace-detail/partner-detail.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import { NamespaceDetail } from './namespace-detail';
-import { Paths } from '../../paths';
+import { Paths } from 'src/paths';
 
 interface IProps extends RouteComponentProps {
   selectedRepo: string;

--- a/src/containers/namespace-list/my-namespaces.tsx
+++ b/src/containers/namespace-list/my-namespaces.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import { NamespaceList } from './namespace-list';
-import { Paths } from '../../paths';
+import { Paths } from 'src/paths';
 
 class MyNamespaces extends React.Component<RouteComponentProps, {}> {
   render() {

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -4,7 +4,7 @@ import './namespace-list.scss';
 import { RouteComponentProps } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 
-import { ParamHelper } from '../../utilities/param-helper';
+import { ParamHelper } from 'src/utilities/param-helper';
 import {
   BaseHeader,
   NamespaceCard,
@@ -15,14 +15,14 @@ import {
   LoadingPageSpinner,
   EmptyStateFilter,
   EmptyStateNoData,
-} from '../../components';
+} from 'src/components';
 import { Button } from '@patternfly/react-core';
 import { ToolbarItem } from '@patternfly/react-core';
-import { NamespaceAPI, NamespaceListType, MyNamespaceAPI } from '../../api';
-import { Paths, formatPath } from '../../paths';
-import { Constants } from '../../constants';
-import { AppContext } from '../../loaders/app-context';
-import { filterIsSet } from '../../utilities';
+import { NamespaceAPI, NamespaceListType, MyNamespaceAPI } from 'src/api';
+import { Paths, formatPath } from 'src/paths';
+import { Constants } from 'src/constants';
+import { AppContext } from 'src/loaders/app-context';
+import { filterIsSet } from 'src/utilities';
 
 interface IState {
   namespaces: NamespaceListType[];

--- a/src/containers/namespace-list/partners.tsx
+++ b/src/containers/namespace-list/partners.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import { NamespaceList } from './namespace-list';
-import { Paths } from '../../paths';
+import { Paths } from 'src/paths';
 
 class Partners extends React.Component<RouteComponentProps, {}> {
   render() {

--- a/src/containers/not-found/not-found.tsx
+++ b/src/containers/not-found/not-found.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import './not-found.scss';
 // had to declare *.gif in src/index.d.ts
-import NotFoundImage from '../../../static/images/not_found.svg';
+import NotFoundImage from 'src/../static/images/not_found.svg';
 
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import { Bullseye } from '@patternfly/react-core';
 
-import { BaseHeader, Main } from '../../components';
+import { BaseHeader, Main } from 'src/components';
 
 class NotFound extends React.Component<RouteComponentProps, {}> {
   render() {

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -11,18 +11,18 @@ import {
   LocalRepositoryTable,
   RemoteForm,
   EmptyStateNoData,
-} from '../../components';
+} from 'src/components';
 import { Section } from '@redhat-cloud-services/frontend-components';
-import { ParamHelper, mapErrorMessages } from '../../utilities';
-import { Constants } from '../../constants';
+import { ParamHelper, mapErrorMessages } from 'src/utilities';
+import { Constants } from 'src/constants';
 import {
   RemoteAPI,
   RemoteType,
   DistributionAPI,
   MyDistributionAPI,
   DistributionType,
-} from '../../api';
-import { AppContext } from '../../loaders/app-context';
+} from 'src/api';
+import { AppContext } from 'src/loaders/app-context';
 
 export class Repository {
   name: string;

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -23,17 +23,17 @@ import {
   AppliedFilters,
   EmptyStateFilter,
   EmptyStateNoData,
-} from '../../components';
+} from 'src/components';
 import {
   CollectionAPI,
   CollectionListType,
   SyncListType,
   MySyncListAPI,
-} from '../../api';
-import { ParamHelper } from '../../utilities/param-helper';
-import { Constants } from '../../constants';
-import { AppContext } from '../../loaders/app-context';
-import { filterIsSet } from '../../utilities';
+} from 'src/api';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { Constants } from 'src/constants';
+import { AppContext } from 'src/loaders/app-context';
+import { filterIsSet } from 'src/utilities';
 
 interface IState {
   collections: CollectionListType[];

--- a/src/containers/settings/user-profile.tsx
+++ b/src/containers/settings/user-profile.tsx
@@ -9,11 +9,11 @@ import {
   AlertType,
   AlertList,
   closeAlertMixin,
-} from '../../components';
-import { UserType, ActiveUserAPI } from '../../api';
-import { Paths } from '../../paths';
-import { mapErrorMessages } from '../../utilities';
-import { AppContext } from '../../loaders/app-context';
+} from 'src/components';
+import { UserType, ActiveUserAPI } from 'src/api';
+import { Paths } from 'src/paths';
+import { mapErrorMessages } from 'src/utilities';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   user: UserType;

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -4,9 +4,9 @@ import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import { ClipboardCopy, Button } from '@patternfly/react-core';
 
-import { Paths } from '../../paths';
-import { BaseHeader, Main } from '../../components';
-import { getRepoUrl } from '../../utilities';
+import { Paths } from 'src/paths';
+import { BaseHeader, Main } from 'src/components';
+import { getRepoUrl } from 'src/utilities';
 
 interface IState {
   tokenData: {

--- a/src/containers/token/token-standalone.tsx
+++ b/src/containers/token/token-standalone.tsx
@@ -4,8 +4,8 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import { ClipboardCopy, Button } from '@patternfly/react-core';
 
-import { BaseHeader, Main } from '../../components';
-import { ActiveUserAPI } from '../../api';
+import { BaseHeader, Main } from 'src/components';
+import { ActiveUserAPI } from 'src/api';
 
 interface IState {
   token: string;

--- a/src/containers/user-management/delete-user-modal.tsx
+++ b/src/containers/user-management/delete-user-modal.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { UserType, UserAPI } from '../../api';
-import { mapErrorMessages } from '../../utilities';
-import { AppContext } from '../../loaders/app-context';
-import { DeleteModal } from '../../components/delete-modal/delete-modal';
+import { UserType, UserAPI } from 'src/api';
+import { mapErrorMessages } from 'src/utilities';
+import { AppContext } from 'src/loaders/app-context';
+import { DeleteModal } from 'src/components/delete-modal/delete-modal';
 
 interface IState {
   isWaitingForResponse: boolean;

--- a/src/containers/user-management/user-create.tsx
+++ b/src/containers/user-management/user-create.tsx
@@ -6,11 +6,11 @@ import {
   Breadcrumbs,
   EmptyStateUnauthorized,
   UserFormPage,
-} from '../../components';
-import { mapErrorMessages } from '../../utilities';
-import { UserType, UserAPI } from '../../api';
-import { Paths } from '../../paths';
-import { AppContext } from '../../loaders/app-context';
+} from 'src/components';
+import { mapErrorMessages } from 'src/utilities';
+import { UserType, UserAPI } from 'src/api';
+import { Paths } from 'src/paths';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   user: UserType;

--- a/src/containers/user-management/user-detail.tsx
+++ b/src/containers/user-management/user-detail.tsx
@@ -12,11 +12,11 @@ import {
   EmptyStateUnauthorized,
   BaseHeader,
   Breadcrumbs,
-} from '../../components';
-import { UserType, UserAPI } from '../../api';
-import { Paths, formatPath } from '../../paths';
+} from 'src/components';
+import { UserType, UserAPI } from 'src/api';
+import { Paths, formatPath } from 'src/paths';
 import { DeleteUserModal } from './delete-user-modal';
-import { AppContext } from '../../loaders/app-context';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   userDetail: UserType;

--- a/src/containers/user-management/user-edit.tsx
+++ b/src/containers/user-management/user-edit.tsx
@@ -7,11 +7,11 @@ import {
   EmptyStateUnauthorized,
   LoadingPageWithHeader,
   UserFormPage,
-} from '../../components';
-import { mapErrorMessages } from '../../utilities';
-import { UserType, UserAPI } from '../../api';
-import { Paths, formatPath } from '../../paths';
-import { AppContext } from '../../loaders/app-context';
+} from 'src/components';
+import { mapErrorMessages } from 'src/utilities';
+import { UserType, UserAPI } from 'src/api';
+import { Paths, formatPath } from 'src/paths';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   user: UserType;

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -21,8 +21,8 @@ import {
 
 import { UserPlusIcon } from '@patternfly/react-icons';
 
-import { UserAPI, UserType } from '../../api';
-import { ParamHelper, filterIsSet } from '../../utilities';
+import { UserAPI, UserType } from 'src/api';
+import { ParamHelper, filterIsSet } from 'src/utilities';
 import {
   StatefulDropdown,
   CompoundFilter,
@@ -38,11 +38,11 @@ import {
   EmptyStateNoData,
   EmptyStateUnauthorized,
   EmptyStateFilter,
-} from '../../components';
+} from 'src/components';
 import { DeleteUserModal } from './delete-user-modal';
 
-import { Paths, formatPath } from '../../paths';
-import { AppContext } from '../../loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   params: {

--- a/src/loaders/app-context.ts
+++ b/src/loaders/app-context.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { UserType } from '../api';
+import { UserType } from 'src/api';
 
 interface IAppContextType {
   user: UserType;

--- a/src/loaders/insights/Routes.js
+++ b/src/loaders/insights/Routes.js
@@ -1,9 +1,9 @@
 import { Route, Switch, Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import React from 'react';
-import asyncComponent from '../../utilities/asyncComponent';
+import asyncComponent from 'src/utilities/asyncComponent';
 import some from 'lodash/some';
-import { Paths } from '../../paths';
+import { Paths } from 'src/paths';
 
 /**
  * Aysnc imports of components

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -5,8 +5,8 @@ import { connect } from 'react-redux';
 import { Routes } from './Routes';
 import '../app.scss';
 import { AppContext } from '../app-context';
-import { ActiveUserAPI } from '../../api';
-import { Paths } from '../../paths';
+import { ActiveUserAPI } from 'src/api';
+import { Paths } from 'src/paths';
 
 const DEFAULT_REPO = 'published';
 

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -26,11 +26,11 @@ import {
   GroupDetail,
   RepositoryList,
   ExecutionEnvironmentList,
-} from '../../containers';
-import { ActiveUserAPI } from '../../api';
+} from 'src/containers';
+import { ActiveUserAPI } from 'src/api';
 import { AppContext } from '../app-context';
 
-import { Paths, formatPath } from '../../paths';
+import { Paths, formatPath } from 'src/paths';
 
 interface IProps extends RouteComponentProps {
   Component: any;

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -25,14 +25,14 @@ import {
 } from '@patternfly/react-core';
 
 import { Routes } from './routes';
-import { Paths, formatPath } from '../../paths';
-import { ActiveUserAPI, UserType } from '../../api';
-import { SmallLogo, StatefulDropdown } from '../../components';
-import { AboutModalWindow } from '../../containers';
+import { Paths, formatPath } from 'src/paths';
+import { ActiveUserAPI, UserType } from 'src/api';
+import { SmallLogo, StatefulDropdown } from 'src/components';
+import { AboutModalWindow } from 'src/containers';
 import { AppContext } from '../app-context';
-import { Constants } from '../../constants';
+import { Constants } from 'src/constants';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
-import Logo from '../../../static/images/logo_large.svg';
+import Logo from 'src/../static/images/logo_large.svg';
 
 interface IState {
   user: UserType;

--- a/src/utilities/asyncComponent.js
+++ b/src/utilities/asyncComponent.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { LoadingPageWithHeader } from '../components';
+import { LoadingPageWithHeader } from 'src/components';
 
 /**
  * Webpack allows loading components asynchronously by using import().

--- a/src/utilities/content-summary.ts
+++ b/src/utilities/content-summary.ts
@@ -1,4 +1,4 @@
-import { ContentSummaryType } from '../api';
+import { ContentSummaryType } from 'src/api';
 
 class Summary {
   total_count: number;

--- a/src/utilities/write-only-fields.ts
+++ b/src/utilities/write-only-fields.ts
@@ -1,4 +1,4 @@
-import { WriteOnlyFieldType } from '../api';
+import { WriteOnlyFieldType } from 'src/api';
 
 export function isFieldSet(
   name: string,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,21 @@
 {
-    "compilerOptions": {
-        "outDir": "./dist/",
-        "sourceMap": true,
-        "strictNullChecks": false,
-        "module": "es6",
-        "jsx": "react",
-        "target": "es5",
-        "allowJs": true,
-        "lib": ["es2018", "dom"],
-        "moduleResolution": "node",
-        "noImplicitAny": false,
-        "allowSyntheticDefaultImports": true
+  "compilerOptions": {
+    "allowJs": true,
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "jsx": "react",
+    "lib": ["es2018", "dom"],
+    "module": "es6",
+    "moduleResolution": "node",
+    "noImplicitAny": false,
+    "outDir": "./dist/",
+    "paths": {
+      "src/*": ["src/*"]
     },
-    "include": ["./src/"],
-    "exclude": ["node_modules"]
+    "sourceMap": true,
+    "strictNullChecks": false,
+    "target": "es5"
+  },
+  "include": ["./src/"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This adds `resolve.alias` to the webpack config, and `compilerOptions.baseUrl` + `compilerOptions.paths` to tsconfig,
allowing for JS/TS imports relative to the repository root (as long as they live under `src/`).

(The second commit just updates most imports, I skipped the `./` ones and only changed the ones with `../`, can be trivially regenerated.)

---

Cc @newswangerd , @ZitaNemeckova WDYT? :)

Does it make sense to go with `src` as the alias? It fits the path so it seems like a reasonable default,
except there *is* a `src` npm package (we don't depend on it, and it's related to redis, so, unlikely in frontend JS), so we *may* want to consider something a bit more exotic like `^/src` or `@/src`?