### PR TITLE
Wrap pre element so it doesn't overflow

### DIFF
--- a/src/containers/collection-detail/collection-detail.scss
+++ b/src/containers/collection-detail/collection-detail.scss
@@ -47,6 +47,6 @@
     }
   }
 }
-pre {
+.docs-container pre {
   white-space: pre-wrap;
 }

--- a/src/containers/collection-detail/collection-detail.scss
+++ b/src/containers/collection-detail/collection-detail.scss
@@ -47,3 +47,6 @@
     }
   }
 }
+pre {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-599

Collection detail documentation page of: `ibm` -> `power_ibm` -> `module > ibmi_install_product_from_savf`

Before:
<img width="1351" alt="Screenshot 2021-06-11 at 10 30 49" src="https://user-images.githubusercontent.com/9210860/121659121-453bed00-caa2-11eb-80ce-01949ba8249f.png">

After:
<img width="1378" alt="Screenshot 2021-06-11 at 10 42 45" src="https://user-images.githubusercontent.com/9210860/121659099-3ead7580-caa2-11eb-9a0b-c9553de96681.png">
