### PR TITLE
insights-loader: fix  Cannot read property 'href' of undefined

### DIFF
--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -31,7 +31,7 @@ class App extends Component {
     // when items in the nav are clicked or the app is loaded for the first
     // time
     this.appNav = insights.chrome.on('APP_NAVIGATION', event => {
-      const to = event.domEvent.href
+      const to = event.domEvent?.href
         ? event.domEvent.href.replace(this.props.basename, '')
         : event.navId;
       // We want to be able to navigate between routes when users click


### PR DESCRIPTION
Follow-up to #669 

The original version caused a load error on cloud/console.redhat.com:

```
TypeError: Cannot read property 'href' of undefined
    at insights-loader.js:34
    at Object.callback (chrome-root.268a63b….js:2)
    at e.value (chrome-root.268a63b….js:2)
    at chrome-root.268a63b….js:2
    at chrome-root.268a63b….js:2
    at 287.45490f2….js:1
    at Di (935.4a8aa8f….js:2)
    at n.unstable_runWithPriority (935.4a8aa8f….js:2)
    at Wl (935.4a8aa8f….js:2)
    at Oi (935.4a8aa8f….js:2)
    at gi (935.4a8aa8f….js:2)
    at 935.4a8aa8f….js:2
    at n.unstable_runWithPriority (935.4a8aa8f….js:2)
    at Wl (935.4a8aa8f….js:2)
    at $l (935.4a8aa8f….js:2)
    at Hl (935.4a8aa8f….js:2)
    at yi (935.4a8aa8f….js:2)
    at rs (935.4a8aa8f….js:2)
    at Object.n.render (935.4a8aa8f….js:2)
    at h (287.45490f2….js:1)
    at Module.63749 (287.45490f2….js:1)
    at Function.__webpack_require__ (chrome-root.268a63b….js:2)
```

(`domEvent` was `null`)

Cc @ZitaNemeckova @Hyperkid123 

---

cherry picked from commit 4b1e0129f1cbf830ef660e6609a6955e0eee4603
This is already merged in master-stable, prod-stable and prod-beta.

Just making sure master is up to date as well :)
