### PR TITLE
workflows/cypress - YAML syntax - have an array of 2 items, not an array of one string

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,9 +4,9 @@ on:
   # allow running manually
   workflow_dispatch:
   pull_request:
-    branches: [ master stable-* ]
+    branches: [ 'master', 'stable-*' ]
   push:
-    branches: [ master stable-* ]
+    branches: [ 'master', 'stable-*' ]
   # daily on master
   schedule:
     - cron:  '30 5 * * *'


### PR DESCRIPTION
Follow-up to #378 

This fixes a syntax error, `[ master stable ]` becomes `["master stable"]` when converted, we want an array of 2 items instead.