### PR TITLE
add tooltip component

### DIFF
--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -9,6 +9,7 @@ import {
   Text,
   TextVariants,
   Badge,
+  Tooltip,
 } from '@patternfly/react-core';
 
 import { Link } from 'react-router-dom';
@@ -72,9 +73,17 @@ export class CollectionCard extends React.Component<IProps> {
           </div>
         </CardHeader>
         <CardBody>
-          <div className='description'>
-            {this.getDescription(latest_version.metadata.description)}
-          </div>
+          <Tooltip
+            content={
+              <div>
+                {this.getDescription(latest_version.metadata.description)}
+              </div>
+            }
+          >
+            <div className='description'>
+              {this.getDescription(latest_version.metadata.description)}
+            </div>
+          </Tooltip>
         </CardBody>
         <CardBody className='type-container'>
           {Object.keys(contentSummary.contents).map(k =>

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -76,7 +76,7 @@ export class CollectionCard extends React.Component<IProps> {
           <Tooltip
             content={
               <div>
-                {this.getDescription(latest_version.metadata.description)}
+                {latest_version.metadata.description}
               </div>
             }
           >


### PR DESCRIPTION
Hi, Zita && Martin :)
Here is a pr for issue:
https://issues.redhat.com/browse/AAH-554

Just adding a tooltip for the descriptions. I did not differentiate between those visibly overflowing and those not. 
![Screen Shot 2021-05-25 at 2 29 04 PM](https://user-images.githubusercontent.com/64337863/119549778-95f2dc80-bd65-11eb-831b-275b8f2561f9.png)
![Screen Shot 2021-05-25 at 2 06 49 PM](https://user-images.githubusercontent.com/64337863/119549784-97bca000-bd65-11eb-8dec-3382396d02b5.png)

