### PR TITLE
stable-release workflow: expect release to exist, only add assets

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -1,5 +1,6 @@
 name: "Stable release"
 
+# creating a release creates a tag as well; this expects the release to exist
 on:
   push:
     tags:
@@ -18,11 +19,9 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v2
 
-    - name: "Set TRAVIS_COMMIT_MESSAGE, RELEASE_TAG"
+    - name: "Set RELEASE_TAG"
       run: |
-        TRAVIS_COMMIT_MESSAGE=`git log -1 --format=%B`
         RELEASE_TAG=`sed 's/^refs\/tags\///' <<< $GITHUB_REF`
-        echo -e "TRAVIS_COMMIT_MESSAGE<<EOF\n${TRAVIS_COMMIT_MESSAGE}\nEOF" >> $GITHUB_ENV
         echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
 
     - name: "Install node 14"
@@ -47,7 +46,7 @@ jobs:
 
     - name: "Release"
       run: |
-        gh release create "$RELEASE_TAG" --notes "$TRAVIS_COMMIT_MESSAGE" "$RELEASE_FILE"
+        gh release upload "$RELEASE_TAG" "$RELEASE_FILE" --clobber
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_FILE: 'automation-hub-ui-dist.tar.gz'


### PR DESCRIPTION
The `stable-release` workflow is triggered by pushing a tag to one of the branches which contain the workflow (master, stable-4.*).

Right now, it expcets only the tag to exists, and tries to create a release and upload assets.

But, what we're actually doing is creating the tag by creating a github release manually.

Before: the workflow creates a new draft github release with the right assets, and fails because it can't undraft it as the release already exists.
After: the workflow expects a release to exist, and only uploads the assets


(Merging after discussing on https://github.com/ansible/ansible-hub-ui/pull/565,
testing a release on master, the removing it, and backporting to the other branches if it works.)