### PR TITLE
change chip to label component

### DIFF
--- a/src/components/tags/tag.tsx
+++ b/src/components/tags/tag.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import './tag.scss';
 
-import { Chip } from '@patternfly/react-core';
+import { Label } from '@patternfly/react-core';
 
 interface IProps {
   /** Value to display in the tag */
@@ -11,9 +11,9 @@ interface IProps {
 export class Tag extends React.Component<IProps, {}> {
   render() {
     return (
-      <Chip className='tag' isReadOnly>
+      <Label className='tag' readOnly>
         {this.props.children}
-      </Chip>
+      </Label>
     );
   }
 }


### PR DESCRIPTION
Hello Zita :) 
I went to Components > Tags > tag.tsx and changed the patternfly import from Chip to Label. Then adjusted 'isReadOnly' to 'readOnly' in the return to eliminate the red squiggly. 

Here are the respective issues posted on Jira: 
https://issues.redhat.com/browse/AAH-543
https://issues.redhat.com/browse/AAH-542


That's it! Let me know if there are any issues.

![Grey label](https://user-images.githubusercontent.com/64337863/118995130-e5e03680-b954-11eb-9b2f-4de355d7ad92.png)

![After with grey labels](https://user-images.githubusercontent.com/64337863/118996088-a36b2980-b955-11eb-8169-fbf275b79945.png)
![before with chip](https://user-images.githubusercontent.com/64337863/118996188-b5e56300-b955-11eb-8286-367306429bb3.png)
