### PR TITLE
Fix sorting problem in Users list view

### DIFF
--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -250,23 +250,24 @@ class UserList extends React.Component<RouteComponentProps, IState> {
         {
           title: _`Username`,
           type: 'alpha',
-          id: 'username__contains',
+          id: 'username',
         },
         {
           title: _`First name`,
           type: 'alpha',
-          id: 'first_name__contains',
+          id: 'first_name',
           className: 'pf-m-wrap',
         },
         {
           title: _`Last name`,
           type: 'alpha',
-          id: 'last_name__contains',
+          id: 'last_name',
+          className: 'pf-m-wrap',
         },
         {
           title: _`Email`,
           type: 'alpha',
-          id: 'email__contains',
+          id: 'email',
         },
         {
           id: 'groups',


### PR DESCRIPTION
Fixes:
 - default filter is set but not shown in UI
- clicking on sorting arrows will start never ending spin

Introduced by https://github.com/ansible/ansible-hub-ui/pull/670 -> no backporting needed

Before:
<img width="1370" alt="Screenshot 2021-08-03 at 12 08 42" src="https://user-images.githubusercontent.com/9210860/127998490-8360cd4c-90eb-4858-a1c1-f03264ea750d.png">
<img width="1368" alt="Screenshot 2021-08-03 at 12 08 55" src="https://user-images.githubusercontent.com/9210860/127998493-03ae9dfe-5e0d-4167-8ebe-5dfbcc4794a3.png">

After:
<img width="1362" alt="Screenshot 2021-08-03 at 12 07 59" src="https://user-images.githubusercontent.com/9210860/127998375-6bf5a133-d82b-44f2-b7f9-1856c042ecc1.png">
