### PR TITLE
Do not allow filter to search for empty string

### DIFF
--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -91,6 +91,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
         <Button
           onClick={() => this.submitFilter()}
           variant={ButtonVariant.control}
+          isDisabled={!this.state.inputText}
         >
           <SearchIcon></SearchIcon>
         </Button>


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-820

Before:
<img width="433" alt="Screenshot 2021-08-03 at 12 48 52" src="https://user-images.githubusercontent.com/9210860/128003453-01b31ba6-724b-434a-9387-d4251d4f103e.png">

After:
<img width="410" alt="Screenshot 2021-08-03 at 12 44 08" src="https://user-images.githubusercontent.com/9210860/128003349-21440110-c34c-4f13-a24a-74fc240f3ce8.png">



@sbuenafe-rh WDYT? Thanks :)