### PR TITLE
Handle errors when adding user to group

### DIFF
--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -562,12 +562,15 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
           title={'No users yet'}
           description={'Users will appear once added to this group'}
           button={
-            <Button
-              variant='primary'
-              onClick={() => this.setState({ addModalVisible: true })}
-            >
-              Add
-            </Button>
+            !!user &&
+            user.model_permissions.change_group && (
+              <Button
+                variant='primary'
+                onClick={() => this.setState({ addModalVisible: true })}
+              >
+                Add
+              </Button>
+            )
           }
         />
       );

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -66,7 +66,6 @@ interface IState {
   showUserRemoveModal: UserType | null;
   permissions: string[];
   originalPermissions: { id: number; name: string }[];
-  loading: boolean;
 }
 
 class GroupDetail extends React.Component<RouteComponentProps, IState> {
@@ -103,7 +102,6 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
       showUserRemoveModal: null,
       permissions: [],
       originalPermissions: [],
-      loading: false,
     };
   }
 
@@ -129,7 +127,6 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
       alerts,
       editPermissions,
       group,
-      loading,
       params,
       showDeleteModal,
       showUserRemoveModal,
@@ -142,7 +139,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
       tabs.push('Users');
     }
 
-    if (!group || loading) {
+    if (!group) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
     if (params.tab == 'users' && !users) {
@@ -739,7 +736,6 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         users: result.data.data,
         itemCount: result.data.meta.count,
         addModalVisible: false,
-        loading: false,
       }),
     );
   }

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -366,7 +366,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
       return null;
     }
 
-    const close = () => this.setState({ addModalVisible: false });
+    const close = () => this.setState({ addModalVisible: false, selected: [] });
 
     return (
       <Modal

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -365,10 +365,13 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
       this.loadOptions();
       return null;
     }
+
+    const close = () => this.setState({ addModalVisible: false });
+
     return (
       <Modal
         variant='large'
-        onClose={() => this.setState({ addModalVisible: false })}
+        onClose={close}
         isOpen={true}
         aria-label='add-user-modal'
         title={''}
@@ -383,16 +386,14 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
             variant='primary'
             isDisabled={this.state.selected.length === 0}
             onClick={() =>
-              this.addUserToGroup(this.state.selected, this.state.group)
+              this.addUserToGroup(this.state.selected, this.state.group).then(
+                close,
+              )
             }
           >
             Add
           </Button>,
-          <Button
-            key='cancel'
-            variant='link'
-            onClick={() => this.setState({ addModalVisible: false })}
-          >
+          <Button key='cancel' variant='link' onClick={close}>
             Cancel
           </Button>,
         ]}
@@ -520,7 +521,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         });
       }),
     )
-      .catch(e => { this.setState({ addModalVisible: false })); this.addAlert('Error updating users.', 'danger', e.message)); })
+      .catch(e => this.addAlert('Error updating users.', 'danger', e.message))
       .then(() => this.queryUsers());
   }
 
@@ -739,7 +740,6 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         this.setState({
           users: result.data.data,
           itemCount: result.data.meta.count,
-          addModalVisible: false,
         }),
       )
       .catch(e => this.addAlert('Error loading users.', 'danger', e.message));

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -221,16 +221,10 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         GroupAPI.addPermission(group.id, {
           permission: permission,
         }).catch(() =>
-          this.setState({
-            alerts: [
-              ...this.state.alerts,
-              {
-                variant: 'danger',
-                title: null,
-                description: `Permission ${permission} was not added`,
-              },
-            ],
-          }),
+          this.addAlert(
+            `Permission ${permission} was not added.`,
+            'danger',
+          ),
         );
       }
     });
@@ -239,16 +233,10 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     originalPermissions.forEach(original => {
       if (!permissions.includes(original.name)) {
         GroupAPI.removePermission(group.id, original.id).catch(() =>
-          this.setState({
-            alerts: [
-              ...this.state.alerts,
-              {
-                variant: 'danger',
-                title: null,
-                description: `Permission ${original.name} was not removed.`,
-              },
-            ],
-          }),
+          this.addAlert(
+            `Permission ${original.name} was not removed.`,
+            'danger',
+          ),
         );
       }
     });
@@ -463,28 +451,12 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         .then(() => {
           this.setState({
             showDeleteModal: false,
-            alerts: [
-              ...this.state.alerts,
-              {
-                variant: 'success',
-                title: null,
-                description: 'Successfully deleted group.',
-              },
-            ],
           });
+          this.addAlert('Successfully deleted group.', 'success');
           this.props.history.push(Paths.groupList);
         })
         .catch(() =>
-          this.setState({
-            alerts: [
-              ...this.state.alerts,
-              {
-                variant: 'danger',
-                title: null,
-                description: 'Error deleting group.',
-              },
-            ],
-          }),
+          this.addAlert('Error deleting group.', 'danger'),
         );
     };
 
@@ -542,6 +514,19 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         a.push({ id: option.id, name: option.username }),
       );
       this.setState({ options: a, allUsers: result.data.data });
+    });
+  }
+
+  private addAlert(title, variant, description?) {
+    this.setState({
+      alerts: [
+        ...this.state.alerts,
+        {
+          description,
+          title,
+          variant,
+        },
+      ],
     });
   }
 
@@ -748,29 +733,13 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     UserAPI.update(user.id, user)
       .then(() => {
         this.setState({
-          alerts: [
-            ...this.state.alerts,
-            {
-              variant: 'success',
-              title: null,
-              description: 'Successfully removed a user from a group.',
-            },
-          ],
           showUserRemoveModal: null,
         });
+        this.addAlert('Successfully removed a user from a group.', 'success');
         this.queryUsers();
       })
       .catch(() =>
-        this.setState({
-          alerts: [
-            ...this.state.alerts,
-            {
-              variant: 'danger',
-              title: null,
-              description: 'Error removing a user from a group.',
-            },
-          ],
-        }),
+        this.addAlert('Error removing user from a group.', 'danger'),
       );
   }
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-209

Added an `addAlert` method, used for all existing alerts, and added more request error handling to `group-detail`,
Also unsetting the selected value in the add modal on close,
and add a permission check for Add on the empty state screen.

---

```
109:    GroupAPI.get(this.state.params.id)
115:    GroupAPI.getPermissions(this.state.params.id)
```

if loading data fails on the intial load, replaced infinispinner with an empty screen with alerts..
![badgroup](https://user-images.githubusercontent.com/289743/115295161-f7ad9e80-a148-11eb-8354-b959554041bb.png)

---

```
404:            UserAPI.list({ username__contains: name, page_size: 5 })
529:    UserAPI.list()
```

failure when autosuggesting groups
![20210419200857](https://user-images.githubusercontent.com/289743/115296943-23318880-a14b-11eb-9ce8-cf89f109fcd9.png)


----

```
518:        return UserAPI.update(id.toString(), {
738:    UserAPI.list({
```

when saving from add modal
![20210419195052](https://user-images.githubusercontent.com/289743/115295758-a520b200-a149-11eb-98c3-234778330643.png)

(modal now closes on failure, maybe it shouldn't?)

---

```
756:    UserAPI.update(user.id, user)
```

when removing user from group
![20210419194945](https://user-images.githubusercontent.com/289743/115295925-d600e700-a149-11eb-82c1-52822dd49415.png)

(modal *doesn't* close on failure, maybe it should?)