### PR TITLE
EmptyStateFilter: replace empty message

### DIFF
--- a/src/components/empty-state/empty-state-filter.tsx
+++ b/src/components/empty-state/empty-state-filter.tsx
@@ -9,7 +9,7 @@ export class EmptyStateFilter extends React.Component<IProps> {
       <EmptyStateCustom
         title={'No results found'}
         description={
-          'No results match the filter criteria. Remove all filters or clear all filters to show results.'
+          'No results match the filter criteria. Try changing your filter settings.'
         }
         icon={SearchIcon}
       />


### PR DESCRIPTION
Updating the No results match the filter criteria message.

Before:

![20210610161736](https://user-images.githubusercontent.com/289743/121560821-6996bb80-ca07-11eb-95d2-f05049c34185.png)

After:

![20210610161637](https://user-images.githubusercontent.com/289743/121560830-6d2a4280-ca07-11eb-8f06-591caef8103e.png)
