### PR TITLE
[stable-4.3] [l10n] Add minimal support for `` _`Localized strings` ``

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,3 +16,6 @@ declare var UI_BASE_PATH;
 declare var DEPLOYMENT_MODE;
 declare var NAMESPACE_TERM;
 declare var APPLICATION_NAME;
+
+// HACK: ensure l10n marked strings can be backported without breaking
+declare var _;

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -58,6 +58,9 @@ export enum Paths {
   repositories = '/repositories',
 }
 
+// HACK: ensure l10n marked strings can be backported without breaking
+window._ = String.raw;
+
 export const namespaceBreadcrumb = {
   name: {
     namespaces: 'Namespaces',


### PR DESCRIPTION
master is now (in the process of being) localized, many strings changed from `'Foo'` to `` _`Foo` ``, backporting any such changes to 4.3 or 4.2 would break on unknown function `_`.

This backports the bare minimum of #677, adding a global template `_` function, but replacing the custom template with the equivalent of plain template strings.

This allows backporting marked strings, without enabling l10n support.