### PR TITLE
Container Registry Manifest

### DIFF
--- a/src/api/execution-environment.ts
+++ b/src/api/execution-environment.ts
@@ -14,6 +14,10 @@ class API extends HubAPI {
   saveReadme(name, readme) {
     return this.http.put(this.apiPath + name + '/_content/readme/', readme);
   }
+
+  image(name, digest) {
+    return this.http.get(`${this.apiPath}${name}/_content/images/${digest}/`);
+  }
 }
 
 export const ExecutionEnvironmentAPI = new API();

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -55,4 +55,5 @@ export { EmptyStateNoData } from './empty-state/empty-state-no-data';
 export { EmptyStateCustom } from './empty-state/empty-state-custom';
 export { MarkdownEditor } from './markdown-editor/markdown-editor';
 export { ShaLabel } from './sha-label/sha-label';
+export { TagLabel } from './tag-label/tag-label';
 export { ExecutionEnvironmentHeader } from './execution-environment-header/execution-environment-header';

--- a/src/components/tag-label/tag-label.tsx
+++ b/src/components/tag-label/tag-label.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { Label } from '@patternfly/react-core';
+import { TagIcon } from '@patternfly/react-icons';
+
+interface IProps {
+  tag: string;
+}
+
+export class TagLabel extends React.Component<IProps> {
+  render() {
+    const { tag } = this.props;
+    return (
+      <Label variant='outline' icon={<TagIcon />}>
+        {tag}
+      </Label>
+    );
+  }
+}

--- a/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+import {
+  Link,
+  Redirect,
+  RouteComponentProps,
+  withRouter,
+} from 'react-router-dom';
 import {
   Main,
   SortTable,
@@ -123,6 +128,23 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
   }
 
   queryActivities(name) {
+    const manifestLink = digestOrTag =>
+      formatPath(Paths.executionEnvironmentManifest, {
+        container: name,
+        digest: digestOrTag,
+      });
+
+    const ShaLink = ({ digest }) => (
+      <Link to={manifestLink(digest)}>
+        <ShaLabel digest={digest} />
+      </Link>
+    );
+    const TagLink = ({ tag }) => (
+      <Link to={manifestLink(tag)}>
+        <TagLabel tag={tag} />
+      </Link>
+    );
+
     this.setState({ loading: true }, () => {
       ActivitiesAPI.list(name)
         .then(result => {
@@ -138,23 +160,23 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
                   if (!!removed) {
                     activityDescription = (
                       <React.Fragment>
-                        <TagLabel tag={action.tag_name} /> was moved to{' '}
-                        <ShaLabel digest={action.manifest_digest} /> from
-                        <ShaLabel digest={removed.manifest_digest} />
+                        <TagLink tag={action.tag_name} /> was moved to{' '}
+                        <ShaLink digest={action.manifest_digest} /> from
+                        <ShaLink digest={removed.manifest_digest} />
                       </React.Fragment>
                     );
                   } else {
                     activityDescription = (
                       <React.Fragment>
-                        <TagLabel tag={action.tag_name} /> was added to{' '}
-                        <ShaLabel digest={action.manifest_digest} />
+                        <TagLink tag={action.tag_name} /> was added to{' '}
+                        <ShaLink digest={action.manifest_digest} />
                       </React.Fragment>
                     );
                   }
                 } else {
                   activityDescription = (
                     <React.Fragment>
-                      <ShaLabel digest={action.manifest_digest} /> was added
+                      <ShaLink digest={action.manifest_digest} /> was added
                     </React.Fragment>
                   );
                 }
@@ -174,7 +196,7 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
                     activityDescription = (
                       <React.Fragment>
                         <TagLabel tag={action.tag_name} /> was removed from{' '}
-                        <ShaLabel digest={action.manifest_digest} />
+                        <ShaLink digest={action.manifest_digest} />
                       </React.Fragment>
                     );
                   } else {

--- a/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
@@ -5,6 +5,7 @@ import {
   SortTable,
   EmptyStateNoData,
   ShaLabel,
+  TagLabel,
   ExecutionEnvironmentHeader,
 } from '../../components';
 import { Section } from '@redhat-cloud-services/frontend-components';
@@ -13,7 +14,6 @@ import { formatPath, Paths } from '../../paths';
 import { ActivitiesAPI } from '../../api';
 import * as moment from 'moment';
 import './execution-environment-detail.scss';
-import { TagIcon } from '@patternfly/react-icons';
 
 interface IState {
   loading: boolean;
@@ -138,10 +138,7 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
                   if (!!removed) {
                     activityDescription = (
                       <React.Fragment>
-                        <Label variant='outline' icon={<TagIcon />}>
-                          {action.tag_name}
-                        </Label>{' '}
-                        was moved to{' '}
+                        <TagLabel tag={action.tag_name} /> was moved to{' '}
                         <ShaLabel digest={action.manifest_digest} /> from
                         <ShaLabel digest={removed.manifest_digest} />
                       </React.Fragment>
@@ -149,10 +146,7 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
                   } else {
                     activityDescription = (
                       <React.Fragment>
-                        <Label variant='outline' icon={<TagIcon />}>
-                          {action.tag_name}
-                        </Label>{' '}
-                        was added to{' '}
+                        <TagLabel tag={action.tag_name} /> was added to{' '}
                         <ShaLabel digest={action.manifest_digest} />
                       </React.Fragment>
                     );
@@ -179,10 +173,7 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
                   ) {
                     activityDescription = (
                       <React.Fragment>
-                        <Label variant='outline' icon={<TagIcon />}>
-                          {action.tag_name}
-                        </Label>{' '}
-                        was removed from{' '}
+                        <TagLabel tag={action.tag_name} /> was removed from{' '}
                         <ShaLabel digest={action.manifest_digest} />
                       </React.Fragment>
                     );

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -13,6 +13,7 @@ import {
   EmptyStateNoData,
   EmptyStateFilter,
   ShaLabel,
+  TagLabel,
   ExecutionEnvironmentHeader,
 } from '../../components';
 import { Section } from '@redhat-cloud-services/frontend-components';
@@ -31,7 +32,6 @@ import { ExecutionEnvironmentAPI, ImagesAPI } from '../../api';
 import { pickBy } from 'lodash';
 import * as moment from 'moment';
 import './execution-environment-detail.scss';
-import { TagIcon } from '@patternfly/react-icons';
 
 interface IState {
   loading: boolean;
@@ -256,9 +256,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
       <tr key={index}>
         <td>
           {image.tags.map(tag => (
-            <Label variant='outline' key={tag} icon={<TagIcon />}>
-              {tag}
-            </Label>
+            <TagLabel key={tag} tag={tag} />
           ))}
         </td>
         <Tooltip content={moment(image.pulp_created).format('MMMM Do YYYY')}>

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+import {
+  Link,
+  Redirect,
+  RouteComponentProps,
+  withRouter,
+} from 'react-router-dom';
 import {
   AppliedFilters,
   BaseHeader,
@@ -247,6 +252,23 @@ class ExecutionEnvironmentDetailImages extends React.Component<
   }
 
   private renderTableRow(image: any, index: number) {
+    const manifestLink = digestOrTag =>
+      formatPath(Paths.executionEnvironmentManifest, {
+        container: this.props.match.params['container'],
+        digest: digestOrTag,
+      });
+
+    const ShaLink = ({ digest }) => (
+      <Link to={manifestLink(digest)}>
+        <ShaLabel digest={digest} />
+      </Link>
+    );
+    const TagLink = ({ tag }) => (
+      <Link to={manifestLink(tag)}>
+        <TagLabel tag={tag} />
+      </Link>
+    );
+
     const url = window.location.href.split('://')[1].split('/ui')[0];
     let instruction =
       image.tags.length === 0
@@ -256,7 +278,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
       <tr key={index}>
         <td>
           {image.tags.map(tag => (
-            <TagLabel key={tag} tag={tag} />
+            <TagLink key={tag} tag={tag} />
           ))}
         </td>
         <Tooltip content={moment(image.pulp_created).format('MMMM Do YYYY')}>
@@ -265,7 +287,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
         <td>{image.layers}</td>
         <td>{getHumanSize(image.size)}</td>
         <td>
-          <ShaLabel digest={image.digest} />
+          <ShaLink digest={image.digest} />
         </td>
         <td>
           <ClipboardCopy isReadOnly>

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.scss
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.scss
@@ -7,3 +7,32 @@
 .layers-max-width {
   max-width: 45%;
 }
+
+.eco-clipboard-copy {
+  display: inline-block;
+
+  .pf-c-clipboard-copy__group {
+    align-items: baseline;
+  }
+
+  input {
+    width: 37em;
+    border: none;
+    background: transparent !important;
+    text-overflow: ellipsis;
+    padding: var(--custom-override);
+    margin: var(--custom-override);
+  }
+
+  button {
+    padding: 0;
+    margin-left: 5px !important;
+    color: var(--pf-global--Color--200) !important;
+  }
+
+  .pf-c-button::after {
+    border: none !important;
+    padding: var(--custom-override);
+    margin: var(--custom-override);
+  }
+}

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.scss
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.scss
@@ -1,10 +1,3 @@
-.clipboard-hide-input > .pf-c-clipboard-copy__group > input {
-  display: none;
-}
-.clipboard-inline {
-  display: inline-block;
-}
-
 .single-line-ellipsis {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.scss
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.scss
@@ -1,0 +1,6 @@
+.clipboard-hide-input > .pf-c-clipboard-copy__group > input {
+  display: none;
+}
+.clipboard-inline {
+  display: inline-block;
+}

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.scss
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.scss
@@ -4,3 +4,9 @@
 .clipboard-inline {
   display: inline-block;
 }
+
+.single-line-ellipsis {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.scss
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.scss
@@ -10,3 +10,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.layers-max-width {
+  max-width: 45%;
+}

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -195,10 +195,10 @@ class ExecutionEnvironmentManifest extends React.Component<
                   </Title>
 
                   {environment.map((line, index) => (
-                    <>
-                      <code key={index}>{line}</code>
+                    <React.Fragment key={index}>
+                      <code>{line}</code>
                       <br />
-                    </>
+                    </React.Fragment>
                   ))}
                 </Section>
               </FlexItem>

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -34,6 +34,7 @@ interface IState {
   labels: string[];
   layers: { text: string; size: string }[];
   loading: boolean;
+  selectedLayer: string;
   size: number;
 }
 
@@ -51,6 +52,7 @@ class ExecutionEnvironmentManifest extends React.Component<
       labels: [],
       layers: [],
       loading: true,
+      selectedLayer: 'layer-0',
       size: 0,
     };
   }
@@ -78,12 +80,15 @@ class ExecutionEnvironmentManifest extends React.Component<
       labels,
       layers,
       loading,
+      selectedLayer,
       size,
     } = this.state;
 
     if (loading) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
+
+    const command = (layers[selectedLayer.split(/-/)[1]] || {}).text;
 
     return (
       <>
@@ -137,9 +142,15 @@ class ExecutionEnvironmentManifest extends React.Component<
                   Image layers
                 </Title>
 
-                <DataList aria-label='Image layers'>
+                <DataList
+                  aria-label='Image layers'
+                  onSelectDataListItem={id =>
+                    this.setState({ selectedLayer: id })
+                  }
+                  selectedDataListItemId={selectedLayer}
+                >
                   {layers.map(({ text, size }, index) => (
-                    <DataListItem key={index}>
+                    <DataListItem key={index} id={`layer-${index}`}>
                       <DataListItemRow>
                         <DataListItemCells
                           dataListCells={[
@@ -160,6 +171,16 @@ class ExecutionEnvironmentManifest extends React.Component<
                     </DataListItem>
                   ))}
                 </DataList>
+              </Section>
+            </FlexItem>
+
+            <FlexItem>
+              <Section className='body'>
+                <Title headingLevel='h2' size='lg'>
+                  Command
+                </Title>
+
+                <code>{command}</code>
               </Section>
             </FlexItem>
 

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -115,7 +115,9 @@ class ExecutionEnvironmentManifest extends React.Component<
           }
         >
           <div>
-            <ClipboardCopy isReadOnly>{digest}</ClipboardCopy>
+            <ClipboardCopy className='eco-clipboard-copy' isReadOnly>
+              {digest}
+            </ClipboardCopy>
           </div>
 
           <LabelGroup numLabels={6}>

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -1,0 +1,133 @@
+import * as React from 'react';
+import { Link, withRouter, RouteComponentProps } from 'react-router-dom';
+import {
+  BaseHeader,
+  Breadcrumbs,
+  Main,
+  ShaLabel,
+  TagLabel,
+} from '../../components';
+import { Section } from '@redhat-cloud-services/frontend-components';
+import {
+  ClipboardCopy,
+  Flex,
+  FlexItem,
+  LabelGroup,
+  Title,
+} from '@patternfly/react-core';
+import { Paths, formatPath } from '../../paths';
+import { ImagesAPI, ActivitiesAPI, ExecutionEnvironmentAPI } from '../../api'; // TODO
+import './execution-environment-manifest.scss';
+
+interface IState {
+  container: { name: string };
+  digest: string;
+  labels: string[];
+  layers: any[]; // FIXME
+  loading: boolean;
+}
+
+class ExecutionEnvironmentManifest extends React.Component<
+  RouteComponentProps,
+  IState
+> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      container: { name: this.props.match.params['container'] },
+      digest: this.props.match.params['digest'],
+      labels: [],
+      layers: [],
+      loading: true,
+    };
+  }
+
+  componentDidMount() {
+    const { container, digest } = this.state;
+    const whileLoading = callback =>
+      this.setState({ loading: true }, () =>
+        callback().then(data => this.setState({ loading: false, ...data })),
+      );
+
+    whileLoading(() =>
+      this.query({
+        container,
+        digest,
+      }),
+    );
+  }
+
+  render() {
+    const { container, digest, labels, layers, loading } = this.state;
+    return (
+      <>
+        <BaseHeader
+          title={'Image layers'}
+          breadcrumbs={
+            <Breadcrumbs
+              links={[
+                {
+                  name: 'Container Registry',
+                  url: Paths.executionEnvironments,
+                },
+                {
+                  name: this.state.container.name,
+                  url: formatPath(Paths.executionEnvironmentDetail, {
+                    container: container.name,
+                  }),
+                },
+                {
+                  name: digest,
+                },
+              ]}
+            />
+          }
+        >
+          <div>
+            <ShaLabel digest={digest} />
+            {/* FIXME: better way? */}
+            <ClipboardCopy
+              isReadOnly
+              className='clipboard-hide-input clipboard-inline'
+            >
+              {digest}
+            </ClipboardCopy>
+          </div>
+
+          <LabelGroup>
+            {labels.map(label => (
+              <TagLabel tag={label} key={label} />
+            ))}
+          </LabelGroup>
+        </BaseHeader>
+
+        <Main>
+          <Flex direction={{ default: 'column' }}>
+            <FlexItem>
+              <Section className='body'>
+                <Title headingLevel='h2' size='lg'>
+                  Image layers
+                </Title>
+              </Section>
+            </FlexItem>
+          </Flex>
+        </Main>
+      </>
+    );
+  }
+
+  query(name) {
+    // FIXME
+    return Promise.resolve({
+      labels: ['focal', 'groovy', 'matcha'],
+      layers: ['ADD file'],
+    });
+    ExecutionEnvironmentAPI.readme(name).then(result => ({
+      labels: [],
+      layers: [],
+    }));
+  }
+}
+
+export default withRouter(ExecutionEnvironmentManifest);

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -135,8 +135,8 @@ class ExecutionEnvironmentManifest extends React.Component<
         </BaseHeader>
 
         <Main>
-          <Flex direction={{ default: 'column' }}>
-            <FlexItem>
+          <Flex>
+            <FlexItem className='layers-max-width'>
               <Section className='body'>
                 <Title headingLevel='h2' size='lg'>
                   Image layers
@@ -174,30 +174,35 @@ class ExecutionEnvironmentManifest extends React.Component<
               </Section>
             </FlexItem>
 
-            <FlexItem>
-              <Section className='body'>
-                <Title headingLevel='h2' size='lg'>
-                  Command
-                </Title>
+            <Flex
+              direction={{ default: 'column' }}
+              className='layers-max-width'
+            >
+              <FlexItem>
+                <Section className='body'>
+                  <Title headingLevel='h2' size='lg'>
+                    Command
+                  </Title>
 
-                <code>{command}</code>
-              </Section>
-            </FlexItem>
+                  <code>{command}</code>
+                </Section>
+              </FlexItem>
 
-            <FlexItem>
-              <Section className='body'>
-                <Title headingLevel='h2' size='lg'>
-                  Environment
-                </Title>
+              <FlexItem>
+                <Section className='body'>
+                  <Title headingLevel='h2' size='lg'>
+                    Environment
+                  </Title>
 
-                {environment.map((line, index) => (
-                  <>
-                    <code key={index}>{line}</code>
-                    <br />
-                  </>
-                ))}
-              </Section>
-            </FlexItem>
+                  {environment.map((line, index) => (
+                    <>
+                      <code key={index}>{line}</code>
+                      <br />
+                    </>
+                  ))}
+                </Section>
+              </FlexItem>
+            </Flex>
           </Flex>
         </Main>
       </>

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -115,14 +115,7 @@ class ExecutionEnvironmentManifest extends React.Component<
           }
         >
           <div>
-            <ShaLabel digest={digest} />
-            {/* custom class hides the associated input and inlines the button after the label */}
-            <ClipboardCopy
-              isReadOnly
-              className='clipboard-hide-input clipboard-inline'
-            >
-              {digest}
-            </ClipboardCopy>
+            <ClipboardCopy isReadOnly>{digest}</ClipboardCopy>
           </div>
 
           <LabelGroup numLabels={6}>

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -143,7 +143,10 @@ class ExecutionEnvironmentManifest extends React.Component<
                       <DataListItemRow>
                         <DataListItemCells
                           dataListCells={[
-                            <DataListCell key='primary content'>
+                            <DataListCell
+                              key='primary content'
+                              className='single-line-ellipsis'
+                            >
                               <code>{text}</code>
                             </DataListCell>,
                             size && (

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -126,7 +126,7 @@ class ExecutionEnvironmentManifest extends React.Component<
             ))}
           </LabelGroup>
 
-          <div>Size: {size}</div>
+          <div style={{ padding: '4px 0' }}>Size: {size}</div>
         </BaseHeader>
 
         <Main>

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -26,4 +26,5 @@ export { default as ExecutionEnvironmentList } from './execution-environment-lis
 export { default as ExecutionEnvironmentDetail } from './execution-environment-detail/execution_environment_detail';
 export { default as ExecutionEnvironmentDetailActivities } from './execution-environment-detail/execution_environment_detail_activities';
 export { default as ExecutionEnvironmentDetailImages } from './execution-environment-detail/execution_environment_detail_images';
+export { default as ExecutionEnvironmentManifest } from './execution-environment-manifest/execution-environment-manifest';
 export { AboutModalWindow } from './about-modal/about-modal';

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -29,6 +29,7 @@ import {
   ExecutionEnvironmentDetail,
   ExecutionEnvironmentDetailActivities,
   ExecutionEnvironmentDetailImages,
+  ExecutionEnvironmentManifest,
 } from 'src/containers';
 import { ActiveUserAPI } from 'src/api';
 import { AppContext } from '../app-context';
@@ -87,10 +88,15 @@ class AuthHandler extends React.Component<IProps, IState> {
 export class Routes extends React.Component<any> {
   static contextType = AppContext;
 
+  // Note: must be ordered from most specific to least specific
   routes = [
     {
       comp: ExecutionEnvironmentDetailActivities,
       path: Paths.executionEnvironmentDetailActivities,
+    },
+    {
+      comp: ExecutionEnvironmentManifest,
+      path: Paths.executionEnvironmentManifest,
     },
     {
       comp: ExecutionEnvironmentDetailImages,

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -19,6 +19,7 @@ export enum Paths {
   executionEnvironmentDetailImages = '/containers/:container+/_content/images',
   executionEnvironmentDetail = '/containers/:container+',
   executionEnvironments = '/containers',
+  executionEnvironmentManifest = '/containers/:container+/_content/images/:digest',
   groupList = '/group-list',
   groupDetail = '/group/:group',
   myCollections = '/my-namespaces/:namespace',


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-449
API PR: https://github.com/ansible/galaxy_ng/pull/693 (merged)
Design: https://marvelapp.com/prototype/27ee1cd6/screen/77680603

Container Registry > detail > tab Images/Activity > click on a sha/tag

This should show the sha, any labels, total size, a list of layers truncated to a single line, with an option to click the detail to see more; and a list of environment variables.

The list of layers also supports layer sizes, but while the current API does provide an ordered list of history items *and* a list of layers with sizes, there is no correspondence or order match between the two.

![docker](https://user-images.githubusercontent.com/289743/114110529-4183c280-98c7-11eb-8d80-b47215d44864.png)
