### PR TITLE
Fix screen blanking when onFilter is called with null event

### DIFF
--- a/src/components/typeahead/typeahead.tsx
+++ b/src/components/typeahead/typeahead.tsx
@@ -90,8 +90,10 @@ export class APISearchTypeAhead extends React.Component<IProps, IState> {
   }
 
   private onFilter = evt => {
-    const textInput = evt.target.value;
-    this.props.loadResults(textInput);
+    if (evt !== null) {
+      const textInput = evt.target.value;
+      this.props.loadResults(textInput);
+    }
     return this.getOptions();
   };
 


### PR DESCRIPTION
go to My Namespaces
click Create
everything disappears...

    typeahead.tsx:93 Uncaught (in promise) TypeError: Cannot read property 'target' of null
    at APISearchTypeAhead._this.onFilter (App.js:8191)
    at Select.updateTypeAheadFilteredChildren (vendor.js:13991)
    at Select.componentDidUpdate (vendor.js:13942)
    at commitLifeCycles (vendor.js:172065)
    at commitLayoutEffects (vendor.js:175033)
    at HTMLUnknownElement.callCallback (vendor.js:152418)
    at Object.invokeGuardedCallbackDev (vendor.js:152467)
    at invokeGuardedCallback (vendor.js:152522)
    at commitRootImpl (vendor.js:174771)
    at unstable_runWithPriority (vendor.js:196356)

    react-dom.development.js:19527 The above error occurred in the <Select> component:
    in Select (created by APISearchTypeAhead)
    in APISearchTypeAhead (created by ObjectPermissionField)
    in div (created by ObjectPermissionField)
    in ObjectPermissionField (created by NamespaceModal)
    in div (created by FormGroup)
    in div (created by FormGroup)
    in FormGroup (created by NamespaceModal)
    in form (created by Form)
    in Form (created by NamespaceModal)
    in div (created by ModalBoxBody)
    in ModalBoxBody (created by ModalContent)
    in div (created by ModalBox)
    in ModalBox (created by ModalContent)
    in div (created by FocusTrap)
    in FocusTrap (created by ModalContent)
    in div (created by Backdrop)
    in Backdrop (created by ModalContent)
    in ModalContent (created by Modal)
    in Modal (created by NamespaceModal)
    in NamespaceModal (created by NamespaceList)
    in div (created by NamespaceList)
    in NamespaceList (created by MyNamespaces)
    in MyNamespaces (created by Route)
    in Route (created by withRouter(MyNamespaces))
    in withRouter(MyNamespaces) (created by AuthHandler)
    in AuthHandler (created by Route)
    in Route (created by Routes)
    in Switch (created by Routes)
    in Routes (created by App)
    in main (created by Page)
    in div (created by Page)
    in Page (created by App)
    in App (created by Route)
    in Route (created by withRouter(App))
    in withRouter(App)
    in Router (created by BrowserRouter)
    in BrowserRouter

it also causes 4 failures during cypress.

Fixing, skipping the logic that needs the event to not be null when it is :).

Cc @ZitaNemeckova , @newswangerd 
