### PR TITLE
[prod-stable] update deploy-cloud workflow

### DIFF
--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
 
-    - name: "Checkout ansible-hub-ui (prod-stable)"
+    - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v2
 
     - name: "Set BRANCH, TRAVIS_BRANCH, TRAVIS_BUILD_NUMBER, TRAVIS_WEB_URL, TRAVIS_COMMIT_MESSAGE"


### PR DESCRIPTION
Follow-up to #526 (+ #534, #538) .. copying workflows to the relevant branches
Parent (+links to other branches): #544

This just updates the existing workflow added to prod-stable in #539 to match master.

NOTE: merging this will cause a build (`prod-stable`)