### PR TITLE
Update to match group detail page changes from pull #317, AAH-364

### DIFF
--- a/test/cypress/integration/group_management.js
+++ b/test/cypress/integration/group_management.js
@@ -34,10 +34,17 @@ describe('Hub Group Management Tests', () => {
         cy.login(adminUsername, adminPassword);
         cy.createGroup(name);
         cy.contains(name).should('exist');
+
         cy.addAllPermissions(name);
-        permissionTypes.forEach(permGroup => cy.get(`.pf-l-flex.pf-m-align-items-center.${permGroup}  [placeholder="No permission"]`).should('not.exist'));;
+        permissionTypes.forEach((permGroup) => {
+            cy.get(`.pf-l-flex.pf-m-align-items-center.${permGroup}`).contains('span', 'No permission').should('not.exist');
+        });
+
         cy.removeAllPermissions(name);
-        permissionTypes.forEach(permGroup => cy.get(`.pf-l-flex.pf-m-align-items-center.${permGroup}  [placeholder="No permission"]`).should('exist'));;
+        permissionTypes.forEach((permGroup) => {
+            cy.get(`.pf-l-flex.pf-m-align-items-center.${permGroup}`).contains('span', 'No permission').should('exist');
+        });
+
         cy.deleteGroup(name);
         cy.contains(name).should('not.exist');
     });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -116,6 +116,8 @@ Cypress.Commands.add('addPermissions', {}, (groupName, permissions) => {
             cy.contains('button', permission).click();
         })
     });
+    // need to click outside dropdown to make save button clickable
+    cy.contains('Edit group permissions').click();
     cy.contains('button', 'Save').click();
 });
 


### PR DESCRIPTION
Changes in the formatting for the group detail page required an update in the group management tests (changing a jquery selector). 

Also found that one of the tests was failing when adding permissions due to the dropdown covering up the 'save' button, so added a click on a nearby element to close the dropdown so we can then hit 'save'.