### PR TITLE
Collections/Detail: move master version dropdown under header; add last updated

### DIFF
--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -31,7 +31,6 @@ export class BaseHeader extends React.Component<IProps, {}> {
       contextSelector,
       versionControl,
     } = this.props;
-    console.log(latestVersion);
     return (
       <div className={cx('background', className)}>
         {contextSelector && (
@@ -64,7 +63,9 @@ export class BaseHeader extends React.Component<IProps, {}> {
           <div className='install-version-column'>
             <span>Version</span>
             <div className='install-version-dropdown'>{versionControl}</div>
-            <span className='last-updated'>Last updated {latestVersion}</span>
+            {latestVersion ? (
+              <span className='last-updated'>Last updated {latestVersion}</span>
+            ) : null}
           </div>
         ) : null}
 

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -44,7 +44,7 @@ export class BaseHeader extends React.Component<IProps, {}> {
             <div className='install-version-column'>
               <span>Version</span>
               <div className='install-version-dropdown'>{pageControls}</div>
-              <span className="last-updated">Last updated [exact time]</span>
+              <span className='last-updated'>Last updated [exact time]</span>
             </div>
           ) : null}
         </div>

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -9,6 +9,7 @@ import { Logo } from 'src/components';
 interface IProps {
   title: string;
   imageURL?: string;
+  latestVersion?: string;
   breadcrumbs?: React.ReactNode;
   pageControls?: React.ReactNode;
   children?: React.ReactNode;
@@ -22,6 +23,7 @@ export class BaseHeader extends React.Component<IProps, {}> {
     const {
       title,
       imageURL,
+      latestVersion,
       pageControls,
       children,
       breadcrumbs,
@@ -29,6 +31,7 @@ export class BaseHeader extends React.Component<IProps, {}> {
       contextSelector,
       versionControl,
     } = this.props;
+    console.log(latestVersion);
     return (
       <div className={cx('background', className)}>
         {contextSelector && (
@@ -39,16 +42,6 @@ export class BaseHeader extends React.Component<IProps, {}> {
         )}
         {!breadcrumbs && !contextSelector && <div className='placeholder' />}
 
-        <div>
-          {' '}
-          {pageControls ? (
-            <div className='install-version-column'>
-              <span>Version</span>
-              <div className='install-version-dropdown'>{pageControls}</div>
-              <span className='last-updated'>Last updated [exact time]</span>
-            </div>
-          ) : null}
-        </div>
         <div className='column-section'>
           <div className='title-box'>
             {imageURL ? (
@@ -63,12 +56,15 @@ export class BaseHeader extends React.Component<IProps, {}> {
               <PageHeaderTitle title={title} />
             </div>
           </div>
+          {pageControls ? (
+            <div className='header-right'>{pageControls}</div>
+          ) : null}
         </div>
         {versionControl ? (
           <div className='install-version-column'>
             <span>Version</span>
             <div className='install-version-dropdown'>{versionControl}</div>
-            <span className='last-updated'>Last updated [exact time]</span>
+            <span className='last-updated'>Last updated {latestVersion}</span>
           </div>
         ) : null}
 

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -26,6 +26,7 @@ export class BaseHeader extends React.Component<IProps, {}> {
       breadcrumbs,
       className,
       contextSelector,
+      versionControl,
     } = this.props;
     return (
       <div className={cx('background', className)}>

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -14,6 +14,7 @@ interface IProps {
   children?: React.ReactNode;
   className?: string;
   contextSelector?: React.ReactNode;
+  versionControl?: React.ReactNode;
 }
 
 export class BaseHeader extends React.Component<IProps, {}> {

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -63,6 +63,13 @@ export class BaseHeader extends React.Component<IProps, {}> {
             </div>
           </div>
         </div>
+        {versionControl ? (
+          <div className='install-version-column'>
+            <span>Version</span>
+            <div className='install-version-dropdown'>{versionControl}</div>
+            <span className='last-updated'>Last updated [exact time]</span>
+          </div>
+        ) : null}
 
         {children ? (
           <div className='header-bottom'>{children}</div>

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -9,7 +9,6 @@ import { Logo } from 'src/components';
 interface IProps {
   title: string;
   imageURL?: string;
-  latestVersion?: string;
   breadcrumbs?: React.ReactNode;
   pageControls?: React.ReactNode;
   children?: React.ReactNode;
@@ -23,7 +22,6 @@ export class BaseHeader extends React.Component<IProps, {}> {
     const {
       title,
       imageURL,
-      latestVersion,
       pageControls,
       children,
       breadcrumbs,
@@ -59,15 +57,7 @@ export class BaseHeader extends React.Component<IProps, {}> {
             <div className='header-right'>{pageControls}</div>
           ) : null}
         </div>
-        {versionControl ? (
-          <div className='install-version-column'>
-            <span>Version</span>
-            <div className='install-version-dropdown'>{versionControl}</div>
-            {latestVersion ? (
-              <span className='last-updated'>Last updated {latestVersion}</span>
-            ) : null}
-          </div>
-        ) : null}
+        {versionControl ? <>{versionControl}</> : null}
 
         {children ? (
           <div className='header-bottom'>{children}</div>

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -37,6 +37,16 @@ export class BaseHeader extends React.Component<IProps, {}> {
         )}
         {!breadcrumbs && !contextSelector && <div className='placeholder' />}
 
+        <div>
+          {' '}
+          {pageControls ? (
+            <div className='install-version-column'>
+              <span>Version</span>
+              <div className='install-version-dropdown'>{pageControls}</div>
+              <span className="last-updated">Last updated [exact time]</span>
+            </div>
+          ) : null}
+        </div>
         <div className='column-section'>
           <div className='title-box'>
             {imageURL ? (
@@ -51,10 +61,6 @@ export class BaseHeader extends React.Component<IProps, {}> {
               <PageHeaderTitle title={title} />
             </div>
           </div>
-
-          {pageControls ? (
-            <div className='header-right'>{pageControls}</div>
-          ) : null}
         </div>
 
         {children ? (

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -44,7 +44,7 @@ export class CollectionHeader extends React.Component<IProps> {
       activeTab,
       className,
     } = this.props;
-    
+
     const all_versions = [...collection.all_versions];
 
     const match = all_versions.find(

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -68,6 +68,7 @@ export class CollectionHeader extends React.Component<IProps> {
 
     return (
       <BaseHeader
+        latestVersion={collection.latest_version.created_at}
         className={className}
         title={collection.name}
         imageURL={collection.namespace.avatar_url}

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -44,7 +44,7 @@ export class CollectionHeader extends React.Component<IProps> {
       activeTab,
       className,
     } = this.props;
-
+    
     const all_versions = [...collection.all_versions];
 
     const match = all_versions.find(

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -104,7 +104,10 @@ export class CollectionHeader extends React.Component<IProps> {
               </FormSelect>
             </div>
             {latestVersion ? (
-              <span className='last-updated'>Last updated <DateComponent date={latestVersion}></DateComponent></span>
+              <span className='last-updated'>
+                Last updated{' '}
+                <DateComponent date={latestVersion}></DateComponent>
+              </span>
             ) : null}
           </div>
         }

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -15,6 +15,7 @@ import {
 import { CollectionDetailType } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
 import { ParamHelper } from 'src/utilities/param-helper';
+import { DateComponent } from '../date-component/date-component';
 
 interface IProps {
   collection: CollectionDetailType;
@@ -103,7 +104,7 @@ export class CollectionHeader extends React.Component<IProps> {
               </FormSelect>
             </div>
             {latestVersion ? (
-              <span className='last-updated'>Last updated {latestVersion}</span>
+              <span className='last-updated'>Last updated <DateComponent date={latestVersion}></DateComponent></span>
             ) : null}
           </div>
         }

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -79,8 +79,8 @@ export class CollectionHeader extends React.Component<IProps> {
           />
         }
         breadcrumbs={<Breadcrumbs links={breadcrumbs} />}
-        pageControls={
-          <div style={{ display: 'flex', alignItems: 'center' }}>
+        versionControl={
+          <div>
             <FormSelect
               onChange={val =>
                 updateParams(ParamHelper.setParam(params, 'version', val))

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -20,6 +20,7 @@ interface IProps {
   collection: CollectionDetailType;
   params: {
     version?: string;
+    latestVersion?: string;
   };
   updateParams: (params) => void;
   breadcrumbs: {
@@ -66,9 +67,10 @@ export class CollectionHeader extends React.Component<IProps> {
       { key: 'repository', name: 'Repo' },
     ];
 
+    const latestVersion = collection.latest_version.created_at;
+
     return (
       <BaseHeader
-        latestVersion={collection.latest_version.created_at}
         className={className}
         title={collection.name}
         imageURL={collection.namespace.avatar_url}
@@ -81,22 +83,28 @@ export class CollectionHeader extends React.Component<IProps> {
         }
         breadcrumbs={<Breadcrumbs links={breadcrumbs} />}
         versionControl={
-          <div>
-            <FormSelect
-              onChange={val =>
-                updateParams(ParamHelper.setParam(params, 'version', val))
-              }
-              value={collection.latest_version.version}
-              aria-label='Select collection version'
-            >
-              {all_versions.map(v => (
-                <FormSelectOption
-                  key={v.version}
-                  value={v.version}
-                  label={'v' + v.version}
-                />
-              ))}
-            </FormSelect>
+          <div className='install-version-column'>
+            <span>Version</span>
+            <div className='install-version-dropdown'>
+              <FormSelect
+                onChange={val =>
+                  updateParams(ParamHelper.setParam(params, 'version', val))
+                }
+                value={collection.latest_version.version}
+                aria-label='Select collection version'
+              >
+                {all_versions.map(v => (
+                  <FormSelectOption
+                    key={v.version}
+                    value={v.version}
+                    label={'v' + v.version}
+                  />
+                ))}
+              </FormSelect>
+            </div>
+            {latestVersion ? (
+              <span className='last-updated'>Last updated {latestVersion}</span>
+            ) : null}
           </div>
         }
       >

--- a/src/components/headers/header.scss
+++ b/src/components/headers/header.scss
@@ -18,6 +18,20 @@
   }
 }
 
+.install-version-column {
+  display: flex;
+  align-items: baseline;
+  gap: .5rem;
+}
+
+.install-version-dropdown {
+  width: 136px;
+}
+
+.last-updated {
+  color: grey;
+}
+
 .background {
   background-color: white;
   padding: 0px 24px 0px 24px;

--- a/src/components/headers/header.scss
+++ b/src/components/headers/header.scss
@@ -21,7 +21,7 @@
 .install-version-column {
   display: flex;
   align-items: baseline;
-  gap: .5rem;
+  gap: 0.5rem;
 }
 
 .install-version-dropdown {


### PR DESCRIPTION
HI:)
Issue https://issues.redhat.com/browse/AAH-549

I moved the install version dropdown onto its own line surrounded by two spans with  text. And then formatted accordingly.

Let me know if you'd like me to change classNames, etc., format or reorganize it in some way. 

Have a great evening! :)

![Screen Shot 2021-05-25 at 4 27 19 PM](https://user-images.githubusercontent.com/64337863/119564283-9c3d8480-bd76-11eb-9f55-5a59ea5e2e94.png)
![Screen Shot 2021-05-25 at 4 30 54 PM](https://user-images.githubusercontent.com/64337863/119564292-9e9fde80-bd76-11eb-93fd-c0472fad44cc.png)
