### PR TITLE
workflows/cypress - fix $default-branch -> master; the macro works in templates, not workflows

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,10 +4,10 @@ on:
   # allow running manually
   workflow_dispatch:
   pull_request:
-    branches: [ $default-branch stable-* ]
+    branches: [ master stable-* ]
   push:
-    branches: [ $default-branch stable-* ]
-  # daily on $default-branch
+    branches: [ master stable-* ]
+  # daily on master
   schedule:
     - cron:  '30 5 * * *'
 


### PR DESCRIPTION
Follow-up to #378 

Actions are not picking up pushes or PRs because the `$default-branch` thing is a macro that works in workflow templates, but an actual workflow needs to refer to a specific branch.