### PR TITLE
[PR #339/8716d6e backport][stable-4.2] npm audit fix (#339)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2925,21 +2925,11 @@
             "dev": true
         },
         "axios": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-            "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
             "requires": {
-                "follow-redirects": "1.5.10"
-            },
-            "dependencies": {
-                "follow-redirects": {
-                    "version": "1.5.10",
-                    "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-                    "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-                    "requires": {
-                        "debug": "=3.1.0"
-                    }
-                }
+                "follow-redirects": "^1.10.0"
             }
         },
         "axios-mock-adapter": {
@@ -4734,6 +4724,7 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
             "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "dev": true,
             "requires": {
                 "ms": "2.0.0"
             }
@@ -9737,7 +9728,8 @@
         "ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
         },
         "multicast-dns": {
             "version": "6.2.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@types/react": "^16.14.1",
         "@types/react-dom": "^16.9.10",
         "@types/react-router-dom": "^4.3.5",
-        "axios": "^0.19.2",
+        "axios": "~0.21.1",
         "classnames": "^2.2.5",
         "csstype": "^3.0.5",
         "detect-browser": "^5.2.0",

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -793,9 +793,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "is-ci": {


### PR DESCRIPTION
**This is a backport of PR #339 as merged into master (8716d6e).**

updates axios to 0.21.1
updates ini to 1.3.8 in test/