### PR TITLE
[stable-4.3] Enable cypress on stable-4.3

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,4 +1,4 @@
-name: Cypress
+name: "Cypress on stable-4.3"
 
 on:
   # allow running manually

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,154 @@
+name: Cypress
+
+on:
+  # allow running manually
+  workflow_dispatch:
+  pull_request:
+    branches: [ 'master', 'stable-*' ]
+  push:
+    branches: [ 'master', 'stable-*' ]
+  # daily on master
+  schedule:
+    - cron:  '30 5 * * *'
+
+jobs:
+  cypress:
+    runs-on: ubuntu-latest
+    env:
+      # base of a PR, or pushed-to branch outside PRs, or master
+      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/master' }}
+
+    steps:
+
+    - name: "Install galaxykit dependency"
+      run: |
+        pip install galaxykit==0.1.0
+
+    - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
+      run: |
+        SHORT_BRANCH=`sed 's/^refs\/heads\///' <<< $BRANCH`
+        GALAXY_NG_COMMIT=`GET https://api.github.com/repos/ansible/galaxy_ng/branches/${SHORT_BRANCH} | jq -r .commit.sha`
+        
+        echo "SHORT_BRANCH=${SHORT_BRANCH}" >> $GITHUB_ENV
+        echo "GALAXY_NG_COMMIT=${GALAXY_NG_COMMIT}" >> $GITHUB_ENV
+
+    - run: "mkdir pulp_galaxy_ng"
+
+    - name: "Cache container image for pulp_galaxy_ng ${{ env.SHORT_BRANCH }} ${{ env.GALAXY_NG_COMMIT }}"
+      id: cache-container
+      uses: actions/cache@v2
+      with:
+        path: pulp_galaxy_ng/image
+        key: ${{ runner.os }}-container-${{ env.GALAXY_NG_COMMIT }}
+
+    - name: "Build pulp-galaxy-ng"
+      if: steps.cache-container.outputs.cache-hit != 'true'
+      working-directory: 'pulp_galaxy_ng'
+      run: |
+        echo '# Containerfile'
+        echo '\
+          FROM docker.io/pulp/pulp-ci-centos:latest
+          
+          RUN pip3 install --upgrade \
+            "click<8.0" \
+            requests \
+            git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
+          
+          RUN mkdir -p /etc/nginx/pulp/
+          RUN ln /usr/local/lib/python3.6/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+          RUN ln /usr/local/lib/python3.6/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+          RUN ln /usr/local/lib/python3.6/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
+        ' | tee Containerfile
+        
+        buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .
+        podman save localhost/pulp/pulp-galaxy-ng:latest -o image
+
+    - name: "Load pulp-galaxy-ng from cache"
+      if: steps.cache-container.outputs.cache-hit == 'true'
+      working-directory: 'pulp_galaxy_ng'
+      run: podman load -i image
+
+    - name: "Configure and run pulp-galaxy-ng"
+      working-directory: 'pulp_galaxy_ng'
+      run: |
+        mkdir settings pulp_storage pgsql containers
+        echo '# settings/settings.py'
+        echo "\
+          ANSIBLE_API_HOSTNAME='http://localhost:8002'
+          ANSIBLE_CONTENT_HOSTNAME='http://localhost:8002/api/galaxy/v3/artifacts/collections'
+          CONTENT_ORIGIN='http://localhost:8002'
+          GALAXY_API_PATH_PREFIX='/api/galaxy/'
+          GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication']
+          GALAXY_DEPLOYMENT_MODE='standalone'
+          PULP_CONTENT_PATH_PREFIX='/api/galaxy/v3/artifacts/collections/'
+          RH_ENTITLEMENT_REQUIRED='insights'
+          TOKEN_AUTH_DISABLED=True
+          X_PULP_CONTENT_HOST='localhost'
+        " | sed 's/^\s\+//' | tee settings/settings.py
+        
+        podman run \
+             --detach \
+             --publish 8002:80 \
+             --name pulp \
+             --volume "$(pwd)/settings":/etc/pulp \
+             --volume "$(pwd)/pulp_storage":/var/lib/pulp \
+             --volume "$(pwd)/pgsql":/var/lib/pgsql \
+             --volume "$(pwd)/containers":/var/lib/containers \
+             --device /dev/fuse \
+             localhost/pulp/pulp-galaxy-ng:latest
+
+    - name: "Checkout ansible-hub-ui (${{ github.ref }})"
+      uses: actions/checkout@v2
+      with:
+        path: 'ansible-hub-ui'
+
+    - name: "Install node 14"
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: "Cache ~/.npm & ~/.cache/Cypress"
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.npm
+          ~/.cache/Cypress
+        key: ${{ runner.os }}-node-${{ env.SHORT_BRANCH }}-${{ hashFiles('ansible-hub-ui/**/package-lock.json') }}
+        restore-keys: |
+          ${{ runner.os }}-node-${{ env.SHORT_BRANCH }}-
+          ${{ runner.os }}-node-
+
+    - name: "Build standalone UI"
+      working-directory: 'ansible-hub-ui'
+      run: |
+        npm ci
+        npm run build-standalone
+        rm -rf ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng/
+        mv -v dist/ ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng
+        podman exec pulp bash -c "s6-svc -r /var/run/s6/services/pulpcore-api" # apply changes, api also serves static assets
+
+    - name: "Finish up and run cypress"
+      working-directory: 'ansible-hub-ui/test'
+      run: |
+        # podman exec pulp pip install django_extensions
+        podman exec pulp pulpcore-manager reset-admin-password --password admin
+        
+        npm ci
+        echo -e '{\n  "prefix": "/api/galaxy/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
+        
+        npm run cypress:chrome
+
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: screenshots_and_videos
+        path: |
+          ansible-hub-ui/test/cypress/screenshots
+          ansible-hub-ui/test/cypress/videos
+
+    - name: "Kill container, show debug info"
+      if: always()
+      run: |
+        podman exec pulp bash -c "pip3 list && pip3 install pipdeptree && pipdeptree"
+        podman logs pulp
+        podman kill pulp

--- a/test/cypress/integration/profile.js
+++ b/test/cypress/integration/profile.js
@@ -17,7 +17,9 @@ describe('My Profile Tests', () => {
     it('only has input fields for name, email, username, password and pass confirmation', () => {
         let inputs = ['first_name', 'last_name', 'email', 'username', 'password', 'password-confirm'];
         cy.get('.body').within(() => {
-            cy.get('input').each(($el, index, $list) => {
+            // restricted to text input types because there's a checkbox now for the
+            // 'super user' option, but it's disabled.
+            cy.get('input[type="text"]').each(($el, index, $list) => {
                 expect(inputs).to.include($el.attr('id'));
             });
         });

--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -17,7 +17,10 @@ describe('Repo Management tests', () => {
         cy.contains('Show advanced options').click();
         cy.get('#download_concurrency').should('exist');
     });
-    it('remote proxy config can be saved and deleted.', () => {
+    /* Needs more work to handle uploading a requirements.yml
+     * when you want to save the remote proxy config.
+     */
+    it.skip('remote proxy config can be saved and deleted.', () => {
         cy.login(adminUsername, adminPassword);
         cy.visit(remoteRepoUrl);
         cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo


### PR DESCRIPTION
Copy `.github/workflows/cypress.yml` from master to stable-4.3. Apparently this is needed to make PRs against stable-4.3 start cypress.

Also backport most of #362 (except parts superceded by #511), to fix 2 failing specs:
`cypress/integration/repo_management.js:32`: Timed out retrying: `cy.click()` failed because this element is `disabled`
`cypress/integration/profile.js:20`: expected [ Array(6) ] to include 'pf-1623184710797zdinfyw6yd'

