### PR TITLE
Fix cypress group_management and namespace-edit failures

### DIFF
--- a/src/utilities/map-error-messages.ts
+++ b/src/utilities/map-error-messages.ts
@@ -3,6 +3,13 @@
 
 export function mapErrorMessages(err) {
   const messages: any = {};
+
+  // 500 errors only have err.response.data string
+  if (typeof err.response.data === 'string') {
+    messages['__nofield'] = err.response.data;
+    return messages;
+  }
+
   for (const e of err.response.data.errors) {
     if (e.source) {
       messages[e.source.parameter] = e.detail;
@@ -12,5 +19,6 @@ export function mapErrorMessages(err) {
       messages['__nofield'] = e.detail || e.title;
     }
   }
+
   return messages;
 }

--- a/test/cypress/integration/menu.js
+++ b/test/cypress/integration/menu.js
@@ -14,10 +14,6 @@ describe('Hub Menu Tests', () => {
     'User Access > Groups',
   ];
 
-  beforeEach(() => {
-    cy.visit(baseUrl);
-  });
-
   it('admin user sees complete menu', () => {
     cy.login(adminUsername, adminPassword);
     menuItems.forEach(item => cy.menuPresent(item));
@@ -26,6 +22,12 @@ describe('Hub Menu Tests', () => {
   describe('user without permissions', () => {
     let username = 'nopermission';
     let password = 'n0permissi0n';
+
+    before(() => {
+      cy.deleteTestUsers();
+      cy.galaxykit('user create', username, password);
+    });
+
     let visibleMenuItems = [
       'Collections > Collections',
       'Collections > Namespaces',
@@ -39,17 +41,6 @@ describe('Hub Menu Tests', () => {
       'User Access > Groups',
       'Collections > Approval',
     ];
-
-    beforeEach(() => {
-      cy.login(adminUsername, adminPassword);
-      cy.createUser(username, password);
-      cy.logout();
-    });
-
-    afterEach(() => {
-      cy.deleteUser(username);
-      cy.logout();
-    });
 
     it('sees limited menu', () => {
       cy.login(username, password);

--- a/test/cypress/integration/namespace-edit.js
+++ b/test/cypress/integration/namespace-edit.js
@@ -42,6 +42,11 @@ describe('Edit a namespace', () => {
     return cy.get('div.pf-c-form__group-control > textarea.pf-c-form-control');
   };
 
+  before(() => {
+    cy.deleteTestGroups();
+    cy.galaxykit('-i group create', 'namespace-owner-autocomplete');
+  });
+
   beforeEach(() => {
     cy.visit(baseUrl);
     cy.login(adminUsername, adminPassword);
@@ -53,7 +58,7 @@ describe('Edit a namespace', () => {
   });
 
   it('tests that the name field is disabled from editing', () => {
-    return cy.get('#name').should('be.disabled');
+    cy.get('#name').should('be.disabled');
   });
 
   it('tests the company name for errors', () => {

--- a/test/cypress/integration/namespace-edit.js
+++ b/test/cypress/integration/namespace-edit.js
@@ -80,12 +80,20 @@ describe('Edit a namespace', () => {
   });
 
   it('tests the namespace owners field', () => {
+    cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/groups/?*').as(
+      'autocomplete',
+    );
+
     cy.get('.pf-c-form-control.pf-c-select__toggle-typeahead')
       .click()
       .type('abcde');
+    cy.wait('@autocomplete');
     cy.get('.pf-c-select__menu-wrapper').should('contain', 'Not found');
+
     cy.get('.pf-c-button.pf-m-plain.pf-c-select__toggle-clear').click();
-    cy.get('.pf-c-select__menu-wrapper').click();
+    cy.wait('@autocomplete');
+    cy.get('.pf-c-select__menu-wrapper').click(); // first group available
+
     saveButton().click();
   });
 

--- a/test/cypress/integration/namespace-edit.js
+++ b/test/cypress/integration/namespace-edit.js
@@ -97,7 +97,7 @@ describe('Edit a namespace', () => {
 
     cy.get('.pf-c-button.pf-m-plain.pf-c-select__toggle-clear').click();
     cy.wait('@autocomplete');
-    cy.get('.pf-c-select__menu-wrapper').click(); // first group available
+    cy.contains('namespace-owner-autocomplete').click();
 
     saveButton().click();
   });

--- a/test/cypress/integration/namespaces.js
+++ b/test/cypress/integration/namespaces.js
@@ -1,9 +1,11 @@
 describe('Namespaces Page Tests', () => {
   var baseUrl = Cypress.config().baseUrl;
-  var adminUsername = Cypress.env('username');
-  var adminPassword = Cypress.env('password');
 
   before(() => {
+    cy.deleteTestUsers();
+    cy.deleteTestGroups();
+    // TODO: cy.deleteTestNamespaces();
+
     cy.galaxykit('-i group create', 'testGroup1');
     cy.galaxykit('-i group create', 'testGroup2');
 
@@ -16,15 +18,6 @@ describe('Namespaces Page Tests', () => {
     cy.galaxykit('namespace addgroup', 'testns2', 'testGroup2');
   });
 
-  beforeEach(() => {
-    cy.visit(baseUrl);
-    // cy.login(adminUsername, adminPassword);
-  });
-
-  // afterEach(() => {
-  //     cy.logout();
-  // })
-
   it('can navigate to pubic namespace list', () => {
     cy.login('testUser2', 'p@ssword1');
     cy.menuGo('Collections > Namespaces');
@@ -36,6 +29,7 @@ describe('Namespaces Page Tests', () => {
   it('can navigate to personal namespace list', () => {
     cy.login('testUser2', 'p@ssword1');
     cy.menuGo('Collections > Namespaces');
+
     cy.contains('My namespaces').click();
 
     cy.contains('testns2').should('exist');

--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -20,7 +20,8 @@ describe('Repo Management tests', () => {
     cy.contains('Show advanced options').click();
     cy.get('#download_concurrency').should('exist');
   });
-  /* Needs more work to handle uploading a requirements.yml
+
+  /* FIXME: Needs more work to handle uploading a requirements.yml
    * when you want to save the remote proxy config.
    */
   it.skip('remote proxy config can be saved and deleted.', () => {
@@ -36,7 +37,7 @@ describe('Repo Management tests', () => {
     cy.get('input[id="proxy_url"]').type('https://example.org');
     cy.get('input[id="proxy_username"]').type('test');
     cy.get('input[id="proxy_password"]').type('test');
-    cy.route(
+    cy.intercept(
       'PUT',
       Cypress.env('prefix') + 'content/community/v3/sync/config/',
     ).as('saveConfig');
@@ -60,10 +61,6 @@ describe('Repo Management tests', () => {
       .click({ multiple: true });
     cy.get('input[id="proxy_url"]').clear();
     cy.get('input[id="proxy_username"]').clear();
-    cy.route(
-      'PUT',
-      Cypress.env('prefix') + 'content/community/v3/sync/config/',
-    ).as('saveConfig');
     cy.contains('Save').click();
     cy.wait('@saveConfig')
       .its('status')

--- a/test/cypress/integration/user_dashboard.js
+++ b/test/cypress/integration/user_dashboard.js
@@ -42,10 +42,6 @@ describe('Hub User Management Tests', () => {
       cy.menuGo('User Access > Users');
     });
 
-    afterEach(() => {
-      cy.logout();
-    });
-
     it('Can create new users', () => {
       cy.contains('[aria-labelledby=test]', 'Test F');
       cy.contains('[aria-labelledby=test]', 'Test L');
@@ -58,9 +54,6 @@ describe('Hub User Management Tests', () => {
   describe('prevents super-user and self deletion', () => {
     beforeEach(() => {
       cy.visit(baseUrl);
-    });
-    afterEach(() => {
-      cy.logout();
     });
 
     function attemptToDelete(toDelete) {
@@ -87,11 +80,5 @@ describe('Hub User Management Tests', () => {
       cy.login(adminUsername, adminPassword);
       attemptToDelete(adminUsername);
     });
-  });
-
-  after(() => {
-    cy.login(adminUsername, adminPassword);
-    cy.deleteUser(username);
-    cy.deleteGroup('delete-user');
   });
 });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -67,6 +67,7 @@ Cypress.Commands.add('logout', {}, () => {
 });
 
 Cypress.Commands.add('login', {}, (username, password) => {
+  cy.visit('/ui/login');
   let loginUrl = urljoin(
     Cypress.config().baseUrl,
     Cypress.env('prefix'),

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -277,8 +277,9 @@ Cypress.Commands.add('deleteUser', {}, username => {
   cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/users/?*').as('userList');
 
   cy.contains('[role=dialog] button', 'Delete').click();
-  cy.wait('@deleteUser');
-  cy.get('@deleteUser').should('have.property', 'status', 204);
+  cy.wait('@deleteUser').then(({ request, response }) => {
+    expect(response.statusCode).to.eq(204);
+  });
 
   // Wait for navigation
   cy.wait('@userList');
@@ -297,8 +298,9 @@ Cypress.Commands.add('deleteGroup', {}, name => {
   );
   cy.get(`[aria-labelledby=${name}] [aria-label=Delete]`).click();
   cy.contains('[role=dialog] button', 'Delete').click();
-  cy.wait('@deleteGroup');
-  cy.get('@deleteGroup').should('have.property', 'status', 204);
+  cy.wait('@deleteGroup').then(({ request, response }) => {
+    expect(response.statusCode).to.eq(204);
+  });
 });
 
 // GalaxyKit Integration

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -284,9 +284,15 @@ Cypress.Commands.add('deleteUser', {}, username => {
     `[aria-labelledby=${username}] [aria-label=Actions]`,
     'Delete',
   ).click();
+
+  cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/users/?*').as('userList');
+
   cy.contains('[role=dialog] button', 'Delete').click();
   cy.wait('@deleteUser');
   cy.get('@deleteUser').should('have.property', 'status', 204);
+
+  // Wait for navigation
+  cy.wait('@userList');
 });
 
 Cypress.Commands.add('deleteGroup', {}, name => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -117,8 +117,8 @@ Cypress.Commands.add(
     cy.contains('Save').click();
     cy.wait('@createUser');
 
-    // The API responded, but the user list page hasn't loaded, wait 100ms.
-    cy.wait(100);
+    // Wait for navigation
+    cy.contains('.pf-c-title', 'Users');
   },
 );
 


### PR DESCRIPTION
Currently we have 2 sporadic test failures:

[This run](https://github.com/ansible/ansible-hub-ui/runs/3021216894?check_suite_focus=true) shows both, but the recent red runs in https://github.com/ansible/ansible-hub-ui/actions all fail with one or the other.

---

> `group_management.js`: Hub Group Management Tests "before each" hook for "admin user can add/remove permissions to/from a group"
> The following error originated from your application code, not from Cypress. It was caused by an unhandled promise rejection.
> Request failed with status code 403

So, the 3rd spec is failing in beforeEach, because a request 403s.
That's because the *2nd* test ends in a `deleteUser` call, which only waits for the API response, but doesn't wait for the redirect to the users list screen. (So the redirect happens during the next test's `beforeEach`, when the cookie is gone, hence the 403.)

=> Adding a wait for the users list screen to load to the end of `deleteUser` - by waiting for the list users API request (since the modal is still on the list screen, detecting the screen by title didn't quite work :)).

And doing the same thing for `createUser` - locally I'm also seeing a failure where `addUserToGroup` calls `menuGo` to Groups *before* the previous `createUser` handler navigates to Users, causing the test to expect Groups, while ending up on the Users page => adding a wait after adding a user, to only return after navigation.

---

> `namespace-edit.js`: Edit a namespace tests the namespace owners field
> Timed out retrying after 4050ms: `cy.click()` failed because this element is detached from the DOM.
> `&lt;li id=&quot;select-option-16257619708947hw15daewze&quot; role=&quot;presentation&quot; class=&quot;pf-c-select__menu-wrapper&quot;&gt;...&lt;/li&gt;`

When filling out the owner group field, making sure that:

* a group always exists that can be autocompleted
* we're waiting for the API autocomplete requests
* using the group name to autocomplete, ensuring the right wrapper to click is found that way
 
---

More fixes:

`cy.visit(baseUrl) + cy.login(...)` can fail: when already logged in, baseUrl is Containers - adding an explicit `cy.visit('/ui/login')`.

Server error responses fail in `mapErrorMessages` because they only contain the error as string, not a json object with an array of errors - adding support for that.

Update `cy.server()` & `cy.route()` calls, both are deprecated, use `cy.intercept()` instead. ([docs](https://docs.cypress.io/api/commands/intercept))

Remove any `after` and `afterAll`, move cleanup to `before`.

Simplify `deleteTestUsers` and `deleteTestGroups` helpers by reusing the `cy.galaxykit` helper, and having it yield a list of nonempty lines.