### PR TITLE
Match text style

### DIFF
--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -86,7 +86,11 @@ export class CollectionListItem extends React.Component<IProps, {}> {
         <div className='entry pf-l-flex pf-m-wrap content'>
           {Object.keys(contentSummary.contents).map(k => (
             <div key={k}>
-              <NumericLabel className="type-label" label={k} number={contentSummary.contents[k]} />
+              <NumericLabel
+                className='type-label'
+                label={k}
+                number={contentSummary.contents[k]}
+              />
             </div>
           ))}
         </div>

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -87,7 +87,7 @@ export class CollectionListItem extends React.Component<IProps, {}> {
           {Object.keys(contentSummary.contents).map(k => (
             <div key={k}>
               <NumericLabel
-                className='type-label'
+                className='numeric-label-capitalize-text'
                 label={k}
                 number={contentSummary.contents[k]}
               />

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -86,7 +86,7 @@ export class CollectionListItem extends React.Component<IProps, {}> {
         <div className='entry pf-l-flex pf-m-wrap content'>
           {Object.keys(contentSummary.contents).map(k => (
             <div key={k}>
-              <NumericLabel label={k} number={contentSummary.contents[k]} />
+              <NumericLabel className="type-label" label={k} number={contentSummary.contents[k]} />
             </div>
           ))}
         </div>

--- a/src/components/collection-list/list-item.scss
+++ b/src/components/collection-list/list-item.scss
@@ -10,7 +10,7 @@
   text-transform: capitalize;
 }
 
-.type-label{
+.type-label {
   font-size: var(--pf-global--FontSize--xs);
   color: var(--pf-global--color--200);
   text-transform: capitalize;

--- a/src/components/collection-list/list-item.scss
+++ b/src/components/collection-list/list-item.scss
@@ -9,3 +9,9 @@
 .content {
   text-transform: capitalize;
 }
+
+.type-label{
+  font-size: var(--pf-global--FontSize--xs);
+  color: var(--pf-global--color--200);
+  text-transform: capitalize;
+}

--- a/src/components/collection-list/list-item.scss
+++ b/src/components/collection-list/list-item.scss
@@ -10,7 +10,7 @@
   text-transform: capitalize;
 }
 
-.type-label {
+.numeric-label-capitalize-text {
   font-size: var(--pf-global--FontSize--xs);
   color: var(--pf-global--color--200);
   text-transform: capitalize;

--- a/src/components/numeric-label/numeric-label.tsx
+++ b/src/components/numeric-label/numeric-label.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 interface IProps {
+  className?: string;
   number: number | string;
   label?: string;
   hideNumber?: boolean;
@@ -8,7 +9,7 @@ interface IProps {
 
 export class NumericLabel extends React.Component<IProps, {}> {
   render() {
-    const { number, label, hideNumber } = this.props;
+    const { className, number, label, hideNumber } = this.props;
     let convertedNum: number;
 
     if (typeof number === 'string') {
@@ -20,10 +21,12 @@ export class NumericLabel extends React.Component<IProps, {}> {
     const plural = number === 1 ? '' : 's';
 
     return (
-      <span>
-        {hideNumber ? null : NumericLabel.roundNumber(convertedNum)}{' '}
-        {label ? label + plural : null}
-      </span>
+      <div>
+        <span>
+          {hideNumber ? null : NumericLabel.roundNumber(convertedNum)}{' '}
+        </span>
+        <span className={className}>{label ? label + plural : null}</span>
+      </div>
     );
   }
 


### PR DESCRIPTION
Hi Zita,
Here is a pr for issue:
https://issues.redhat.com/browse/AAH-553

I added className? to the <NumericLabel/> component and then split the number and label properties into 2 spans in the JSX. In collection-list-item.tsx I added a className to the label span. Then in the list-item.scss added the following properties:
.type-label {
  font-size: var(--pf-global--FontSize--xs);
  color: var(--pf-global--color--200);
  text-transform: capitalize;
}
that should now match what is in the collections list in card view. 
Lmk if I should try another approach. :)
![Screen Shot 2021-05-24 at 5 14 07 PM](https://user-images.githubusercontent.com/64337863/119408294-7b602b00-bcb3-11eb-97a1-bbb6c133c3bb.png)
![Screen Shot 2021-05-24 at 1 15 44 PM](https://user-images.githubusercontent.com/64337863/119408354-8e72fb00-bcb3-11eb-8e2d-449110a33fda.png)
