### PR TITLE
by default sort tasks by date created

### DIFF
--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -55,7 +55,7 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
     }
 
     if (!params['sort']) {
-      params['sort'] = 'name';
+      params['sort'] = 'created_by';
     }
 
     this.state = {
@@ -74,10 +74,6 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
     const { params, itemCount, loading, items } = this.state;
     const noData =
       items.length === 0 && !filterIsSet(params, ['name__contains', 'state']);
-
-    if (!params['sort']) {
-      params['sort'] = 'name';
-    }
 
     return (
       <React.Fragment>


### PR DESCRIPTION
See issue: https://issues.redhat.com/browse/AAH-806

This pr sorts tasks by the date created by default, instead of by task name. 

Before:
![Screen Shot 2021-07-28 at 2 02 55 PM](https://user-images.githubusercontent.com/64337863/127373315-a3d34ddd-74aa-466e-aeb5-b197ebde4da3.png)
After:
![Screen Shot 2021-07-28 at 2 02 38 PM](https://user-images.githubusercontent.com/64337863/127373326-2df8eaf0-1e64-4373-9d88-1846a51404f8.png)

