### PR TITLE
remove padding-left from searchbar on collection list

### DIFF
--- a/src/containers/search/search.scss
+++ b/src/containers/search/search.scss
@@ -26,6 +26,10 @@
     border-bottom: 1px solid #d8d8d8;
   }
 
+  .pf-c-toolbar__content {
+    padding-left: 0px;
+  }
+
   .collection-container {
     padding-top: 24px;
 


### PR DESCRIPTION
Hi :)

See issue:
https://issues.redhat.com/browse/AAH-555
Left padding should be removed from the searchbar in both Collection list and Namespace list views.

This time I removed the padding-left on .pf-c-toolbar__content in search.scss/search.tsx.
Lmk if this needs more triage!

![Screen Shot 2021-06-04 at 3 16 30 PM](https://user-images.githubusercontent.com/64337863/120852884-d530e280-c548-11eb-944e-058dd2b0d8f5.png)
![Screen Shot 2021-06-04 at 3 17 50 PM](https://user-images.githubusercontent.com/64337863/120852893-d8c46980-c548-11eb-80d6-7eb41c38af6e.png)
