### PR TITLE
[stable-4.2] Change source to children in ReactMarkdown to be according to 6.0.0

### DIFF
--- a/src/components/namespace-form/resources-form.tsx
+++ b/src/components/namespace-form/resources-form.tsx
@@ -52,9 +52,9 @@ export class ResourcesForm extends React.Component<IProps, {}> {
             Preview
             <div className='pf-c-content preview'>
               {namespace.resources ? (
-                <ReactMarkdown source={namespace.resources} />
+                <ReactMarkdown children={namespace.resources} />
               ) : (
-                <ReactMarkdown source={placeholder} />
+                <ReactMarkdown children={placeholder} />
               )}
             </div>
           </div>

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -241,7 +241,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
   private renderResources(namespace: NamespaceType) {
     return (
       <div className='pf-c-content preview'>
-        <ReactMarkdown source={namespace.resources} />
+        <ReactMarkdown children={namespace.resources} />
       </div>
     );
   }


### PR DESCRIPTION
`stable-4.2` of #455 