### PR TITLE
Add Enter handling to Group create modal

### DIFF
--- a/src/components/group-management/group-modal.tsx
+++ b/src/components/group-management/group-modal.tsx
@@ -59,7 +59,12 @@ export class GroupModal extends React.Component<IProps, IState> {
           </Button>,
         ]}
       >
-        <Form>
+        <Form
+          onSubmit={e => {
+            e.preventDefault();
+            onSave(this.state.name);
+          }}
+        >
           <FormGroup
             isRequired={true}
             key='name'


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-229

Steps to reproduce:
- login with an account that can create groups
- navigate to the groups page
- hit 'create'
- enter a name for the group - try it with new name as well as a name of an existing group
- hit the <Enter> key
- observe the page reloading, but your new group doesn't exist/seethere's no create request

Before: The form disappears, the page reloads, but no group is created.
After:
- When filling out the new group form, after filling out a new name of the new group hitting <Enter> submits the form and the group is created.
- When filling out the new group form, after filling out a name of an existing group hitting <Enter> you can see that the name input is invalid with error message.