### PR TITLE
Toolbar aligning with top pagination on group list page and container registry page

### DIFF
--- a/src/containers/execution-environment-list/execution-environment.scss
+++ b/src/containers/execution-environment-list/execution-environment.scss
@@ -1,0 +1,5 @@
+.container-list-toolbar {
+  .pf-c-toolbar__content {
+    padding-left: 0px;
+  }
+}

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import './execution-environment.scss';
+
 import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import {
   Toolbar,
@@ -114,7 +116,7 @@ class ExecutionEnvironmentList extends React.Component<
               <LoadingPageSpinner />
             ) : (
               <section className='body'>
-                <div className='toolbar'>
+                <div className='container-list-toolbar'>
                   <Toolbar>
                     <ToolbarContent>
                       <ToolbarGroup>

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import './group-management.scss';
 
 import {
   withRouter,
@@ -144,7 +145,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
         ) : (
           <Main>
             <section className='body'>
-              <div className='toolbar'>
+              <div className='group-list-toolbar'>
                 <Toolbar>
                   <ToolbarContent>
                     <ToolbarGroup>

--- a/src/containers/group-management/group-management.scss
+++ b/src/containers/group-management/group-management.scss
@@ -1,0 +1,5 @@
+.group-list-toolbar {
+  .pf-c-toolbar__content {
+    padding-left: 0px;
+  }
+}


### PR DESCRIPTION
Merged two issues into one branch, hope that's not a problem.

Issue: [AAH-775](https://issues.redhat.com/browse/AAH-775)
Note: Added `.container-list-toolbar` class to `execution-environment.scss` to align toolbar with top pagination.
before:
![container_before](https://user-images.githubusercontent.com/19647757/125640474-8e28c727-9fa0-4007-b423-de1faf8cafda.png)

after:
![container_after](https://user-images.githubusercontent.com/19647757/125640440-047a0ca0-afcd-49b2-8ccc-0ce838100ce4.png)


Issue: [AAH-776](https://issues.redhat.com/browse/AAH-776)
Note: Same fix as the previous issue, added `group-management.scss` file and renamed className to `group-list-toolbar`.
before:
![group_before](https://user-images.githubusercontent.com/19647757/125640659-88c2edd6-83ca-4ad7-a514-a041f25ae181.png)

after:
![groups_after](https://user-images.githubusercontent.com/19647757/125640667-f561a7d0-1d8d-4007-8a3c-861c59963d00.png)


