### PR TITLE
Dependabot: use [stable-4.x] prefix for non-master branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,22 @@
 version: 2
 updates:
-  # Enable version updates for npm
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/"
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
+    directory: '/'
     target-branch: 'stable-4.3'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/"
+      interval: 'weekly'
+    commit_message:
+      prefix: '[stable-4.3] '
+
+  - package-ecosystem: 'npm'
+    directory: '/'
     target-branch: 'stable-4.2'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
+    commit_message:
+      prefix: '[stable-4.2] '


### PR DESCRIPTION
Follow-up to https://github.com/ansible/ansible-hub-ui/pull/366

Add a prefix for the PRs against stable-4.x.

Otherwise they all look the same in the list screen.