### PR TITLE
cypress workflow: use npm install, add check for package-lock.json changes

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -121,7 +121,7 @@ jobs:
     - name: "Build standalone UI"
       working-directory: 'ansible-hub-ui'
       run: |
-        npm ci || npm install
+        npm install
         npm run build-standalone
         rm -rf ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng/
         mv -v dist/ ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng
@@ -133,10 +133,14 @@ jobs:
         # podman exec pulp pip install django_extensions
         podman exec pulp pulpcore-manager reset-admin-password --password admin
         
-        npm ci || npm install
+        npm install
         echo -e '{\n  "prefix": "/api/galaxy/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
         
         npm run cypress:chrome
+
+    - name: "Fail if npm install had to change package-lock.json"
+      working-directory: 'ansible-hub-ui'
+      run: 'git diff --exit-code package-lock.json'
 
     - uses: actions/upload-artifact@v2
       if: failure()


### PR DESCRIPTION
npm install instead of ci because ci doesn't match what actually happens..
example: on a PR changing just package.json,
`npm ci`: ignores new versions, sticks to old `package-lock.json`
`npm install`: updates `package-lock.json`, uses new versions

and adding a `git diff --exit-code package-lock.json` step, which fails the tests if `package-lock.json` doesn't match `package.json`
(making sure to run cypress first to allow it to fail first, more useful when debugging)

(If this fails too often, we might want to change this to push the fix back on push runs, but I suspect dependabot handles the problem - rebasing a dependabot PR and merging it would fix such a situation)

---

Example failure when package.json and package-lock.json don't match.. https://github.com/ansible/ansible-hub-ui/pull/617/checks?check_run_id=3051546218#step:14:24