### PR TITLE
Menu refactor & Repo switcher

### DIFF
--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -29,11 +29,11 @@ export class BaseHeader extends React.Component<IProps, {}> {
     } = this.props;
     return (
       <div className={cx('background', className)}>
-        {breadcrumbs && (
-          <div className='breadcrumb-container'>{breadcrumbs}</div>
-        )}
         {contextSelector && (
           <div className='breadcrumb-container'>{contextSelector}</div>
+        )}
+        {breadcrumbs && (
+          <div className='breadcrumb-container'>{breadcrumbs}</div>
         )}
         {!breadcrumbs && !contextSelector && <div className='placeholder' />}
 

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -13,6 +13,7 @@ interface IProps {
   pageControls?: React.ReactNode;
   children?: React.ReactNode;
   className?: string;
+  contextSelector?: React.ReactNode;
 }
 
 export class BaseHeader extends React.Component<IProps, {}> {
@@ -24,11 +25,17 @@ export class BaseHeader extends React.Component<IProps, {}> {
       children,
       breadcrumbs,
       className,
+      contextSelector,
     } = this.props;
     return (
       <div className={cx('background', className)}>
         {breadcrumbs ? (
           <div className='breadcrumb-container'>{breadcrumbs}</div>
+        ) : (
+          <div className='placeholder' />
+        )}
+        {contextSelector ? (
+          <div className='breadcrumb-container'>{contextSelector}</div>
         ) : (
           <div className='placeholder' />
         )}

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -29,16 +29,14 @@ export class BaseHeader extends React.Component<IProps, {}> {
     } = this.props;
     return (
       <div className={cx('background', className)}>
-        {breadcrumbs ? (
+        {breadcrumbs && (
           <div className='breadcrumb-container'>{breadcrumbs}</div>
-        ) : (
-          <div className='placeholder' />
         )}
-        {contextSelector ? (
+        {contextSelector && (
           <div className='breadcrumb-container'>{contextSelector}</div>
-        ) : (
-          <div className='placeholder' />
         )}
+        {!breadcrumbs && !contextSelector && <div className='placeholder' />}
+
         <div className='column-section'>
           <div className='title-box'>
             {imageURL ? (

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -6,7 +6,7 @@ import { Link } from 'react-router-dom';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { FormSelect, FormSelectOption, Alert } from '@patternfly/react-core';
 
-import { BaseHeader, Breadcrumbs } from 'src/components';
+import { BaseHeader, Breadcrumbs, RepoSelector } from 'src/components';
 import { CollectionDetailType } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
 import { ParamHelper } from 'src/utilities/param-helper';
@@ -65,6 +65,13 @@ export class CollectionHeader extends React.Component<IProps> {
         className={className}
         title={collection.name}
         imageURL={collection.namespace.avatar_url}
+        contextSelector={
+          <RepoSelector
+            selectedRepo={this.context.selectedRepo}
+            path={Paths.searchByRepo}
+            isDisabled
+          />
+        }
         breadcrumbs={<Breadcrumbs links={breadcrumbs} />}
         pageControls={
           <div style={{ display: 'flex', alignItems: 'center' }}>

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -17,16 +17,18 @@ interface IProps {
   updateParams: (p) => void;
 
   pageControls?: React.ReactNode;
+  contextSelector?: React.ReactNode;
 }
 
 export class PartnerHeader extends React.Component<IProps, {}> {
   render() {
     const {
-      namespace,
       breadcrumbs,
-      tabs,
+      contextSelector,
+      namespace,
       pageControls,
       params,
+      tabs,
       updateParams,
     } = this.props;
     return (
@@ -35,6 +37,7 @@ export class PartnerHeader extends React.Component<IProps, {}> {
         imageURL={namespace.avatar_url}
         breadcrumbs={<Breadcrumbs links={breadcrumbs} />}
         pageControls={pageControls}
+        contextSelector={contextSelector}
       >
         {namespace.description ? <div>{namespace.description}</div> : null}
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -57,3 +57,4 @@ export { ShaLabel } from './sha-label/sha-label';
 export { TagLabel } from './tag-label/tag-label';
 export { ExecutionEnvironmentHeader } from './execution-environment-header/execution-environment-header';
 export { RepositoryForm } from './execution-environment/repository-form';
+export { RepoSelector } from './repo-selector/repo-selector';

--- a/src/components/repo-selector/repo-selector.scss
+++ b/src/components/repo-selector/repo-selector.scss
@@ -1,0 +1,3 @@
+.input-group-text-no-wrap {
+  white-space: nowrap;
+}

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -31,13 +31,9 @@ export class RepoSelector extends React.Component<IProps, IState> {
         <FlexItem>
           <Select
             className='nav-select'
-            variant='single'
+            isDisabled={this.props.isDisabled}
             isOpen={this.state.selectExpanded}
-            selections={this.getRepoName(this.props.selectedRepo)}
             isPlain={false}
-            onToggle={isExpanded => {
-              this.setState({ selectExpanded: isExpanded });
-            }}
             onSelect={(event, value) => {
               const originalRepo = this.props.selectedRepo;
               const newRepo = this.getRepoBasePath(value.toString());
@@ -49,6 +45,11 @@ export class RepoSelector extends React.Component<IProps, IState> {
                 this.context.setRepo(path);
               }
             }}
+            onToggle={isExpanded => {
+              this.setState({ selectExpanded: isExpanded });
+            }}
+            selections={this.getRepoName(this.props.selectedRepo)}
+            variant='single'
           >
             <SelectOption key={'published'} value={'Published'} />
             <SelectOption key={'rh-certified'} value={'Red Hat Certified'} />

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -10,6 +10,7 @@ interface IProps {
   // Path of the component that's using the component. This is required so that
   // the url for the repo can be updated correctly.
   path: Paths;
+  pathParams?: any;
   isDisabled?: boolean;
 }
 
@@ -41,7 +42,10 @@ export class RepoSelector extends React.Component<IProps, IState> {
               this.setState({ selectExpanded: false });
 
               if (newRepo !== originalRepo) {
-                const path = formatPath(this.props.path, { repo: newRepo });
+                const path = formatPath(this.props.path, {
+                  ...this.props.pathParams,
+                  repo: newRepo,
+                });
                 this.context.setRepo(path);
               }
             }}

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -1,9 +1,17 @@
 import * as React from 'react';
 
-import { Flex, FlexItem, Select, SelectOption } from '@patternfly/react-core';
+import {
+  Flex,
+  FlexItem,
+  InputGroup,
+  InputGroupText,
+  Select,
+  SelectOption,
+} from '@patternfly/react-core';
 import { Constants } from 'src/constants';
 import { Paths, formatPath } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
+import './repo-selector.scss';
 
 interface IProps {
   selectedRepo: string;
@@ -30,35 +38,43 @@ export class RepoSelector extends React.Component<IProps, IState> {
     return (
       <Flex>
         <FlexItem>
-          <Select
-            className='nav-select'
-            isDisabled={this.props.isDisabled}
-            isOpen={this.state.selectExpanded}
-            isPlain={false}
-            onSelect={(event, value) => {
-              const originalRepo = this.props.selectedRepo;
-              const newRepo = this.getRepoBasePath(value.toString());
+          <InputGroup>
+            <InputGroupText
+              variant='plain'
+              className='input-group-text-no-wrap'
+            >
+              Filter by repository
+            </InputGroupText>
+            <Select
+              className='nav-select'
+              isDisabled={this.props.isDisabled}
+              isOpen={this.state.selectExpanded}
+              isPlain={false}
+              onSelect={(event, value) => {
+                const originalRepo = this.props.selectedRepo;
+                const newRepo = this.getRepoBasePath(value.toString());
 
-              this.setState({ selectExpanded: false });
+                this.setState({ selectExpanded: false });
 
-              if (newRepo !== originalRepo) {
-                const path = formatPath(this.props.path, {
-                  ...this.props.pathParams,
-                  repo: newRepo,
-                });
-                this.context.setRepo(path);
-              }
-            }}
-            onToggle={isExpanded => {
-              this.setState({ selectExpanded: isExpanded });
-            }}
-            selections={this.getRepoName(this.props.selectedRepo)}
-            variant='single'
-          >
-            <SelectOption key={'published'} value={'Published'} />
-            <SelectOption key={'rh-certified'} value={'Red Hat Certified'} />
-            <SelectOption key={'community'} value={'Community'} />
-          </Select>
+                if (newRepo !== originalRepo) {
+                  const path = formatPath(this.props.path, {
+                    ...this.props.pathParams,
+                    repo: newRepo,
+                  });
+                  this.context.setRepo(path);
+                }
+              }}
+              onToggle={isExpanded => {
+                this.setState({ selectExpanded: isExpanded });
+              }}
+              selections={this.getRepoName(this.props.selectedRepo)}
+              variant='single'
+            >
+              <SelectOption key={'published'} value={'Published'} />
+              <SelectOption key={'rh-certified'} value={'Red Hat Certified'} />
+              <SelectOption key={'community'} value={'Community'} />
+            </Select>
+          </InputGroup>
         </FlexItem>
       </Flex>
     );

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -1,0 +1,81 @@
+import * as React from 'react';
+
+import { Select, SelectOption } from '@patternfly/react-core';
+import { Constants } from 'src/constants';
+import { Paths, formatPath } from 'src/paths';
+import { AppContext } from 'src/loaders/app-context';
+
+interface IProps {
+  selectedRepo: string;
+  onUpdateRepo: (repo: string) => void;
+  // Path of the component that's using the component. This is required so that
+  // the url for the repo can be updated correctly.
+  path: Paths;
+  isDisabled?: boolean;
+}
+
+interface IState {
+  selectExpanded: boolean;
+}
+
+export class RepoSelector extends React.Component<IProps, IState> {
+  static contextType = AppContext;
+  constructor(props) {
+    super(props);
+
+    this.state = { selectExpanded: false };
+  }
+
+  render() {
+    return (
+      <Select
+        className='nav-select'
+        variant='single'
+        isOpen={this.state.selectExpanded}
+        selections={this.getRepoName(this.props.selectedRepo)}
+        isPlain={false}
+        onToggle={isExpanded => {
+          this.setState({ selectExpanded: isExpanded });
+        }}
+        onSelect={(event, value) => {
+          const originalRepo = this.props.selectedRepo;
+          const newRepo = this.getRepoBasePath(value.toString());
+
+          if (newRepo !== originalRepo) {
+            this.setState({ selectExpanded: false }, () => {
+              this.context.setRepo(
+                formatPath(this.props.path, { repo: newRepo }),
+                () => this.props.onUpdateRepo(newRepo),
+              );
+            });
+          }
+        }}
+      >
+        <SelectOption key={'published'} value={'Published'} />
+        <SelectOption key={'rh-certified'} value={'Red Hat Certified'} />
+        <SelectOption key={'community'} value={'Community'} />
+      </Select>
+    );
+  }
+
+  private getRepoName(basePath) {
+    const newRepoName = Object.keys(Constants.REPOSITORYNAMES).find(
+      key => Constants.REPOSITORYNAMES[key] === basePath,
+    );
+
+    // allowing the repo to go through even if isn't one that we support so
+    // that 404s bubble up naturally from the child components.
+    if (!newRepoName) {
+      return basePath;
+    }
+    return newRepoName;
+  }
+
+  private getRepoBasePath(repoName) {
+    if (Constants.REPOSITORYNAMES[repoName]) {
+      return Constants.REPOSITORYNAMES[repoName];
+    }
+
+    return repoName;
+  }
+}

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 
-import { Select, SelectOption } from '@patternfly/react-core';
+import { Flex, FlexItem, Select, SelectOption } from '@patternfly/react-core';
 import { Constants } from 'src/constants';
 import { Paths, formatPath } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
 
 interface IProps {
   selectedRepo: string;
-  onUpdateRepo: (repo: string) => void;
   // Path of the component that's using the component. This is required so that
   // the url for the repo can be updated correctly.
   path: Paths;
@@ -28,33 +27,35 @@ export class RepoSelector extends React.Component<IProps, IState> {
 
   render() {
     return (
-      <Select
-        className='nav-select'
-        variant='single'
-        isOpen={this.state.selectExpanded}
-        selections={this.getRepoName(this.props.selectedRepo)}
-        isPlain={false}
-        onToggle={isExpanded => {
-          this.setState({ selectExpanded: isExpanded });
-        }}
-        onSelect={(event, value) => {
-          const originalRepo = this.props.selectedRepo;
-          const newRepo = this.getRepoBasePath(value.toString());
+      <Flex>
+        <FlexItem>
+          <Select
+            className='nav-select'
+            variant='single'
+            isOpen={this.state.selectExpanded}
+            selections={this.getRepoName(this.props.selectedRepo)}
+            isPlain={false}
+            onToggle={isExpanded => {
+              this.setState({ selectExpanded: isExpanded });
+            }}
+            onSelect={(event, value) => {
+              const originalRepo = this.props.selectedRepo;
+              const newRepo = this.getRepoBasePath(value.toString());
 
-          if (newRepo !== originalRepo) {
-            this.setState({ selectExpanded: false }, () => {
-              this.context.setRepo(
-                formatPath(this.props.path, { repo: newRepo }),
-                () => this.props.onUpdateRepo(newRepo),
-              );
-            });
-          }
-        }}
-      >
-        <SelectOption key={'published'} value={'Published'} />
-        <SelectOption key={'rh-certified'} value={'Red Hat Certified'} />
-        <SelectOption key={'community'} value={'Community'} />
-      </Select>
+              this.setState({ selectExpanded: false });
+
+              if (newRepo !== originalRepo) {
+                const path = formatPath(this.props.path, { repo: newRepo });
+                this.context.setRepo(path);
+              }
+            }}
+          >
+            <SelectOption key={'published'} value={'Published'} />
+            <SelectOption key={'rh-certified'} value={'Red Hat Certified'} />
+            <SelectOption key={'community'} value={'Community'} />
+          </Select>
+        </FlexItem>
+      </Flex>
     );
   }
 

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -28,6 +28,7 @@ import {
   EmptyStateUnauthorized,
   EmptyStateFilter,
   EmptyStateNoData,
+  RepoSelector,
 } from 'src/components';
 
 import { ImportModal } from './import-modal/import-modal';
@@ -172,6 +173,13 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           params={params}
           updateParams={p => this.updateParams(p)}
           pageControls={this.renderPageControls()}
+          contextSelector={
+            <RepoSelector
+              selectedRepo={this.context.selectedRepo}
+              path={this.props.match.path as any} // Paths.namespaceByRepo or Paths.myCollectionsByRepo
+              pathParams={{ namespace: namespace.name }}
+            />
+          }
         ></PartnerHeader>
         <Main>
           {tab.toLowerCase() === 'collections' ? (

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -118,7 +118,6 @@ class Search extends React.Component<RouteComponentProps, IState> {
             <RepoSelector
               selectedRepo={this.context.selectedRepo}
               path={Paths.searchByRepo}
-              onUpdateRepo={() => this.queryCollections()}
             />
           }
         >

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -23,6 +23,7 @@ import {
   AppliedFilters,
   EmptyStateFilter,
   EmptyStateNoData,
+  RepoSelector,
 } from 'src/components';
 import {
   CollectionAPI,
@@ -34,6 +35,7 @@ import { ParamHelper } from 'src/utilities/param-helper';
 import { Constants } from 'src/constants';
 import { AppContext } from 'src/loaders/app-context';
 import { filterIsSet } from 'src/utilities';
+import { Paths } from 'src/paths';
 
 interface IState {
   collections: CollectionListType[];
@@ -109,7 +111,17 @@ class Search extends React.Component<RouteComponentProps, IState> {
 
     return (
       <div className='search-page'>
-        <BaseHeader className='header' title='Collections'>
+        <BaseHeader
+          className='header'
+          title='Collections'
+          contextSelector={
+            <RepoSelector
+              selectedRepo={this.context.selectedRepo}
+              path={Paths.searchByRepo}
+              onUpdateRepo={() => this.queryCollections()}
+            />
+          }
+        >
           {!noData && (
             <div className='toolbar-wrapper'>
               <div className='toolbar'>

--- a/src/loaders/app.scss
+++ b/src/loaders/app.scss
@@ -10,10 +10,7 @@
 .clickable {
   cursor: pointer;
 }
-li.pf-c-nav__item.nav-select > div > button {
-  background-color: black;
-  color: #f8f8f8;
-}
+
 #page-sidebar > div {
   padding-top: 0px;
 }
@@ -22,14 +19,13 @@ li.pf-c-nav__item.nav-select > div > button {
   border-top-width: var(--pf-global--BorderWidth--sm);
   border-top-color: var(--pf-global--palette--black-800);
 }
+
 section.pf-c-nav__section.nav-title > h2 {
   height: 50px;
   font-size: var(--pf-c-nav__link--FontSize);
   font-weight: var(--pf-c-nav__link--FontWeight);
 }
-.question-mark-dropdown {
-  padding-right: 10px;
-}
+
 // this was getting applied globally when it was in the collection-info.scss file
 // which means other components now rely on it, so I'm just going move it here
 // so that it's explicitly setting these styles globally.

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -22,6 +22,10 @@ import {
   PageHeaderTools,
   PageSidebar,
 } from '@patternfly/react-core';
+import {
+  ExternalLinkAltIcon,
+  QuestionCircleIcon,
+} from '@patternfly/react-icons';
 import { some } from 'lodash';
 
 import { Routes } from './routes';
@@ -30,7 +34,6 @@ import { ActiveUserAPI, UserType, FeatureFlagsType } from 'src/api';
 import { SmallLogo, StatefulDropdown } from 'src/components';
 import { AboutModalWindow } from 'src/containers';
 import { AppContext } from '../app-context';
-import { QuestionCircleIcon } from '@patternfly/react-icons';
 import Logo from 'src/../static/images/logo_large.svg';
 
 interface IState {
@@ -77,8 +80,8 @@ class App extends React.Component<RouteComponentProps, IState> {
     }
 
     let aboutModal = null;
-    let dropdownItems,
-      dropdownItemsCog = [];
+    let docsDropdownItems = [];
+    let userDropdownItems = [];
     let userName: string;
 
     if (user) {
@@ -88,7 +91,7 @@ class App extends React.Component<RouteComponentProps, IState> {
         userName = user.username;
       }
 
-      dropdownItems = [
+      userDropdownItems = [
         <DropdownItem isDisabled key='username'>
           Username: {user.username}
         </DropdownItem>,
@@ -108,36 +111,21 @@ class App extends React.Component<RouteComponentProps, IState> {
           Logout
         </DropdownItem>,
       ];
-      dropdownItemsCog = [
+
+      docsDropdownItems = [
         <DropdownItem
           key='customer_support'
-          onClick={() =>
-            window.open('https://access.redhat.com/support', '_blank')
-          }
+          href='https://access.redhat.com/support'
+          target='_blank'
         >
-          Customer Support
+          Customer Support <ExternalLinkAltIcon />
         </DropdownItem>,
         <DropdownItem
           key='training'
-          onClick={() =>
-            window.open(
-              'https://www.ansible.com/resources/webinars-training',
-              '_blank',
-            )
-          }
+          href='https://www.ansible.com/resources/webinars-training'
+          target='_blank'
         >
-          Training
-        </DropdownItem>,
-        <DropdownItem
-          key='documentation'
-          onClick={() =>
-            window.open(
-              'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
-              '_blank',
-            )
-          }
-        >
-          Documentation
+          Training <ExternalLinkAltIcon />
         </DropdownItem>,
         <DropdownItem
           key='about'
@@ -148,6 +136,7 @@ class App extends React.Component<RouteComponentProps, IState> {
           About
         </DropdownItem>,
       ];
+
       aboutModal = (
         <AboutModalWindow
           isOpen={this.state.aboutModalVisible}
@@ -189,17 +178,16 @@ class App extends React.Component<RouteComponentProps, IState> {
             ) : (
               <div>
                 <StatefulDropdown
-                  items={dropdownItemsCog}
+                  ariaLabel={'docs-dropdown'}
                   defaultText={<QuestionCircleIcon />}
+                  items={docsDropdownItems}
                   toggleType='icon'
-                  ariaLabel={'cog-dropdown'}
                 />
-
                 <StatefulDropdown
-                  defaultText={userName}
-                  toggleType='dropdown'
-                  items={dropdownItems}
                   ariaLabel={'user-dropdown'}
+                  defaultText={userName}
+                  items={userDropdownItems}
+                  toggleType='dropdown'
                 />
               </div>
             )}
@@ -252,8 +240,9 @@ class App extends React.Component<RouteComponentProps, IState> {
               url: Paths.executionEnvironments,
             }),
             menuItem('Documentation', {
-              // TODO
-              condition: false,
+              url:
+                'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
+              external: true,
             }),
             menuSection('User Access', {}, [
               menuItem('Users', {
@@ -288,8 +277,22 @@ class App extends React.Component<RouteComponentProps, IState> {
       );
     const MenuItem = ({ item }) =>
       !('condition' in item) || !!item.condition ? (
-        <NavItem isActive={item.active}>
-          <Link to={item.url}>{item.name}</Link>
+        <NavItem
+          isActive={item.active}
+          onClick={() => item.onclick && item.onclick()}
+        >
+          {item.url && item.external ? (
+            <a href={item.url} target='_blank'>
+              {item.name}
+              <ExternalLinkAltIcon
+                style={{ position: 'absolute', right: '32px' }}
+              />
+            </a>
+          ) : item.url ? (
+            <Link to={item.url}>{item.name}</Link>
+          ) : (
+            item.name
+          )}
         </NavItem>
       ) : null;
     const Menu = ({ items }) => (

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -38,7 +38,6 @@ import Logo from 'src/../static/images/logo_large.svg';
 
 interface IState {
   user: UserType;
-  selectExpanded: boolean;
   selectedRepo: string;
   aboutModalVisible: boolean;
   toggleOpen: boolean;
@@ -51,7 +50,6 @@ class App extends React.Component<RouteComponentProps, IState> {
     super(props);
     this.state = {
       user: null,
-      selectExpanded: false,
       selectedRepo: 'published',
       aboutModalVisible: false,
       toggleOpen: false,
@@ -424,13 +422,8 @@ class App extends React.Component<RouteComponentProps, IState> {
     });
   };
 
-  private setRepo = (path: string, callback?: () => void) => {
-    // this.setState({ selectedRepo: repo }, () => {
-    if (callback) {
-      this.props.history.push(path);
-      callback();
-    }
-    // });
+  private setRepo = (path: string) => {
+    this.props.history.push(path);
   };
 }
 

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -20,8 +20,6 @@ import {
   DropdownItem,
   DropdownSeparator,
   NavGroup,
-  Select,
-  SelectOption,
 } from '@patternfly/react-core';
 
 import { Routes } from './routes';
@@ -30,7 +28,6 @@ import { ActiveUserAPI, UserType, FeatureFlagsType } from 'src/api';
 import { SmallLogo, StatefulDropdown } from 'src/components';
 import { AboutModalWindow } from 'src/containers';
 import { AppContext } from '../app-context';
-import { Constants } from 'src/constants';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 import Logo from 'src/../static/images/logo_large.svg';
 
@@ -219,43 +216,6 @@ class App extends React.Component<RouteComponentProps, IState> {
                 className={'nav-title'}
                 title={APPLICATION_NAME}
               ></NavGroup>
-              <NavItem className={'nav-select'}>
-                <Select
-                  className='nav-select'
-                  variant='single'
-                  isOpen={this.state.selectExpanded}
-                  selections={this.getRepoName(this.state.selectedRepo)}
-                  isPlain={false}
-                  onToggle={isExpanded => {
-                    this.setState({ selectExpanded: isExpanded });
-                  }}
-                  onSelect={(event, value) => {
-                    const originalRepo = this.state.selectedRepo;
-                    this.setState(
-                      {
-                        selectedRepo: this.getRepoBasePath(value.toString()),
-                        selectExpanded: false,
-                      },
-                      () => {
-                        this.props.history.push(
-                          formatPath(Paths.searchByRepo, {
-                            repo: this.getRepoBasePath(value.toString()),
-                          }),
-                        );
-                        // history.go(0) forces a reload of the page
-                        this.props.history.go(0);
-                      },
-                    );
-                  }}
-                >
-                  <SelectOption key={'published'} value={'Published'} />
-                  <SelectOption
-                    key={'rh-certified'}
-                    value={'Red Hat Certified'}
-                  />
-                  <SelectOption key={'community'} value={'Community'} />
-                </Select>
-              </NavItem>
               <NavItem>
                 <Link
                   to={formatPath(Paths.searchByRepo, {
@@ -344,27 +304,6 @@ class App extends React.Component<RouteComponentProps, IState> {
     });
   }
 
-  private getRepoBasePath(repoName) {
-    if (Constants.REPOSITORYNAMES[repoName]) {
-      return Constants.REPOSITORYNAMES[repoName];
-    }
-
-    return repoName;
-  }
-
-  private getRepoName(basePath) {
-    const newRepoName = Object.keys(Constants.REPOSITORYNAMES).find(
-      key => Constants.REPOSITORYNAMES[key] === basePath,
-    );
-
-    // allowing the repo to go through even if isn't one that we support so
-    // that 404s bubble up naturally from the child components.
-    if (!newRepoName) {
-      return basePath;
-    }
-    return newRepoName;
-  }
-
   private ctx(component) {
     return (
       <AppContext.Provider
@@ -389,8 +328,13 @@ class App extends React.Component<RouteComponentProps, IState> {
     });
   };
 
-  private setRepo = repo => {
-    this.setState({ selectedRepo: repo });
+  private setRepo = (path: string, callback?: () => void) => {
+    // this.setState({ selectedRepo: repo }, () => {
+    if (callback) {
+      this.props.history.push(path);
+      callback();
+    }
+    // });
   };
 }
 

--- a/test/cypress/integration/menu.js
+++ b/test/cypress/integration/menu.js
@@ -2,6 +2,18 @@ describe('Hub Menu Tests', () => {
     let baseUrl = Cypress.config().baseUrl;
     let adminUsername = Cypress.env('username');
     let adminPassword = Cypress.env('password');
+    let menuItems = [
+        'Collections > Collections',
+        'Collections > Namespaces',
+        'Collections > My Namespaces',
+        'Collections > Repository Management',
+        'Collections > API Token',
+        'Collections > Approval',
+        'Container Registry',
+        'Documentation',
+        'User Access > Users',
+        'User Access > Groups',
+    ];
 
     beforeEach(() => {
         cy.visit(baseUrl);
@@ -9,28 +21,42 @@ describe('Hub Menu Tests', () => {
 
     it('admin user sees complete menu', () => {
         cy.login(adminUsername, adminPassword);
-        let menuItems = [ 'Collections', 'Namespaces', 'My Namespaces', 'API Token', 'Users', 'Groups', 'Approval', 'Repo Management' ];
-        menuItems.forEach(item => cy.menuItem(item));
+        menuItems.forEach(item => cy.menuPresent(item));
     });
 
-    describe('', () => {
+    describe('user without permissions', () => {
         let username = 'nopermission';
         let password = 'n0permissi0n';
+        let visibleMenuItems = [
+            'Collections > Collections',
+            'Collections > Namespaces',
+            'Collections > My Namespaces',
+            'Collections > Repository Management',
+            'Collections > API Token',
+            'Container Registry',
+            'Documentation',
+        ];
+        let missingMenuItems = [
+            'User Access > Users',
+            'User Access > Groups',
+            'Collections > Approval',
+        ];
 
         beforeEach(() => {
             cy.login(adminUsername, adminPassword);
             cy.createUser(username, password);
+            cy.logout();
         });
+
         afterEach(() => {
             cy.deleteUser(username);
-        });
-        it('a user without permissions sees limited menu', () => {
-            let menuItems = [ 'Collections', 'Namespaces', 'My Namespaces', 'API Token', 'Repo Management' ];
-            let menuMissingItems = [ 'Users', 'Groups', 'Approval' ];
             cy.logout();
+        });
+
+        it('sees limited menu', () => {
             cy.login(username, password);
-            menuItems.forEach(item => cy.menuItem(item));
-            menuMissingItems.forEach(item => cy.menuItem(item).should('not.exist'));
+            visibleMenuItems.forEach(item => cy.menuPresent(item));
+            missingMenuItems.forEach(item => cy.menuMissing(item));
         });
     });
 });

--- a/test/cypress/integration/user_dashboard.js
+++ b/test/cypress/integration/user_dashboard.js
@@ -22,7 +22,7 @@ describe('Hub User Management Tests', () => {
         beforeEach(() => {
             cy.visit(baseUrl);
             cy.login(adminUsername, adminPassword);
-            cy.contains('#page-sidebar a', 'Users').click();
+            cy.menuGo('User Access > Users');
         });
 
         it('User table lists users', () => {
@@ -34,7 +34,7 @@ describe('Hub User Management Tests', () => {
         beforeEach(() => {
             cy.visit(baseUrl);
             cy.login(adminUsername, adminPassword);
-            cy.contains('#page-sidebar a', 'Users').click();
+            cy.menuGo('User Access > Users');
         });
 
         afterEach(() => {
@@ -59,7 +59,7 @@ describe('Hub User Management Tests', () => {
         });
 
         function attemptToDelete(toDelete) {
-            cy.contains('#page-sidebar a', 'Users').click();
+            cy.menuGo('User Access > Users');
             cy.get(`[aria-labelledby=${toDelete}] [aria-label=Actions]`).click();
             cy.containsnear(`[aria-labelledby=${toDelete}] [aria-label=Actions]`, 'Delete').click();
             cy.get('footer > button:contains("Delete")').should('be.disabled');
@@ -80,7 +80,7 @@ describe('Hub User Management Tests', () => {
             attemptToDelete(adminUsername);
         });
     });
-    
+
     after(() => {
         cy.login(adminUsername, adminPassword);
         cy.deleteUser(username);

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -39,9 +39,21 @@ Cypress.Commands.add('containsnear', {}, (...args) => {
     cy.log('constainsnear requires selector and content parameters');
 });
 
-Cypress.Commands.add('menuItem', {}, (name) => {
-    return cy.contains('#page-sidebar a', name);
+Cypress.Commands.add('menuPresent', {}, (name) => {
+    const last = name.split(' > ').pop();
+    return cy.contains('#page-sidebar a', last).should('exist');
 });
+
+Cypress.Commands.add('menuMissing', {}, (name) => {
+    const last = name.split(' > ').pop();
+    return cy.contains('#page-sidebar a', last).should('not.exist');
+});
+
+Cypress.Commands.add('menuGo', {}, (name) => {
+    const last = name.split(' > ').pop();
+    return cy.contains('#page-sidebar a', last).click({ force: true });
+});
+
 Cypress.Commands.add('logout', {}, () => {
     cy.server();
     cy.route('GET', urljoin(Cypress.config().baseUrl, Cypress.env('prefix'), '_ui/v1/me/')).as('me');
@@ -62,7 +74,7 @@ Cypress.Commands.add('login', {}, (username, password) => {
 });
 
 Cypress.Commands.add('createUser', {}, (username, password = null, firstName = null, lastName = null, email = null) => {
-    cy.contains('#page-sidebar a', 'Users').click();
+    cy.menuGo('User Access > Users');
 
     const user = {
         firstName: firstName || 'First Name',
@@ -88,7 +100,7 @@ Cypress.Commands.add('createUser', {}, (username, password = null, firstName = n
 
 Cypress.Commands.add('createGroup', {}, (name) => {
     cy.route('GET', Cypress.env('prefix') + '_ui/v1/groups/?sort=name&offset=0&limit=10').as('createGroup');
-    cy.contains('#page-sidebar a', 'Groups').click();
+    cy.menuGo('User Access > Groups');
     cy.wait('@createGroup');
 
     cy.contains('Create').click();
@@ -101,7 +113,7 @@ Cypress.Commands.add('createGroup', {}, (name) => {
 Cypress.Commands.add('addPermissions', {}, (groupName, permissions) => {
     cy.server();
     cy.route('GET', Cypress.env('prefix') + '_ui/v1/groups/*/model-permissions/*').as('groups');
-    cy.contains('#page-sidebar a', 'Groups').click();
+    cy.menuGo('User Access > Groups');
     cy.get(`[aria-labelledby=${groupName}] a`).click();
     cy.wait('@groups');
     cy.contains('button', 'Edit').click();
@@ -119,7 +131,7 @@ Cypress.Commands.add('addPermissions', {}, (groupName, permissions) => {
 });
 
 Cypress.Commands.add('removePermissions', {}, (groupName, permissions) => {
-    cy.contains('#page-sidebar a', 'Groups').click();
+    cy.menuGo('User Access > Groups');
     cy.get(`[aria-labelledby=${groupName}] a`).click();
     cy.contains('button', 'Edit').click();
     permissions.forEach(permissionElement => {
@@ -167,7 +179,7 @@ Cypress.Commands.add('addAllPermissions', {}, (groupName) => {
 });
 
 Cypress.Commands.add('addUserToGroup', {}, (groupName, userName) => {
-    cy.contains('#page-sidebar a', 'Groups').click();
+    cy.menuGo('User Access > Groups');
     cy.get(`[aria-labelledby=${groupName}] a`).click();
     cy.contains('button', 'Users').click();
     cy.contains('button', 'Add').click();
@@ -180,7 +192,7 @@ Cypress.Commands.add('addUserToGroup', {}, (groupName, userName) => {
 });
 
 Cypress.Commands.add('removeUserFromGroup', {}, (groupName, userName) => {
-    cy.contains('#page-sidebar a', 'Groups').click();
+    cy.menuGo('User Access > Groups');
     cy.get(`[aria-labelledby=${groupName}] a`).click();
     cy.contains('button', 'Users').click();
     cy.get(`[aria-labelledby=${userName}] [aria-label=Actions]`).click();
@@ -189,6 +201,7 @@ Cypress.Commands.add('removeUserFromGroup', {}, (groupName, userName) => {
     cy.contains(userName).should('not.exist');
 });
 
+// FIXME: createUser doesn't change logins, deleteUser does => TODO consistency
 Cypress.Commands.add('deleteUser', {}, (username) => {
     let adminUsername = Cypress.env('username');
     let adminPassword = Cypress.env('password');
@@ -196,7 +209,7 @@ Cypress.Commands.add('deleteUser', {}, (username) => {
     cy.logout();
     cy.login(adminUsername, adminPassword);
 
-    cy.contains('#page-sidebar a', 'Users').click();
+    cy.menuGo('User Access > Users');
     cy.server();
     cy.route('DELETE', Cypress.env('prefix') + '_ui/v1/users/**').as('deleteUser');
     cy.get(`[aria-labelledby=${username}] [aria-label=Actions]`).click();
@@ -213,7 +226,7 @@ Cypress.Commands.add('deleteGroup', {}, (name) => {
     cy.logout();
     cy.login(adminUsername, adminPassword);
 
-    cy.contains('#page-sidebar a', 'Groups').click();
+    cy.menuGo('User Access > Groups');
     cy.server();
     cy.route('DELETE', Cypress.env('prefix') + '_ui/v1/groups/**').as('deleteGroup');
     cy.get(`[aria-labelledby=${name}] [aria-label=Delete]`).click();


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-485

This moves the repository select from the menu to the relevant screens, and updates the menu to a new design, with sections.

Menu change:

|**before**|**after** - expanded|**after** - collapsed|
|-|-|-|
| ![20210423193639](https://user-images.githubusercontent.com/289743/115921620-44f07f80-a46b-11eb-8aa5-0ab605f23f6e.png) | ![20210423193238](https://user-images.githubusercontent.com/289743/115921307-d3b0cc80-a46a-11eb-9e05-7af196a9c897.png) | ![20210423193259](https://user-images.githubusercontent.com/289743/115921316-d8758080-a46a-11eb-9c54-98a2a17f75e6.png) |

The menu is also highlighting the active item now, based on url prefix match,
remembering open sections during navigation (but on reload, defaults to only expanding the current section),
and hiding empty sections when the user can't access any items under these.

The question mark menu is updated to use external links with the icon, and Documentation moved to menu..

![20210423193316](https://user-images.githubusercontent.com/289743/115921807-8ed96580-a46b-11eb-89e6-480cc0bee0a6.png)


Screens with the selector:

* `src/containers/search/search.tsx` (r/w, goes to `/ui/repo/:selectedRepo`)
  * `/ui/repo/:selectedRepo/` - Collections

![20210426225015](https://user-images.githubusercontent.com/289743/116160725-17f9d200-a6e2-11eb-8e3e-f0304ee56a35.png)
![20210426225029](https://user-images.githubusercontent.com/289743/116160731-19c39580-a6e2-11eb-9d87-6216945295ac.png)
![20210426225038](https://user-images.githubusercontent.com/289743/116160735-1b8d5900-a6e2-11eb-85d0-4fbfe0ebf92f.png)

* `src/components/headers/collection-header.tsx` (r/o)
  * `/ui/repo/:selectedRepo/:namespace/:collection` - Collection detail, tab Details
  * `/ui/repo/:selectedRepo/:namespace/:collection/docs` - Collection detail, tab Documentation
  * `/ui/repo/:selectedRepo/:namespace/:collection/content` - Collection detail, tab Contents
  * `/ui/repo/:selectedRepo/:namespace/:collection/import-log` - Collection detail, tab Import log

![20210426225057](https://user-images.githubusercontent.com/289743/116160753-234cfd80-a6e2-11eb-94a6-868d80f4d6a7.png)

* `src/containers/namespace-detail/namespace-detail.tsx` via `src/components/headers/partner-header.tsx` (r/w, goes to TODO)
  * `/ui/repo/:selectedRepo/:namespace` - Collections under a namespace
  * `/ui/repo/:selectedRepo/my-namespaces/:namespace` - My Collections under a namespace
  * `/ui/my-namespaces/:namespace` - My Collections under a namespace (alias)

![20210426225133](https://user-images.githubusercontent.com/289743/116160765-26e08480-a6e2-11eb-825d-3ae3de8d13b2.png)
![20210426225151](https://user-images.githubusercontent.com/289743/116160770-2942de80-a6e2-11eb-9ae1-d7845b6ac93b.png)

(+ artefact: created a [list of screens](https://github.com/himdel/ansible-hub-ui/wiki/Screens))