### PR TITLE
dev-release: add missing backticks to match the existing release

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -54,6 +54,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_NAME: "UI Dev Release"
-        RELEASE_BODY: "This is a special release that provides an up to date build off of the latest changes in the master branch. The automation-hub-ui-dist.tar.gz artifact provided here corresponds to the latest version of master."
+        RELEASE_BODY: "This is a special release that provides an up to date build off of the latest changes in the `master` branch. The `automation-hub-ui-dist.tar.gz` artifact provided here corresponds to the latest version of `master`."
         RELEASE_FILE: 'automation-hub-ui-dist.tar.gz'
         RELEASE_TAG: 'dev'


### PR DESCRIPTION
Follow-up to #550, #526 

dev-release now successfully updates assets, just updating the body message to monospace the branch and file names.