### PR TITLE
Cypress on GitHub Actions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,13 +1,15 @@
-name: Manual workflow
+name: Cypress
 
 on:
+  # allow running manually
   workflow_dispatch:
-#  pull_request:
-#    branches: [ $default-branch stable-* ]
-#  push:
-#    branches: [ $default-branch stable-* ]
-#  schedule:
-#    - cron:  '30 5 * * *'
+  pull_request:
+    branches: [ $default-branch stable-* ]
+  push:
+    branches: [ $default-branch stable-* ]
+  # daily on $default-branch
+  schedule:
+    - cron:  '30 5 * * *'
 
 jobs:
   cypress:
@@ -28,14 +30,14 @@ jobs:
 
     - run: "mkdir pulp_galaxy_ng"
 
-    - name: "Cache container image for pulp_galaxy_ng ${{ env.GALAXY_NG_COMMIT }}"
+    - name: "Cache container image for pulp_galaxy_ng ${{ env.SHORT_BRANCH }} ${{ env.GALAXY_NG_COMMIT }}"
       id: cache-containers
       uses: actions/cache@v2
       with:
         path: pulp_galaxy_ng/image
         key: ${{ runner.os }}-containers-${{ env.GALAXY_NG_COMMIT }}
 
-    - name: "Build pulp-galaxy-ng (with galaxy_ng ${{ env.SHORT_BRANCH }})"
+    - name: "Build pulp-galaxy-ng"
       if: steps.cache-containers.outputs.cache-hit != 'true'
       working-directory: 'pulp_galaxy_ng'
       run: |
@@ -55,15 +57,14 @@ jobs:
         buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .
         podman save localhost/pulp/pulp-galaxy-ng:latest -o image
 
-    - name: "Load pulp-galaxy-ng (with galaxy_ng ${{ env.SHORT_BRANCH }})"
+    - name: "Load pulp-galaxy-ng from cache"
       if: steps.cache-containers.outputs.cache-hit == 'true'
       working-directory: 'pulp_galaxy_ng'
-      run: |
-        podman load -i image
+      run: podman load -i image
 
     - name: "Configure and run pulp-galaxy-ng"
       working-directory: 'pulp_galaxy_ng'
-      run: |        
+      run: |
         mkdir settings pulp_storage pgsql containers
         echo "\
           ANSIBLE_API_HOSTNAME='http://localhost:8002'
@@ -77,7 +78,7 @@ jobs:
           TOKEN_AUTH_DISABLED=True
           X_PULP_CONTENT_HOST='localhost'
         " | sed 's/^\s\+//' > settings/settings.py
-
+        
         podman run \
              --detach \
              --publish 8002:80 \
@@ -109,7 +110,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-node-${{ env.SHORT_BRANCH }}-
           ${{ runner.os }}-node-
-        
+
     - name: "Build standalone UI"
       working-directory: 'ansible-hub-ui'
       run: |
@@ -120,7 +121,7 @@ jobs:
 
     - name: "Finish up and run cypress"
       working-directory: 'ansible-hub-ui/test'
-      run: |        
+      run: |
         # podman exec pulp pip install django_extensions
         podman exec pulp pulpcore-manager reset-admin-password --password admin
         
@@ -128,7 +129,7 @@ jobs:
         echo -e '{\n  "prefix": "/api/galaxy/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
         
         npm run cypress:chrome
-        
+
     - uses: actions/upload-artifact@v2
       if: failure()
       with:
@@ -139,5 +140,4 @@ jobs:
 
     - name: "Kill container"
       if: always()
-      run: |
-        podman kill pulp
+      run: podman kill pulp

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -21,8 +21,8 @@ jobs:
         node-version: '14'
     - name: "Build pulp-galaxy-ng (with galaxy_ng master)"
       run: |
-        echo buildah `buildah --version`
-        echo podman `podman --version`
+        echo jq `jq --version`
+        echo SHA`GET https://api.github.com/repos/ansible/galaxy_ng/branches/master | jq -r .commit.sha`
         
         mkdir pulp_galaxy_ng
         cd pulp_galaxy_ng
@@ -84,3 +84,11 @@ jobs:
         npm ci
         echo -e '{\n  "prefix": "/api/galaxy/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
         npm run cypress:chrome
+        
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: screenshots_and_videos
+        path: |
+          ansible-hub-ui/test/cypress/screenshots
+          ansible-hub-ui/test/cypress/videos

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -15,38 +15,51 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        repository: 'ansible/galaxy_ng'
-        path: 'galaxy_ng'
-    - working-directory: 'galaxy_ng'
+        repository: 'pulp/pulp-oci-images'
+        path: 'pulp-oci-images'   
+    - working-directory: 'pulp-oci-images'
       run: |
-        cp .compose.env.example .compose.env
-        ./compose build
-
-    - uses: actions/checkout@v2
-      with:
-        path: 'ansible-hub-ui'
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '14'
-    - working-directory: 'ansible-hub-ui'
-      run: 'npm ci'
-    - working-directory: 'ansible-hub-ui/test'
-      run: |
-        npm ci
-        echo -e '{\n  "prefix": "/api/automation-hub/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
-
-    - working-directory: 'galaxy_ng'
-      run: |
-        ./compose up -d postgres redis
-        ./compose run --rm api manage migrate
-        ./compose down
-
-    - working-directory: 'galaxy_ng'
-      run: ./compose up -d
-    - working-directory: 'ansible-hub-ui'
-      run: |
-        # FIXME nowatch, or build-standalone+nginx?
-        npm run start-standalone &
-        cd test/
-        sleep 2m
-        npm run cypress:chrome
+        sed -i 's/galaxy-ng\${GALAXY_NG_VERSION}/git+https:\/\/github.com\/ansible\/galaxy_ng.git/' pulp_galaxy_ng/Containerfile
+        wget https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz
+        docker build --file pulp_ci_centos/Containerfile --tag pulp/pulp-ci-centos:latest .
+        docker build --file pulp/Containerfile --tag pulp/pulp:latest .
+        docker build --file pulp_galaxy_ng/Containerfile --tag pulp/pulp-galaxy-ng:latest .
+    
+#    - uses: actions/checkout@v2
+#      with:
+#        repository: 'ansible/galaxy_ng'
+#        path: 'galaxy_ng'
+#    - working-directory: 'galaxy_ng'
+#      run: |
+#        cp .compose.env.example .compose.env
+#        ./compose build
+#
+#    - uses: actions/checkout@v2
+#      with:
+#        path: 'ansible-hub-ui'
+#    - uses: actions/setup-node@v2
+#      with:
+#        node-version: '14'
+#    - working-directory: 'ansible-hub-ui'
+#      run: 'npm ci'
+#    - working-directory: 'ansible-hub-ui/test'
+#      run: |
+#        npm ci
+#        echo -e '{\n  "prefix": "/api/automation-hub/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
+#
+#    - working-directory: 'galaxy_ng'
+#      run: |
+#        ./compose up -d postgres redis
+#        ./compose run --rm api manage migrate
+#        ./compose down
+#
+#    - working-directory: 'galaxy_ng'
+#      run: ./compose up -d
+#    - working-directory: 'ansible-hub-ui'
+#      run: |
+#        # FIXME nowatch, or build-standalone+nginx?
+#        npm run start-standalone &
+#        cd test/
+#        sleep 2m
+#        npm run cypress:chrome
+#

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -21,47 +21,50 @@ jobs:
       run: |
         sed -i.bak -e '/^ARG/d' -e 's/\${.*}//' -e 's/galaxy-ng/git+https:\/\/github.com\/ansible\/galaxy_ng.git/' pulp_galaxy_ng/Containerfile
         diff -Naur pulp_galaxy_ng/Containerfile{.bak,} || true
-        wget https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz
-        docker build --file pulp_ci_centos/Containerfile --tag pulp/pulp-ci-centos:latest .
-        docker build --file pulp/Containerfile --tag pulp/pulp:latest .
-        docker build --file pulp_galaxy_ng/Containerfile --tag pulp/pulp-galaxy-ng:latest .
-       
         
-#    - uses: actions/checkout@v2
-#      with:
-#        repository: 'ansible/galaxy_ng'
-#        path: 'galaxy_ng'
-#    - working-directory: 'galaxy_ng'
-#      run: |
-#        cp .compose.env.example .compose.env
-#        ./compose build
-#
-#    - uses: actions/checkout@v2
-#      with:
-#        path: 'ansible-hub-ui'
-#    - uses: actions/setup-node@v2
-#      with:
-#        node-version: '14'
-#    - working-directory: 'ansible-hub-ui'
-#      run: 'npm ci'
-#    - working-directory: 'ansible-hub-ui/test'
-#      run: |
-#        npm ci
-#        echo -e '{\n  "prefix": "/api/automation-hub/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
-#
-#    - working-directory: 'galaxy_ng'
-#      run: |
-#        ./compose up -d postgres redis
-#        ./compose run --rm api manage migrate
-#        ./compose down
-#
-#    - working-directory: 'galaxy_ng'
-#      run: ./compose up -d
-#    - working-directory: 'ansible-hub-ui'
-#      run: |
-#        # FIXME nowatch, or build-standalone+nginx?
-#        npm run start-standalone &
-#        cd test/
-#        sleep 2m
-#        npm run cypress:chrome
-#
+        # TODO not needed, already prebuilt? (except galaxy)
+        #wget https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz
+        #docker build --file pulp_ci_centos/Containerfile --tag pulp/pulp-ci-centos:latest .
+        #docker build --file pulp/Containerfile --tag pulp/pulp:latest .
+        docker build --file pulp_galaxy_ng/Containerfile --tag pulp/pulp-galaxy-ng:latest .
+        
+        mkdir settings pulp_storage pgsql containers
+        echo "
+          CONTENT_ORIGIN='http://localhost:5001'
+          ANSIBLE_API_HOSTNAME='http://localhost:5001'
+          ANSIBLE_CONTENT_HOSTNAME='http://localhost:5001/pulp/content'
+          TOKEN_AUTH_DISABLED=True
+        " >> settings/settings.py
+       
+        docker run \
+             --detach \
+             --publish 5001:80 \
+             --name pulp \
+             --volume "$(pwd)/settings":/etc/pulp \
+             --volume "$(pwd)/pulp_storage":/var/lib/pulp \
+             --volume "$(pwd)/pgsql":/var/lib/pgsql \
+             --volume "$(pwd)/containers":/var/lib/containers \
+             --device /dev/fuse \
+             pulp/pulp
+             
+    - uses: actions/checkout@v2
+      with:
+        path: 'ansible-hub-ui'
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - working-directory: 'ansible-hub-ui'
+      run: |
+        # FIXME migrations? manage migrate
+        # FIXME nowatch, or build-standalone+nginx?
+        # FIXME wait-for-http
+
+        npm ci
+        (
+          cd test/
+          npm ci
+          echo -e '{\n  "prefix": "/api/automation-hub/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
+        )
+
+        npm run start-standalone &
+        ( cd test/ ; npm run cypress:chrome )

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -15,27 +15,46 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        repository: 'pulp/pulp-oci-images'
-        path: 'pulp-oci-images'   
-    - working-directory: 'pulp-oci-images'
-      run: |
-        sed -i.bak -e '/^ARG/d' -e 's/\${.*}//' -e 's/galaxy-ng/git+https:\/\/github.com\/ansible\/galaxy_ng.git/' pulp_galaxy_ng/Containerfile
-        diff -Naur pulp_galaxy_ng/Containerfile{.bak,} || true
+        path: 'ansible-hub-ui'
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - run: |
+        echo wait-for-http `which wait-for-http`
+        echo wait-for-tcp `which wait-for-tcp`
         
-        # TODO not needed, already prebuilt? (except galaxy)
-        #wget https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz
-        #docker build --file pulp_ci_centos/Containerfile --tag pulp/pulp-ci-centos:latest .
-        #docker build --file pulp/Containerfile --tag pulp/pulp:latest .
-        docker build --file pulp_galaxy_ng/Containerfile --tag pulp/pulp-galaxy-ng:latest .
+        mkdir pulp_galaxy_ng
+        cd pulp_galaxy_ng
+        
+        echo '\
+          FROM pulp/pulp-ci-centos:latest
+          
+          RUN pip3 install --upgrade \
+            requests \
+            git+https://github.com/ansible/galaxy_ng.git
+          
+          RUN mkdir -p /etc/nginx/pulp/
+          RUN ln /usr/local/lib/python3.6/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+          RUN ln /usr/local/lib/python3.6/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+          RUN ln /usr/local/lib/python3.6/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
+        ' > Containerfile
+        
+        docker build --file Containerfile --tag pulp/pulp-galaxy-ng:latest .
         
         mkdir settings pulp_storage pgsql containers
-        echo "
-          CONTENT_ORIGIN='http://localhost:5001'
+        echo "\
           ANSIBLE_API_HOSTNAME='http://localhost:5001'
-          ANSIBLE_CONTENT_HOSTNAME='http://localhost:5001/pulp/content'
+          ANSIBLE_CONTENT_HOSTNAME='http://localhost:5001/api/automation-hub/v3/artifacts/collections'
+          CONTENT_ORIGIN='http://localhost:5001'
+          GALAXY_API_PATH_PREFIX='/api/automation-hub/'
+          GALAXY_AUTHENTICATION_CLASSES=['galaxy_ng.app.auth.auth.RHIdentityAuthentication']
+          GALAXY_DEPLOYMENT_MODE='standalone'
+          PULP_CONTENT_PATH_PREFIX='/api/automation-hub/v3/artifacts/collections/'
+          RH_ENTITLEMENT_REQUIRED='insights'
           TOKEN_AUTH_DISABLED=True
-        " >> settings/settings.py
-       
+          X_PULP_CONTENT_HOST='localhost'
+        " > settings/settings.py
+
         docker run \
              --detach \
              --publish 5001:80 \
@@ -45,26 +64,26 @@ jobs:
              --volume "$(pwd)/pgsql":/var/lib/pgsql \
              --volume "$(pwd)/containers":/var/lib/containers \
              --device /dev/fuse \
-             pulp/pulp
-             
-    - uses: actions/checkout@v2
-      with:
-        path: 'ansible-hub-ui'
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '14'
-    - working-directory: 'ansible-hub-ui'
-      run: |
-        # FIXME migrations? manage migrate
-        # FIXME nowatch, or build-standalone+nginx?
-        # FIXME wait-for-http
+             pulp/pulp-galaxy-ng:latest
+         
+         sleep 5m
+         docker exec -it pulp bash -c 'pip install django_extensions' # pulpcore-manager show_urls
+         docker exec -it pulp bash -c 'pulpcore-manager reset-admin-password --password admin' || echo ERR $?
+         curl -v http://localhost:5001/api/automation-hub/
+         curl http://localhost:5001/ui/
 
-        npm ci
-        (
-          cd test/
-          npm ci
-          echo -e '{\n  "prefix": "/api/automation-hub/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
-        )
-
-        npm run start-standalone &
-        ( cd test/ ; npm run cypress:chrome )
+         
+#    - working-directory: 'ansible-hub-ui'
+#      run: |
+#        # FIXME build-standalone, move to pulp_storage/assets/galaxy_ng +-
+#        # FIXME wait-for-http
+#
+#        npm ci
+#        (
+#          cd test/
+#          npm ci
+#          echo -e '{\n  "prefix": "/api/automation-hub/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
+#        )
+#
+#        npm run start-standalone &
+#        ( cd test/ ; npm run cypress:chrome )

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -21,6 +21,9 @@ jobs:
         node-version: '14'
     - name: "Build pulp-galaxy-ng (with galaxy_ng master)"
       run: |
+        echo buildah `buildah --version`
+        echo podman `podman --version`
+        
         mkdir pulp_galaxy_ng
         cd pulp_galaxy_ng
         
@@ -37,7 +40,7 @@ jobs:
           RUN ln /usr/local/lib/python3.6/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
         ' > Containerfile
         
-        docker build --file Containerfile --tag pulp/pulp-galaxy-ng:latest .
+        buildah bud --file Containerfile --tag pulp/pulp-galaxy-ng:latest .
     - name: "Configure and run pulp-galaxy-ng"
       working-directory: 'pulp_galaxy_ng'
       run: |        
@@ -55,7 +58,7 @@ jobs:
           X_PULP_CONTENT_HOST='localhost'
         " | sed 's/^\s\+//' > settings/settings.py
 
-        docker run \
+        podman run \
              --detach \
              --publish 8002:80 \
              --name pulp \
@@ -70,13 +73,13 @@ jobs:
       run: |
         npm ci
         npm run build-standalone
-        sudo rm -rf ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng/
-        sudo mv -v dist/ ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng
+        rm -rf ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng/
+        mv -v dist/ ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng
     - name: "Finish up and run cypress"
       working-directory: 'ansible-hub-ui/test'
       run: |        
-        #docker exec pulp pip install django_extensions
-        docker exec pulp pulpcore-manager reset-admin-password --password admin
+        #podman exec pulp pip install django_extensions
+        podman exec pulp pulpcore-manager reset-admin-password --password admin
         
         npm ci
         echo -e '{\n  "prefix": "/api/galaxy/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,52 @@
+name: Manual workflow
+
+on:
+  workflow_dispatch:
+#  pull_request:
+#    branches: [ $default-branch stable-* ]
+#  push:
+#    branches: [ $default-branch stable-* ]
+#  schedule:
+#    - cron:  '30 5 * * *'
+
+jobs:
+  cypress:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        repository: 'ansible/galaxy_ng'
+        path: 'galaxy_ng'
+    - working-directory: 'galaxy_ng'
+      run: |
+        cp .compose.env.example .compose.env
+        ./compose build
+
+    - uses: actions/checkout@v2
+      with:
+        path: 'ansible-hub-ui'
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - working-directory: 'ansible-hub-ui'
+      run: 'npm ci'
+    - working-directory: 'ansible-hub-ui/test'
+      run: |
+        npm ci
+        echo -e '{\n  "prefix": "/api/automation-hub/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
+
+    - working-directory: 'galaxy_ng'
+      run: |
+        ./compose up -d postgres redis
+        ./compose run --rm api manage migrate
+        ./compose down
+
+    - working-directory: 'galaxy_ng'
+      run: ./compose up -d
+    - working-directory: 'ansible-hub-ui'
+      run: |
+        # FIXME nowatch, or build-standalone+nginx?
+        npm run start-standalone &
+        cd test/
+        sleep 2m
+        npm run cypress:chrome

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -130,9 +130,14 @@ jobs:
         npm run cypress:chrome
         
     - uses: actions/upload-artifact@v2
-      if: failure() # or always()
+      if: failure()
       with:
         name: screenshots_and_videos
         path: |
           ansible-hub-ui/test/cypress/screenshots
           ansible-hub-ui/test/cypress/videos
+
+    - name: "Kill container"
+      if: always()
+      run: |
+        podman kill pulp

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -19,10 +19,8 @@ jobs:
     - uses: actions/setup-node@v2
       with:
         node-version: '14'
-    - run: |
-        echo wait-for-http `which wait-for-http`
-        echo wait-for-tcp `which wait-for-tcp`
-        
+    - name: "Build pulp-galaxy-ng (with galaxy_ng master)"
+      run: |
         mkdir pulp_galaxy_ng
         cd pulp_galaxy_ng
         
@@ -40,24 +38,26 @@ jobs:
         ' > Containerfile
         
         docker build --file Containerfile --tag pulp/pulp-galaxy-ng:latest .
-        
+    - name: "Configure and run pulp-galaxy-ng"
+      working-directory: 'pulp_galaxy_ng'
+      run: |        
         mkdir settings pulp_storage pgsql containers
         echo "\
-          ANSIBLE_API_HOSTNAME='http://localhost:5001'
-          ANSIBLE_CONTENT_HOSTNAME='http://localhost:5001/api/automation-hub/v3/artifacts/collections'
-          CONTENT_ORIGIN='http://localhost:5001'
-          GALAXY_API_PATH_PREFIX='/api/automation-hub/'
-          GALAXY_AUTHENTICATION_CLASSES=['galaxy_ng.app.auth.auth.RHIdentityAuthentication']
+          ANSIBLE_API_HOSTNAME='http://localhost:8002'
+          ANSIBLE_CONTENT_HOSTNAME='http://localhost:8002/api/galaxy/v3/artifacts/collections'
+          CONTENT_ORIGIN='http://localhost:8002'
+          GALAXY_API_PATH_PREFIX='/api/galaxy/'
+          GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication']
           GALAXY_DEPLOYMENT_MODE='standalone'
-          PULP_CONTENT_PATH_PREFIX='/api/automation-hub/v3/artifacts/collections/'
+          PULP_CONTENT_PATH_PREFIX='/api/galaxy/v3/artifacts/collections/'
           RH_ENTITLEMENT_REQUIRED='insights'
           TOKEN_AUTH_DISABLED=True
           X_PULP_CONTENT_HOST='localhost'
-        " > settings/settings.py
+        " | sed 's/^\s\+//' > settings/settings.py
 
         docker run \
              --detach \
-             --publish 5001:80 \
+             --publish 8002:80 \
              --name pulp \
              --volume "$(pwd)/settings":/etc/pulp \
              --volume "$(pwd)/pulp_storage":/var/lib/pulp \
@@ -65,25 +65,19 @@ jobs:
              --volume "$(pwd)/containers":/var/lib/containers \
              --device /dev/fuse \
              pulp/pulp-galaxy-ng:latest
-         
-         sleep 5m
-         docker exec -it pulp bash -c 'pip install django_extensions' # pulpcore-manager show_urls
-         docker exec -it pulp bash -c 'pulpcore-manager reset-admin-password --password admin' || echo ERR $?
-         curl -v http://localhost:5001/api/automation-hub/
-         curl http://localhost:5001/ui/
-
-         
-#    - working-directory: 'ansible-hub-ui'
-#      run: |
-#        # FIXME build-standalone, move to pulp_storage/assets/galaxy_ng +-
-#        # FIXME wait-for-http
-#
-#        npm ci
-#        (
-#          cd test/
-#          npm ci
-#          echo -e '{\n  "prefix": "/api/automation-hub/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
-#        )
-#
-#        npm run start-standalone &
-#        ( cd test/ ; npm run cypress:chrome )
+    - name: "Build standalone UI (with ansible-hub-ui current branch)"
+      working-directory: 'ansible-hub-ui'
+      run: |
+        npm ci
+        npm run build-standalone
+        sudo rm -rf ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng/
+        sudo mv -v dist/ ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng
+    - name: "Finish up and run cypress"
+      working-directory: 'ansible-hub-ui/test'
+      run: |        
+        #docker exec pulp pip install django_extensions
+        docker exec pulp pulpcore-manager reset-admin-password --password admin
+        
+        npm ci
+        echo -e '{\n  "prefix": "/api/galaxy/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
+        npm run cypress:chrome

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -12,27 +12,39 @@ on:
 jobs:
   cypress:
     runs-on: ubuntu-latest
+    env:
+      # base of a PR, or pushed-to branch outside PRs, or master
+      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/master' }}
+
     steps:
-    - uses: actions/checkout@v2
-      with:
-        path: 'ansible-hub-ui'
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '14'
-    - name: "Build pulp-galaxy-ng (with galaxy_ng master)"
+
+    - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |
-        echo jq `jq --version`
-        echo SHA`GET https://api.github.com/repos/ansible/galaxy_ng/branches/master | jq -r .commit.sha`
+        SHORT_BRANCH=`sed 's/^refs\/heads\///' <<< $BRANCH`
+        GALAXY_NG_COMMIT=`GET https://api.github.com/repos/ansible/galaxy_ng/branches/${SHORT_BRANCH} | jq -r .commit.sha`
         
-        mkdir pulp_galaxy_ng
-        cd pulp_galaxy_ng
-        
+        echo "SHORT_BRANCH=${SHORT_BRANCH}" >> $GITHUB_ENV
+        echo "GALAXY_NG_COMMIT=${GALAXY_NG_COMMIT}" >> $GITHUB_ENV
+
+    - run: "mkdir pulp_galaxy_ng"
+
+    - name: "Cache container image for pulp_galaxy_ng ${{ env.GALAXY_NG_COMMIT }}"
+      id: cache-containers
+      uses: actions/cache@v2
+      with:
+        path: pulp_galaxy_ng/image
+        key: ${{ runner.os }}-containers-${{ env.GALAXY_NG_COMMIT }}
+
+    - name: "Build pulp-galaxy-ng (with galaxy_ng ${{ env.SHORT_BRANCH }})"
+      if: steps.cache-containers.outputs.cache-hit != 'true'
+      working-directory: 'pulp_galaxy_ng'
+      run: |
         echo '\
-          FROM pulp/pulp-ci-centos:latest
+          FROM docker.io/pulp/pulp-ci-centos:latest
           
           RUN pip3 install --upgrade \
             requests \
-            git+https://github.com/ansible/galaxy_ng.git
+            git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
           
           RUN mkdir -p /etc/nginx/pulp/
           RUN ln /usr/local/lib/python3.6/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
@@ -40,7 +52,15 @@ jobs:
           RUN ln /usr/local/lib/python3.6/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
         ' > Containerfile
         
-        buildah bud --file Containerfile --tag pulp/pulp-galaxy-ng:latest .
+        buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .
+        podman save localhost/pulp/pulp-galaxy-ng:latest -o image
+
+    - name: "Load pulp-galaxy-ng (with galaxy_ng ${{ env.SHORT_BRANCH }})"
+      if: steps.cache-containers.outputs.cache-hit == 'true'
+      working-directory: 'pulp_galaxy_ng'
+      run: |
+        podman load -i image
+
     - name: "Configure and run pulp-galaxy-ng"
       working-directory: 'pulp_galaxy_ng'
       run: |        
@@ -67,26 +87,50 @@ jobs:
              --volume "$(pwd)/pgsql":/var/lib/pgsql \
              --volume "$(pwd)/containers":/var/lib/containers \
              --device /dev/fuse \
-             pulp/pulp-galaxy-ng:latest
-    - name: "Build standalone UI (with ansible-hub-ui current branch)"
+             localhost/pulp/pulp-galaxy-ng:latest
+
+    - name: "Checkout ansible-hub-ui (${{ github.ref }})"
+      uses: actions/checkout@v2
+      with:
+        path: 'ansible-hub-ui'
+
+    - name: "Install node 14"
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: "Cache ~/.npm & ~/.cache/Cypress"
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.npm
+          ~/.cache/Cypress
+        key: ${{ runner.os }}-node-${{ env.SHORT_BRANCH }}-${{ hashFiles('ansible-hub-ui/**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-${{ env.SHORT_BRANCH }}-
+          ${{ runner.os }}-node-
+        
+    - name: "Build standalone UI"
       working-directory: 'ansible-hub-ui'
       run: |
         npm ci
         npm run build-standalone
         rm -rf ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng/
         mv -v dist/ ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng
+
     - name: "Finish up and run cypress"
       working-directory: 'ansible-hub-ui/test'
       run: |        
-        #podman exec pulp pip install django_extensions
+        # podman exec pulp pip install django_extensions
         podman exec pulp pulpcore-manager reset-admin-password --password admin
         
         npm ci
         echo -e '{\n  "prefix": "/api/galaxy/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
+        
         npm run cypress:chrome
         
     - uses: actions/upload-artifact@v2
-      if: failure()
+      if: failure() # or always()
       with:
         name: screenshots_and_videos
         path: |

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -19,12 +19,14 @@ jobs:
         path: 'pulp-oci-images'   
     - working-directory: 'pulp-oci-images'
       run: |
-        sed -i 's/galaxy-ng\${GALAXY_NG_VERSION}/git+https:\/\/github.com\/ansible\/galaxy_ng.git/' pulp_galaxy_ng/Containerfile
+        sed -i.bak -e '/^ARG/d' -e 's/\${.*}//' -e 's/galaxy-ng/git+https:\/\/github.com\/ansible\/galaxy_ng.git/' pulp_galaxy_ng/Containerfile
+        diff -Naur pulp_galaxy_ng/Containerfile{.bak,} || true
         wget https://github.com/just-containers/s6-overlay/releases/download/v1.22.1.0/s6-overlay-amd64.tar.gz
         docker build --file pulp_ci_centos/Containerfile --tag pulp/pulp-ci-centos:latest .
         docker build --file pulp/Containerfile --tag pulp/pulp:latest .
         docker build --file pulp_galaxy_ng/Containerfile --tag pulp/pulp-galaxy-ng:latest .
-    
+       
+        
 #    - uses: actions/checkout@v2
 #      with:
 #        repository: 'ansible/galaxy_ng'


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-529

This adds a Cypress workflow to github actions, configured to:

* allow to be triggered manually on a specific branch
* run on push to `master`, `stable-4.2` and `stable-4.3` (`stable-*` really)
* run on PRs against those same branches
* run daily on `master`

The workflow is using the [Pulp in One Container](https://github.com/pulp/pulp-oci-images/) images, big thanks to @fao89 for getting these running. ([More](https://pulpproject.org/pulp-in-one-container/) [docs](https://hackmd.io/@pulp/ansible-containers#/).)

* we build our own version of https://github.com/pulp/pulp-oci-images/blob/latest/pulp_galaxy_ng/Containerfile changed to download galaxy_ng master (or other branch, see below) and remove conflicting versions of dependencies.
* then we build ansible-hub-ui using build-standalone, and move those files to replace the original static UI files in the container
* Cypress is running outside the container, connecting to `localhost:8002/api/galaxy`

Branches:

* for a PR from `pr_branch` against ansible-hub-ui `base`:  
checking out `ansible-hub-ui@pr_branch`
`BRANCH=refs/heads/base`  
`SHORT_BRANCH=base`  
`pip install ...galaxy_ng@base`

* for a `branch` push on ansible-hub-ui:  
checking out `ansible-hub-ui@branch`
`BRANCH=refs/heads/branch`  
`SHORT_BRANCH=branch`  
`pip install ...galaxy_ng@branch`

* for manual builds, branch is whatever the user chooses, for cron builds it's master

Caching:

* `~/.npm` and `~/.cache/Cypress` get cached with a `package-lock.json` hash key, with fallback to the last cache on the same base branch
* `pulp_galaxy_ng/image` gets cached with a key that is the sha of the top commit on the relevant galaxy_ng branch, no fallback, if the cache doesn't exist, we build the image (~4 minutes) and save it (~1 minute), if it does, we just load it (~1 minute).
   * example of a build run: https://github.com/himdel/ansible-hub-ui/runs/2472425653?check_suite_focus=true
   * example of a cached run: https://github.com/himdel/ansible-hub-ui/runs/2472476282?check_suite_focus=true

Artifacts:

on failure, we upload `cypress/screenshots` and `cypress/videos`
(example: https://github.com/himdel/ansible-hub-ui/actions/runs/797934949)

Timing:

* ~8 minutes total when using cache, ~12 when rebuilding container
* ~3 minutes of that is webpack
* Cypress runs under 3 minutes

Cc @newswangerd 