### PR TITLE
dependabot: fix schema error in config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     target-branch: 'stable-4.3'
     schedule:
       interval: 'weekly'
-    commit_message:
+    commit-message:
       prefix: '[stable-4.3] '
 
   - package-ecosystem: 'npm'
@@ -18,5 +18,5 @@ updates:
     target-branch: 'stable-4.2'
     schedule:
       interval: 'weekly'
-    commit_message:
+    commit-message:
       prefix: '[stable-4.2] '


### PR DESCRIPTION
Related to #366

Schema error introduced in #418, the correct form is `commit-message`, not `commit_message`.

[docs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#commit-message)

This should fix the dependabot PR prefix for the stable-* branches.
(The intent being use "Bump whatever" for master, but "[stable-4.2] Bump whatever" for stable.)

Validation is visible in https://github.com/ansible/ansible-hub-ui/network/updates
(and currently says

    The property '#/updates/1/' contains additional properties ["commit_message"] outside of the schema when none are allowed
    The property '#/updates/2/' contains additional properties ["commit_message"] outside of the schema when none are allowed

)