### PR TITLE
[PR #464/efa00ff backport][stable-4.3] Test the namespace page modes with galaxykit test data

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -71,3 +71,36 @@ After the tests have run you can view a video recording of the run is test/cypre
 
 See Cypress documentation:
     https://docs.cypress.io/guides/core-concepts/writing-and-organizing-tests.html#Folder-Structure
+
+## GalaxyKit Integration
+
+In order to help manage test data, our Cypress setup includes wrappers around the galaxykit command. The galakxykit command is an interface to the GalaxyNG API.
+
+You can install the dependency on your machine with pip, the Python dependency manager:
+
+    pip install galaxykit
+
+At this time, galaxykit is exposed in three commands: galaxykit, deleteTestUsers, and deleteTestGroups.
+
+### cy.deleteTestUsers()
+
+This command will delete any users in the system with the word "test" in their name.
+
+### cy.deleteTestGroups()
+
+This command will delete any groups in the system with the word "test" in the name.
+
+### cy.galaxykit(command, ...args)
+
+This low-level wrapper allows you to call any sub-command of the galaxykit tool. Extra parameters will be escaped safely for the shell.
+
+You may use these commands:
+
+* cy.galaxykit("user create", username, password)
+* cy.galaxykit("user delete", username)
+* cy.galaxykit("user group add", username)
+* cy.galaxykit("group create", name)
+* cy.galaxykit("group delete", name)
+* cy.galaxykit("namespace create", name, [initial group])
+* cy.galaxykit("namespace addgroup", namespace, group)
+* cy.galaxykit("namespace removegroup", namespace, group)

--- a/test/cypress/integration/group_management.js
+++ b/test/cypress/integration/group_management.js
@@ -4,6 +4,8 @@ describe('Hub Group Management Tests', () => {
     var adminPassword = Cypress.env("password");
 
     beforeEach(() => {
+        cy.deleteTestGroups();
+        cy.deleteTestUsers();
         cy.visit(baseUrl);
     });
 

--- a/test/cypress/integration/namespaces.js
+++ b/test/cypress/integration/namespaces.js
@@ -1,0 +1,45 @@
+describe('Namespaces Page Tests', () => {
+    var baseUrl = Cypress.config().baseUrl;
+    var adminUsername = Cypress.env("username");
+    var adminPassword = Cypress.env("password");
+
+    before(() => {
+        cy.galaxykit("-i group create", "testGroup1")
+        cy.galaxykit("-i group create", "testGroup2")
+
+        cy.galaxykit("-i user create", "testUser2", "p@ssword1")
+        cy.galaxykit("user group add", "testUser2", "testGroup2")
+
+        cy.galaxykit("-i namespace create", "testns1")
+        cy.galaxykit("-i namespace create", "testns2")
+        cy.galaxykit("namespace addgroup", "testns1", "testGroup1")
+        cy.galaxykit("namespace addgroup", "testns2", "testGroup2")
+    });
+
+    beforeEach(() => {
+        cy.visit(baseUrl);
+        // cy.login(adminUsername, adminPassword);
+    });
+
+    // afterEach(() => {
+    //     cy.logout();
+    // })
+
+    it('can navigate to pubic namespace list', () => {
+        cy.login("testUser2", "p@ssword1");
+        cy.menuGo("Collections > Namespaces");
+
+        cy.contains("testns2").should("exist")
+        cy.contains("testns1").should("exist")
+    });
+
+    it('can navigate to personal namespace list', () => {
+        cy.login("testUser2", "p@ssword1");
+        cy.menuGo("Collections > Namespaces");
+        cy.contains("My namespaces").click()
+
+        cy.contains("testns2").should("exist")
+        cy.contains("testns1").should("not.exist")
+    });
+
+});

--- a/test/cypress/integration/user_dashboard.js
+++ b/test/cypress/integration/user_dashboard.js
@@ -6,6 +6,9 @@ describe('Hub User Management Tests', () => {
     let password = 'p@ssword1';
 
     before(() => {
+        cy.deleteTestUsers();
+        cy.deleteTestGroups();
+
         cy.visit(baseUrl);
         cy.login(adminUsername, adminPassword);
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -24,6 +24,7 @@
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
+import shell from 'shell-escape-tag'
 var urljoin = require('url-join');
 
 Cypress.Commands.add('findnear', {prevSubject: true}, (subject, selector) => {
@@ -96,6 +97,9 @@ Cypress.Commands.add('createUser', {}, (username, password = null, firstName = n
 
     cy.contains('Save').click();
     cy.wait('@createUser');
+
+    // The API responded, but the user list page hasn't loaded, wait 100ms.
+    cy.wait(100);
 });
 
 Cypress.Commands.add('createGroup', {}, (name) => {
@@ -225,4 +229,72 @@ Cypress.Commands.add('deleteGroup', {}, (name) => {
     cy.contains('[role=dialog] button', 'Delete').click();
     cy.wait('@deleteGroup');
     cy.get('@deleteGroup').should('have.property', 'status', 204);
+});
+
+// GalaxyKit Integration
+
+Cypress.Commands.add('galaxykit', {}, (operation, ...args) => {
+    var options = {}
+    var adminUsername = Cypress.env('username');
+    var adminPassword = Cypress.env('password');
+    var server = Cypress.config().baseUrl + Cypress.env('prefix');
+    var cmd = shell`galaxykit -s ${server} -u ${adminUsername} -p ${adminPassword}`;
+
+    if (args.length >= 1) {
+        if (typeof args[args.length - 1] == "object") {
+            options = args.splice(args.length - 1, 1)[0];
+        }
+    }
+
+    cmd += " " + operation;
+    Array.prototype.forEach.call(args, (arg) => {
+        cmd += " " + shell`${arg}`;
+    })
+
+    return cy.exec(cmd, options, (error, stdout) => {
+        if (error) {
+            throw new Error(`Galaxykit failed: ${error}`)
+        } else {
+            console.log(`RUN galaxykit ${args}`)
+            console.log(stdout);
+        }
+    });
+});
+
+Cypress.Commands.add('deleteTestUsers', {}, (args) => {
+    var adminUsername = Cypress.env('username');
+    var adminPassword = Cypress.env('password');
+    var server = Cypress.config().baseUrl + Cypress.env('prefix');
+    var cmd = `galaxykit -s '${server}' -u '${adminUsername}' -p '${adminPassword}' user list`;
+
+    var users = cy.exec(cmd);
+    users.then((result) => {
+        var stdout = result.stdout;
+        var lines = stdout.split('\n');
+        lines.forEach(line => {
+            var username = line.split(' ')[0];
+            if (username.trim().length > 0) {
+                cy.galaxykit(`user delete ${username}`, {failOnNonZeroExit: false})
+            }
+        });
+    })
+});
+
+Cypress.Commands.add('deleteTestGroups', {}, (args) => {
+    var adminUsername = Cypress.env('username');
+    var adminPassword = Cypress.env('password');
+    var server = Cypress.config().baseUrl + Cypress.env('prefix');
+    var cmd = shell`galaxykit -s ${server} -u ${adminUsername} -p ${adminPassword} group list`;
+
+    var p = cy.exec(cmd);
+    p.then((result) => {
+        var stdout = result.stdout;
+        var lines = stdout.split('\n');
+        lines.forEach(line => {
+            var name = line.split(' ')[0];
+            if (name.trim().length > 0) {
+                cy.galaxykit(`group delete ${name}`, {failOnNonZeroExit: false})
+            }
+        });
+    })
 });

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -143,6 +143,11 @@
       "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
       "dev": true
     },
+    "any-shell-escape": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/any-shell-escape/-/any-shell-escape-0.1.1.tgz",
+      "integrity": "sha1-1Vq5ciRMcaml4asIefML8RCAaVk="
+    },
     "arch": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.2.tgz",
@@ -832,6 +837,11 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
+    "inspect-custom-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/inspect-custom-symbol/-/inspect-custom-symbol-1.1.1.tgz",
+      "integrity": "sha512-GOucsp9EcdlLdhPUyOTvQDnbFJtp2WBWZV1Jqe+mVnkJQBL3w96+fB84C+JL+EKXOspMdB0eMDQPDp5w9fkfZA=="
+    },
     "is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -952,6 +962,16 @@
         "json-schema": "0.2.3",
         "verror": "1.10.0"
       }
+    },
+    "just-flatten-it": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/just-flatten-it/-/just-flatten-it-2.2.1.tgz",
+      "integrity": "sha512-VwvlzikphspzZL38LiZpoBsFGQy6MnmXYekBeZA8lSNwgSC87zA3a93bCZKkDuOM+djMZhfjd3lXAZyxficKCg=="
+    },
+    "just-zip-it": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/just-zip-it/-/just-zip-it-2.1.0.tgz",
+      "integrity": "sha512-+5+Gd4t/VWUpWeCM0pxUFvNdYnkIKhjQCQrLyMkVUUyMeJQwxkf/E7pih5hLui8JMRR2VpuizXqs3c3rop1URw=="
     },
     "lazy-ass": {
       "version": "1.6.0",
@@ -1438,6 +1458,17 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shell-escape-tag": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/shell-escape-tag/-/shell-escape-tag-2.0.2.tgz",
+      "integrity": "sha512-kqmtJG6VzTahZl8Y3384ldskA9rzoEMdXLoMEBAq9334/UDdmfWl3OtmrGJPlVcyXvcSy3poDKka57gMxskMPw==",
+      "requires": {
+        "any-shell-escape": "^0.1.1",
+        "inspect-custom-symbol": "^1.1.1",
+        "just-flatten-it": "^2.1.0",
+        "just-zip-it": "^2.1.0"
+      }
     },
     "signal-exit": {
       "version": "3.0.3",

--- a/test/package.json
+++ b/test/package.json
@@ -17,6 +17,7 @@
     "cypress-log-to-output": "^1.1.2"
   },
   "dependencies": {
+    "shell-escape-tag": "^2.0.2",
     "url-join": "^4.0.1"
   }
 }


### PR DESCRIPTION
**This is a backport of PR #464 as merged into master (efa00ff).**

Manual backport, because there is no `.github/workflows/cypress.yml` outside master.

Cc @ironfroggy 

---

* Test the namespace page modes after setting up test data via the new galaxykit helper.

* Small fixes from PR feedback

* Install galaxykit tool before running Cypress tests.

* Use galaxykit to clear test users and groups before running user dashboard tests

* Ignore errors for already existing data, to make more stable re-runs

* Use galaxykit to clear test users and groups before running user dashboard tests

* Update galaxykit commands to use better error handling now available

* Allow escaped parameters to be safely passed as individual arguments to galaxykit after the command.

* Document galaxykit wrapper, and add escaping mechanics

* Handle unexpected output from user and group list; wait for user list after user creation;

* Use released version of galaykit, 0.1.0

* Use released version of galaykit, 0.1.0 (fix)