### PR TITLE
prettierignore: add png and mp4 to ignore list, for cypress screenshots and videos

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,5 @@ src/index.html
 Dockerfile
 .DS_Store
 *.md
+*.png
+*.mp4


### PR DESCRIPTION
These are already gitignored, but prettier does not ignore gitignored files by default.
Related to #518, cc @ZitaNemeckova :)