### PR TITLE
User detail/form UX changes

### DIFF
--- a/src/components/shared/data-form.tsx
+++ b/src/components/shared/data-form.tsx
@@ -39,21 +39,24 @@ export class DataForm extends React.Component<IProps> {
         <FormGroup
           fieldId={field.id}
           helperTextInvalid={errorMessages[field.id]}
-          isRequired={requiredFields.includes(field.id)}
+          isRequired={!isReadonly && requiredFields.includes(field.id)}
           key={field.id}
           label={field.title}
-          labelIcon={field.formGroupLabelIcon as any}
-          validated={validated}
+          labelIcon={!isReadonly && (field.formGroupLabelIcon as any)}
+          validated={isReadonly ? 'default' : validated}
         >
-          <TextInput
-            id={field.id}
-            isDisabled={isReadonly}
-            onChange={updateField}
-            placeholder={field.placeholder}
-            type={(field.type as any) || 'text'}
-            validated={validated}
-            value={model[field.id]}
-          />
+          {isReadonly ? (
+            model[field.id]
+          ) : (
+            <TextInput
+              id={field.id}
+              onChange={updateField}
+              placeholder={field.placeholder}
+              type={(field.type as any) || 'text'}
+              validated={validated}
+              value={model[field.id]}
+            />
+          )}
         </FormGroup>
       );
     });

--- a/src/components/shared/data-form.tsx
+++ b/src/components/shared/data-form.tsx
@@ -33,6 +33,10 @@ export class DataForm extends React.Component<IProps> {
     } = this.props;
 
     const fields = formFields.map(field => {
+      if (!field) {
+        return <></>;
+      }
+
       const validated = field.id in errorMessages ? 'error' : 'default';
 
       return (

--- a/src/components/shared/data-form.tsx
+++ b/src/components/shared/data-form.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+
+import { Form, FormGroup, TextInput } from '@patternfly/react-core';
+
+interface IProps {
+  errorMessages: any; // FIXME: { [key: string]: string }, but all callers use {}, object or any
+  formFields: {
+    formGroupLabelIcon?: React.ReactNode;
+    id: string;
+    placeholder?: string;
+    title: string;
+    type?: string;
+  }[];
+  formPrefix?: React.ReactNode;
+  formSuffix?: React.ReactNode;
+  isReadonly: boolean;
+  model: any;
+  requiredFields: string[];
+  updateField: (value, event) => void;
+}
+
+export class DataForm extends React.Component<IProps> {
+  render() {
+    const {
+      errorMessages,
+      formFields,
+      formPrefix,
+      formSuffix,
+      isReadonly,
+      model,
+      requiredFields,
+      updateField,
+    } = this.props;
+
+    const fields = formFields.map(field => {
+      const validated = field.id in errorMessages ? 'error' : 'default';
+
+      return (
+        <FormGroup
+          fieldId={field.id}
+          helperTextInvalid={errorMessages[field.id]}
+          isRequired={requiredFields.includes(field.id)}
+          key={field.id}
+          label={field.title}
+          labelIcon={field.formGroupLabelIcon as any}
+          validated={validated}
+        >
+          <TextInput
+            id={field.id}
+            isDisabled={isReadonly}
+            onChange={updateField}
+            placeholder={field.placeholder}
+            type={(field.type as any) || 'text'}
+            validated={validated}
+            value={model[field.id]}
+          />
+        </FormGroup>
+      );
+    });
+
+    return (
+      <Form>
+        {formPrefix}
+        {fields}
+        {formSuffix}
+      </Form>
+    );
+  }
+}

--- a/src/components/user-form/user-form-page.tsx
+++ b/src/components/user-form/user-form-page.tsx
@@ -43,11 +43,11 @@ export class UserFormPage extends React.Component<IProps> {
       <React.Fragment>
         <BaseHeader
           breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}
+          pageControls={extraControls}
           title={title}
         ></BaseHeader>
         <Main>
           <Section className='body'>
-            {extraControls}
             <UserForm
               isMe={isMe}
               isReadonly={isReadonly}

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -78,7 +78,7 @@ export class UserForm extends React.Component<IProps, IState> {
       { id: 'first_name', title: 'First name' },
       { id: 'last_name', title: 'Last name' },
       { id: 'email', title: 'Email' },
-      {
+      !isReadonly && {
         id: 'password',
         title: 'Password',
         type: 'password',

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -74,10 +74,10 @@ export class UserForm extends React.Component<IProps, IState> {
     } = this.props;
     const { passwordConfirm } = this.state;
     const formFields = [
+      { id: 'username', title: 'Username' },
       { id: 'first_name', title: 'First name' },
       { id: 'last_name', title: 'Last name' },
       { id: 'email', title: 'Email' },
-      { id: 'username', title: 'Username' },
       {
         id: 'password',
         title: 'Password',

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -123,16 +123,9 @@ export class UserForm extends React.Component<IProps, IState> {
 
     const readonlyGroups = () => (
       <FormGroup fieldId='groups' key='readonlyGroups' label='Groups'>
-        {user.groups.length !== 0 && (
-          <ChipGroup>
-            {' '}
-            {user.groups.map(group => (
-              <Chip isReadOnly cellPadding={'1px'} key={group.name}>
-                {group.name}
-              </Chip>
-            ))}{' '}
-          </ChipGroup>
-        )}
+        {user.groups.map(group => (
+          <Label key={group.name}>{group.name}</Label>
+        ))}
       </FormGroup>
     );
 

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 import {
-  Form,
   FormGroup,
   TextInput,
   ActionGroup,
@@ -14,6 +13,7 @@ import {
 import { UserPlusIcon } from '@patternfly/react-icons';
 
 import { APISearchTypeAhead, HelperText } from 'src/components';
+import { DataForm } from 'src/components/shared/data-form';
 
 import { UserType, GroupAPI } from 'src/api';
 
@@ -83,122 +83,122 @@ export class UserForm extends React.Component<IProps, IState> {
         title: 'Password',
         type: 'password',
         placeholder: isNewUser ? '' : '••••••••••••••••••••••',
+        formGroupLabelIcon: (
+          <HelperText
+            content={
+              'Create a password using at least 9 characters, including special characters , ex <!@$%>. Avoid using common names or expressions.'
+            }
+          />
+        ),
       },
     ];
     const requiredFields = ['username', ...(isNewUser ? ['password'] : [])];
 
-    return (
-      <Form>
-        {formFields.map(v => (
-          <FormGroup
-            isRequired={requiredFields.includes(v.id)}
-            key={v.id}
-            fieldId={v.id}
-            label={v.title}
-            validated={this.toError(!(v.id in errorMessages))}
-            helperTextInvalid={errorMessages[v.id]}
-            labelIcon={
-              v.id === 'password' && (
-                <HelperText
-                  content={
-                    'Create a password using at least 9 characters, including special characters , ex <!@$%>. Avoid using common names or expressions.'
-                  }
-                />
-              )
-            }
-          >
-            <TextInput
-              validated={this.toError(!(v.id in errorMessages))}
-              isDisabled={isReadonly}
-              id={v.id}
-              placeholder={v.placeholder}
-              value={user[v.id]}
-              onChange={this.updateField}
-              type={(v.type as any) || 'text'}
-            />
-          </FormGroup>
-        ))}
-        <FormGroup
-          fieldId={'password-confirm'}
-          label={'Password confirmation'}
-          helperTextInvalid={'Passwords do not match'}
-          isRequired={isNewUser || !!user.password}
+    const passwordConfirmGroup = (
+      <FormGroup
+        fieldId={'password-confirm'}
+        label={'Password confirmation'}
+        helperTextInvalid={'Passwords do not match'}
+        isRequired={isNewUser || !!user.password}
+        validated={this.toError(
+          this.isPassSame(user.password, passwordConfirm),
+        )}
+      >
+        <TextInput
+          placeholder={isNewUser ? '' : '••••••••••••••••••••••'}
           validated={this.toError(
             this.isPassSame(user.password, passwordConfirm),
           )}
+          isDisabled={isReadonly}
+          id={'password-confirm'}
+          value={passwordConfirm}
+          onChange={value => {
+            this.setState({ passwordConfirm: value });
+          }}
+          type='password'
+        />
+      </FormGroup>
+    );
+
+    const readonlyGroups = (
+      <FormGroup fieldId={'groups'} label={'Groups'}>
+        {user.groups.length !== 0 && (
+          <ChipGroup>
+            {' '}
+            {user.groups.map(group => (
+              <Chip isReadOnly cellPadding={'1px'}>
+                {group.name}
+              </Chip>
+            ))}{' '}
+          </ChipGroup>
+        )}
+      </FormGroup>
+    );
+
+    const editGroups = (
+      <FormGroup
+        fieldId='groups'
+        label='Groups'
+        helperTextInvalid={errorMessages['groups']}
+        validated={this.toError(!('groups' in errorMessages))}
+      >
+        <APISearchTypeAhead
+          results={this.state.searchGroups}
+          loadResults={this.loadGroups}
+          onSelect={this.onSelectGroup}
+          placeholderText='Select groups'
+          selections={user.groups}
+          multiple={true}
+          onClear={this.clearGroups}
+          isDisabled={isReadonly}
+        />
+      </FormGroup>
+    );
+
+    const superuserLabel = (
+      <FormGroup fieldId='is_superuser' label='User type'>
+        <Tooltip content='Super users have all system permissions regardless of what groups they are in.'>
+          <Label icon={<UserPlusIcon />} color='orange'>
+            Super user
+          </Label>
+        </Tooltip>
+      </FormGroup>
+    );
+
+    const formButtons = (
+      <ActionGroup>
+        <Button
+          isDisabled={
+            !this.isPassValid(user.password, passwordConfirm) ||
+            !this.requiredFilled(user)
+          }
+          onClick={() => saveUser()}
         >
-          <TextInput
-            placeholder={isNewUser ? '' : '••••••••••••••••••••••'}
-            validated={this.toError(
-              this.isPassSame(user.password, passwordConfirm),
-            )}
-            isDisabled={isReadonly}
-            id={'password-confirm'}
-            value={passwordConfirm}
-            onChange={value => {
-              this.setState({ passwordConfirm: value });
-            }}
-            type='password'
-          />
-        </FormGroup>
-        {isMe ? (
-          <FormGroup fieldId={'groups'} label={'Groups'}>
-            {user.groups.length !== 0 && (
-              <ChipGroup>
-                {' '}
-                {user.groups.map(group => (
-                  <Chip isReadOnly cellPadding={'1px'}>
-                    {group.name}
-                  </Chip>
-                ))}{' '}
-              </ChipGroup>
-            )}
-          </FormGroup>
-        ) : (
-          <FormGroup
-            fieldId='groups'
-            label='Groups'
-            helperTextInvalid={errorMessages['groups']}
-            validated={this.toError(!('groups' in errorMessages))}
-          >
-            <APISearchTypeAhead
-              results={this.state.searchGroups}
-              loadResults={this.loadGroups}
-              onSelect={this.onSelectGroup}
-              placeholderText='Select groups'
-              selections={user.groups}
-              multiple={true}
-              onClear={this.clearGroups}
-              isDisabled={isReadonly}
-            />
-          </FormGroup>
-        )}
-        {user.is_superuser && (
-          <FormGroup fieldId='is_superuser' label='User type'>
-            <Tooltip content='Super users have all system permissions regardless of what groups they are in.'>
-              <Label icon={<UserPlusIcon />} color='orange'>
-                Super user
-              </Label>
-            </Tooltip>
-          </FormGroup>
-        )}
-        {!isReadonly && (
-          <ActionGroup>
-            <Button
-              isDisabled={
-                !this.isPassValid(user.password, passwordConfirm) ||
-                !this.requiredFilled(user)
-              }
-              onClick={() => saveUser()}
-            >
-              Save
-            </Button>
-            <Button onClick={() => onCancel()} variant='link'>
-              Cancel
-            </Button>
-          </ActionGroup>
-        )}
-      </Form>
+          Save
+        </Button>
+        <Button onClick={() => onCancel()} variant='link'>
+          Cancel
+        </Button>
+      </ActionGroup>
+    );
+
+    const formSuffix = [
+      passwordConfirmGroup,
+      isMe ? readonlyGroups : editGroups,
+      user.is_superuser && superuserLabel,
+      !isReadonly && formButtons,
+    ];
+
+    return (
+      <DataForm
+        errorMessages={errorMessages}
+        formFields={formFields}
+        formSuffix={<>{formSuffix}</>}
+        isReadonly={isReadonly}
+        model={user}
+        requiredFields={requiredFields}
+        updateField={(v, e) => this.updateField(v, e)}
+      />
     );
   }
 

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -94,12 +94,13 @@ export class UserForm extends React.Component<IProps, IState> {
     ];
     const requiredFields = ['username', ...(isNewUser ? ['password'] : [])];
 
-    const passwordConfirmGroup = (
+    const passwordConfirmGroup = () => (
       <FormGroup
-        fieldId={'password-confirm'}
-        label={'Password confirmation'}
-        helperTextInvalid={'Passwords do not match'}
+        fieldId='password-confirm'
+        helperTextInvalid='Passwords do not match'
         isRequired={isNewUser || !!user.password}
+        key='confirm-group'
+        label='Password confirmation'
         validated={this.toError(
           this.isPassSame(user.password, passwordConfirm),
         )}
@@ -110,7 +111,7 @@ export class UserForm extends React.Component<IProps, IState> {
             this.isPassSame(user.password, passwordConfirm),
           )}
           isDisabled={isReadonly}
-          id={'password-confirm'}
+          id='password-confirm'
           value={passwordConfirm}
           onChange={value => {
             this.setState({ passwordConfirm: value });
@@ -120,13 +121,13 @@ export class UserForm extends React.Component<IProps, IState> {
       </FormGroup>
     );
 
-    const readonlyGroups = (
-      <FormGroup fieldId={'groups'} label={'Groups'}>
+    const readonlyGroups = () => (
+      <FormGroup fieldId='groups' key='readonlyGroups' label='Groups'>
         {user.groups.length !== 0 && (
           <ChipGroup>
             {' '}
             {user.groups.map(group => (
-              <Chip isReadOnly cellPadding={'1px'}>
+              <Chip isReadOnly cellPadding={'1px'} key={group.name}>
                 {group.name}
               </Chip>
             ))}{' '}
@@ -135,11 +136,12 @@ export class UserForm extends React.Component<IProps, IState> {
       </FormGroup>
     );
 
-    const editGroups = (
+    const editGroups = () => (
       <FormGroup
         fieldId='groups'
-        label='Groups'
         helperTextInvalid={errorMessages['groups']}
+        key='editGroups'
+        label='Groups'
         validated={this.toError(!('groups' in errorMessages))}
       >
         <APISearchTypeAhead
@@ -156,7 +158,7 @@ export class UserForm extends React.Component<IProps, IState> {
     );
 
     const superuserLabel = (
-      <FormGroup fieldId='is_superuser' label='User type'>
+      <FormGroup fieldId='is_superuser' key='superuserLabel' label='User type'>
         <Tooltip content='Super users have all system permissions regardless of what groups they are in.'>
           <Label icon={<UserPlusIcon />} color='orange'>
             Super user
@@ -165,7 +167,7 @@ export class UserForm extends React.Component<IProps, IState> {
       </FormGroup>
     );
 
-    const formButtons = (
+    const formButtons = () => (
       <ActionGroup>
         <Button
           isDisabled={
@@ -183,10 +185,10 @@ export class UserForm extends React.Component<IProps, IState> {
     );
 
     const formSuffix = [
-      !isReadonly && passwordConfirmGroup,
-      isMe || isReadonly ? readonlyGroups : editGroups,
+      !isReadonly && passwordConfirmGroup(),
+      isMe || isReadonly ? readonlyGroups() : editGroups(),
       user.is_superuser && superuserLabel,
-      !isReadonly && formButtons,
+      !isReadonly && formButtons(),
     ];
 
     return (

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -183,8 +183,8 @@ export class UserForm extends React.Component<IProps, IState> {
     );
 
     const formSuffix = [
-      passwordConfirmGroup,
-      isMe ? readonlyGroups : editGroups,
+      !isReadonly && passwordConfirmGroup,
+      isMe || isReadonly ? readonlyGroups : editGroups,
       user.is_superuser && superuserLabel,
       !isReadonly && formButtons,
     ];

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -248,9 +248,9 @@ class UserList extends React.Component<RouteComponentProps, IState> {
           id: 'username',
         },
         {
-          title: 'Email',
+          title: 'First name',
           type: 'alpha',
-          id: 'email',
+          id: 'first_name',
         },
         {
           title: 'Last name',
@@ -258,9 +258,9 @@ class UserList extends React.Component<RouteComponentProps, IState> {
           id: 'last_name',
         },
         {
-          title: 'First name',
+          title: 'Email',
           type: 'alpha',
-          id: 'first_name',
+          id: 'email',
         },
         {
           id: 'groups',
@@ -331,16 +331,19 @@ class UserList extends React.Component<RouteComponentProps, IState> {
           </Link>
 
           {user.is_superuser && (
-            <Tooltip content='Super users have all system permissions regardless of what groups they are in.'>
-              <Label icon={<UserPlusIcon />} color='orange'>
-                Super user
-              </Label>
-            </Tooltip>
+            <>
+              {' '}
+              <Tooltip content='Super users have all system permissions regardless of what groups they are in.'>
+                <Label icon={<UserPlusIcon />} color='orange'>
+                  Super user
+                </Label>
+              </Tooltip>
+            </>
           )}
         </td>
-        <td>{user.email}</td>
-        <td>{user.last_name}</td>
         <td>{user.first_name}</td>
+        <td>{user.last_name}</td>
+        <td>{user.email}</td>
         <td>
           {user.groups.map(g => (
             <Label key={g.id}>{g.name}</Label>

--- a/test/cypress/integration/profile.js
+++ b/test/cypress/integration/profile.js
@@ -10,7 +10,8 @@ describe('My Profile Tests', () => {
         cy.get('[aria-label="user-dropdown"] button').click();
         // a little hacky, but basically
         // just click the one link that says 'My profile'.
-        cy.get('a').contains('My profile').click(); 
+        cy.get('a').contains('My profile').click();
+        cy.get('button:contains("Edit")').click();
     });
 
     it('only has input fields for name, email, username, password and pass confirmation', () => {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-360

> Use plain text styling (remove gray blocks behind input text) unless in edit mode
> Move edit/delete buttons to header
> Reorder info to match table column order (see attachments for orders)
> > Order of info confusing. Previous page table shows username first + breadcrumb also shows username, but here username is hidden in the middle of the page -> reorder to match?

This moves the "render form fields based on definition" logic out of UserForm to a separate DataForm component,
changes the readonly view to simplify the formgroups, and only render the text value instead of an input,
removes the password & password confirmation fields in read only mode,
pushes the username field to the top,
and moves the Edit/Delete buttons to page header.

Cc @ZitaNemeckova , @sbuenafe-rh this should be ready for review :)

That said, 2 major questions..

* how *should* the view only mode actually look?, in Group we put the list of labels on the same line as the field name, so I'm not sure which way to go.
* the order of fields in list view is username, email, last name, first name, groups, created  
the order in detail/form now is username, first name, last name, email, passwords, groups  
I don't think it makes sense to go with "last name, first name" in edit, that would confuse everybody. And not sure if last name, first name in the list is intentional. So.. should we have the same order? Which one?

---

Affected screens:

Users > detail
Users > detail > Edit
Users > Create user
navbar > My Profile
navbar > My Profile > Edit


---

Screenshots...

Create user (before and after)
![create-before](https://user-images.githubusercontent.com/289743/111228080-8889db00-85db-11eb-98f2-b35c76c98961.png)
![create-after](https://user-images.githubusercontent.com/289743/111228084-89227180-85db-11eb-9b54-ff1b4398fe20.png)

My profile - edit (before and after)
![myedit-before](https://user-images.githubusercontent.com/289743/111228169-ab1bf400-85db-11eb-93f4-099c8c537b6e.png)
![myedit-after](https://user-images.githubusercontent.com/289743/111228174-ace5b780-85db-11eb-8971-e74399523081.png)

My profile - view (before and after)
![myprof-before](https://user-images.githubusercontent.com/289743/111228180-af481180-85db-11eb-9dff-845693ba836f.png)
![myprof-after](https://user-images.githubusercontent.com/289743/111228183-afe0a800-85db-11eb-9a70-3f3a35463535.png)

User detail (view) (before and after)
![uder-before](https://user-images.githubusercontent.com/289743/111228194-b3742f00-85db-11eb-80bf-74e7382969e7.png)
![uder-after](https://user-images.githubusercontent.com/289743/111228195-b4a55c00-85db-11eb-9be2-46b1efe99122.png)

User edit (before and after)
![uedt-before](https://user-images.githubusercontent.com/289743/111228200-b838e300-85db-11eb-9475-fe475f81ba32.png)
![uedt-after](https://user-images.githubusercontent.com/289743/111228204-b8d17980-85db-11eb-965d-a2f163c9349d.png)

