### PR TITLE
Fix nav listener basename replacement.

### DIFF
--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -31,18 +31,23 @@ class App extends Component {
     // when items in the nav are clicked or the app is loaded for the first
     // time
     this.appNav = insights.chrome.on('APP_NAVIGATION', event => {
-      const to = event.domEvent?.href
-        ? event.domEvent.href.replace(this.props.basename, '')
-        : event.navId;
-      // We want to be able to navigate between routes when users click
-      // on the nav, so rewriting the entire route is acceptable, however,
-      // we also need to avoid rewriting the route when the page is
-      // loaded for the first time, so ignore this the first time it's
-      // called.
-      if (!this.firstLoad) {
-        this.props.history.push(to === '' ? '/' : to);
-      } else {
-        this.firstLoad = false;
+      if (typeof event?.domEvent === 'object') {
+        const to = event.domEvent.href
+          ? event.domEvent.href.replace(
+              this.props.basename.replace(/^\/beta\//, '/'),
+              '',
+            )
+          : event.navId;
+        // We want to be able to navigate between routes when users click
+        // on the nav, so rewriting the entire route is acceptable, however,
+        // we also need to avoid rewriting the route when the page is
+        // loaded for the first time, so ignore this the first time it's
+        // called.
+        if (!this.firstLoad) {
+          this.props.history.push(to === '' ? '/' : to);
+        } else {
+          this.firstLoad = false;
+        }
       }
     });
 
@@ -125,6 +130,7 @@ class App extends Component {
 
 App.propTypes = {
   history: PropTypes.object,
+  basename: PropTypes.string.isRequired,
 };
 
 /**


### PR DESCRIPTION
Application in beta env has additional `/beta/` prefix in the router
basename. However the navigation event href attribute does not include
that prefix. Therefore the replacement fails and an incorrect pathname is
pushed to the router history. Which leads to permanent 404s.

Also, the `domEvent` is sometimes `undefined`. We don't want to perform any action when that is the case.