### PR TITLE
wrap namespace name in card container

### DIFF
--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -1,15 +1,10 @@
 .ns-card-container {
   width: 300px;
-  height: 280px;
 
   .title {
     font-weight: bold;
   }
 
-  .wrap {
-    width: 300px;
-    word-break: break-word;
-  }
 
   .ns-name {
     text-overflow: ellipsis;

--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -1,5 +1,6 @@
 .ns-card-container {
   width: 300px;
+  flex-wrap: wrap;
 
   .title {
     font-weight: bold;

--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -1,11 +1,16 @@
 .ns-card-container {
   width: 300px;
-  flex-wrap: wrap;
+  height: 280px;
 
   .title {
     font-weight: bold;
   }
 
+  .wrap {
+    width: 300px;
+    word-break: break-word;
+  }
+  
   .ns-name {
     text-overflow: ellipsis;
     overflow: hidden;

--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -10,7 +10,7 @@
     width: 300px;
     word-break: break-word;
   }
-  
+
   .ns-name {
     text-overflow: ellipsis;
     overflow: hidden;

--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -5,7 +5,6 @@
     font-weight: bold;
   }
 
-
   .ns-name {
     text-overflow: ellipsis;
     overflow: hidden;

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -40,8 +40,8 @@ export class NamespaceCard extends React.Component<IProps, {}> {
           </CardHeaderMain>
         </CardHeader>
         <Tooltip content={<CardTitle>{company || name}</CardTitle>}>
-        <CardTitle>{this.getDescription(company || name)}</CardTitle>
-          </Tooltip>
+          <CardTitle>{this.getDescription(company || name)}</CardTitle>
+        </Tooltip>
         <CardBody className={'wrap'}>{name}</CardBody>
         {namespaceURL && (
           <CardFooter className={'wrap'}>

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -39,15 +39,15 @@ export class NamespaceCard extends React.Component<IProps, {}> {
             />
           </CardHeaderMain>
         </CardHeader>
-        <Tooltip content={<CardTitle>{company || name}</CardTitle>}>
+        <Tooltip content={company || name}>
           <CardTitle>{this.getDescription(company || name)}</CardTitle>
         </Tooltip>
-        <Tooltip content={<CardBody>{name}</CardBody>}>
+        <Tooltip content={name}>
           <CardBody>{this.getDescription(name)}</CardBody>
         </Tooltip>
 
         {namespaceURL && (
-          <CardFooter className={'wrap'}>
+          <CardFooter>
             <Link to={namespaceURL}>View collections</Link>
           </CardFooter>
         )}

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -37,10 +37,10 @@ export class NamespaceCard extends React.Component<IProps, {}> {
             />
           </CardHeaderMain>
         </CardHeader>
-        <CardTitle>{company || name}</CardTitle>
-        <CardBody>{name}</CardBody>
+        <CardTitle className={"wrap"}>{company || name}</CardTitle>
+        <CardBody className={"wrap"}>{name}</CardBody>
         {namespaceURL && (
-          <CardFooter>
+          <CardFooter className={"wrap"}>
             <Link to={namespaceURL}>View collections</Link>
           </CardFooter>
         )}
@@ -48,3 +48,5 @@ export class NamespaceCard extends React.Component<IProps, {}> {
     );
   }
 }
+
+

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -42,7 +42,10 @@ export class NamespaceCard extends React.Component<IProps, {}> {
         <Tooltip content={<CardTitle>{company || name}</CardTitle>}>
           <CardTitle>{this.getDescription(company || name)}</CardTitle>
         </Tooltip>
-        <CardBody className={'wrap'}>{name}</CardBody>
+        <Tooltip content={<CardBody>{name}</CardBody>}>
+          <CardBody>{this.getDescription(name)}</CardBody>
+        </Tooltip>
+
         {namespaceURL && (
           <CardFooter className={'wrap'}>
             <Link to={namespaceURL}>View collections</Link>

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -24,7 +24,7 @@ interface IProps {
 }
 
 export class NamespaceCard extends React.Component<IProps, {}> {
-  MAX_DESCRIPTION_LENGTH = 32;
+  MAX_DESCRIPTION_LENGTH = 26;
   render() {
     const { avatar_url, name, company, namespaceURL } = this.props;
     return (

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -37,10 +37,10 @@ export class NamespaceCard extends React.Component<IProps, {}> {
             />
           </CardHeaderMain>
         </CardHeader>
-        <CardTitle className={"wrap"}>{company || name}</CardTitle>
-        <CardBody className={"wrap"}>{name}</CardBody>
+        <CardTitle className={'wrap'}>{company || name}</CardTitle>
+        <CardBody className={'wrap'}>{name}</CardBody>
         {namespaceURL && (
-          <CardFooter className={"wrap"}>
+          <CardFooter className={'wrap'}>
             <Link to={namespaceURL}>View collections</Link>
           </CardFooter>
         )}
@@ -48,5 +48,3 @@ export class NamespaceCard extends React.Component<IProps, {}> {
     );
   }
 }
-
-

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -8,6 +8,7 @@ import {
   CardHeader,
   CardHeaderMain,
   CardTitle,
+  Tooltip,
 } from '@patternfly/react-core';
 
 import { Link } from 'react-router-dom';
@@ -23,6 +24,7 @@ interface IProps {
 }
 
 export class NamespaceCard extends React.Component<IProps, {}> {
+  MAX_DESCRIPTION_LENGTH = 32;
   render() {
     const { avatar_url, name, company, namespaceURL } = this.props;
     return (
@@ -37,7 +39,9 @@ export class NamespaceCard extends React.Component<IProps, {}> {
             />
           </CardHeaderMain>
         </CardHeader>
-        <CardTitle className={'wrap'}>{company || name}</CardTitle>
+        <Tooltip content={<CardTitle>{company || name}</CardTitle>}>
+        <CardTitle>{this.getDescription(company || name)}</CardTitle>
+          </Tooltip>
         <CardBody className={'wrap'}>{name}</CardBody>
         {namespaceURL && (
           <CardFooter className={'wrap'}>
@@ -46,5 +50,16 @@ export class NamespaceCard extends React.Component<IProps, {}> {
         )}
       </Card>
     );
+  }
+
+  private getDescription(d: string) {
+    if (!d) {
+      return '';
+    }
+    if (d.length > this.MAX_DESCRIPTION_LENGTH) {
+      return d.slice(0, this.MAX_DESCRIPTION_LENGTH) + '...';
+    } else {
+      return d;
+    }
   }
 }


### PR DESCRIPTION
Hi David!!
Issue:
https://issues.redhat.com/browse/AAH-165
I simply put flex-wrap on the .ns-card-container class. See cards.scss & namespace-card.tsx. 
![Screen Shot 2021-06-03 at 2 33 27 PM](https://user-images.githubusercontent.com/64337863/120695340-4a34e700-c479-11eb-9ae8-aed3678796d2.png)
![Screen Shot 2021-06-03 at 2 29 26 PM](https://user-images.githubusercontent.com/64337863/120695355-4ef99b00-c479-11eb-99bf-72147bfc6db9.png)

Seems to have done the trick. 