### PR TITLE
Clarify and fix missing permissions on container repo form.

### DIFF
--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -12,6 +12,7 @@ import { Constants } from 'src/constants';
 
 interface IProps {
   name: string;
+  namespace: string;
   description: string;
   selectedGroups: GroupObjectPermissionType[];
   onSave: (string, []) => void;
@@ -34,7 +35,7 @@ export class RepositoryForm extends React.Component<IProps, IState> {
   }
 
   render() {
-    const { name, onSave, onCancel } = this.props;
+    const { name, onSave, onCancel, namespace } = this.props;
     const { description, selectedGroups } = this.state;
     return (
       <Modal
@@ -59,6 +60,14 @@ export class RepositoryForm extends React.Component<IProps, IState> {
           <FormGroup key='name' fieldId='name' label='Name'>
             <TextInput id='name' value={name} isDisabled={true} type='text' />
           </FormGroup>
+          <FormGroup key='name' fieldId='name' label='Container namespace'>
+            <TextInput
+              id='name'
+              value={namespace}
+              isDisabled={true}
+              type='text'
+            />
+          </FormGroup>
           <FormGroup
             key='description'
             fieldId='description'
@@ -77,6 +86,10 @@ export class RepositoryForm extends React.Component<IProps, IState> {
             />
           </FormGroup>
           <FormGroup key='groups' fieldId='groups' label='Groups with access'>
+            <div className='pf-c-form__helper-text'>
+              Adding groups provides access to all repositories in the "
+              {namespace}" container namespace.
+            </div>
             <ObjectPermissionField
               groups={this.state.selectedGroups}
               availablePermissions={Constants.CONTAINER_NAMESPACE_PERMISSIONS}

--- a/src/components/permissions/obect-permission-field.tsx
+++ b/src/components/permissions/obect-permission-field.tsx
@@ -47,7 +47,6 @@ export class ObjectPermissionField extends React.Component<IProps, IState> {
           isDisabled={!!this.props.isDisabled}
         />
         <br />
-        <br />
         <div>
           {groups.map((group, i) => (
             <Flex

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -124,16 +124,16 @@ export class Constants {
     upload_to_namespace: 'Upload to namespace',
     add_containernamespace: 'Create new containers',
     namespace_pull_containerdistribution: 'Pull private containers',
-    namespace_change_containerdistribution: 'Change containers',
+    namespace_change_containerdistribution: 'Update container information',
     namespace_view_containerdistribution: 'View private containers',
     namespace_modify_content_containerpushrepository: 'Change image tags',
     change_containernamespace: 'Change container namespace permissions',
-    namespace_push_containerdistribution: 'Push to existing containers',
+    namespace_push_containerdistribution: 'Push images to existing containers',
     view_containernamespace: "View container's namespace",
     delete_containernamespace: "Delete container's namespace",
     namespace_delete_containerdistribution: "Delete container's distribution",
     namespace_view_containerpushrepository: "View container's repository",
-    namespace_add_containerdistribution: 'Add distribution',
+    namespace_add_containerdistribution: 'Push new containers',
     change_containerdistribution: 'Change distribution',
     delete_containerdistribution: 'Delete distribution',
     push_containerdistribution: 'Push distribution',
@@ -141,12 +141,11 @@ export class Constants {
     view_containerdistribution: 'View distribution',
   };
   static CONTAINER_NAMESPACE_PERMISSIONS = [
-    'namespace_delete_containerdistribution',
-    'namespace_view_containerpushrepository',
     'change_containernamespace',
     'namespace_push_containerdistribution',
     'namespace_change_containerdistribution',
     'namespace_modify_content_containerpushrepository',
+    'namespace_add_containerdistribution',
   ];
   static UPSTREAM_HOSTS = [
     'galaxy.ansible.com',

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -111,7 +111,8 @@ export function withContainerRepo(WrappedComponent) {
           <Main>
             {this.state.editing && (
               <RepositoryForm
-                name={this.props.match.params['container']}
+                name={this.state.repo.name}
+                namespace={this.state.repo.namespace.name}
                 selectedGroups={cloneDeep(this.state.selectedGroups)}
                 description={this.state.repo.description}
                 permissions={permissions}


### PR DESCRIPTION
- Update exposed namespace permissions
- Wordsmith descriptions of permissions
- Add a note about permissions being assigned to namespaces, not repos on the repo edit form.
![Screen Shot 2021-04-22 at 4 04 05 PM](https://user-images.githubusercontent.com/6063371/115779707-4d22bf00-a386-11eb-8c6d-1dd9889693a6.png)
