### PR TITLE
Fix left nav even listener.

### DIFF
--- a/src/entry-dev.js
+++ b/src/entry-dev.js
@@ -9,10 +9,12 @@ import getBaseName from './utilities/getBaseName';
 
 // Entrypoint for compiling the app to run in insights dev mode.
 
+const basename = getBaseName(window.location.pathname)
+
 ReactDOM.render(
   <Provider store={init(logger).getStore()}>
-    <Router basename={getBaseName(window.location.pathname)}>
-      <App />
+    <Router basename={basename}>
+      <App basename={basename} />
     </Router>
   </Provider>,
 

--- a/src/entry.js
+++ b/src/entry.js
@@ -8,10 +8,12 @@ import getBaseName from './utilities/getBaseName';
 
 // Entrypoint for compiling the app to run in insights production mode.
 
+const basename = getBaseName(window.location.pathname)
+
 ReactDOM.render(
   <Provider store={init().getStore()}>
-    <Router basename={getBaseName(window.location.pathname)}>
-      <App />
+    <Router basename={basename}>
+      <App basename={basename} />
     </Router>
   </Provider>,
 


### PR DESCRIPTION
The left navigation listener was using a deprecated attribute to navigate within the application. Now the event attribute is sending the exact link `href` to remove any ambiguity.

This change can work with both the old and the current navigation events. On Monday (July 26th) we will stop supporting the old `APP_NAVIGATION` event shape. After that this condition
```js
const to = event.domEvent.href ? event.domEvent.href.replace(this.props.basename, '') : event.navId
```
can be reduced to
```js
const to = event.domEvent.href.replace(this.props.basename, '')
```