### PR TITLE
dependabot: watch the stable-4.[23] branches as well as master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: 'stable-4.3'
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: 'stable-4.2'
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
[docs](https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates)

This (hopefully) sets dependabot to watch all 3 branches, and update each of them when needed. (Because backporting package-lock changes seldom works without conflicts.)

Cc @newswangerd 

(I'm not quite sure how to test this...)