### PR TITLE
MyImports: `poll()` one more time if `selectedImport.state` is `running`, despite `selectedImportDetail.state` having `failed`

### DIFF
--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -75,10 +75,13 @@ class MyImports extends React.Component<RouteComponentProps, IState> {
     );
 
     this.polling = setInterval(() => {
+      const { selectedImport, selectedImportDetails } = this.state;
+      const allowedStates = [PulpStatus.running, PulpStatus.waiting];
+
+      // selectedImportDetails can be failed while selectedImport is still running, poll() updates selectedImport
       if (
-        this.state.selectedImportDetails &&
-        (this.state.selectedImportDetails.state === PulpStatus.running ||
-          this.state.selectedImportDetails.state === PulpStatus.waiting)
+        allowedStates.includes(selectedImportDetails?.state) ||
+        allowedStates.includes(selectedImport?.state)
       ) {
         this.poll();
       }


### PR DESCRIPTION
Fixes [AAH-204](https://issues.redhat.com/browse/AAH-204)

On the `/ui/my-imports` screen, right after attempting to upload a collection...

on start, we run `loadNamespaces => loadImportList => loadTaskDetails`

a task can fail between the `loadImportList` call and the `loadTaskDetails` call

when that happens,
`selectedImport` (set in `loadImportList`) can still read `state: "running"` while
`selectedImportDetails` (set in `loadTaskDetails`) already gets `state: "failed"`, without ever calling `poll()`

when *that* happens, the UI gets stuck showing running status (read from `selectedImport`) without ever running `poll()` again (based on `selectedImportDetails`)

updating to run `poll()` if *at least one of* `selectedImport`, `selectedImportDetails` is still in a pollable state,
which should in practice cause `poll()` to get called once more, and update `selectedImport` with the new state

---

Testing: that situation almost always happens when trying to import a collection with invalid MANIFEST, such as 
[alikins-collection_inspect_nameless-0.0.49.tar.gz](https://github.com/ansible/ansible-hub-ui/files/6844192/alikins-collection_inspect_nameless-0.0.49.tar.gz) (I started with a random collection, untarred, edited MANIFEST to remove name, re-tarred.)

Cc @ZitaNemeckova 