### PR TITLE
ExecutionEnvironmentList - remove double sort default

### DIFF
--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -91,10 +91,6 @@ class ExecutionEnvironmentList extends React.Component<
       </Button>
     );
 
-    if (!params['sort']) {
-      params['sort'] = 'name';
-    }
-
     return (
       <React.Fragment>
         <AlertList


### PR DESCRIPTION
`constructor` already sets the default value, removing from `render` :)

(noticed during review of https://github.com/ansible/ansible-hub-ui/pull/712, which removes it from `TaskListView`)

introduced in #627 (`TaskListView`) and #290 (`ExecutionEnvironmentList`), adding `backport-4.3` for execution environments.