### PR TITLE
Update to python 3.8 in Cypress workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -48,18 +48,18 @@ jobs:
         echo '# Containerfile'
         echo '\
           FROM docker.io/pulp/pulp-ci-centos:latest
-          
+
           RUN pip3 install --upgrade \
             "click<8.0" \
             requests \
             git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
-          
+
           RUN mkdir -p /etc/nginx/pulp/
-          RUN ln /usr/local/lib/python3.6/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-          RUN ln /usr/local/lib/python3.6/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-          RUN ln /usr/local/lib/python3.6/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
+          RUN ln /usr/local/lib/python3.8/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+          RUN ln /usr/local/lib/python3.8/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+          RUN ln /usr/local/lib/python3.8/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
         ' | tee Containerfile
-        
+
         buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .
         podman save localhost/pulp/pulp-galaxy-ng:latest -o image
 


### PR DESCRIPTION
Cypress workflow got broken by https://github.com/ansible/galaxy_ng/pull/836

TODO: find a way to prevent it, if possible.

