### PR TITLE
Fix wrong path in Partners All tab in insigths mode

### DIFF
--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -149,9 +149,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
                 tabs={[
                   {
                     title: 'All',
-                    link: Constants.INSIGHTS_DEPLOYMENT_MODE
-                      ? Paths.partners
-                      : Paths.namespaces,
+                    link: Paths[NAMESPACE_TERM],
                     active: !filterOwner,
                   },
                   {

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -149,7 +149,9 @@ export class NamespaceList extends React.Component<IProps, IState> {
                 tabs={[
                   {
                     title: 'All',
-                    link: Paths.namespaces,
+                    link: Constants.INSIGHTS_DEPLOYMENT_MODE
+                      ? Paths.partners
+                      : Paths.namespaces,
                     active: !filterOwner,
                   },
                   {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-651

In Insights mode tab All in Partners has wrong link. Clicking on All tab will result in 404 page.

Current link:

`/ansible/automation-hub/namespaces`

Expected link

`/ansible/automation-hub/partners`

Introuced by https://github.com/ansible/ansible-hub-ui/pull/396