### PR TITLE
cloud.redhat.com -> console.redhat.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The app will run on http://localhost:8002 and proxy requests for `api/automation
 
 To enable insights mode set `DEPLOYMENT_MODE: 'insights'` in [custom.dev.config.js](./custom.dev.config.js).
 
-This app is part of the Red Hat cloud platform. Because of that the app needs to be loaded within the context of cloud.redhat.com. This is done by accessing the app via the [insights-proxy project](https://github.com/RedHatInsights/insights-proxy).
+This app is part of the Red Hat cloud platform. Because of that the app needs to be loaded within the context of console.redhat.com. This is done by accessing the app via the [insights-proxy project](https://github.com/RedHatInsights/insights-proxy).
 
 #### Set up Insights Proxy
 
@@ -86,12 +86,12 @@ The Github Action invokes the [RedHatInsights/insights-frontend-builder-common//
 - any push to the `prod-stable` branch will deploy to a `ansible-hub-ui-build` `prod-stable` branch
 - the `ansible-hub-ui-build` `master` branch is not used, as PRs against `master` end up in `ci-beta` and `qa-beta`
 
-- `ci-beta` builds end up on `ci.cloud.redhat.com/beta`
-- `ci-stable` builds end up on `ci.cloud.redhat.com`
-- `qa-beta` builds end up on `qa.cloud.redhat.com/beta`
-- `qa-stable` builds end up on `qa.cloud.redhat.com`
-- `prod-beta` builds end up on `cloud.redhat.com/beta`
-- `prod-stable` builds end up on `cloud.redhat.com`
+- `ci-beta` builds end up on `ci.console.redhat.com/beta`
+- `ci-stable` builds end up on `ci.console.redhat.com`
+- `qa-beta` builds end up on `qa.console.redhat.com/beta`
+- `qa-stable` builds end up on `qa.console.redhat.com`
+- `prod-beta` builds end up on `console.redhat.com/beta`
+- `prod-stable` builds end up on `console.redhat.com`
 
 ### Workflows
 

--- a/config/insights.dev.webpack.config.js
+++ b/config/insights.dev.webpack.config.js
@@ -24,7 +24,7 @@ module.exports = webpackBase({
   APPLICATION_NAME: 'Automation Hub',
 
   // Disables custom favicons. Used to turn off our favicon so we inherit
-  // the correct one from cloud.redhat.com
+  // the correct one from console.redhat.com
   USE_FAVICON: false,
 
   // Serve the UI over http or https. Options: true, false

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -56,7 +56,7 @@ module.exports = inputConfigs => {
   };
 
   // being able to turn off the favicon is useful for deploying to insights mode
-  // cloud.redhat.com sets it's own favicon and ours tends to override it if we
+  // console.redhat.com sets its own favicon and ours tends to override it if we
   // set one
   if (customConfigs.USE_FAVICON) {
     htmlPluginConfig['favicon'] = 'static/images/favicon.ico';

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -155,10 +155,16 @@ export class Constants {
     'galaxy-qa.ansible.com',
   ];
   static DOWNSTREAM_HOSTS = [
+    // FIXME 2021-09: remove obsolete cloud* references
     'cloud.redhat.com',
     'cloud.stage.redhat.com',
     'ci.cloud.redhat.com',
     'qa.cloud.redhat.com',
+
+    'console.redhat.com',
+    'console.stage.redhat.com',
+    'ci.console.redhat.com',
+    'qa.console.redhat.com',
   ];
   static REPOSITORYNAMES = {
     'Red Hat Certified': 'rh-certified',

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -63,7 +63,7 @@ class App extends Component {
     // view repositories other than "published", but all other views are locked
     // to "published"
     // We do this because there is not currently a way to toggle repositories
-    // in automation hub on cloud.redhat.com, so it's important to ensure the user
+    // in automation hub on console.redhat.com, so it's important to ensure the user
     // always lands on the published repo
 
     // check if the URL matches the base path for the collection detail page


### PR DESCRIPTION
Related to https://issues.redhat.com/browse/AAH-749

This updates all cloud.redhat.com references to point to console.redhat.com instead.

Keeping the cloud logic for now, as the transition will take a while (hence the FIXME for later).

Note: actually test deploy once possible, if `@redhat-cloud-services/frontend-components-config` has to be updated, we need webpack 5 first

(Dev mode `ci.foo.redhat.com` is not affected by this.)