### PR TITLE
[WIP] Refactor logins  to cookieLogin of many tests

### DIFF
--- a/test/cypress/integration/docs_menu.js
+++ b/test/cypress/integration/docs_menu.js
@@ -4,7 +4,7 @@ describe('Token Management Tests', () => {
 
   beforeEach(() => {
     cy.visit('/');
-    cy.login(adminUsername, adminPassword);
+    cy.cookieLogin(adminUsername, adminPassword);
   });
 
   it('user can open docs dropdown menu', () => {

--- a/test/cypress/integration/namespace-edit.js
+++ b/test/cypress/integration/namespace-edit.js
@@ -46,7 +46,7 @@ describe('Edit a namespace', () => {
 
   beforeEach(() => {
     cy.visit(baseUrl);
-    cy.login(adminUsername, adminPassword);
+    cy.cookieLogin(adminUsername, adminPassword);
     cy.galaxykit('-i namespace create', 'testns1');
     cy.menuGo('Collections > Namespaces');
     cy.get('a[href*="ui/repo/published/testns1"]').click();

--- a/test/cypress/integration/namespace_form.js
+++ b/test/cypress/integration/namespace_form.js
@@ -1,5 +1,4 @@
 describe('A namespace form', () => {
-  let baseUrl = Cypress.config().baseUrl;
   let adminUsername = Cypress.env('username');
   let adminPassword = Cypress.env('password');
 
@@ -26,8 +25,8 @@ describe('A namespace form', () => {
   };
 
   beforeEach(() => {
-    cy.visit(baseUrl);
-    cy.login(adminUsername, adminPassword);
+    cy.visit('/');
+    cy.cookieLogin(adminUsername, adminPassword);
     createNamespace();
     cy.menuGo('Collections > Namespaces');
     getCreateNamespace().click();

--- a/test/cypress/integration/namespaces.js
+++ b/test/cypress/integration/namespaces.js
@@ -19,7 +19,7 @@ describe('Namespaces Page Tests', () => {
   });
 
   it('can navigate to pubic namespace list', () => {
-    cy.login('testUser2', 'p@ssword1');
+    cy.cookieLogin('testUser2', 'p@ssword1');
     cy.menuGo('Collections > Namespaces');
 
     cy.contains('testns2').should('exist');
@@ -27,7 +27,7 @@ describe('Namespaces Page Tests', () => {
   });
 
   it('can navigate to personal namespace list', () => {
-    cy.login('testUser2', 'p@ssword1');
+    cy.cookieLogin('testUser2', 'p@ssword1');
     cy.menuGo('Collections > Namespaces');
 
     cy.contains('My namespaces').click();

--- a/test/cypress/integration/profile.js
+++ b/test/cypress/integration/profile.js
@@ -1,11 +1,11 @@
 describe('My Profile Tests', () => {
-  var baseUrl = Cypress.config().baseUrl;
+  var baseUrl = '/';
   var adminUsername = Cypress.env('username');
   var adminPassword = Cypress.env('password');
 
   beforeEach(() => {
     cy.visit(baseUrl);
-    cy.login(adminUsername, adminPassword);
+    cy.cookieLogin(adminUsername, adminPassword);
     // open the dropdown labeled with the username and then...
     cy.get('[aria-label="user-dropdown"] button').click();
     // a little hacky, but basically

--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -5,7 +5,7 @@ describe('Repo Management tests', () => {
   let adminPassword = Cypress.env('password');
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.cookieLogin(adminUsername, adminPassword);
   });
 
   it('admin user sees download_concurrency in remote config', () => {

--- a/test/cypress/integration/token_management.js
+++ b/test/cypress/integration/token_management.js
@@ -9,7 +9,7 @@ describe('Token Management Tests', () => {
 
   beforeEach(() => {
     cy.visit('/');
-    cy.login(adminUsername, adminPassword);
+    cy.cookieLogin(adminUsername, adminPassword);
   });
 
   it('user can load token', () => {


### PR DESCRIPTION
Remaining tests up to date were refactored, so they now use cookieLogin for faster tests. Only one file was not refactored - group_management.js which failed every time. This will be work rather for new PR.

