### PR TITLE
Add spinner to Repo Management

### DIFF
--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -152,7 +152,8 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
           />
         )}
         <BaseHeader title='Repo Management'>
-          {DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE ? (
+          {DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE &&
+          !loading ? (
             <div className='header-bottom'>
               <div className='tab-link-container'>
                 <div className='tabs'>
@@ -172,7 +173,11 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
             </div>
           ) : null}
         </BaseHeader>
-        {this.renderContent(params, loading, itemCount, content)}
+        {loading ? (
+          <LoadingPageSpinner />
+        ) : (
+          this.renderContent(params, loading, itemCount, content)
+        )}
       </React.Fragment>
     );
   }

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -95,7 +95,6 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
   render() {
     const {
       params,
-      itemCount,
       loading,
       content,
       remoteToEdit,
@@ -173,16 +172,12 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
             </div>
           ) : null}
         </BaseHeader>
-        {loading ? (
-          <LoadingPageSpinner />
-        ) : (
-          this.renderContent(params, loading, itemCount, content)
-        )}
+        {loading ? <LoadingPageSpinner /> : this.renderContent(params, content)}
       </React.Fragment>
     );
   }
 
-  private renderContent(params, loading, itemCount, content) {
+  private renderContent(params, content) {
     const { user } = this.context;
     // Dont show remotes on insights
     if (
@@ -192,14 +187,10 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
       return (
         <Main className='repository-list'>
           <Section className='body'>
-            {loading ? (
-              <LoadingPageSpinner />
-            ) : (
-              <LocalRepositoryTable
-                repositories={content}
-                updateParams={this.updateParams}
-              />
-            )}
+            <LocalRepositoryTable
+              repositories={content}
+              updateParams={this.updateParams}
+            />
           </Section>
         </Main>
       );
@@ -213,22 +204,18 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
       ) : (
         <Main className='repository-list'>
           <Section className='body'>
-            {loading ? (
-              <LoadingPageSpinner />
-            ) : (
-              <RemoteRepositoryTable
-                remotes={content}
-                updateParams={this.updateParams}
-                editRemote={(remote: RemoteType) =>
-                  this.selectRemoteToEdit(remote)
-                }
-                syncRemote={distro =>
-                  RemoteAPI.sync(distro).then(result => this.loadContent())
-                }
-                user={user}
-                refreshRemotes={this.refreshContent}
-              />
-            )}
+            <RemoteRepositoryTable
+              remotes={content}
+              updateParams={this.updateParams}
+              editRemote={(remote: RemoteType) =>
+                this.selectRemoteToEdit(remote)
+              }
+              syncRemote={distro =>
+                RemoteAPI.sync(distro).then(result => this.loadContent())
+              }
+              user={user}
+              refreshRemotes={this.refreshContent}
+            />
           </Section>
         </Main>
       );


### PR DESCRIPTION
Go to Repo Management.

Before:
There's an empty statepage before data loads.
After:
There's a spinner before data loads.
