### PR TITLE
Collection-detail: add Requires Ansible

### DIFF
--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -34,6 +34,7 @@ export class CollectionVersionDetail extends CollectionVersion {
     issues: string;
     repository: string;
   };
+  requires_ansible?: string;
   docs_blob: DocsBlobType;
 }
 

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -130,6 +130,14 @@ export class CollectionInfo extends React.Component<IProps> {
               </SplitItem>
             </Split>
           </GridItem>
+          <GridItem>
+            <Split hasGutter={true}>
+              <SplitItem className='install-title'>Requires Ansible</SplitItem>
+              <SplitItem isFilled>
+                {latest_version.requires_ansible || 'No'}
+              </SplitItem>
+            </Split>
+          </GridItem>
 
           {latest_version.docs_blob.collection_readme ? (
             <GridItem>

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -134,7 +134,7 @@ export class CollectionInfo extends React.Component<IProps> {
             <Split hasGutter={true}>
               <SplitItem className='install-title'>Requires Ansible</SplitItem>
               <SplitItem isFilled>
-                {latest_version.requires_ansible || 'No'}
+                {latest_version.requires_ansible || 'unspecified'}
               </SplitItem>
             </Split>
           </GridItem>

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -130,14 +130,18 @@ export class CollectionInfo extends React.Component<IProps> {
               </SplitItem>
             </Split>
           </GridItem>
-          <GridItem>
-            <Split hasGutter={true}>
-              <SplitItem className='install-title'>Requires Ansible</SplitItem>
-              <SplitItem isFilled>
-                {latest_version.requires_ansible || 'unspecified'}
-              </SplitItem>
-            </Split>
-          </GridItem>
+          {latest_version.requires_ansible && (
+            <GridItem>
+              <Split hasGutter={true}>
+                <SplitItem className='install-title'>
+                  Requires Ansible
+                </SplitItem>
+                <SplitItem isFilled>
+                  {latest_version.requires_ansible}
+                </SplitItem>
+              </Split>
+            </GridItem>
+          )}
 
           {latest_version.docs_blob.collection_readme ? (
             <GridItem>


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/AAH-410

This adds a "Requires Ansible" row to collection detail, defaulting to "No" if not present.

When present.. (last line)

![requires-yes](https://user-images.githubusercontent.com/289743/112201476-30209200-8c08-11eb-845f-bda89809e666.png)

When absent.. 

not displayed


---

~~Question: should that be a "No" or more something like "Any"?~~ ~~(updated to "unspecified")~~ Updated to nothing :)