### PR TITLE
dev-release workflow: fix input_tag_name -> tag_name

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         body: "This is a special release that provides an up to date build off of the latest changes in the master branch. The automation-hub-ui-dist.tar.gz artifact provided here corresponds to the latest version of master."
         files: "automation-hub-ui-dist.tar.gz"
-        input_tag_name: 'dev'
+        tag_name: 'dev'
         name: "UI Dev Release"
         prerelease: true
       env:


### PR DESCRIPTION
Follow-up to #526, #534

`input_tag_name` is the name of the variable in [actions-gh-release](https://github.com/softprops/action-gh-release/blob/master/src/github.ts#L148), but it fails with `Unexpected input(s) 'input_tag_name', valid inputs are ['body', 'body_path', 'name', 'tag_name', 'draft', 'prerelease', 'files']` ([log](https://github.com/ansible/ansible-hub-ui/runs/2830154091?check_suite_focus=true#step:7:1))

Renaming :)