### PR TITLE
More login tests and correction of cookieLogin command

### DIFF
--- a/test/cypress/integration/login.js
+++ b/test/cypress/integration/login.js
@@ -9,7 +9,7 @@ describe('Login helpers', () => {
     cy.galaxykit('user create', username, password);
   });
 
-  /*it('can login manually and logout as admin or different user', () => {
+  it('can login manually and logout as admin or different user', () => {
     cy.login(username, password);
     cy.contains(username);
     cy.logout();
@@ -70,22 +70,18 @@ describe('Login helpers', () => {
     });
     cy.cookieLogin(adminUsername, adminPassword);
     cy.contains(adminUsername);
-  });*/
+  });
 
   it('can login again to user that has been deleted and created again', () => {
     cy.deleteTestUsers();
-    cy.deleteTestGroups();
-    let groupName = 'testGroup';
-    let userName = 'testUser12345';
 
+    let userName = 'testUser12345';
     for (var i = 0; i <= 1; i++) {
-      cy.cookieLogin(adminUsername, adminPassword);
-      cy.createGroup(groupName);
-      cy.createUser(userName, userName);
-      cy.addUserToGroup(groupName, userName);
-      cy.cookieLogin(userName, userName);
+	  cy.galaxykit('user create', userName, userName);
+	  cy.cookieLogin(userName, userName);
+	  cy.visit('/');
+	  cy.contains(userName);
       cy.deleteTestUsers();
-      cy.deleteTestGroups();
     }
   });
 });

--- a/test/cypress/integration/login.js
+++ b/test/cypress/integration/login.js
@@ -77,10 +77,10 @@ describe('Login helpers', () => {
 
     let userName = 'testUser12345';
     for (var i = 0; i <= 1; i++) {
-	  cy.galaxykit('user create', userName, userName);
-	  cy.cookieLogin(userName, userName);
-	  cy.visit('/');
-	  cy.contains(userName);
+      cy.galaxykit('user create', userName, userName);
+      cy.cookieLogin(userName, userName);
+      cy.visit('/');
+      cy.contains(userName);
       cy.deleteTestUsers();
     }
   });

--- a/test/cypress/integration/login.js
+++ b/test/cypress/integration/login.js
@@ -9,7 +9,7 @@ describe('Login helpers', () => {
     cy.galaxykit('user create', username, password);
   });
 
-  it('can login manually and logout as admin or different user', () => {
+  /*it('can login manually and logout as admin or different user', () => {
     cy.login(username, password);
     cy.contains(username);
     cy.logout();
@@ -70,5 +70,22 @@ describe('Login helpers', () => {
     });
     cy.cookieLogin(adminUsername, adminPassword);
     cy.contains(adminUsername);
+  });*/
+
+  it('can login again to user that has been deleted and created again', () => {
+    cy.deleteTestUsers();
+    cy.deleteTestGroups();
+    let groupName = 'testGroup';
+    let userName = 'testUser12345';
+
+    for (var i = 0; i <= 1; i++) {
+      cy.cookieLogin(adminUsername, adminPassword);
+      cy.createGroup(groupName);
+      cy.createUser(userName, userName);
+      cy.addUserToGroup(groupName, userName);
+      cy.cookieLogin(userName, userName);
+      cy.deleteTestUsers();
+      cy.deleteTestGroups();
+    }
   });
 });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -95,15 +95,22 @@ Cypress.Commands.add('cookieLogin', {}, (username, password) => {
     cy.setCookie('csrftoken', csrftoken);
     cy.setCookie('sessionid', sessionid);
     cy.visit('/');
-    cy.request({
-      url: '/api/automation-hub/_ui/v1/me/',
-      failOnStatusCode: false,
-    }).then((response) => {
-      if (response.statusText != 'OK') {
-        delete user_tokens[username];
-        cookieManualLogin(username, password);
-      }
-    });
+    
+	// we must test if the user is really still available, because
+	// normal users (different than admin) can be deleted during test, so we must
+	// relogin manualy
+	if (username != 'admin')
+	{
+		cy.request({
+		url: '/api/automation-hub/_ui/v1/me/',
+		failOnStatusCode: false,
+		}).then((response) => {
+		if (response.statusText != 'OK') {
+			delete user_tokens[username];
+			cookieManualLogin(username, password);
+		}
+		});
+	}
   }
 });
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -67,43 +67,43 @@ Cypress.Commands.add('getUserTokens', {}, (func) => {
   func(user_tokens);
 });
 
-function cookieManualLogin(username, password)
-{
-    cy.login(username, password);
-    cy.getCookies().then((cookies) => {
-      let sessionid;
-      let csrftoken;
+function cookieManualLogin(username, password) {
+  cy.login(username, password);
+  cy.getCookies().then((cookies) => {
+    let sessionid;
+    let csrftoken;
 
-      cookies.forEach((cookie) => {
-        if (cookie.name == 'sessionid') {
-          sessionid = cookie.value;
-        }
-        if (cookie.name == 'csrftoken') {
-          csrftoken = cookie.value;
-        }
-      });
+    cookies.forEach((cookie) => {
+      if (cookie.name == 'sessionid') {
+        sessionid = cookie.value;
+      }
+      if (cookie.name == 'csrftoken') {
+        csrftoken = cookie.value;
+      }
+    });
 
-      user_tokens[username] = { sessionid, csrftoken };
-	});
+    user_tokens[username] = { sessionid, csrftoken };
+  });
 }
 
 Cypress.Commands.add('cookieLogin', {}, (username, password) => {
   if (!user_tokens[username]) {
-	cookieManualLogin(username, password);
-  }
-  else {
-	let csrftoken = user_tokens[username].csrftoken;
-	let sessionid = user_tokens[username].sessionid;
-	cy.setCookie('csrftoken', csrftoken);
-	cy.setCookie('sessionid', sessionid);
-	cy.visit('/');
-	cy.request({url: '/api/automation-hub/_ui/v1/me/', failOnStatusCode: false}).then((response) => {
-		if (response.statusText != 'OK')
-		{
-			delete user_tokens[username];
-			cookieManualLogin(username, password);	
-		}
-	});
+    cookieManualLogin(username, password);
+  } else {
+    let csrftoken = user_tokens[username].csrftoken;
+    let sessionid = user_tokens[username].sessionid;
+    cy.setCookie('csrftoken', csrftoken);
+    cy.setCookie('sessionid', sessionid);
+    cy.visit('/');
+    cy.request({
+      url: '/api/automation-hub/_ui/v1/me/',
+      failOnStatusCode: false,
+    }).then((response) => {
+      if (response.statusText != 'OK') {
+        delete user_tokens[username];
+        cookieManualLogin(username, password);
+      }
+    });
   }
 });
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -95,22 +95,21 @@ Cypress.Commands.add('cookieLogin', {}, (username, password) => {
     cy.setCookie('csrftoken', csrftoken);
     cy.setCookie('sessionid', sessionid);
     cy.visit('/');
-    
-	// we must test if the user is really still available, because
-	// normal users (different than admin) can be deleted during test, so we must
-	// relogin manualy
-	if (username != 'admin')
-	{
-		cy.request({
-		url: '/api/automation-hub/_ui/v1/me/',
-		failOnStatusCode: false,
-		}).then((response) => {
-		if (response.statusText != 'OK') {
-			delete user_tokens[username];
-			cookieManualLogin(username, password);
-		}
-		});
-	}
+
+    // we must test if the user is really still available, because
+    // normal users (different than admin) can be deleted during test, so we must
+    // relogin manualy
+    if (username != 'admin') {
+      cy.request({
+        url: '/api/automation-hub/_ui/v1/me/',
+        failOnStatusCode: false,
+      }).then((response) => {
+        if (response.statusText != 'OK') {
+          delete user_tokens[username];
+          cookieManualLogin(username, password);
+        }
+      });
+    }
   }
 });
 


### PR DESCRIPTION
Bug found in cookieLogin. When user is deleted and created again, cookieLogin still has its cookies in local storage and tries to login using cookies that are not valid now. New functionality adds request to the server that returns ok if user is looged and error if its not. If error is received, local storage for that user is deleted and manual login using UI is done. Then, local storage is updated to new cookies.