### PR TITLE
Github actions follow-up: try to fix deploy-cloud on master, dev-release

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -121,7 +121,7 @@ jobs:
     - name: "Build standalone UI"
       working-directory: 'ansible-hub-ui'
       run: |
-        npm ci
+        npm ci || npm install
         npm run build-standalone
         rm -rf ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng/
         mv -v dist/ ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng
@@ -133,7 +133,7 @@ jobs:
         # podman exec pulp pip install django_extensions
         podman exec pulp pulpcore-manager reset-admin-password --password admin
         
-        npm ci
+        npm ci || npm install
         echo -e '{\n  "prefix": "/api/galaxy/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
         
         npm run cypress:chrome

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -53,6 +53,6 @@ jobs:
     - name: "Build and deploy"
       run: |
         npm cache verify
-        npm ci
+        npm ci || npm install
         npm run deploy && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh | bash -s
 

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -52,6 +52,7 @@ jobs:
 
     - name: "Build and deploy"
       run: |
+        npm cache verify
         npm ci
         npm run deploy && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh | bash -s
 

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -52,6 +52,7 @@ jobs:
       with:
         body: "This is a special release that provides an up to date build off of the latest changes in the master branch. The automation-hub-ui-dist.tar.gz artifact provided here corresponds to the latest version of master."
         files: "automation-hub-ui-dist.tar.gz"
+        input_tag_name: 'dev'
         name: "UI Dev Release"
         prerelease: true
       env:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: "Build a tarball"
       run: |
-        npm ci
+        npm ci || npm install
         npm run build-standalone
         tar -C dist/ -czvf automation-hub-ui-dist.tar.gz .
 

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: "Build a tarball"
       run: |
-        npm ci
+        npm ci || npm install
         npm run build-standalone
         tar -C dist/ -czvf automation-hub-ui-dist.tar.gz .
 

--- a/README.md
+++ b/README.md
@@ -74,20 +74,19 @@ To access the app, visit: https://ci.foo.redhat.com:1337/insights/automation-hub
 
 ## Deploying
 
-- The Platform team is using Travis to deploy the application
-  - The Platform team will help you set up the Travis instance if this is the route you are wanting to take
+We're using Github Actions for deployment.
 
 ### How it works
 
-- any push to the `{REPO}` `master` branch will deploy to a `{REPO}-build` `ci-beta` branch
-- any push to the `{REPO}` `master-stable` branch will deploy to a `{REPO}-build` `ci-stable` branch
-- any push to the `{REPO}` `qa-beta` branch will deploy to a `{REPO}-build` `qa-beta` branch
-- any push to the `{REPO}` `qa-stable` branch will deploy to a `{REPO}-build` `qa-stable` branch
+- any push to the `ansible-hub-ui` `master` branch will deploy to a `ansible-hub-ui-build` `ci-beta` branch
+- any push to the `ansible-hub-ui` `master-stable` branch will deploy to a `ansible-hub-ui-build` `ci-stable` branch
+- any push to the `ansible-hub-ui` `qa-beta` branch will deploy to a `ansible-hub-ui-build` `qa-beta` branch
+- any push to the `ansible-hub-ui` `qa-stable` branch will deploy to a `ansible-hub-ui-build` `qa-stable` branch
   - `qa-{beta|stable}` also deploy to cloud.stage.redhat.com
-- any push to the `{REPO}` `prod-beta` branch will deploy to a `{REPO}-build` `prod-beta` branch
-- any push to the `{REPO}` `prod-stable` branch will deploy to a `{REPO}-build` `prod-stable` branch
-- Pull requests (based on master) will not be pushed to `{REPO}-build` `master` branch
-  - If the PR is accepted and merged, master will be rebuilt and will deploy to `{REPO}-build` `ci-beta` branch
+- any push to the `ansible-hub-ui` `prod-beta` branch will deploy to a `ansible-hub-ui-build` `prod-beta` branch
+- any push to the `ansible-hub-ui` `prod-stable` branch will deploy to a `ansible-hub-ui-build` `prod-stable` branch
+- Pull requests (based on master) will not be pushed to `ansible-hub-ui-build` `master` branch
+  - If the PR is accepted and merged, master will be rebuilt and will deploy to `ansible-hub-ui-build` `ci-beta` branch
 
 ## Patternfly
 

--- a/README.md
+++ b/README.md
@@ -78,15 +78,20 @@ We're using Github Actions for deployment.
 
 ### How it works
 
-- any push to the `ansible-hub-ui` `master` branch will deploy to a `ansible-hub-ui-build` `ci-beta` branch
-- any push to the `ansible-hub-ui` `master-stable` branch will deploy to a `ansible-hub-ui-build` `ci-stable` branch
-- any push to the `ansible-hub-ui` `qa-beta` branch will deploy to a `ansible-hub-ui-build` `qa-beta` branch
-- any push to the `ansible-hub-ui` `qa-stable` branch will deploy to a `ansible-hub-ui-build` `qa-stable` branch
-  - `qa-{beta|stable}` also deploy to cloud.stage.redhat.com
-- any push to the `ansible-hub-ui` `prod-beta` branch will deploy to a `ansible-hub-ui-build` `prod-beta` branch
-- any push to the `ansible-hub-ui` `prod-stable` branch will deploy to a `ansible-hub-ui-build` `prod-stable` branch
-- Pull requests (based on master) will not be pushed to `ansible-hub-ui-build` `master` branch
-  - If the PR is accepted and merged, master will be rebuilt and will deploy to `ansible-hub-ui-build` `ci-beta` branch
+The Github Action invokes the [RedHatInsights/insights-frontend-builder-common//bootstrap.sh](https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh) script, which builds the local branch and pushes the results to [RedHatInsights/ansible-hub-ui-build](https://github.com/RedHatInsights/ansible-hub-ui-build/branches). There, a separate Jenkins process awaits.
+
+- any push to the `master` branch will deploy to `ansible-hub-ui-build` branches `ci-beta` and `qa-beta`
+- any push to the `master-stable` branch will deploy to `ansible-hub-ui-build` branches `ci-stable` and `qa-stable`
+- any push to the `prod-beta` branch will deploy to a `ansible-hub-ui-build` `prod-beta` branch
+- any push to the `prod-stable` branch will deploy to a `ansible-hub-ui-build` `prod-stable` branch
+- the `ansible-hub-ui-build` `master` branch is not used, as PRs against `master` end up in `ci-beta` and `qa-beta`
+
+- `ci-beta` builds end up on `ci.cloud.redhat.com/beta`
+- `ci-stable` builds end up on `ci.cloud.redhat.com`
+- `qa-beta` builds end up on `qa.cloud.redhat.com/beta`
+- `qa-stable` builds end up on `qa.cloud.redhat.com`
+- `prod-beta` builds end up on `cloud.redhat.com/beta`
+- `prod-stable` builds end up on `cloud.redhat.com`
 
 ## Patternfly
 


### PR DESCRIPTION
Follow-up to #526 (https://github.com/ansible/ansible-hub-ui/pull/526#issuecomment-860753116)

dev-release: errors on `GitHub Releases requires a tag`
because we're just adding the tag in a previous step, it can't figure out which tag to use,
providing via `input_tag_name`

deploy-cloud: errors on `npm ERR! cb() never called!` (on master, but works on prod-beta)
this is a generic "we don't know what's wrong" npm error,
the hive mind suggests a local caching issue, or a http issue, trying to add `npm cache verify` and see what happens.

Cc @newswangerd @ZitaNemeckova 