### PR TITLE
remove 'Galaxy NG: ' from human readable constants

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -186,14 +186,14 @@ export class Constants {
   ];
 
   static TASK_NAMES = {
-    'galaxy_ng.app.tasks.promotion._remove_content_from_repository': _`Galaxy NG: Remove content from repository`,
-    'galaxy_ng.app.tasks.publishing.import_and_auto_approve': _`Galaxy NG: Import and auto approve`,
-    'galaxy_ng.app.tasks.curate_synclist_repository': _`Galaxy NG: Curate synclist repository`,
-    'galaxy_ng.app.tasks': _`Galaxy NG: Tasks`,
-    'galaxy_ng.app.tasks.import_and_move_to_staging': _`Galaxy NG: Import and move to staging`,
-    'galaxy_ng.app.tasks.import_and_auto_approve': _`Galaxy NG: Import and auto approve`,
-    'galaxy_ng.app.tasks.curate_all_synclist_repository': _`Galaxy NG: Curate all synclist repository`,
-    'galaxy_ng.app.tasks.synclist.curate_synclist_repository_batch': _`Galaxy NG: Curate synclist repository batch`,
+    'galaxy_ng.app.tasks.promotion._remove_content_from_repository': _`Remove content from repository`,
+    'galaxy_ng.app.tasks.publishing.import_and_auto_approve': _`Import and auto approve`,
+    'galaxy_ng.app.tasks.curate_synclist_repository': _`Curate synclist repository`,
+    'galaxy_ng.app.tasks': _`Tasks`,
+    'galaxy_ng.app.tasks.import_and_move_to_staging': _`Import and move to staging`,
+    'galaxy_ng.app.tasks.import_and_auto_approve': _`Import and auto approve`,
+    'galaxy_ng.app.tasks.curate_all_synclist_repository': _`Curate all synclist repository`,
+    'galaxy_ng.app.tasks.synclist.curate_synclist_repository_batch': _`Curate synclist repository batch`,
     'pulp_ansible.app.tasks.collections.sync': _`Pulp Ansible: Collections sync`,
     'pulp_ansible.app.tasks.copy.copy_content': _`Pulp ansible: Copy content`,
     'pulp_ansible.app.tasks.collections.collection_sync': _`Pulp ansible: collection sync`,

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -189,7 +189,6 @@ export class Constants {
     'galaxy_ng.app.tasks.promotion._remove_content_from_repository': _`Remove content from repository`,
     'galaxy_ng.app.tasks.publishing.import_and_auto_approve': _`Import and auto approve`,
     'galaxy_ng.app.tasks.curate_synclist_repository': _`Curate synclist repository`,
-    'galaxy_ng.app.tasks': _`Tasks`,
     'galaxy_ng.app.tasks.import_and_move_to_staging': _`Import and move to staging`,
     'galaxy_ng.app.tasks.import_and_auto_approve': _`Import and auto approve`,
     'galaxy_ng.app.tasks.curate_all_synclist_repository': _`Curate all synclist repository`,


### PR DESCRIPTION
See issue: https://issues.redhat.com/browse/AAH-831

Remove 'Galaxy NG: ' from the human readable constants. 

Before: 
![Screen Shot 2021-08-02 at 2 11 18 PM](https://user-images.githubusercontent.com/64337863/127906026-5fb1132e-34c3-4328-a42c-427f54db4f5a.png)
After:
![Screen Shot 2021-08-02 at 2 16 51 PM](https://user-images.githubusercontent.com/64337863/127906035-06842897-ea3e-4c9e-a3da-45a0f78a29c3.png)
