### PR TITLE
Bump react-markdown from 4.3.1 to 6.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2302,6 +2302,14 @@
                 "@types/node": "*"
             }
         },
+        "@types/hast": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
+            "integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
+            "requires": {
+                "@types/unist": "*"
+            }
+        },
         "@types/history": {
             "version": "4.7.8",
             "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
@@ -2342,7 +2350,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.3.tgz",
             "integrity": "sha512-SXPBMnFVQg1s00dlMCc/jCdvPqdE4mXaMMCeRlxLDmTAEoegHT53xKtkDnzDTOcmMHUfcjyf36/YYZ6SxRdnsw==",
-            "dev": true,
             "requires": {
                 "@types/unist": "*"
             }
@@ -2432,8 +2439,7 @@
         "@types/unist": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-            "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
-            "dev": true
+            "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
         },
         "@types/yargs": {
             "version": "13.0.11",
@@ -4755,11 +4761,6 @@
             "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
             "dev": true
         },
-        "collapse-white-space": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-            "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
-        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -4797,6 +4798,11 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
+        },
+        "comma-separated-tokens": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+            "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
         },
         "commander": {
             "version": "7.2.0",
@@ -7681,30 +7687,6 @@
             "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
             "dev": true
         },
-        "html-to-react": {
-            "version": "1.4.5",
-            "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.5.tgz",
-            "integrity": "sha512-KONZUDFPg5OodWaQu2ymfkDmU0JA7zB1iPfvyHehTmMUZnk0DS7/TyCMTzsLH6b4BvxX15g88qZCXFhJWktsmA==",
-            "requires": {
-                "domhandler": "^3.3.0",
-                "htmlparser2": "^5.0",
-                "lodash.camelcase": "^4.3.0",
-                "ramda": "^0.27.1"
-            },
-            "dependencies": {
-                "htmlparser2": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
-                    "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
-                    "requires": {
-                        "domelementtype": "^2.0.1",
-                        "domhandler": "^3.3.0",
-                        "domutils": "^2.4.2",
-                        "entities": "^2.0.0"
-                    }
-                }
-            }
-        },
         "html-webpack-plugin": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
@@ -8307,13 +8289,19 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "ini": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
             "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
             "dev": true
+        },
+        "inline-style-parser": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+            "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
         },
         "inquirer": {
             "version": "7.3.3",
@@ -8560,7 +8548,8 @@
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+            "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+            "dev": true
         },
         "is-callable": {
             "version": "1.2.3",
@@ -8767,7 +8756,8 @@
         "is-plain-obj": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -8851,21 +8841,11 @@
             "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
             "dev": true
         },
-        "is-whitespace-character": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-            "integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
-        },
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
-        },
-        "is-word-character": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
-            "integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
         },
         "is-wsl": {
             "version": "1.1.0",
@@ -9667,11 +9647,6 @@
                 "lodash": "^4.17.20"
             }
         },
-        "lodash.camelcase": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-            "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-        },
         "lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -9824,11 +9799,6 @@
                 "object-visit": "^1.0.0"
             }
         },
-        "markdown-escapes": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-            "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
-        },
         "mathml-tag-names": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
@@ -9846,19 +9816,18 @@
                 "safe-buffer": "^5.1.2"
             }
         },
-        "mdast-add-list-metadata": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/mdast-add-list-metadata/-/mdast-add-list-metadata-1.0.1.tgz",
-            "integrity": "sha512-fB/VP4MJ0LaRsog7hGPxgOrSL3gE/2uEdZyDuSEnKCv/8IkYHiDkIQSbChiJoHyxZZXZ9bzckyRk+vNxFzh8rA==",
+        "mdast-util-definitions": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz",
+            "integrity": "sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==",
             "requires": {
-                "unist-util-visit-parents": "1.1.2"
+                "unist-util-visit": "^2.0.0"
             }
         },
         "mdast-util-from-markdown": {
             "version": "0.8.5",
             "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
             "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
-            "dev": true,
             "requires": {
                 "@types/mdast": "^3.0.0",
                 "mdast-util-to-string": "^2.0.0",
@@ -9871,7 +9840,6 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
                     "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-                    "dev": true,
                     "requires": {
                         "character-entities": "^1.0.0",
                         "character-entities-legacy": "^1.0.0",
@@ -9885,11 +9853,25 @@
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
                     "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-                    "dev": true,
                     "requires": {
                         "@types/unist": "^2.0.2"
                     }
                 }
+            }
+        },
+        "mdast-util-to-hast": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz",
+            "integrity": "sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==",
+            "requires": {
+                "@types/mdast": "^3.0.0",
+                "@types/unist": "^2.0.0",
+                "mdast-util-definitions": "^4.0.0",
+                "mdurl": "^1.0.0",
+                "unist-builder": "^2.0.0",
+                "unist-util-generated": "^1.0.0",
+                "unist-util-position": "^3.0.0",
+                "unist-util-visit": "^2.0.0"
             }
         },
         "mdast-util-to-markdown": {
@@ -9925,8 +9907,12 @@
         "mdast-util-to-string": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-            "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-            "dev": true
+            "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
+        },
+        "mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
         },
         "media-typer": {
             "version": "0.3.0",
@@ -10037,7 +10023,6 @@
             "version": "2.11.4",
             "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
             "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
-            "dev": true,
             "requires": {
                 "debug": "^4.0.0",
                 "parse-entities": "^2.0.0"
@@ -10047,7 +10032,6 @@
                     "version": "4.3.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
                     "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.1.2"
                     }
@@ -10055,14 +10039,12 @@
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
                 },
                 "parse-entities": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
                     "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-                    "dev": true,
                     "requires": {
                         "character-entities": "^1.0.0",
                         "character-entities-legacy": "^1.0.0",
@@ -11213,19 +11195,6 @@
                 "safe-buffer": "^5.1.1"
             }
         },
-        "parse-entities": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
-            "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-            "requires": {
-                "character-entities": "^1.0.0",
-                "character-entities-legacy": "^1.0.0",
-                "character-reference-invalid": "^1.0.0",
-                "is-alphanumerical": "^1.0.0",
-                "is-decimal": "^1.0.0",
-                "is-hexadecimal": "^1.0.0"
-            }
-        },
         "parse-json": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -11739,6 +11708,14 @@
                 "warning": "^4.0.0"
             }
         },
+        "property-information": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
+            "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
+            "requires": {
+                "xtend": "^4.0.0"
+            }
+        },
         "proxy-addr": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.6.tgz",
@@ -11890,11 +11867,6 @@
             "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
             "dev": true
         },
-        "ramda": {
-            "version": "0.27.1",
-            "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-            "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
-        },
         "randexp": {
             "version": "0.4.6",
             "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
@@ -12027,18 +11999,30 @@
             "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
         },
         "react-markdown": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.3.1.tgz",
-            "integrity": "sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-6.0.2.tgz",
+            "integrity": "sha512-Et2AjXAsbmPP1nLQQRqmVgcqzfwcz8uQJ8VAdADs8Nk/aaUA0YeU9RDLuCtD+GwajCnm/+Iiu2KPmXzmD/M3vA==",
             "requires": {
-                "html-to-react": "^1.3.4",
-                "mdast-add-list-metadata": "1.0.1",
+                "@types/hast": "^2.0.0",
+                "@types/unist": "^2.0.3",
+                "comma-separated-tokens": "^1.0.0",
                 "prop-types": "^15.7.2",
-                "react-is": "^16.8.6",
-                "remark-parse": "^5.0.0",
-                "unified": "^6.1.5",
-                "unist-util-visit": "^1.3.0",
-                "xtend": "^4.0.1"
+                "property-information": "^5.0.0",
+                "react-is": "^17.0.0",
+                "remark-parse": "^9.0.0",
+                "remark-rehype": "^8.0.0",
+                "space-separated-tokens": "^1.1.0",
+                "style-to-object": "^0.3.0",
+                "unified": "^9.0.0",
+                "unist-util-visit": "^2.0.0",
+                "vfile": "^4.0.0"
+            },
+            "dependencies": {
+                "react-is": {
+                    "version": "17.0.2",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+                    "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+                }
             }
         },
         "react-redux": {
@@ -12561,25 +12545,19 @@
             }
         },
         "remark-parse": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
-            "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
+            "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
             "requires": {
-                "collapse-white-space": "^1.0.2",
-                "is-alphabetical": "^1.0.0",
-                "is-decimal": "^1.0.0",
-                "is-whitespace-character": "^1.0.0",
-                "is-word-character": "^1.0.0",
-                "markdown-escapes": "^1.0.0",
-                "parse-entities": "^1.1.0",
-                "repeat-string": "^1.5.4",
-                "state-toggle": "^1.0.0",
-                "trim": "0.0.1",
-                "trim-trailing-lines": "^1.0.0",
-                "unherit": "^1.0.4",
-                "unist-util-remove-position": "^1.0.0",
-                "vfile-location": "^2.0.0",
-                "xtend": "^4.0.1"
+                "mdast-util-from-markdown": "^0.8.0"
+            }
+        },
+        "remark-rehype": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-8.1.0.tgz",
+            "integrity": "sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==",
+            "requires": {
+                "mdast-util-to-hast": "^10.2.0"
             }
         },
         "remark-stringify": {
@@ -12696,7 +12674,8 @@
         "repeat-string": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
         },
         "repeating": {
             "version": "2.0.1",
@@ -12706,11 +12685,6 @@
             "requires": {
                 "is-finite": "^1.0.0"
             }
-        },
-        "replace-ext": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-            "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
         },
         "request": {
             "version": "2.88.2",
@@ -13784,6 +13758,11 @@
             "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
             "dev": true
         },
+        "space-separated-tokens": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+            "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
+        },
         "spdx-correct": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -13940,11 +13919,6 @@
                     "dev": true
                 }
             }
-        },
-        "state-toggle": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-            "integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
         },
         "static-extend": {
             "version": "0.1.2",
@@ -14281,6 +14255,14 @@
             "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
             "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
             "dev": true
+        },
+        "style-to-object": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+            "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+            "requires": {
+                "inline-style-parser": "0.1.1"
+            }
         },
         "stylelint": {
             "version": "13.12.0",
@@ -15473,21 +15455,11 @@
                 "punycode": "^2.1.1"
             }
         },
-        "trim": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-            "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
-        },
         "trim-newlines": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
             "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
             "dev": true
-        },
-        "trim-trailing-lines": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
-            "integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ=="
         },
         "trough": {
             "version": "1.0.5",
@@ -15630,15 +15602,6 @@
                 "which-boxed-primitive": "^1.0.2"
             }
         },
-        "unherit": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
-            "integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
-            "requires": {
-                "inherits": "^2.0.0",
-                "xtend": "^4.0.0"
-            }
-        },
         "unicode-canonical-property-names-ecmascript": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -15668,16 +15631,28 @@
             "dev": true
         },
         "unified": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-6.2.0.tgz",
-            "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
+            "version": "9.2.1",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.1.tgz",
+            "integrity": "sha512-juWjuI8Z4xFg8pJbnEZ41b5xjGUWGHqXALmBZ3FC3WX0PIx1CZBIIJ6mXbYMcf6Yw4Fi0rFUTA1cdz/BglbOhA==",
             "requires": {
                 "bail": "^1.0.0",
                 "extend": "^3.0.0",
-                "is-plain-obj": "^1.1.0",
+                "is-buffer": "^2.0.0",
+                "is-plain-obj": "^2.0.0",
                 "trough": "^1.0.0",
-                "vfile": "^2.0.0",
-                "x-is-string": "^0.1.0"
+                "vfile": "^4.0.0"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+                    "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+                },
+                "is-plain-obj": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+                    "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+                }
             }
         },
         "union-value": {
@@ -15725,6 +15700,11 @@
                 "crypto-random-string": "^1.0.0"
             }
         },
+        "unist-builder": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
+            "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw=="
+        },
         "unist-util-find-all-after": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.2.tgz",
@@ -15742,46 +15722,47 @@
                 }
             }
         },
-        "unist-util-is": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-            "integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
+        "unist-util-generated": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
+            "integrity": "sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg=="
         },
-        "unist-util-remove-position": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
-            "integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
-            "requires": {
-                "unist-util-visit": "^1.1.0"
-            }
+        "unist-util-is": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+            "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="
+        },
+        "unist-util-position": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
+            "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA=="
         },
         "unist-util-stringify-position": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-            "integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
+            "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+            "requires": {
+                "@types/unist": "^2.0.2"
+            }
         },
         "unist-util-visit": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
-            "integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+            "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
             "requires": {
-                "unist-util-visit-parents": "^2.0.0"
-            },
-            "dependencies": {
-                "unist-util-visit-parents": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
-                    "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-                    "requires": {
-                        "unist-util-is": "^3.0.0"
-                    }
-                }
+                "@types/unist": "^2.0.0",
+                "unist-util-is": "^4.0.0",
+                "unist-util-visit-parents": "^3.0.0"
             }
         },
         "unist-util-visit-parents": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-1.1.2.tgz",
-            "integrity": "sha512-yvo+MMLjEwdc3RhhPYSximset7rwjMrdt9E41Smmvg25UQIenzrN83cRnF1JMzoMi9zZOQeYXHSDf7p+IQkW3Q=="
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+            "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+            "requires": {
+                "@types/unist": "^2.0.0",
+                "unist-util-is": "^4.0.0"
+            }
         },
         "unpipe": {
             "version": "1.0.0",
@@ -16033,27 +16014,30 @@
             }
         },
         "vfile": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-2.3.0.tgz",
-            "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
+            "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
             "requires": {
-                "is-buffer": "^1.1.4",
-                "replace-ext": "1.0.0",
-                "unist-util-stringify-position": "^1.0.0",
-                "vfile-message": "^1.0.0"
+                "@types/unist": "^2.0.0",
+                "is-buffer": "^2.0.0",
+                "unist-util-stringify-position": "^2.0.0",
+                "vfile-message": "^2.0.0"
+            },
+            "dependencies": {
+                "is-buffer": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+                    "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+                }
             }
         },
-        "vfile-location": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-            "integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
-        },
         "vfile-message": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-            "integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
+            "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
             "requires": {
-                "unist-util-stringify-position": "^1.1.1"
+                "@types/unist": "^2.0.0",
+                "unist-util-stringify-position": "^2.0.0"
             }
         },
         "vm-browserify": {
@@ -17331,11 +17315,6 @@
             "requires": {
                 "async-limiter": "~1.0.0"
             }
-        },
-        "x-is-string": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
-            "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI="
         },
         "xdg-basedir": {
             "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "moment": "^2.29.1",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "react-markdown": "^4.3.1",
+        "react-markdown": "^6.0.1",
         "react-redux": "^5.1.2",
         "react-router-dom": "^4.2.2",
         "react-router-hash-link": "^1.2.2",


### PR DESCRIPTION
manual backport for 4.3, we already have this in 4.2 (#393) and master (#389).

Needed to backport #455 