### PR TITLE
repo_management: fix prettier

### DIFF
--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -29,10 +29,7 @@ describe('Repo Management tests', () => {
     cy.contains('rejected');
     cy.contains('rh-certified');
     cy.contains('staging');
-    cy.get('button')
-      .contains('Remote')
-      .parent()
-      .click();
+    cy.get('button').contains('Remote').parent().click();
     cy.get('[aria-labelledby="headers"]').contains('Remote name');
     cy.get('[aria-labelledby="headers"]').contains('Repositories');
     cy.get('[aria-labelledby="headers"]').contains('Last updated');


### PR DESCRIPTION
Merged #680 but it was not rebased after #351, leading to a prettier issue breaking deploy (https://github.com/ansible/ansible-hub-ui/runs/3230888847?check_suite_focus=true#step:6:212). Fixing

Cc @MilanPospisil @ZitaNemeckova 