### PR TITLE
[pending api] NamespaceList, NamespaceCard - show "My namespace" label, Edit on editable namespaces

### DIFF
--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -8,6 +8,7 @@ import {
   CardHeader,
   CardHeaderMain,
   CardTitle,
+  Label,
 } from '@patternfly/react-core';
 
 import { Link } from 'react-router-dom';
@@ -20,11 +21,16 @@ interface IProps {
   name: string;
   company: string;
   namespaceURL?: string;
+  editable?: boolean;
 }
 
 export class NamespaceCard extends React.Component<IProps, {}> {
   render() {
-    const { avatar_url, name, company, namespaceURL } = this.props;
+    const { avatar_url, name, company, namespaceURL, editable } = this.props;
+
+    const heading = company || name;
+    const body = name;
+
     return (
       <Card className='ns-card-container'>
         <CardHeader>
@@ -37,13 +43,16 @@ export class NamespaceCard extends React.Component<IProps, {}> {
             />
           </CardHeaderMain>
         </CardHeader>
-        <CardTitle>{company || name}</CardTitle>
-        <CardBody>{name}</CardBody>
-        {namespaceURL && (
-          <CardFooter>
-            <Link to={namespaceURL}>View collections</Link>
-          </CardFooter>
-        )}
+        <CardTitle>
+          {namespaceURL ? <Link to={namespaceURL}>{heading}</Link> : heading}
+        </CardTitle>
+        <CardBody>{body}</CardBody>
+        <CardFooter>
+          {editable && <Label>My namespace</Label>}
+          {editable || (
+            <span style={{ display: 'inline-block', height: '22px' }}></span>
+          ) /* constant footer height */}
+        </CardFooter>
       </Card>
     );
   }


### PR DESCRIPTION
Follow up to #396
Related to https://issues.redhat.com/browse/AAH-487 and https://issues.redhat.com/browse/AAH-1087

Design: 
![image-2021-04-08-08-50-00-925](https://user-images.githubusercontent.com/289743/118043233-a1590780-b364-11eb-89b0-b7b7e954d320.png)

This changes the Namespaces (& My namespaces) list screen to:

* make each collection title clickable
* add a `My namespace` label for editable namespaces
* TODO add a kebab menu linking to edit-namespace Edit

![20210511022315](https://user-images.githubusercontent.com/289743/117748658-f7f90100-b1ff-11eb-875c-9b0e2be87528.png)

---

WIP: this doesn't work with paging, needs to wait for an API change