### PR TITLE
Add filter to documentation

### DIFF
--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -71,7 +71,9 @@ export class CollectionContentList extends React.Component<IProps> {
                   onChange={val =>
                     updateParams(ParamHelper.setParam(params, 'keywords', val))
                   }
-                  onClear={ () => updateParams(ParamHelper.setParam(params, 'keywords', ''))}
+                  onClear={() =>
+                    updateParams(ParamHelper.setParam(params, 'keywords', ''))
+                  }
                   aria-label='find-content'
                   placeholder='Find content'
                 />

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -46,24 +46,15 @@ export class CollectionContentList extends React.Component<IProps> {
     const keywords = params.keywords || '';
 
     for (let c of contents) {
-      // summary['all']++;
-      // if (summary[c.content_type]) {
-      //   summary[c.content_type]++;
-      // } else {
-      // summary[c.content_type] = 1;
-      // }
-
       const typeMatch = showing === 'all' ? true : c.content_type === showing;
+      if (!summary[c.content_type]) {
+        summary[c.content_type] = 0;
+      }
 
       if (typeMatch && c.name.match(keywords)) {
         toShow.push(c);
-        if (summary[c.content_type]) {
-          summary[c.content_type]++;
-          summary['all']++;
-        } else {
-          summary[c.content_type] = 1;
-          summary['all']++;
-        }
+        summary[c.content_type]++;
+        summary['all']++;
       }
     }
 

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -46,19 +46,27 @@ export class CollectionContentList extends React.Component<IProps> {
     const keywords = params.keywords || '';
 
     for (let c of contents) {
-      summary['all']++;
-      if (summary[c.content_type]) {
-        summary[c.content_type]++;
-      } else {
-        summary[c.content_type] = 1;
-      }
+      // summary['all']++;
+      // if (summary[c.content_type]) {
+      //   summary[c.content_type]++;
+      // } else {
+        // summary[c.content_type] = 1;
+      // }
 
       const typeMatch = showing === 'all' ? true : c.content_type === showing;
 
       if (typeMatch && c.name.match(keywords)) {
         toShow.push(c);
+        if (summary[c.content_type]) {
+          summary[c.content_type]++;
+          summary['all']++;
+        } else {
+          summary[c.content_type] = 1;
+          summary['all']++;
+        }
       }
     }
+
 
     return (
       <div>

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -50,7 +50,7 @@ export class CollectionContentList extends React.Component<IProps> {
       // if (summary[c.content_type]) {
       //   summary[c.content_type]++;
       // } else {
-        // summary[c.content_type] = 1;
+      // summary[c.content_type] = 1;
       // }
 
       const typeMatch = showing === 'all' ? true : c.content_type === showing;
@@ -66,7 +66,6 @@ export class CollectionContentList extends React.Component<IProps> {
         }
       }
     }
-
 
     return (
       <div>

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -4,6 +4,7 @@ import './collection-content-list.scss';
 
 import { Link } from 'react-router-dom';
 import {
+  SearchInput,
   TextInput,
   Toolbar,
   ToolbarGroup,
@@ -65,11 +66,12 @@ export class CollectionContentList extends React.Component<IProps> {
           <Toolbar>
             <ToolbarGroup>
               <ToolbarItem>
-                <TextInput
+                <SearchInput
                   value={params.keywords || ''}
                   onChange={val =>
                     updateParams(ParamHelper.setParam(params, 'keywords', val))
                   }
+                  onClear={ () => updateParams(ParamHelper.setParam(params, 'keywords', ''))}
                   aria-label='find-content'
                   placeholder='Find content'
                 />

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -209,7 +209,7 @@ export class TableOfContents extends React.Component<IProps, IState> {
     return (
       <NavExpandable
         key={title}
-        title={capitalize(`${title} (${links.length})`)}
+        title={capitalize(`${title} (${filteredLinks.length})`)}
         isExpanded={isExpanded}
         isActive={this.getSelectedCategory() === title}
       >

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -189,8 +189,8 @@ export class TableOfContents extends React.Component<IProps, IState> {
 
   private renderLinks(links: DocsEntry[], title, filterString: string) {
     const isExpanded = !this.state.collapsedCategories.includes(title);
-    const filteredLinks = links.filter(
-      link => link.display.includes(filterString)
+    const filteredLinks = links.filter(link =>
+      link.display.includes(filterString),
     );
     return (
       <NavExpandable

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -190,7 +190,7 @@ export class TableOfContents extends React.Component<IProps, IState> {
   private renderLinks(links: DocsEntry[], title, filterString: string) {
     const isExpanded = !this.state.collapsedCategories.includes(title);
     const filteredLinks = links.filter(
-      link => link.display.indexOf(filterString) > -1,
+      link => link.display.includes(filterString)
     );
     return (
       <NavExpandable

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -47,6 +47,7 @@ interface IProps {
   selectedType?: string;
   className?: string;
   updateParams: (p) => void;
+  searchBarRef?: React.Ref<HTMLInputElement>;
 }
 
 export class TableOfContents extends React.Component<IProps, IState> {
@@ -86,6 +87,7 @@ export class TableOfContents extends React.Component<IProps, IState> {
           <ToolbarGroup>
             <ToolbarItem>
               <TextInput
+              ref={this.props.searchBarRef}
                 value={params.keywords}
                 onChange={val => {
                   updateParams(ParamHelper.setParam(params, 'keywords', val));

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -88,7 +88,7 @@ export class TableOfContents extends React.Component<IProps, IState> {
           <ToolbarGroup>
             <ToolbarItem>
               <SearchInput
-                // ref={this.props.searchBarRef}
+                ref={this.props.searchBarRef}
                 value={params.keywords}
                 onChange={val => {
                   updateParams(ParamHelper.setParam(params, 'keywords', val));

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -9,7 +9,6 @@ import {
   NavItem,
   NavList,
   SearchInput,
-  TextInput,
   Toolbar,
   ToolbarGroup,
   ToolbarItem,

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -8,6 +8,7 @@ import {
   NavExpandable,
   NavItem,
   NavList,
+  SearchInput,
   TextInput,
   Toolbar,
   ToolbarGroup,
@@ -86,12 +87,13 @@ export class TableOfContents extends React.Component<IProps, IState> {
         <Toolbar>
           <ToolbarGroup>
             <ToolbarItem>
-              <TextInput
+              <SearchInput
                 ref={this.props.searchBarRef}
                 value={params.keywords}
                 onChange={val => {
                   updateParams(ParamHelper.setParam(params, 'keywords', val));
                 }}
+                onClear={ () => updateParams(ParamHelper.setParam(params, 'keywords', ''))}
                 aria-label='find-content'
                 placeholder='Find content'
               />

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -36,7 +36,6 @@ class Table {
 
 interface IState {
   collapsedCategories: string[];
-  searchBarValue: string;
 }
 
 interface IProps {
@@ -60,7 +59,6 @@ export class TableOfContents extends React.Component<IProps, IState> {
 
     this.state = {
       collapsedCategories: [],
-      searchBarValue: this.props.params.keywords || '',
     };
   }
 
@@ -88,10 +86,9 @@ export class TableOfContents extends React.Component<IProps, IState> {
           <ToolbarGroup>
             <ToolbarItem>
               <TextInput
-                value={this.state.searchBarValue}
+                value={params.keywords}
                 onChange={val => {
-                  this.setState({ searchBarValue: val });
-                  ParamHelper.setParam(params, 'keywords', val);
+                  updateParams(ParamHelper.setParam(params, 'keywords', val));
                 }}
                 aria-label='find-content'
                 placeholder='Find content'
@@ -104,7 +101,7 @@ export class TableOfContents extends React.Component<IProps, IState> {
             {Object.keys(table).map(key =>
               table[key].length === 0
                 ? null
-                : this.renderLinks(table[key], key, this.state.searchBarValue),
+                : this.renderLinks(table[key], key, this.props.params.keywords),
             )}
           </NavList>
         </Nav>

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -3,7 +3,13 @@ import * as React from 'react';
 import { capitalize } from 'lodash';
 import { Link } from 'react-router-dom';
 
-import { Nav, NavExpandable, NavItem, NavList, TextInput } from '@patternfly/react-core';
+import {
+  Nav,
+  NavExpandable,
+  NavItem,
+  NavList,
+  TextInput,
+} from '@patternfly/react-core';
 
 import { DocsBlobType } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
@@ -73,9 +79,7 @@ export class TableOfContents extends React.Component<IProps, IState> {
       <div className={className}>
         <TextInput
           value={this.state.searchBarValue}
-          onChange={val =>
-            this.setState({searchBarValue: val})    
-          }
+          onChange={val => this.setState({ searchBarValue: val })}
           aria-label='find-content'
           placeholder='Filter by keyword'
         />
@@ -176,7 +180,9 @@ export class TableOfContents extends React.Component<IProps, IState> {
 
   private renderLinks(links: DocsEntry[], title, filterString: string) {
     const isExpanded = !this.state.collapsedCategories.includes(title);
-    const filteredLinks = links.filter((link) => link.display.indexOf(filterString) > -1);
+    const filteredLinks = links.filter(
+      link => link.display.indexOf(filterString) > -1,
+    );
     return (
       <NavExpandable
         key={title}

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -58,7 +58,10 @@ export class TableOfContents extends React.Component<IProps, IState> {
   constructor(props) {
     super(props);
 
-    this.state = { collapsedCategories: [], searchBarValue: this.props.params.keywords || '' };
+    this.state = {
+      collapsedCategories: [],
+      searchBarValue: this.props.params.keywords || '',
+    };
   }
 
   render() {
@@ -86,7 +89,10 @@ export class TableOfContents extends React.Component<IProps, IState> {
             <ToolbarItem>
               <TextInput
                 value={this.state.searchBarValue}
-                onChange={val => {this.setState({ searchBarValue: val}); (ParamHelper.setParam(params, 'keywords', val))}}
+                onChange={val => {
+                  this.setState({ searchBarValue: val });
+                  ParamHelper.setParam(params, 'keywords', val);
+                }}
                 aria-label='find-content'
                 placeholder='Find content'
               />

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -3,13 +3,7 @@ import * as React from 'react';
 import { capitalize } from 'lodash';
 import { Link } from 'react-router-dom';
 
-import {
-  Nav,
-  NavExpandable,
-  NavItem,
-  NavList,
-  TextInput,
-} from '@patternfly/react-core';
+import { Nav, NavExpandable, NavItem, NavList, TextInput, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 
 import { DocsBlobType } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
@@ -77,12 +71,18 @@ export class TableOfContents extends React.Component<IProps, IState> {
 
     return (
       <div className={className}>
-        <TextInput
-          value={this.state.searchBarValue}
-          onChange={val => this.setState({ searchBarValue: val })}
-          aria-label='find-content'
-          placeholder='Filter by keyword'
-        />
+          <Toolbar>
+              <ToolbarGroup>
+                <ToolbarItem>
+                  <TextInput
+                    value={this.state.searchBarValue}
+                    onChange={val => this.setState({ searchBarValue: val })}
+                    aria-label='find-content'
+                    placeholder='Find content'
+                  />
+                </ToolbarItem>
+              </ToolbarGroup>
+            </Toolbar>
         <Nav theme='light'>
           <NavList>
             {Object.keys(table).map(key =>

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -87,7 +87,7 @@ export class TableOfContents extends React.Component<IProps, IState> {
           <ToolbarGroup>
             <ToolbarItem>
               <TextInput
-              ref={this.props.searchBarRef}
+                ref={this.props.searchBarRef}
                 value={params.keywords}
                 onChange={val => {
                   updateParams(ParamHelper.setParam(params, 'keywords', val));

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -3,7 +3,16 @@ import * as React from 'react';
 import { capitalize } from 'lodash';
 import { Link } from 'react-router-dom';
 
-import { Nav, NavExpandable, NavItem, NavList, TextInput, Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import {
+  Nav,
+  NavExpandable,
+  NavItem,
+  NavList,
+  TextInput,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
 
 import { DocsBlobType } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
@@ -71,18 +80,18 @@ export class TableOfContents extends React.Component<IProps, IState> {
 
     return (
       <div className={className}>
-          <Toolbar>
-              <ToolbarGroup>
-                <ToolbarItem>
-                  <TextInput
-                    value={this.state.searchBarValue}
-                    onChange={val => this.setState({ searchBarValue: val })}
-                    aria-label='find-content'
-                    placeholder='Find content'
-                  />
-                </ToolbarItem>
-              </ToolbarGroup>
-            </Toolbar>
+        <Toolbar>
+          <ToolbarGroup>
+            <ToolbarItem>
+              <TextInput
+                value={this.state.searchBarValue}
+                onChange={val => this.setState({ searchBarValue: val })}
+                aria-label='find-content'
+                placeholder='Find content'
+              />
+            </ToolbarItem>
+          </ToolbarGroup>
+        </Toolbar>
         <Nav theme='light'>
           <NavList>
             {Object.keys(table).map(key =>

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -93,7 +93,9 @@ export class TableOfContents extends React.Component<IProps, IState> {
                 onChange={val => {
                   updateParams(ParamHelper.setParam(params, 'keywords', val));
                 }}
-                onClear={ () => updateParams(ParamHelper.setParam(params, 'keywords', ''))}
+                onClear={() =>
+                  updateParams(ParamHelper.setParam(params, 'keywords', ''))
+                }
                 aria-label='find-content'
                 placeholder='Find content'
               />

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -202,8 +202,6 @@ export class TableOfContents extends React.Component<IProps, IState> {
     const filteredLinks = links.filter(link =>
       link.display.toLowerCase().includes(filterString.toLowerCase()),
     );
-    console.log('filterstring: ', filterString);
-    console.log(links);
     return (
       <NavExpandable
         key={title}

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -43,10 +43,11 @@ interface IProps {
   docs_blob: DocsBlobType;
   namespace: string;
   collection: string;
-  params: {keywords?: string};
+  params: { keywords?: string };
   selectedName?: string;
   selectedType?: string;
   className?: string;
+  updateParams: (p) => void;
 }
 
 export class TableOfContents extends React.Component<IProps, IState> {
@@ -57,11 +58,11 @@ export class TableOfContents extends React.Component<IProps, IState> {
   constructor(props) {
     super(props);
 
-    this.state = { collapsedCategories: [], searchBarValue: '' };
+    this.state = { collapsedCategories: [], searchBarValue: this.props.params.keywords || '' };
   }
 
   render() {
-    const { className, docs_blob } = this.props;
+    const { className, docs_blob, updateParams, params } = this.props;
 
     // There's a lot of heavy processing that goes into formatting the table
     // variable. To prevent running everything each time the component renders,
@@ -85,7 +86,7 @@ export class TableOfContents extends React.Component<IProps, IState> {
             <ToolbarItem>
               <TextInput
                 value={this.state.searchBarValue}
-                onChange={val => this.setState({ searchBarValue: val })}
+                onChange={val => {this.setState({ searchBarValue: val}); (ParamHelper.setParam(params, 'keywords', val))}}
                 aria-label='find-content'
                 placeholder='Find content'
               />

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -43,7 +43,7 @@ interface IProps {
   docs_blob: DocsBlobType;
   namespace: string;
   collection: string;
-  params: object;
+  params: {keywords?: string};
   selectedName?: string;
   selectedType?: string;
   className?: string;

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -103,7 +103,7 @@ export class TableOfContents extends React.Component<IProps, IState> {
             {Object.keys(table).map(key =>
               table[key].length === 0
                 ? null
-                : this.renderLinks(table[key], key, this.props.params.keywords),
+                : this.renderLinks(table[key], key, this.props.params.keywords || ''),
             )}
           </NavList>
         </Nav>
@@ -196,8 +196,10 @@ export class TableOfContents extends React.Component<IProps, IState> {
   private renderLinks(links: DocsEntry[], title, filterString: string) {
     const isExpanded = !this.state.collapsedCategories.includes(title);
     const filteredLinks = links.filter(link =>
-      link.display.includes(filterString),
+      link.display.toLowerCase().includes(filterString.toLowerCase()),
     );
+    console.log('filterstring: ', filterString);
+    console.log(links);
     return (
       <NavExpandable
         key={title}

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -103,7 +103,11 @@ export class TableOfContents extends React.Component<IProps, IState> {
             {Object.keys(table).map(key =>
               table[key].length === 0
                 ? null
-                : this.renderLinks(table[key], key, this.props.params.keywords || ''),
+                : this.renderLinks(
+                    table[key],
+                    key,
+                    this.props.params.keywords || '',
+                  ),
             )}
           </NavList>
         </Nav>

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { capitalize } from 'lodash';
 import { Link } from 'react-router-dom';
 
-import { Nav, NavExpandable, NavItem, NavList } from '@patternfly/react-core';
+import { Nav, NavExpandable, NavItem, NavList, TextInput } from '@patternfly/react-core';
 
 import { DocsBlobType } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
@@ -27,6 +27,7 @@ class Table {
 
 interface IState {
   collapsedCategories: string[];
+  searchBarValue: string;
 }
 
 interface IProps {
@@ -47,7 +48,7 @@ export class TableOfContents extends React.Component<IProps, IState> {
   constructor(props) {
     super(props);
 
-    this.state = { collapsedCategories: [] };
+    this.state = { collapsedCategories: [], searchBarValue: '' };
   }
 
   render() {
@@ -70,12 +71,20 @@ export class TableOfContents extends React.Component<IProps, IState> {
 
     return (
       <div className={className}>
+        <TextInput
+          value={this.state.searchBarValue}
+          onChange={val =>
+            this.setState({searchBarValue: val})    
+          }
+          aria-label='find-content'
+          placeholder='Filter by keyword'
+        />
         <Nav theme='light'>
           <NavList>
             {Object.keys(table).map(key =>
               table[key].length === 0
                 ? null
-                : this.renderLinks(table[key], key),
+                : this.renderLinks(table[key], key, this.state.searchBarValue),
             )}
           </NavList>
         </Nav>
@@ -165,9 +174,9 @@ export class TableOfContents extends React.Component<IProps, IState> {
     return table;
   }
 
-  private renderLinks(links, title) {
+  private renderLinks(links: DocsEntry[], title, filterString: string) {
     const isExpanded = !this.state.collapsedCategories.includes(title);
-
+    const filteredLinks = links.filter((link) => link.display.indexOf(filterString) > -1);
     return (
       <NavExpandable
         key={title}
@@ -175,7 +184,7 @@ export class TableOfContents extends React.Component<IProps, IState> {
         isExpanded={isExpanded}
         isActive={this.getSelectedCategory() === title}
       >
-        {links.map((link: DocsEntry, index) => (
+        {filteredLinks.map((link: DocsEntry, index) => (
           <NavItem key={index} isActive={this.isSelected(link)}>
             <Link
               style={{

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -88,7 +88,7 @@ export class TableOfContents extends React.Component<IProps, IState> {
           <ToolbarGroup>
             <ToolbarItem>
               <SearchInput
-                ref={this.props.searchBarRef}
+                // ref={this.props.searchBarRef}
                 value={params.keywords}
                 onChange={val => {
                   updateParams(ParamHelper.setParam(params, 'keywords', val));

--- a/src/containers/collection-detail/collection-detail.scss
+++ b/src/containers/collection-detail/collection-detail.scss
@@ -9,6 +9,10 @@
   border-bottom: 1px solid #d8d8d8;
 }
 
+.pf-c-toolbar__group {
+  margin-left: 16px;
+}
+
 .docs-container {
   padding-top: 24px;
   background-color: white;

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -197,17 +197,18 @@ class CollectionDocs extends React.Component<
     );
   }
 
- 
- 
- executeScroll() {
-   this.docsRef.current.scrollIntoView()
- }
-
+  executeScroll() {
+    this.docsRef.current.scrollIntoView();
+  }
 
   private renderDocLink(name, href, collection, params) {
     if (!!href && href.startsWith('http')) {
       return (
-        <a href={href} target='_blank' onClick={this.docsRef.current.scrollIntoView()}>
+        <a
+          href={href}
+          target='_blank'
+          onClick={this.docsRef.current.scrollIntoView()}
+        >
           {name}
         </a>
       );

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -197,8 +197,10 @@ class CollectionDocs extends React.Component<
     );
   }
 
-  executeScroll() {
-    this.docsRef.current.scrollIntoView();
+  executeScroll = () =>{
+    setTimeout(function() {
+      this.docsRef.current.scrollIntoView();
+    }, 5000);
   }
 
   private renderDocLink(name, href, collection, params) {
@@ -207,7 +209,6 @@ class CollectionDocs extends React.Component<
         <a
           href={href}
           target='_blank'
-          onClick={this.docsRef.current.scrollIntoView()}
         >
           {name}
         </a>
@@ -228,6 +229,7 @@ class CollectionDocs extends React.Component<
             },
             params,
           )}
+          onClick={this.executeScroll}
         >
           {name}
         </Link>

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -117,8 +117,7 @@ class CollectionDocs extends React.Component<
     // scroll to top of page
 
     if (
-      this.docsRef.current
-      &&
+      this.docsRef.current &&
       this.searchBarRef.current !== window.document.activeElement
     ) {
       this.docsRef.current.scrollIntoView();

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -144,6 +144,11 @@ class CollectionDocs extends React.Component<
               selectedName={contentName}
               selectedType={contentType}
               params={params}
+              updateParams={p =>
+                this.updateParams(p, () =>
+                  this.loadCollection(this.context.selectedRepo, true),
+                )
+              }
             ></TableOfContents>
             <div className='body docs pf-c-content' ref={this.docsRef}>
               {displayHTML || pluginData ? (

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -29,7 +29,7 @@ class CollectionDocs extends React.Component<
   IBaseCollectionState
 > {
   docsRef: any;
-  searchBarRef: React.RefObject<HTMLInputElement>;
+  // searchBarRef: React.RefObject<HTMLInputElement>;
   constructor(props) {
     super(props);
     const params = ParamHelper.parseParamString(props.location.search);
@@ -38,9 +38,8 @@ class CollectionDocs extends React.Component<
       collection: undefined,
       params: params,
     };
-
     this.docsRef = React.createRef();
-    this.searchBarRef = React.createRef();
+    // this.searchBarRef = React.createRef();
   }
 
   componentDidMount() {
@@ -151,7 +150,7 @@ class CollectionDocs extends React.Component<
               selectedType={contentType}
               params={params}
               updateParams={p => this.updateParams(p)}
-              searchBarRef={this.searchBarRef}
+              // searchBarRef={this.searchBarRef}
             ></TableOfContents>
 
             <div className='body docs pf-c-content' ref={this.docsRef}>
@@ -196,13 +195,11 @@ class CollectionDocs extends React.Component<
       </React.Fragment>
     );
   }
-
   executeScroll = () => {
     setTimeout(function() {
       this.docsRef.current.scrollIntoView();
     }, 5000);
   };
-
   private renderDocLink(name, href, collection, params) {
     if (!!href && href.startsWith('http')) {
       return (
@@ -226,7 +223,6 @@ class CollectionDocs extends React.Component<
             },
             params,
           )}
-          onClick={this.executeScroll}
         >
           {name}
         </Link>

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -116,12 +116,12 @@ class CollectionDocs extends React.Component<
 
     // scroll to top of page
 
-    if (
-      this.docsRef.current &&
-      this.searchBarRef.current !== window.document.activeElement
-    ) {
-      this.docsRef.current.scrollIntoView();
-    }
+    // if (
+    //   this.docsRef.current &&
+    //   this.searchBarRef.current !== window.document.activeElement
+    // ) {
+    //   this.docsRef.current.scrollIntoView();
+    // }
 
     return (
       <React.Fragment>

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -197,19 +197,16 @@ class CollectionDocs extends React.Component<
     );
   }
 
-  executeScroll = () =>{
+  executeScroll = () => {
     setTimeout(function() {
       this.docsRef.current.scrollIntoView();
     }, 5000);
-  }
+  };
 
   private renderDocLink(name, href, collection, params) {
     if (!!href && href.startsWith('http')) {
       return (
-        <a
-          href={href}
-          target='_blank'
-        >
+        <a href={href} target='_blank'>
           {name}
         </a>
       );

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -144,11 +144,7 @@ class CollectionDocs extends React.Component<
               selectedName={contentName}
               selectedType={contentType}
               params={params}
-              updateParams={p =>
-                this.updateParams(p, () =>
-                  this.loadCollection(this.context.selectedRepo, true),
-                )
-              }
+              updateParams={p => this.updateParams(p)}
             ></TableOfContents>
             <div className='body docs pf-c-content' ref={this.docsRef}>
               {displayHTML || pluginData ? (

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -123,6 +123,7 @@ class CollectionDocs extends React.Component<
     // ) {
     //   this.docsRef.current.scrollIntoView();
     // }
+  
 
     return (
       <React.Fragment>
@@ -195,17 +196,19 @@ class CollectionDocs extends React.Component<
       </React.Fragment>
     );
   }
+
   executeScroll = () => {
-    setTimeout(function() {
-      this.docsRef.current.scrollIntoView();
-    }, 5000);
+    this.docsRef.current.scrollIntoView();
   };
+
+
+
   private renderDocLink(name, href, collection, params) {
     if (!!href && href.startsWith('http')) {
       return (
         <a href={href} target='_blank'>
           {name}
-        </a>
+          </a>
       );
     } else if (!!href) {
       // TODO: right now this will break if people put

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -117,8 +117,8 @@ class CollectionDocs extends React.Component<
 
     // scroll to top of page
     if (
-      this.docsRef.current 
-      // this.searchBarRef.current !== window.document.activeElement
+      this.docsRef.current &&
+      this.searchBarRef.current !== window.document.activeElement
     ) {
       this.docsRef.current.scrollIntoView();
     }

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -123,7 +123,6 @@ class CollectionDocs extends React.Component<
     // ) {
     //   this.docsRef.current.scrollIntoView();
     // }
-  
 
     return (
       <React.Fragment>
@@ -201,14 +200,12 @@ class CollectionDocs extends React.Component<
     this.docsRef.current.scrollIntoView();
   };
 
-
-
   private renderDocLink(name, href, collection, params) {
     if (!!href && href.startsWith('http')) {
       return (
         <a href={href} target='_blank'>
           {name}
-          </a>
+        </a>
       );
     } else if (!!href) {
       // TODO: right now this will break if people put

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -4,7 +4,7 @@ import './collection-detail.scss';
 import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
 
-import { Alert } from '@patternfly/react-core';
+import { Alert, TextInputBase } from '@patternfly/react-core';
 
 import {
   CollectionHeader,
@@ -29,7 +29,7 @@ class CollectionDocs extends React.Component<
   IBaseCollectionState
 > {
   docsRef: any;
-
+  searchBarRef: React.RefObject<HTMLInputElement>;
   constructor(props) {
     super(props);
     const params = ParamHelper.parseParamString(props.location.search);
@@ -40,6 +40,7 @@ class CollectionDocs extends React.Component<
     };
 
     this.docsRef = React.createRef();
+    this.searchBarRef = React.createRef();
   }
 
   componentDidMount() {
@@ -115,7 +116,10 @@ class CollectionDocs extends React.Component<
     ];
 
     // scroll to top of page
-    if (this.docsRef.current) {
+    if (
+      this.docsRef.current 
+      // this.searchBarRef.current !== window.document.activeElement
+    ) {
       this.docsRef.current.scrollIntoView();
     }
 
@@ -145,7 +149,9 @@ class CollectionDocs extends React.Component<
               selectedType={contentType}
               params={params}
               updateParams={p => this.updateParams(p)}
+              searchBarRef={this.searchBarRef}
             ></TableOfContents>
+
             <div className='body docs pf-c-content' ref={this.docsRef}>
               {displayHTML || pluginData ? (
                 // if neither variable is set, render not found

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -116,12 +116,14 @@ class CollectionDocs extends React.Component<
     ];
 
     // scroll to top of page
-    if (
-      this.docsRef.current &&
-      this.searchBarRef.current !== window.document.activeElement
-    ) {
-      this.docsRef.current.scrollIntoView();
-    }
+
+    // if (
+    //   this.docsRef.current
+    //   // &&
+    //   // this.searchBarRef.current !== window.document.activeElement
+    // ) {
+    //   this.docsRef.current.scrollIntoView();
+    // }
 
     return (
       <React.Fragment>
@@ -195,10 +197,17 @@ class CollectionDocs extends React.Component<
     );
   }
 
+ 
+ 
+ executeScroll() {
+   this.docsRef.current.scrollIntoView()
+ }
+
+
   private renderDocLink(name, href, collection, params) {
     if (!!href && href.startsWith('http')) {
       return (
-        <a href={href} target='_blank'>
+        <a href={href} target='_blank' onClick={this.docsRef.current.scrollIntoView()}>
           {name}
         </a>
       );

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -29,7 +29,7 @@ class CollectionDocs extends React.Component<
   IBaseCollectionState
 > {
   docsRef: any;
-  // searchBarRef: React.RefObject<HTMLInputElement>;
+  searchBarRef: React.RefObject<HTMLInputElement>;
   constructor(props) {
     super(props);
     const params = ParamHelper.parseParamString(props.location.search);
@@ -39,7 +39,7 @@ class CollectionDocs extends React.Component<
       params: params,
     };
     this.docsRef = React.createRef();
-    // this.searchBarRef = React.createRef();
+    this.searchBarRef = React.createRef();
   }
 
   componentDidMount() {
@@ -116,13 +116,13 @@ class CollectionDocs extends React.Component<
 
     // scroll to top of page
 
-    // if (
-    //   this.docsRef.current
-    //   // &&
-    //   // this.searchBarRef.current !== window.document.activeElement
-    // ) {
-    //   this.docsRef.current.scrollIntoView();
-    // }
+    if (
+      this.docsRef.current
+      &&
+      this.searchBarRef.current !== window.document.activeElement
+    ) {
+      this.docsRef.current.scrollIntoView();
+    }
 
     return (
       <React.Fragment>
@@ -150,7 +150,7 @@ class CollectionDocs extends React.Component<
               selectedType={contentType}
               params={params}
               updateParams={p => this.updateParams(p)}
-              // searchBarRef={this.searchBarRef}
+              searchBarRef={this.searchBarRef}
             ></TableOfContents>
 
             <div className='body docs pf-c-content' ref={this.docsRef}>
@@ -195,10 +195,6 @@ class CollectionDocs extends React.Component<
       </React.Fragment>
     );
   }
-
-  executeScroll = () => {
-    this.docsRef.current.scrollIntoView();
-  };
 
   private renderDocLink(name, href, collection, params) {
     if (!!href && href.startsWith('http')) {


### PR DESCRIPTION
HI Martin && Zita!!

See issue:
https://issues.redhat.com/browse/AAH-242
A new searchbar containing the same filter as Contents tab has been implemented for the documentation.
"X" button clears the input field.
Count in parentheses reflects the number of filtered results. 

The scroll feature was removed, at the direction of @himdel, until a new stateless component can be created for the searchbar itself.


Before:
![Screen Shot 2021-06-02 at 3 34 11 PM](https://user-images.githubusercontent.com/64337863/120541540-03cb8380-c3b8-11eb-82f1-701e50d88e9a.png)
After:
![Screen Shot 2021-06-30 at 4 07 21 PM](https://user-images.githubusercontent.com/64337863/124024530-5438ff80-d9bd-11eb-88c1-daaaf702f470.png)
