### PR TITLE
CollectionDocs: filter out doc_fragments and module_utils

### DIFF
--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -6,6 +6,44 @@ import {
 } from 'src/api';
 import axios from 'axios';
 
+function filterContents(contents) {
+  return contents.filter(
+    item => !['doc_fragments', 'module_utils'].includes(item.content_type),
+  );
+}
+
+function filterListItem(item: CollectionListType) {
+  return {
+    ...item,
+    latest_version: {
+      ...item.latest_version,
+      contents: filterContents(item.latest_version.contents), // deprecated
+      metadata: {
+        ...item.latest_version.metadata,
+        contents: filterContents(item.latest_version.metadata.contents),
+      },
+    },
+  };
+}
+
+function filterDetailItem(item: CollectionDetailType) {
+  return {
+    ...item,
+    latest_version: {
+      ...item.latest_version,
+      contents: filterContents(item.latest_version.contents), // deprecated
+      docs_blob: {
+        ...item.latest_version.docs_blob,
+        contents: filterContents(item.latest_version.docs_blob.contents),
+      },
+      metadata: {
+        ...item.latest_version.metadata,
+        contents: filterContents(item.latest_version.metadata.contents),
+      },
+    },
+  };
+}
+
 export class API extends HubAPI {
   apiPath = this.getUIPath('repo/');
   cachedCollection: CollectionDetailType;
@@ -16,7 +54,14 @@ export class API extends HubAPI {
 
   list(params?: any, repo?: string) {
     const path = this.apiPath + repo + '/';
-    return super.list(params, path);
+    return super.list(params, path).then(response => ({
+      ...response,
+      data: {
+        ...response.data,
+        // remove module_utils, doc_fragments from each item
+        data: response.data.data.map(filterListItem),
+      },
+    }));
   }
 
   setDeprecation(
@@ -81,35 +126,26 @@ export class API extends HubAPI {
     params?,
     forceReload?: boolean,
   ): Promise<CollectionDetailType> {
-    const path = `${this.apiPath}${repo}/${namespace}/${name}/`;
     if (
       !forceReload &&
       this.cachedCollection &&
       this.cachedCollection.name === name &&
       this.cachedCollection.namespace.name === namespace
     ) {
-      return new Promise((resolve, reject) => {
-        if (this.cachedCollection) {
-          resolve(this.cachedCollection);
-        } else {
-          reject(this.cachedCollection);
-        }
-      });
-    } else {
-      return new Promise((resolve, reject) => {
-        this.http
-          .get(path, {
-            params: params,
-          })
-          .then(result => {
-            this.cachedCollection = result.data;
-            resolve(result.data);
-          })
-          .catch(result => {
-            reject(result);
-          });
-      });
+      return Promise.resolve(this.cachedCollection);
     }
+
+    const path = `${this.apiPath}${repo}/${namespace}/${name}/`;
+    return this.http
+      .get(path, {
+        params: params,
+      })
+      .then(result => {
+        // remove module_utils, doc_fragments from item
+        const item = filterDetailItem(result.data);
+        this.cachedCollection = item;
+        return item;
+      });
   }
 
   getDownloadURL(distro_base_path, namespace, name, version) {

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -17,7 +17,7 @@ function filterListItem(item: CollectionListType) {
     ...item,
     latest_version: {
       ...item.latest_version,
-      contents: filterContents(item.latest_version.contents), // deprecated
+      contents: null, // deprecated
       metadata: {
         ...item.latest_version.metadata,
         contents: filterContents(item.latest_version.metadata.contents),
@@ -31,7 +31,7 @@ function filterDetailItem(item: CollectionDetailType) {
     ...item,
     latest_version: {
       ...item.latest_version,
-      contents: filterContents(item.latest_version.contents), // deprecated
+      contents: null, // deprecated
       docs_blob: {
         ...item.latest_version.docs_blob,
         contents: filterContents(item.latest_version.docs_blob.contents),

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -13,7 +13,7 @@ export class CollectionVersion {
     tags: string[];
   };
   created_at: string;
-  contents: ContentSummaryType[]; // deprecated
+  // contents: ContentSummaryType[]; // deprecated
   namespace: string;
   name: string;
   repository_list: string[];

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -8,11 +8,12 @@ export class CollectionVersion {
   id: string;
   version: string;
   metadata: {
-    tags: string[];
+    contents: ContentSummaryType[];
     description: string;
+    tags: string[];
   };
   created_at: string;
-  contents: ContentSummaryType[];
+  contents: ContentSummaryType[]; // deprecated
   namespace: string;
   name: string;
   repository_list: string[];
@@ -25,6 +26,7 @@ class RenderedFile {
 
 export class CollectionVersionDetail extends CollectionVersion {
   metadata: {
+    contents: ContentSummaryType[];
     description: string;
     tags: string[];
     authors: string[];

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -39,7 +39,9 @@ export class CollectionCard extends React.Component<IProps> {
     } = this.props;
 
     const company = namespace.company || namespace.name;
-    const contentSummary = convertContentSummaryCounts(latest_version.contents);
+    const contentSummary = convertContentSummaryCounts(
+      latest_version.metadata.contents,
+    );
 
     return (
       <Card className={cx('collection-card-container', className)}>

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -54,7 +54,9 @@ export class CollectionListItem extends React.Component<IProps, {}> {
       );
     }
 
-    const contentSummary = convertContentSummaryCounts(latest_version.contents);
+    const contentSummary = convertContentSummaryCounts(
+      latest_version.metadata.contents,
+    );
 
     cells.push(
       <DataListCell key='content'>

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -80,7 +80,7 @@ class CollectionContent extends React.Component<
         <Main>
           <Section className='body'>
             <CollectionContentList
-              contents={collection.latest_version.contents}
+              contents={collection.latest_version.metadata.contents}
               collection={collection.name}
               namespace={collection.namespace.name}
               params={params}

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -167,7 +167,7 @@ class CollectionDocs extends React.Component<
                         moduleName,
                         collection,
                         params,
-                        collection.latest_version.contents,
+                        collection.latest_version.metadata.contents,
                       )
                     }
                     renderDocLink={(name, href) =>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-53

This alters the result of both `CollectionsAPI.list` (each item in the `.data.data` list) and `CollectionsAPI.getCached` (caching the altered version),
to filter the lists under `latest_version.metadata.contents` and (only in `getCached`) `latest_version.docs_blob.contents`
to remove any items with `content_type` `module_utils` or `doc_fragments`.

This also changes any previous code using `latest_version.contents` to use `latest_version.metadata.contents` instead.

Cc @newswangerd , @ZitaNemeckova 

Affected screens:

* list of collections (counters)
* list of collections under namespace (counters)
* collection detail, documentation tab (left side list)
* collection detail, contents tab (counter and list)

Before:

![before](https://user-images.githubusercontent.com/289743/114113653-b0b0e500-98ce-11eb-89aa-07859de2dc32.png)
![xui repo published](https://user-images.githubusercontent.com/289743/114472227-5e7b0700-9be1-11eb-81b1-ad149d7e1f37.png)
![xui repo published awcrosby](https://user-images.githubusercontent.com/289743/114472231-6044ca80-9be1-11eb-98f4-bcee6220ad70.png)
![xui repo published awcrosby cisco_ios_test content](https://user-images.githubusercontent.com/289743/114472326-89655b00-9be1-11eb-9619-34b0a51dc2fd.png)


After:

![after](https://user-images.githubusercontent.com/289743/114113659-b27aa880-98ce-11eb-90ca-2b5b55cee478.png)
![ui repo published](https://user-images.githubusercontent.com/289743/114472251-689d0580-9be1-11eb-9fff-51da859c1e5c.png)
![ui repo published awcrosby](https://user-images.githubusercontent.com/289743/114472256-6a66c900-9be1-11eb-9cd4-26a4c7d89f39.png)
![ui repo published awcrosby cisco_ios_test content](https://user-images.githubusercontent.com/289743/114472342-8ec2a580-9be1-11eb-8838-285bc61f37c0.png)