### PR TITLE
[master-stable] Collection-info: replace Download tarball button with a warning banner when on cloud.redhat.com

### DIFF
--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -5,6 +5,7 @@ import * as moment from 'moment';
 import { Link } from 'react-router-dom';
 
 import {
+  Banner,
   ClipboardCopy,
   Split,
   SplitItem,
@@ -55,6 +56,8 @@ export class CollectionInfo extends React.Component<IProps> {
       installCommand += `:${params.version}`;
     }
 
+    const cloudWarning = document.location.hostname.match('cloud.redhat.com');
+
     return (
       <div className='pf-c-content info-panel'>
         <h1>Info</h1>
@@ -81,24 +84,35 @@ export class CollectionInfo extends React.Component<IProps> {
                   <b>Note:</b> Installing collections with ansible-galaxy is
                   only supported in ansible 2.9+
                 </div>
-                <div>
-                  <a ref={this.downloadLinkRef} style={{ display: 'none' }}></a>
-                  <Button
-                    className='download-button'
-                    variant='link'
-                    icon={<DownloadIcon />}
-                    onClick={() =>
-                      this.download(
-                        this.context.selectedRepo,
-                        namespace,
-                        name,
-                        latest_version,
-                      )
-                    }
-                  >
-                    Download tarball
-                  </Button>
-                </div>
+                {cloudWarning ? (
+                  <Banner variant='warning'>
+                    Please log in to{' '}
+                    <a href='https://console.redhat.com/'>console.redhat.com</a>{' '}
+                    for downloads to work.
+                  </Banner>
+                ) : (
+                  <div>
+                    <a
+                      ref={this.downloadLinkRef}
+                      style={{ display: 'none' }}
+                    ></a>
+                    <Button
+                      className='download-button'
+                      variant='link'
+                      icon={<DownloadIcon />}
+                      onClick={() =>
+                        this.download(
+                          this.context.selectedRepo,
+                          namespace,
+                          name,
+                          latest_version,
+                        )
+                      }
+                    >
+                      Download tarball
+                    </Button>
+                  </div>
+                )}
               </SplitItem>
             </Split>
           </GridItem>


### PR DESCRIPTION
The API is already redirecting to console.redhat.com, so when using the UI on cloud, the download links lead to console, which fails authentication.

Hiding the download button when the domain matches cloud.redhat.com

Before:
![before](https://user-images.githubusercontent.com/289743/127033529-6810732f-febe-4af6-8ed0-ef66a8a439c4.png)

After (only on cloud.redhat.com, not locally, not console.redhat.com):
![after](https://user-images.githubusercontent.com/289743/127033537-0adc3e4a-de50-453e-9207-c23ec08a4a78.png)
