### PR TITLE
add LabelGroup to collection-list-item.tsx

### DIFF
--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -97,9 +97,9 @@ export class CollectionListItem extends React.Component<IProps, {}> {
         </div>
         <div className='entry pf-l-flex pf-m-wrap'>
           <LabelGroup>
-          {latest_version.metadata.tags.map((tag, index) => (
-            <Tag key={index}>{tag}</Tag>
-          ))}
+            {latest_version.metadata.tags.map((tag, index) => (
+              <Tag key={index}>{tag}</Tag>
+            ))}
           </LabelGroup>
         </div>
       </DataListCell>,

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -6,6 +6,7 @@ import {
   DataListItemRow,
   DataListItemCells,
   DataListCell,
+  LabelGroup,
   TextContent,
   Text,
   TextVariants,
@@ -95,9 +96,11 @@ export class CollectionListItem extends React.Component<IProps, {}> {
           ))}
         </div>
         <div className='entry pf-l-flex pf-m-wrap'>
+          <LabelGroup>
           {latest_version.metadata.tags.map((tag, index) => (
             <Tag key={index}>{tag}</Tag>
           ))}
+          </LabelGroup>
         </div>
       </DataListCell>,
     );


### PR DESCRIPTION



Happy Thursday, Zita && Martin :)

This pr hopefully takes care of issue:
https://issues.redhat.com/browse/AAH-240

Add <LabelGroup to wrap the <Tag component in collection-list-item.tsx.

I did not change collection-info.tsx.

Contact me with q's!
~Shaiah

![Screen Shot 2021-05-27 at 3 54 30 PM](https://user-images.githubusercontent.com/64337863/119889325-69c19200-bf04-11eb-970e-f7aee645bd5f.png)
![Screen Shot 2021-05-27 at 3 53 56 PM](https://user-images.githubusercontent.com/64337863/119889330-6b8b5580-bf04-11eb-926b-0a5229f57c16.png)