### PR TITLE
Add horizontal scroll to documentation

### DIFF
--- a/src/containers/collection-detail/collection-detail.scss
+++ b/src/containers/collection-detail/collection-detail.scss
@@ -29,6 +29,7 @@
     flex-grow: 1;
     padding: 24px;
     padding-top: 0px;
+    overflow-x: auto;
 
     // make the height close to the height ofthe page so short docs don't
     // look weird


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-599

For https://cloud.redhat.com/ansible/automation-hub/repo/published/ibm/power_ibmi/content/module/ibmi_display_fix
Note: it looks really bad in `standalone`. In c.r.com you cannot read everything but left nav is visible.

Steps to reproduce:

- Create ibm namespace
- Upload https://cloud.redhat.com/ansible/automation-hub/repo/published/ibm/power_ibmi
- Go to that collection 
- Select Documentation
- Select Modules
- Select `ibmi_display_fix`

Before:
<img width="1672" alt="Screenshot 2021-05-11 at 8 58 57" src="https://user-images.githubusercontent.com/9210860/117775392-c4879800-b23a-11eb-87ce-d9e171e254db.png">

After:
<img width="1648" alt="Screenshot 2021-05-11 at 9 19 55" src="https://user-images.githubusercontent.com/9210860/117775404-cb160f80-b23a-11eb-83e4-8431fb09de99.png">
<img width="1662" alt="Screenshot 2021-05-11 at 9 20 39" src="https://user-images.githubusercontent.com/9210860/117775419-cd786980-b23a-11eb-866b-74ce5a98861c.png">
