### PR TITLE
Return link only when href exists

### DIFF
--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -192,13 +192,13 @@ class CollectionDocs extends React.Component<
   }
 
   private renderDocLink(name, href, collection, params) {
-    if (href.startsWith('http')) {
+    if (!!href && href.startsWith('http')) {
       return (
         <a href={href} target='_blank'>
           {name}
         </a>
       );
-    } else {
+    } else if (!!href) {
       // TODO: right now this will break if people put
       // ../ at the front of their urls. Need to find a
       // way to document this
@@ -218,6 +218,8 @@ class CollectionDocs extends React.Component<
           {name}
         </Link>
       );
+    } else {
+      return null;
     }
   }
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-33

Before:
<img width="1349" alt="Screenshot 2021-05-04 at 12 16 46" src="https://user-images.githubusercontent.com/9210860/116990106-f3e65400-acd2-11eb-9ccf-dc65f68aff72.png">

After:
<img width="1350" alt="Screenshot 2021-05-04 at 12 15 46" src="https://user-images.githubusercontent.com/9210860/116990096-f0eb6380-acd2-11eb-8343-4079d8bfb9bf.png">

Same as https://docs.ansible.com/ansible/latest/collections/arista/eos/eos_acl_interfaces_module.html

