### PR TITLE
Workflows: Fix dev-release asset upload, switch to github cli

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -48,12 +48,12 @@ jobs:
         tar -C dist/ -czvf automation-hub-ui-dist.tar.gz .
 
     - name: "Release"
-      uses: softprops/action-gh-release@v1
-      with:
-        body: "This is a special release that provides an up to date build off of the latest changes in the master branch. The automation-hub-ui-dist.tar.gz artifact provided here corresponds to the latest version of master."
-        files: "automation-hub-ui-dist.tar.gz"
-        tag_name: 'dev'
-        name: "UI Dev Release"
-        prerelease: true
+      run: |
+        gh release create -p "$RELEASE_TAG" --title "$RELEASE_NAME" --notes "$RELEASE_BODY" || true # may already exist
+        gh release upload "$RELEASE_TAG" "$RELEASE_FILE" --clobber
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_NAME: "UI Dev Release"
+        RELEASE_BODY: "This is a special release that provides an up to date build off of the latest changes in the master branch. The automation-hub-ui-dist.tar.gz artifact provided here corresponds to the latest version of master."
+        RELEASE_FILE: 'automation-hub-ui-dist.tar.gz'
+        RELEASE_TAG: 'dev'

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -18,10 +18,12 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v2
 
-    - name: "Set TRAVIS_COMMIT_MESSAGE"
+    - name: "Set TRAVIS_COMMIT_MESSAGE, RELEASE_TAG"
       run: |
         TRAVIS_COMMIT_MESSAGE=`git log -1 --format=%B`
+        RELEASE_TAG=`sed 's/^refs\/tags\///' <<< $GITHUB_REF`
         echo -e "TRAVIS_COMMIT_MESSAGE<<EOF\n${TRAVIS_COMMIT_MESSAGE}\nEOF" >> $GITHUB_ENV
+        echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
 
     - name: "Install node 14"
       uses: actions/setup-node@v2
@@ -44,9 +46,8 @@ jobs:
         tar -C dist/ -czvf automation-hub-ui-dist.tar.gz .
 
     - name: "Release"
-      uses: softprops/action-gh-release@v1
-      with:
-        files: "automation-hub-ui-dist.tar.gz"
-        body: ${{ env.TRAVIS_COMMIT_MESSAGE }}
+      run: |
+        gh release create "$RELEASE_TAG" --notes "$TRAVIS_COMMIT_MESSAGE" "$RELEASE_FILE"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_FILE: 'automation-hub-ui-dist.tar.gz'


### PR DESCRIPTION
Follow-up to #526 

This switches the create release action to use [gh](https://cli.github.com/manual), to fix the issue of not being able to re-upload assets to an existing release.

(both `gh` and `hub` are available out of the box:

    $ hub --version
    git version 2.32.0
    hub version 2.14.2
    
    $ gh --version
    gh version 1.11.0 (2021-06-03)
    https://github.com/cli/cli/releases/tag/v1.11.0

)