### PR TITLE
Add backported-* label on stable-* merges

### DIFF
--- a/.github/workflows/backported-labels.yml
+++ b/.github/workflows/backported-labels.yml
@@ -5,8 +5,6 @@ on:
   workflow_dispatch:
   push:
     branches: [ 'stable-*' ]
-  pull_request: # debug
-    branches: [ 'master' ] # debug
 
 jobs:
   labels:
@@ -14,18 +12,15 @@ jobs:
     steps:
     - name: 'Set $LABEL from branch name'
       run: |
-        GITHUB_REF='refs/heads/stable-4.2' # debug
         VERSION=`sed 's/^refs\/heads\/stable-//' <<< $GITHUB_REF`
         LABEL="backported-${VERSION}"
         echo "LABEL=${LABEL}" >> $GITHUB_ENV
 
     - uses: actions/checkout@v2
-      with: # debug
-        ref: 'stable-4.3' # debug
 
     - name: 'Set $PR to PR number'
       run: |
-        git log -1 --oneline # debug
+        git log -1 --oneline
         echo PR=`git log -1 --oneline | perl -ne 'print if s/^.*?\(#(\d+)\).*\(#\d+\).*$/$1/'` >> $GITHUB_ENV
 
     - name: "Add ${{ env.LABEL }} to #${{ env.PR }}"

--- a/.github/workflows/backported-labels.yml
+++ b/.github/workflows/backported-labels.yml
@@ -30,7 +30,8 @@ jobs:
 
     - name: "Add ${{ env.LABEL }} to #${{ env.PR }}"
       if: ${{ env.PR }}
-      run: |
-        gh pr edit "$PR" --add-label "$LABEL"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        labels: ${{ env.LABEL }}
+        number: ${{ env.PR }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/backported-labels.yml
+++ b/.github/workflows/backported-labels.yml
@@ -1,0 +1,36 @@
+name: 'Add backported-* labels'
+
+on:
+  # allow running manually
+  workflow_dispatch:
+  push:
+    branches: [ 'stable-*' ]
+  pull_request: # debug
+    branches: [ 'master' ] # debug
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Set $LABEL from branch name'
+      run: |
+        GITHUB_REF='refs/heads/stable-4.2' # debug
+        VERSION=`sed 's/^refs\/heads\/stable-//' <<< $GITHUB_REF`
+        LABEL="backported-${VERSION}"
+        echo "LABEL=${LABEL}" >> $GITHUB_ENV
+
+    - uses: actions/checkout@v2
+      with: # debug
+        ref: 'stable-4.3' # debug
+
+    - name: 'Set $PR to PR number'
+      run: |
+        git log -1 --oneline # debug
+        echo PR=`git log -1 --oneline | perl -ne 'print if s/^.*?\(#(\d+)\).*\(#\d+\).*$/$1/'` >> $GITHUB_ENV
+
+    - name: "Add ${{ env.LABEL }} to #${{ env.PR }}"
+      if: ${{ env.PR }}
+      run: |
+        gh pr edit "$PR" --add-label "$LABEL"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
runs on push to a `stable-\*` branch,
takes the first line of the topmost commit message:

> Original PR title (#original PR number) (#backport PR number)

extracts the first parenthesised PR number, as long as there are 2
and adds a `backported-${branch number}` label to the original PR

Cc @ZitaNemeckova , @newswangerd 

Also relevant: https://github.com/sanitizers/patchback-github-app/issues/12