### PR TITLE
change details tab name and info section header to install

### DIFF
--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -57,7 +57,7 @@ export class CollectionInfo extends React.Component<IProps> {
 
     return (
       <div className='pf-c-content info-panel'>
-        <h1>Info</h1>
+        <h1>Install</h1>
         <Grid hasGutter={true}>
           <GridItem>{latest_version.metadata.description}</GridItem>
           <GridItem>

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -142,8 +142,8 @@ export class CollectionHeader extends React.Component<IProps> {
 
     const tabs = [
       {
-        active: active === 'details',
-        title: 'Details',
+        active: active === 'install',
+        title: 'Install',
         link: formatPath(Paths.collectionByRepo, pathParams, reduced),
       },
       {

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -66,7 +66,7 @@ class CollectionDetail extends React.Component<
             )
           }
           breadcrumbs={breadcrumbs}
-          activeTab='details'
+          activeTab='install'
           repo={this.context.selectedRepo}
         />
         <Main>


### PR DESCRIPTION
Hi Zita!!
Here is my pr. I changed the 'details' tab name and 'info' section header to both read 'Install.'
See screenshots below. 
Issues covered:
https://issues.redhat.com/browse/AAH-546

![Screen Shot 2021-05-20 at 11 56 50 AM](https://user-images.githubusercontent.com/64337863/119011493-1e870c80-b963-11eb-840b-4e114e9dc0c5.png)
![Screen Shot 2021-05-20 at 11 05 22 AM](https://user-images.githubusercontent.com/64337863/119011511-234bc080-b963-11eb-9c27-b3af068b302c.png)


