### PR TITLE
[WIP] Add MaintenancePage

### DIFF
--- a/src/components/MaintenancePage/MaintenancePage.jsx
+++ b/src/components/MaintenancePage/MaintenancePage.jsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import { Main } from '../../components';
+import {
+  Title,
+  EmptyState,
+  EmptyStateVariant,
+  EmptyStateIcon,
+  EmptyStateBody,
+} from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+
+class MaintenancePage extends React.Component {
+  componentDidMount() {
+    insights.chrome.init();
+    insights.chrome.identifyApp('automation-hub');
+  }
+  render() {
+    return (
+      <React.Fragment>
+        <Main>
+          <EmptyState variant={EmptyStateVariant.full}>
+            <EmptyStateIcon
+              icon={ExclamationTriangleIcon}
+              style={{ color: 'var(--pf-global--warning-color--100)' }}
+            />
+            <Title headingLevel='h5' size='lg'>
+              Maintenance in progress
+            </Title>
+            <EmptyStateBody>
+              We are currently undergoing scheduled maintenance from 07:00 -
+              13:00 UTC.
+            </EmptyStateBody>
+            <EmptyStateBody>
+              We'll be back shortly, thank you for your patience.
+            </EmptyStateBody>
+          </EmptyState>
+        </Main>
+      </React.Fragment>
+    );
+  }
+}
+export default MaintenancePage;


### PR DESCRIPTION
It's not up by default. To use it make following changes: 
```diff
--- a/src/entry.js
+++ b/src/entry.js
@@ -6,15 +6,12 @@ import { init } from './store';
 import App from './loaders/insights/insights-loader';
 import logger from 'redux-logger';
 import getBaseName from './utilities/getBaseName';
+import MaintenancePage from './components/MaintenancePage/MaintenancePage';
 
 // Entrypoint for compiling the app to run in insights dev mode.
 
 ReactDOM.render(
-  <Provider store={init(logger).getStore()}>
-    <Router basename={getBaseName(window.location.pathname)}>
-      <App />
-    </Router>
-  </Provider>,
+  <MaintenancePage></MaintenancePage>,
 
   document.getElementById('root'),
 );
```

<img width="1662" alt="Screenshot 2021-06-15 at 9 50 46" src="https://user-images.githubusercontent.com/9210860/122014469-762c6280-cdbf-11eb-8b88-787a1245b78b.png">
