### PR TITLE
Add npm run start-pulp command to run with vagrant backend.

### DIFF
--- a/config/standalone.dev.webpack.config.js
+++ b/config/standalone.dev.webpack.config.js
@@ -3,13 +3,14 @@ const webpackBase = require('./webpack.base.config');
 // Used for getting the correct host when running in a container
 const proxyHost = process.env.API_PROXY_HOST || 'localhost';
 const proxyPort = process.env.API_PROXY_PORT || '5001';
+const apiBasePath = process.env.API_BASE_PATH || '/api/automation-hub/';
 
 module.exports = webpackBase({
   // The host where the API lives. EX: https://localhost:5001
   API_HOST: '',
 
   // Path to the API on the API host. EX: /api/automation-hub
-  API_BASE_PATH: '/api/automation-hub/',
+  API_BASE_PATH: apiBasePath,
 
   // Path on the host where the UI is found. EX: /apps/automation-hub
   UI_BASE_PATH: '/ui/',
@@ -36,7 +37,7 @@ module.exports = webpackBase({
   // https://webpack.js.org/configuration/dev-server/#devserverproxy
   // used to get around CORS requirements when running in dev mode
   WEBPACK_PROXY: {
-    '/api/automation-hub/': `http://${proxyHost}:${proxyPort}`,
+    '/api/': `http://${proxyHost}:${proxyPort}`,
     '/pulp/api/': `http://${proxyHost}:${proxyPort}`,
   },
 });

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
         "server:ctr": "node src/server/generateServerKey.js",
         "start": "NODE_ENV=development webpack serve --host 0.0.0.0 --config config/insights.dev.webpack.config.js",
         "start-standalone": "NODE_ENV=development webpack serve --host 0.0.0.0 --config config/standalone.dev.webpack.config.js",
+        "start-pulp": "NODE_ENV=development API_PROXY_PORT=8080 API_BASE_PATH='/api/galaxy/' webpack serve --host 0.0.0.0 --config config/standalone.dev.webpack.config.js",
         "build:prod": "NODE_ENV=production webpack --config config/insights.prod.webpack.config.js",
         "deploy": "npm-run-all build:prod test-prettier",
         "verify": "npm-run-all build lint",


### PR DESCRIPTION
This starts webpack and with `/api/galaxy` as the api base path and sets it to proxy to port 8080 on localhost.