### PR TITLE
[stable-4.3] Use a python36 version of pulp-ci-centos

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -47,7 +47,7 @@ jobs:
       run: |
         echo '# Containerfile'
         echo '\
-          FROM docker.io/pulp/pulp-ci-centos:latest
+          FROM docker.io/pulp/pulp-ci-centos:python36
           
           RUN pip3 install --upgrade \
             "click<8.0" \


### PR DESCRIPTION
`pulp-ci-centos:latest` is python 3.8,
but `stable-4.3` only supports python 3.6.

@fao89 released a `python36` tag for us to base 4.3 tests on, thanks! :)

---

(Last working 4.3 build from latest was https://github.com/ansible/ansible-hub-ui/runs/3052279337?check_suite_focus=true#step:6:39 ,
currently 4.3 is failing on https://github.com/ansible/ansible-hub-ui/runs/3123350899?check_suite_focus=true#step:6:323 ,
and backporting https://github.com/ansible/ansible-hub-ui/pull/639 would only work if galaxy_ng stable-4.3 supported python 3.8, which @newswangerd mentions it doesn't.)