### PR TITLE
Update the createGroup command to use <enter> rather than click

### DIFF
--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -93,11 +93,8 @@ Cypress.Commands.add('createGroup', {}, (name) => {
 
     cy.contains('Create').click();
 
-    cy.contains('div', 'Name *').findnear('input').first().type(name);
-
-    cy.server();
     cy.route('POST', Cypress.env('prefix') + '_ui/v1/groups/').as('createGroup');
-    cy.contains('[role=dialog] button', 'Create').click();
+    cy.contains('div', 'Name *').findnear('input').first().type(`${name}{enter}`);
     cy.wait('@createGroup');
 });
 


### PR DESCRIPTION
To verify AAH-229 (handle <enter> in the "create group" modal), I've updated the `createGroup` command to use <enter> to submit the form rather than click the button on the modal.

I also removed a redundant call to `cy.server()` in the middle of the command.