### PR TITLE
Rename Name to Task name to be same as filter

### DIFF
--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -154,7 +154,10 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
                     }
                     params={params}
                     ignoredParams={['page_size', 'page', 'sort', 'ordering']}
-                    niceNames={{ name__contains: _`Name`, state: _`Status` }}
+                    niceNames={{
+                      name__contains: _`Task name`,
+                      state: _`Status`,
+                    }}
                   />
                 </div>
                 {this.renderTable(params)}


### PR DESCRIPTION
Solves https://github.com/ansible/ansible-hub-ui/pull/744#issuecomment-893473513

>@ZitaNemeckova I think the chip category would just need to reflect the same attribute name (Task name) and then everything else looks good!

Before:
<img width="1364" alt="Screenshot 2021-08-05 at 16 33 13" src="https://user-images.githubusercontent.com/9210860/128368073-32833844-3744-48a3-a34d-4c6654cbf8a4.png">

After:
<img width="471" alt="Screenshot 2021-08-05 at 16 16 14" src="https://user-images.githubusercontent.com/9210860/128367998-6b7595de-661f-423f-8b96-216548323f08.png">
