### PR TITLE
Approval Dashboard issues 

### DIFF
--- a/src/components/patternfly-wrappers/applied-filters.tsx
+++ b/src/components/patternfly-wrappers/applied-filters.tsx
@@ -69,7 +69,7 @@ export class AppliedFilters extends React.Component<IProps, {}> {
                 updateParams(ParamHelper.deleteParam(params, key, v))
               }
             >
-              {v}
+              {niceNames[v] || v}
             </Chip>
           ))}
         </ChipGroup>

--- a/src/components/patternfly-wrappers/applied-filters.tsx
+++ b/src/components/patternfly-wrappers/applied-filters.tsx
@@ -19,6 +19,7 @@ interface IProps {
    * when displaying the param field name
    */
   niceNames?: object;
+  niceValues?: object;
   style?: React.CSSProperties;
   className?: string;
 }
@@ -49,7 +50,7 @@ export class AppliedFilters extends React.Component<IProps, {}> {
   }
 
   private renderGroup(key: string) {
-    const { niceNames, params, updateParams } = this.props;
+    const { niceNames, niceValues, params, updateParams } = this.props;
 
     let chips;
 
@@ -69,7 +70,7 @@ export class AppliedFilters extends React.Component<IProps, {}> {
                 updateParams(ParamHelper.deleteParam(params, key, v))
               }
             >
-              {niceNames[v] || v}
+              {niceValues?.[key]?.[v] || v}
             </Chip>
           ))}
         </ChipGroup>

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -135,7 +135,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
           <StatefulDropdown
             toggleType='dropdown'
             defaultText={
-              this.state.inputText ||
+              this.selectTitleById(this.state.inputText, selectedFilter) ||
               selectedFilter.placeholder ||
               selectedFilter.title
             }
@@ -219,4 +219,10 @@ export class CompoundFilter extends React.Component<IProps, IState> {
     }
     this.submitMultiple(newParams);
   };
+
+  private selectTitleById(inputText: string, selectedFilter: FilterOption) {
+    if (!inputText || !selectedFilter?.options) return inputText;
+
+    return selectedFilter.options.find(opt => opt.id === inputText).title;
+  }
 }

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -183,7 +183,13 @@ class CertificationDashboard extends React.Component<
                   }
                   params={params}
                   ignoredParams={['page_size', 'page', 'sort']}
-                  niceNames={{ staging: 'Needs review' }}
+                  niceValues={{
+                    status: {
+                      [Constants.PUBLISHED]: 'Approved',
+                      [Constants.NEEDSREVIEW]: 'Needs Review',
+                      [Constants.NOTCERTIFIED]: 'Rejected',
+                    },
+                  }}
                 />
               </div>
               {loading ? (

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -23,7 +23,7 @@ import {
   ExclamationCircleIcon,
   CheckCircleIcon,
 } from '@patternfly/react-icons';
-import _ from 'lodash';
+import { omit } from 'lodash';
 
 import { CollectionVersionAPI, CollectionVersion, TaskAPI } from 'src/api';
 import { filterIsSet, ParamHelper } from 'src/utilities';
@@ -523,7 +523,7 @@ class CertificationDashboard extends React.Component<
   private queryCollections() {
     const updatedCollectionParams =
       'status' in this.state.params
-        ? _.omit(
+        ? omit(
             {
               repository: this.state.params['status'],
               ...this.state.params,

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -79,8 +79,8 @@ class CertificationDashboard extends React.Component<
       params['sort'] = '-pulp_created';
     }
 
-    if (!params['status']) {
-      params['status'] = 'staging';
+    if (!params['repository']) {
+      params['repository'] = 'staging';
     }
 
     this.state = {
@@ -143,7 +143,7 @@ class CertificationDashboard extends React.Component<
                             title: 'Collection Name',
                           },
                           {
-                            id: 'status',
+                            id: 'repository',
                             title: 'Status',
                             inputType: 'select',
                             options: [
@@ -184,11 +184,14 @@ class CertificationDashboard extends React.Component<
                   params={params}
                   ignoredParams={['page_size', 'page', 'sort']}
                   niceValues={{
-                    status: {
+                    repository: {
                       [Constants.PUBLISHED]: 'Approved',
                       [Constants.NEEDSREVIEW]: 'Needs Review',
                       [Constants.NOTCERTIFIED]: 'Rejected',
                     },
+                  }}
+                  niceNames={{
+                    repository: 'status',
                   }}
                 />
               </div>
@@ -216,7 +219,7 @@ class CertificationDashboard extends React.Component<
 
   private renderTable(versions, params) {
     if (versions.length === 0) {
-      return filterIsSet(params, ['namespace', 'name', 'status']) ? (
+      return filterIsSet(params, ['namespace', 'name', 'repository']) ? (
         <EmptyStateFilter />
       ) : (
         <EmptyStateNoData
@@ -527,19 +530,8 @@ class CertificationDashboard extends React.Component<
   }
 
   private queryCollections() {
-    const updatedCollectionParams =
-      'status' in this.state.params
-        ? omit(
-            {
-              repository: this.state.params['status'],
-              ...this.state.params,
-            },
-            ['status'],
-          )
-        : this.state.params;
-
     this.setState({ loading: true }, () =>
-      CollectionVersionAPI.list(updatedCollectionParams).then(result => {
+      CollectionVersionAPI.list(this.state.params).then(result => {
         this.setState({
           versions: result.data.data,
           itemCount: result.data.meta.count,

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -23,7 +23,6 @@ import {
   ExclamationCircleIcon,
   CheckCircleIcon,
 } from '@patternfly/react-icons';
-import { omit } from 'lodash';
 
 import { CollectionVersionAPI, CollectionVersion, TaskAPI } from 'src/api';
 import { filterIsSet, ParamHelper } from 'src/utilities';

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -190,7 +190,7 @@ class CertificationDashboard extends React.Component<
                     },
                   }}
                   niceNames={{
-                    repository: 'status',
+                    repository: 'Status',
                   }}
                 />
               </div>


### PR DESCRIPTION
Issue [AAH-359](https://issues.redhat.com/browse/AAH-359)

- changed dropdown option "repository" to "status":
Found a little problem here, the `repository` attribute is used as a param in API, changing it to `status` breaks the API filtering. Fixed it by passing a new object `updatedCollectionParams`, which doesn't contain `status` attr, and also added `repository` attribute that is expected. 
`
  const updatedCollectionParams =
      'status' in this.state.params
        ? _.omit(
            {
              repository: this.state.params['status'],
              ...this.state.params,
            },
            ['status'],
          )
        : this.state.params;
`
Maybe a cleaner solution would be to solve it on the backend and rename it API attribute to status?

- Staging should be a dropdown option if it's a chip as it is currently (needs review goes into staging, approved goes into published): 
I think this is already solved, but with this change `niceNames={{ staging: 'Needs review' }}` It's now "Needs review" chip.  

before: 
![filter_before](https://user-images.githubusercontent.com/19647757/125621254-e7c26fe2-903b-4095-bf70-f73b893fe832.png)

after:
![staging_after](https://user-images.githubusercontent.com/19647757/125620996-615988ce-4473-4cd5-b66c-039bf09ba187.png)

According to the issue, the dropdown option `status` should be the second option, but it's third item in the dropdown filter? Should I change this? 
![expanded_dropdown](https://user-images.githubusercontent.com/19647757/125622094-10900dcb-4f12-4c5e-bbfb-4e08ed3a3f40.png)

 
