### PR TITLE
Namespace details, Collections tab - use the same filter as Collections screen

### DIFF
--- a/src/components/collection-list/collection-filter.scss
+++ b/src/components/collection-list/collection-filter.scss
@@ -1,0 +1,12 @@
+.toolbar-wrapper {
+  .toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    .pagination-container {
+      display: flex;
+      align-items: center;
+    }
+  }
+}

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import {
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+
+import { AppliedFilters, CompoundFilter } from 'src/components';
+
+interface IProps {
+  ignoredParams: string[];
+  params: {};
+  updateParams: (p) => void;
+}
+
+export class CollectionFilter extends React.Component<IProps> {
+  render() {
+    const { ignoredParams, params, updateParams } = this.props;
+
+    const tags = [
+      'cloud',
+      'linux',
+      'networking',
+      'storage',
+      'security',
+      'windows',
+      'infrastructure',
+      'monitoring',
+      'tools',
+      'database',
+      'application',
+    ];
+
+    const filterConfig = [
+      {
+        id: 'keywords',
+        title: 'Keywords',
+      },
+      {
+        id: 'tags',
+        title: 'Tag',
+        inputType: 'multiple' as 'multiple',
+        options: tags.map(tag => ({
+          id: tag,
+          title: tag,
+        })),
+      },
+    ];
+
+    return (
+      <Toolbar>
+        <ToolbarContent>
+          <ToolbarGroup>
+            <ToolbarItem>
+              <CompoundFilter
+                updateParams={updateParams}
+                params={params}
+                filterConfig={filterConfig}
+              />
+              <ToolbarItem>
+                <AppliedFilters
+                  style={{ marginTop: '16px' }}
+                  updateParams={updateParams}
+                  params={params}
+                  ignoredParams={ignoredParams}
+                />
+              </ToolbarItem>
+            </ToolbarItem>
+          </ToolbarGroup>
+        </ToolbarContent>
+      </Toolbar>
+    );
+  }
+}

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -7,6 +7,7 @@ import {
 } from '@patternfly/react-core';
 
 import { AppliedFilters, CompoundFilter } from 'src/components';
+import { Constants } from 'src/constants';
 
 interface IProps {
   ignoredParams: string[];
@@ -18,20 +19,6 @@ export class CollectionFilter extends React.Component<IProps> {
   render() {
     const { ignoredParams, params, updateParams } = this.props;
 
-    const tags = [
-      'cloud',
-      'linux',
-      'networking',
-      'storage',
-      'security',
-      'windows',
-      'infrastructure',
-      'monitoring',
-      'tools',
-      'database',
-      'application',
-    ];
-
     const filterConfig = [
       {
         id: 'keywords',
@@ -41,7 +28,7 @@ export class CollectionFilter extends React.Component<IProps> {
         id: 'tags',
         title: 'Tag',
         inputType: 'multiple' as 'multiple',
-        options: tags.map(tag => ({
+        options: Constants.COLLECTION_FILTER_TAGS.map(tag => ({
           id: tag,
           title: tag,
         })),

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import './collection-filter.scss';
 import {
   Toolbar,
   ToolbarContent,

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -21,6 +21,7 @@ interface IProps {
   };
   updateParams: (params) => void;
   itemCount: number;
+  ignoredParams: string[];
 
   showNamespace?: boolean;
   showControls?: boolean;
@@ -28,12 +29,14 @@ interface IProps {
   repo?: string;
 }
 
+// only used in namespace detail, collections uses individual items
 export class CollectionList extends React.Component<IProps> {
   render() {
     const {
       collections,
       params,
       updateParams,
+      ignoredParams,
       itemCount,
       showControls,
       repo,
@@ -54,7 +57,15 @@ export class CollectionList extends React.Component<IProps> {
               />
             ))
           ) : (
-            <EmptyStateFilter />
+            <EmptyStateFilter
+              clearAllFilters={() => {
+                ParamHelper.clearAllFilters({
+                  params,
+                  ignoredParams,
+                  updateParams,
+                });
+              }}
+            />
           )}
         </DataList>
 

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -6,7 +6,6 @@ import { Button, DropdownItem, DataList } from '@patternfly/react-core';
 import { CollectionListType } from 'src/api';
 import {
   CollectionListItem,
-  Toolbar,
   Pagination,
   StatefulDropdown,
   EmptyStateFilter,
@@ -42,23 +41,6 @@ export class CollectionList extends React.Component<IProps> {
 
     return (
       <React.Fragment>
-        <div className='controls top'>
-          <Toolbar
-            searchPlaceholder='Find collection by name'
-            updateParams={updateParams}
-            params={params}
-          />
-
-          <div>
-            <Pagination
-              params={params}
-              updateParams={p => updateParams(p)}
-              count={itemCount}
-              isTop
-            />
-          </div>
-        </div>
-
         <DataList aria-label={'List of Collections'}>
           {collections.length > 0 ? (
             collections.map(c => (

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -29,16 +29,7 @@ interface IProps {
   repo?: string;
 }
 
-interface IState {
-  kwField: string;
-}
-
-export class CollectionList extends React.Component<IProps, IState> {
-  constructor(props) {
-    super(props);
-    this.state = { kwField: props.params['keywords'] || '' };
-  }
-
+export class CollectionList extends React.Component<IProps> {
   render() {
     const {
       collections,
@@ -97,14 +88,6 @@ export class CollectionList extends React.Component<IProps, IState> {
         </div>
       </React.Fragment>
     );
-  }
-
-  private handleEnter(e) {
-    if (e.key === 'Enter') {
-      this.props.updateParams(
-        ParamHelper.setParam(this.props.params, 'keywords', this.state.kwField),
-      );
-    }
   }
 
   private renderCollectionControls(collection: CollectionListType) {

--- a/src/components/empty-state/empty-state-filter.tsx
+++ b/src/components/empty-state/empty-state-filter.tsx
@@ -1,7 +1,11 @@
 import * as React from 'react';
+import { Button } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
 import { EmptyStateCustom } from './empty-state-custom';
-interface IProps {}
+
+interface IProps {
+  clearAllFilters?: () => void;
+}
 
 export class EmptyStateFilter extends React.Component<IProps> {
   render() {
@@ -12,6 +16,13 @@ export class EmptyStateFilter extends React.Component<IProps> {
           'No results match the filter criteria. Remove all filters or clear all filters to show results.'
         }
         icon={SearchIcon}
+        button={
+          this.props.clearAllFilters ? (
+            <Button onClick={this.props.clearAllFilters} variant='link'>
+              Clear all filters
+            </Button>
+          ) : null
+        }
       />
     );
   }

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -18,6 +18,7 @@ interface IProps {
 
   pageControls?: React.ReactNode;
   contextSelector?: React.ReactNode;
+  filters?: React.ReactNode;
 }
 
 export class PartnerHeader extends React.Component<IProps, {}> {
@@ -25,6 +26,7 @@ export class PartnerHeader extends React.Component<IProps, {}> {
     const {
       breadcrumbs,
       contextSelector,
+      filters,
       namespace,
       pageControls,
       params,
@@ -38,6 +40,7 @@ export class PartnerHeader extends React.Component<IProps, {}> {
         breadcrumbs={<Breadcrumbs links={breadcrumbs} />}
         pageControls={pageControls}
         contextSelector={contextSelector}
+        className='header'
       >
         {namespace.description ? <div>{namespace.description}</div> : null}
 
@@ -66,6 +69,8 @@ export class PartnerHeader extends React.Component<IProps, {}> {
             </div>
           ) : null}
         </div>
+
+        {filters || null}
       </BaseHeader>
     );
   }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,6 +12,7 @@ export { CollectionCard } from './cards/collection-card';
 export { CollectionContentList } from './collection-detail/collection-content-list';
 export { CollectionHeader } from './headers/collection-header';
 export { CollectionInfo } from './collection-detail/collection-info';
+export { CollectionFilter } from './collection-list/collection-filter';
 export { CollectionList } from './collection-list/collection-list';
 export { CollectionListItem } from './collection-list/collection-list-item';
 export { CompoundFilter } from './patternfly-wrappers/compound-filter';

--- a/src/components/patternfly-wrappers/applied-filters.tsx
+++ b/src/components/patternfly-wrappers/applied-filters.tsx
@@ -78,15 +78,7 @@ export class AppliedFilters extends React.Component<IProps, {}> {
   }
 
   private clearAllFilters = () => {
-    let params = this.props.params;
-    const deleteKeys = Object.keys(
-      ParamHelper.getReduced(params, this.props.ignoredParams),
-    );
-
-    for (const key of deleteKeys) {
-      params = ParamHelper.deleteParam(params, key);
-    }
-
-    this.props.updateParams(params);
+    const { params, ignoredParams, updateParams } = this.props;
+    ParamHelper.clearAllFilters({ params, ignoredParams, updateParams });
   };
 }

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -167,4 +167,18 @@ export class Constants {
   };
 
   static ALLOWEDREPOS = ['community', 'published', 'rh-certified'];
+
+  static COLLECTION_FILTER_TAGS = [
+    'application',
+    'cloud',
+    'database',
+    'infrastructure',
+    'linux',
+    'monitoring',
+    'networking',
+    'security',
+    'storage',
+    'tools',
+    'windows',
+  ];
 }

--- a/src/containers/namespace-detail/namespace-detail.scss
+++ b/src/containers/namespace-detail/namespace-detail.scss
@@ -1,0 +1,5 @@
+.namespace-detail {
+  .pf-c-toolbar__content {
+    padding-left: 0px;
+  }
+}

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -8,11 +8,11 @@ import {
 } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
 import {
-  Button,
-  DropdownItem,
   Alert,
   AlertActionCloseButton,
+  Button,
   ClipboardCopy,
+  DropdownItem,
 } from '@patternfly/react-core';
 
 import * as ReactMarkdown from 'react-markdown';
@@ -27,14 +27,14 @@ import {
 
 import {
   CollectionList,
-  PartnerHeader,
-  StatefulDropdown,
+  CollectionFilter,
+  EmptyStateNoData,
   LoadingPageWithHeader,
   Main,
-  EmptyStateUnauthorized,
-  EmptyStateFilter,
-  EmptyStateNoData,
+  Pagination,
+  PartnerHeader,
   RepoSelector,
+  StatefulDropdown,
 } from 'src/components';
 
 import { ImportModal } from './import-modal/import-modal';
@@ -134,6 +134,9 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
     const noData = itemCount === 0 && !filterIsSet(params, ['keywords']);
 
+    const updateParams = params =>
+      this.updateParams(params, () => this.loadCollections());
+
     return (
       <React.Fragment>
         <ImportModal
@@ -185,6 +188,35 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
               pathParams={{ namespace: namespace.name }}
             />
           }
+          filters={
+            tab.toLowerCase() === 'collections' ? (
+              <div className='toolbar-wrapper namespace-detail'>
+                <div className='toolbar'>
+                  <CollectionFilter
+                    ignoredParams={[
+                      'namespace',
+                      'page',
+                      'page_size',
+                      'sort',
+                      'tab',
+                      'view_type',
+                    ]}
+                    params={params}
+                    updateParams={updateParams}
+                  />
+
+                  <div className='pagination-container'>
+                    <Pagination
+                      params={params}
+                      updateParams={updateParams}
+                      count={itemCount}
+                      isTop
+                    />
+                  </div>
+                </div>
+              </div>
+            ) : null
+          }
         ></PartnerHeader>
         <Main>
           {tab.toLowerCase() === 'collections' ? (
@@ -205,9 +237,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             ) : (
               <Section className='body'>
                 <CollectionList
-                  updateParams={params =>
-                    this.updateParams(params, () => this.loadCollections())
-                  }
+                  updateParams={updateParams}
                   params={params}
                   collections={collections}
                   itemCount={itemCount}

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -138,6 +138,15 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
     const updateParams = params =>
       this.updateParams(params, () => this.loadCollections());
 
+    const ignoredParams = [
+      'namespace',
+      'page',
+      'page_size',
+      'sort',
+      'tab',
+      'view_type',
+    ];
+
     return (
       <React.Fragment>
         <ImportModal
@@ -194,14 +203,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
               <div className='toolbar-wrapper namespace-detail'>
                 <div className='toolbar'>
                   <CollectionFilter
-                    ignoredParams={[
-                      'namespace',
-                      'page',
-                      'page_size',
-                      'sort',
-                      'tab',
-                      'view_type',
-                    ]}
+                    ignoredParams={ignoredParams}
                     params={params}
                     updateParams={updateParams}
                   />
@@ -240,6 +242,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                 <CollectionList
                   updateParams={updateParams}
                   params={params}
+                  ignoredParams={ignoredParams}
                   collections={collections}
                   itemCount={itemCount}
                   showControls={this.state.showControls}

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import './namespace-detail.scss';
 
 import {
   withRouter,

--- a/src/containers/search/search.scss
+++ b/src/containers/search/search.scss
@@ -5,21 +5,8 @@
   display: flex;
   flex-direction: column;
 
-  .toolbar-wrapper {
-    .toolbar {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-
-      .pagination-container {
-        display: flex;
-        align-items: center;
-
-        .card-list-switcher {
-          margin-right: 24px;
-        }
-      }
-    }
+  .toolbar-wrapper .toolbar .pagination-container .card-list-switcher {
+    margin-right: 24px;
   }
 
   .header {

--- a/src/containers/search/search.scss
+++ b/src/containers/search/search.scss
@@ -56,6 +56,10 @@
     }
   }
 
+  .pf-c-toolbar__content {
+    padding-left: 0px;
+  }
+
   .footer {
     border-top: 1px solid #d8d8d8;
     flex-shrink: 0;

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -3,26 +3,18 @@ import './search.scss';
 
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { Section } from '@redhat-cloud-services/frontend-components';
-import {
-  DataList,
-  Toolbar,
-  ToolbarGroup,
-  ToolbarItem,
-  ToolbarContent,
-  Switch,
-} from '@patternfly/react-core';
+import { DataList, Switch } from '@patternfly/react-core';
 
 import {
   BaseHeader,
-  CollectionCard,
   CardListSwitcher,
+  CollectionCard,
+  CollectionFilter,
   CollectionListItem,
-  CompoundFilter,
-  Pagination,
-  LoadingPageSpinner,
-  AppliedFilters,
   EmptyStateFilter,
   EmptyStateNoData,
+  LoadingPageSpinner,
+  Pagination,
   RepoSelector,
 } from 'src/components';
 import {
@@ -95,19 +87,8 @@ class Search extends React.Component<RouteComponentProps, IState> {
     const noData =
       collections.length === 0 && !filterIsSet(params, ['keywords', 'tags']);
 
-    const tags = [
-      'cloud',
-      'linux',
-      'networking',
-      'storage',
-      'security',
-      'windows',
-      'infrastructure',
-      'monitoring',
-      'tools',
-      'database',
-      'application',
-    ];
+    const updateParams = p =>
+      this.updateParams(p, () => this.queryCollections());
 
     return (
       <div className='search-page'>
@@ -124,52 +105,11 @@ class Search extends React.Component<RouteComponentProps, IState> {
           {!noData && (
             <div className='toolbar-wrapper'>
               <div className='toolbar'>
-                <Toolbar>
-                  <ToolbarContent>
-                    <ToolbarGroup>
-                      <ToolbarItem>
-                        <CompoundFilter
-                          updateParams={p =>
-                            this.updateParams(p, () => this.queryCollections())
-                          }
-                          params={params}
-                          filterConfig={[
-                            {
-                              id: 'keywords',
-                              title: 'Keywords',
-                            },
-                            {
-                              id: 'tags',
-                              title: 'Tag',
-                              inputType: 'multiple',
-                              options: tags.map(tag => ({
-                                id: tag,
-                                title: tag,
-                              })),
-                            },
-                          ]}
-                        />
-                        <ToolbarItem>
-                          <AppliedFilters
-                            style={{ marginTop: '16px' }}
-                            updateParams={p =>
-                              this.updateParams(p, () =>
-                                this.queryCollections(),
-                              )
-                            }
-                            params={params}
-                            ignoredParams={[
-                              'page_size',
-                              'page',
-                              'sort',
-                              'view_type',
-                            ]}
-                          />
-                        </ToolbarItem>
-                      </ToolbarItem>
-                    </ToolbarGroup>
-                  </ToolbarContent>
-                </Toolbar>
+                <CollectionFilter
+                  ignoredParams={['page', 'page_size', 'sort', 'view_type']}
+                  params={params}
+                  updateParams={updateParams}
+                />
 
                 <div className='pagination-container'>
                   <div className='card-list-switcher'>
@@ -194,9 +134,7 @@ class Search extends React.Component<RouteComponentProps, IState> {
 
                   <Pagination
                     params={params}
-                    updateParams={p =>
-                      this.updateParams(p, () => this.queryCollections())
-                    }
+                    updateParams={updateParams}
                     count={numberOfResults}
                     perPageOptions={Constants.CARD_DEFAULT_PAGINATION_OPTIONS}
                     isTop

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -152,7 +152,7 @@ class Search extends React.Component<RouteComponentProps, IState> {
         ) : (
           <React.Fragment>
             <Section className='collection-container'>
-              {this.renderCollections(collections, params)}
+              {this.renderCollections(collections, params, updateParams)}
             </Section>
             <Section className='footer'>
               <Pagination
@@ -170,12 +170,22 @@ class Search extends React.Component<RouteComponentProps, IState> {
     );
   }
 
-  private renderCollections(collections, params) {
+  private renderCollections(collections, params, updateParams) {
     if (this.state.loading) {
       return <LoadingPageSpinner></LoadingPageSpinner>;
     }
     if (collections.length === 0) {
-      return <EmptyStateFilter />;
+      return (
+        <EmptyStateFilter
+          clearAllFilters={() => {
+            ParamHelper.clearAllFilters({
+              params,
+              ignoredParams: ['page', 'page_size', 'sort', 'view_type'],
+              updateParams,
+            });
+          }}
+        />
+      );
     }
     if (params.view_type === 'list') {
       return this.renderList(collections);

--- a/src/utilities/param-helper.tsx
+++ b/src/utilities/param-helper.tsx
@@ -134,4 +134,17 @@ export class ParamHelper {
       });
     };
   }
+
+  // removes any params not in ignoredParams from params and calls updateParams with it
+  static clearAllFilters({ params, ignoredParams, updateParams }) {
+    const deleteKeys = Object.keys(
+      ParamHelper.getReduced(params, ignoredParams),
+    );
+
+    for (const key of deleteKeys) {
+      params = ParamHelper.deleteParam(params, key);
+    }
+
+    updateParams(params);
+  }
 }


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-245, https://issues.redhat.com/browse/AAH-544, https://issues.redhat.com/browse/AAH-555

This unifies filtering on both collection list screens:

**Collections > Collections**

![20210604215800](https://user-images.githubusercontent.com/289743/120866747-11cc0080-c580-11eb-8ab5-33c279b7d190.png)
(no change)

**Collections > Namespaces > View Collections > tab Collections**

before:
![20210604215959](https://user-images.githubusercontent.com/289743/120866869-48098000-c580-11eb-8df2-bf58a0f9848b.png)

after:
![20210604215723](https://user-images.githubusercontent.com/289743/120866764-1b556880-c580-11eb-8821-2f3d090c890b.png)

---

This also allows EmptyStateFilter to reset the filters, enabled in Collections and in Namespace detail:

![20210607211256](https://user-images.githubusercontent.com/289743/121088486-5ac8c280-c7d5-11eb-8315-972acc02b311.png)
![20210607211242](https://user-images.githubusercontent.com/289743/121088491-5c928600-c7d5-11eb-8867-08b25ea772dc.png)


---

Two remaining differences remain:
* no card view on namespace detail page, only list view
* clearing filters doesn't clear the search input (also present in users, but not groups, with a similar issue in containers)