### PR TITLE
cypress: remove click<8 dependency, we're fine with 8+ now

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -50,7 +50,6 @@ jobs:
           FROM docker.io/pulp/pulp-ci-centos:latest
 
           RUN pip3 install --upgrade \
-            "click<8.0" \
             requests \
             git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
 


### PR DESCRIPTION
to match https://github.com/ansible/galaxy_ng/pull/844/

(This will be relevant for 4.3 if we ever switch to python3.8, so just mentiononing #639, #642 for linkage.)