### PR TITLE
[stable-4.3] backport stable-release workflow changes: #550 + #566

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -18,10 +18,12 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v2
 
-    - name: "Set TRAVIS_COMMIT_MESSAGE"
+    - name: "Set TRAVIS_COMMIT_MESSAGE, RELEASE_TAG"
       run: |
         TRAVIS_COMMIT_MESSAGE=`git log -1 --format=%B`
+        RELEASE_TAG=`sed 's/^refs\/tags\///' <<< $GITHUB_REF`
         echo -e "TRAVIS_COMMIT_MESSAGE<<EOF\n${TRAVIS_COMMIT_MESSAGE}\nEOF" >> $GITHUB_ENV
+        echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
 
     - name: "Install node 14"
       uses: actions/setup-node@v2
@@ -44,9 +46,8 @@ jobs:
         tar -C dist/ -czvf automation-hub-ui-dist.tar.gz .
 
     - name: "Release"
-      uses: softprops/action-gh-release@v1
-      with:
-        files: "automation-hub-ui-dist.tar.gz"
-        body: ${{ env.TRAVIS_COMMIT_MESSAGE }}
+      run: |
+        gh release create "$RELEASE_TAG" --notes "$TRAVIS_COMMIT_MESSAGE" "$RELEASE_FILE"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_FILE: 'automation-hub-ui-dist.tar.gz'

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,5 +1,6 @@
 name: "Stable release from stable-4.3"
 
+# creating a release creates a tag as well; this expects the release to exist
 on:
   push:
     tags:
@@ -18,11 +19,9 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v2
 
-    - name: "Set TRAVIS_COMMIT_MESSAGE, RELEASE_TAG"
+    - name: "Set RELEASE_TAG"
       run: |
-        TRAVIS_COMMIT_MESSAGE=`git log -1 --format=%B`
         RELEASE_TAG=`sed 's/^refs\/tags\///' <<< $GITHUB_REF`
-        echo -e "TRAVIS_COMMIT_MESSAGE<<EOF\n${TRAVIS_COMMIT_MESSAGE}\nEOF" >> $GITHUB_ENV
         echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
 
     - name: "Install node 14"
@@ -47,7 +46,7 @@ jobs:
 
     - name: "Release"
       run: |
-        gh release create "$RELEASE_TAG" --notes "$TRAVIS_COMMIT_MESSAGE" "$RELEASE_FILE"
+        gh release upload "$RELEASE_TAG" "$RELEASE_FILE" --clobber
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_FILE: 'automation-hub-ui-dist.tar.gz'


### PR DESCRIPTION
Backports #550 to stable-4.3 - use `gh` for github releases.
(Part of https://github.com/ansible/ansible-hub-ui/pull/548 for stable-4.2, and no other branches are doing stable releases.)

And backports #566 - expect a release to exist, add assets there, don't create a new one
(With #565 for stable-4.2.)
