### PR TITLE
ObjectPermissionField - don't offer already added groups

### DIFF
--- a/src/components/permissions/obect-permission-field.tsx
+++ b/src/components/permissions/obect-permission-field.tsx
@@ -102,9 +102,13 @@ export class ObjectPermissionField extends React.Component<IProps, IState> {
   }
 
   private loadGroups = name => {
-    GroupAPI.list({ name__contains: name }).then(result =>
-      this.setState({ searchGroups: result.data.data }),
-    );
+    GroupAPI.list({ name__contains: name }).then(result => {
+      const added = this.props.groups.map(group => group.name);
+      const groups = result.data.data.filter(
+        group => !added.includes(group.name),
+      );
+      this.setState({ searchGroups: groups });
+    });
   };
 
   private onSelect = (event, selection, isPlaceholder) => {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-501

Go to My Namespaces > Create, or #313 Container Edit form, select groups..

Filtering out already added groups from showing up in the search results.

Cc @newswangerd , @ZitaNemeckova 