### PR TITLE
Update lodash to 4.17.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -323,12 +323,6 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
-        "node_modules/@babel/generator/node_modules/lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-            "dev": true
-        },
         "node_modules/@babel/generator/node_modules/source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -1258,12 +1252,6 @@
                 "lodash": "^4.17.13",
                 "to-fast-properties": "^2.0.0"
             }
-        },
-        "node_modules/@babel/helper-split-export-declaration/node_modules/lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-            "dev": true
         },
         "node_modules/@babel/helper-validator-identifier": {
             "version": "7.9.5",
@@ -3177,12 +3165,6 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
-        "node_modules/@babel/template/node_modules/lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-            "dev": true
-        },
         "node_modules/@babel/traverse": {
             "version": "7.6.2",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.2.tgz",
@@ -3219,12 +3201,6 @@
             "dependencies": {
                 "ms": "^2.1.1"
             }
-        },
-        "node_modules/@babel/traverse/node_modules/lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-            "dev": true
         },
         "node_modules/@babel/traverse/node_modules/ms": {
             "version": "2.1.2",
@@ -12543,12 +12519,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/inquirer/node_modules/lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-            "dev": true
-        },
         "node_modules/inquirer/node_modules/strip-ansi": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -13338,12 +13308,6 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
-        "node_modules/istanbul-lib-instrument/node_modules/lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-            "dev": true
-        },
         "node_modules/istanbul-lib-instrument/node_modules/semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -14106,9 +14070,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/lodash-webpack-plugin": {
             "version": "0.11.5",
@@ -24470,12 +24434,6 @@
                         "to-fast-properties": "^2.0.0"
                     }
                 },
-                "lodash": {
-                    "version": "4.17.20",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-                    "dev": true
-                },
                 "source-map": {
                     "version": "0.5.7",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -25398,12 +25356,6 @@
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
-                },
-                "lodash": {
-                    "version": "4.17.20",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-                    "dev": true
                 }
             }
         },
@@ -27403,12 +27355,6 @@
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
-                },
-                "lodash": {
-                    "version": "4.17.20",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-                    "dev": true
                 }
             }
         },
@@ -27448,12 +27394,6 @@
                     "requires": {
                         "ms": "^2.1.1"
                     }
-                },
-                "lodash": {
-                    "version": "4.17.20",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-                    "dev": true
                 },
                 "ms": {
                     "version": "2.1.2",
@@ -35336,12 +35276,6 @@
                         "supports-color": "^5.3.0"
                     }
                 },
-                "lodash": {
-                    "version": "4.17.20",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-                    "dev": true
-                },
                 "strip-ansi": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -35961,12 +35895,6 @@
                         "lodash": "^4.17.13",
                         "to-fast-properties": "^2.0.0"
                     }
-                },
-                "lodash": {
-                    "version": "4.17.20",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-                    "dev": true
                 },
                 "semver": {
                     "version": "6.3.0",
@@ -36604,9 +36532,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.20",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "lodash-webpack-plugin": {
             "version": "0.11.5",


### PR DESCRIPTION
Used `npm update lodash`
Checked it's ok with `find node_modules/ -name lodash\* -a -type d | while read foo; do grep -H version.: $foo/package.json ; done`

More info https://snyk.io/vuln/SNYK-JS-LODASH-1040724