### PR TITLE
Update tests to handle recent changes to UI

### DIFF
--- a/test/cypress/integration/profile.js
+++ b/test/cypress/integration/profile.js
@@ -17,7 +17,9 @@ describe('My Profile Tests', () => {
     it('only has input fields for name, email, username, password and pass confirmation', () => {
         let inputs = ['first_name', 'last_name', 'email', 'username', 'password', 'password-confirm'];
         cy.get('.body').within(() => {
-            cy.get('input').each(($el, index, $list) => {
+            // restricted to text input types because there's a checkbox now for the
+            // 'super user' option, but it's disabled.
+            cy.get('input[type="text"]').each(($el, index, $list) => {
                 expect(inputs).to.include($el.attr('id'));
             });
         });

--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -17,7 +17,10 @@ describe('Repo Management tests', () => {
         cy.contains('Show advanced options').click();
         cy.get('#download_concurrency').should('exist');
     });
-    it('remote proxy config can be saved and deleted.', () => {
+    /* Needs more work to handle uploading a requirements.yml
+     * when you want to save the remote proxy config.
+     */
+    it.skip('remote proxy config can be saved and deleted.', () => {
         cy.login(adminUsername, adminPassword);
         cy.visit(remoteRepoUrl);
         cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -150,7 +150,15 @@ const allPerms = [{
 },{
     group: 'remotes', permissions: ['Change collection remote', 'View collection remote']
 }, {
-    group: 'execution.environments', permissions: ['Change execution environment namespace permissions', 'Change execution environments', 'Change image tags', 'Pull private execution environments', 'View private execution environments']
+    group: 'execution.environments',
+    permissions: [
+        'Change container namespace permissions',
+        'Change containers',
+        'Change image tags',
+        'Create new containers',
+        'Pull private containers',
+        'Push to existing containers',
+        'View private containers']
 }];
 
 Cypress.Commands.add('removeAllPermissions', {}, (groupName) => {


### PR DESCRIPTION
Just a few updates to track some of the changes that have been merged into the UI over the last little while.

Had to disable one of the repo management tests that verifies we can save and delete info from the proxy configuration - now that we no longer bundle in a requirements.yml, we need to figure out some way to upload one in the future.

I looked around a little bit and it's not totally obvious that it's supported by cypress (might require the addition of a plugin). So if we elect to do that we should make an issue and track it. Until then, this fixes the other two failures I saw.