### PR TITLE
[stable-4.3] Fix group_permissions spec to ignore private container permissions (#508)

### DIFF
--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -163,7 +163,18 @@ const allPerms = [{
 },{
     group: 'remotes', permissions: ['Change collection remote', 'View collection remote']
 }, {
-    group: 'execution.environments', permissions: ['Change execution environment namespace permissions', 'Change execution environments', 'Change image tags', 'Pull private execution environments', 'View private execution environments']
+    group: 'containers',
+    permissions: [
+        // Turning off private container permissions since they aren't supported yet
+        // 'Pull private containers', // container.namespace_pull_containerdistribution
+        // 'View private containers', // container.namespace_view_containerdistribution
+
+        'Change container namespace permissions',
+        'Change containers',
+        'Change image tags',
+        'Create new containers',
+        'Push to existing containers',
+    ],
 }];
 
 Cypress.Commands.add('removeAllPermissions', {}, (groupName) => {


### PR DESCRIPTION
manually cherry-picked from 2edc1a54e68ab62fc407920b82f32219b6132be4 (#508),

#490 disables 2 container permissions and renames the group,
this updates the tests to do the same.

This should get cypress green on master,
the same change was also backported as #501 => adding backport-4.3 as well.

---

on stable-4.3 these 2 were also missing (but present in constants, presumably from #370 / #371 :
'Create new containers',
'Push to existing containers',