### PR TITLE
Change source to children in ReactMarkdown to be according to 6.0.0

### DIFF
--- a/src/components/markdown-editor/markdown-editor.tsx
+++ b/src/components/markdown-editor/markdown-editor.tsx
@@ -37,9 +37,9 @@ export class MarkdownEditor extends React.Component<IProps, {}> {
             {editing && 'Preview'}
             <div className={editing ? 'pf-c-content preview' : 'pf-c-content'}>
               {text ? (
-                <ReactMarkdown source={text} />
+                <ReactMarkdown children={text} />
               ) : (
-                <ReactMarkdown source={placeholder} />
+                <ReactMarkdown children={placeholder} />
               )}
             </div>
           </div>


### PR DESCRIPTION
Go to Container Registries -> select one -> see README section 

Before:
![image](https://user-images.githubusercontent.com/9210860/118805983-d30f2880-b8a6-11eb-9382-a75d9be1b4a2.png)
![image](https://user-images.githubusercontent.com/9210860/118806024-e3270800-b8a6-11eb-9dcc-47dc8b16b5f2.png)

After:
![image](https://user-images.githubusercontent.com/9210860/118806038-e7532580-b8a6-11eb-871c-3da59368c568.png)
![image](https://user-images.githubusercontent.com/9210860/118806049-e9b57f80-b8a6-11eb-8372-c144bd0c97de.png)

Changelog: https://github.com/remarkjs/react-markdown/blob/main/changelog.md#change-source-to-children

NOTE: NOT TO BE BACKPORTED TO 4.3 AS IT STILL HAS OLD VERSION OF `react-markdown` PACKAGE.