### PR TITLE
Fix group_permissions spec to ignore private container permissions

### DIFF
--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -163,15 +163,18 @@ const allPerms = [{
 },{
     group: 'remotes', permissions: ['Change collection remote', 'View collection remote']
 }, {
-    group: 'execution.environments',
+    group: 'containers',
     permissions: [
+        // Turning off private container permissions since they aren't supported yet
+        // 'Pull private containers', // container.namespace_pull_containerdistribution
+        // 'View private containers', // container.namespace_view_containerdistribution
+
         'Change container namespace permissions',
         'Change containers',
         'Change image tags',
         'Create new containers',
-        'Pull private containers',
         'Push to existing containers',
-        'View private containers']
+    ],
 }];
 
 Cypress.Commands.add('removeAllPermissions', {}, (groupName) => {


### PR DESCRIPTION
 #490 disables 2 container permissions and renames the group,
 this updates the tests to do the same.

This should get cypress green on master,
the same change was also backported as #501 => adding `backport-4.3` as well.