### PR TITLE
[stable-4.3] Test group permissions - backport non-test changes, fix group-list loading, unauthorized typo (#681)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ test/cypress/screenshots/*
 test/cypress/videos/*
 test/cypress.env.json
 test/results
+test/cypress/fixtures/example.json

--- a/src/components/empty-state/empty-state-unauthorized.tsx
+++ b/src/components/empty-state/empty-state-unauthorized.tsx
@@ -9,10 +9,8 @@ export class EmptyStateUnauthorized extends React.Component<IProps> {
     return (
       <EmptyStateCustom
         icon={LockIcon}
-        title={'You do not have have access to Automation Hub'}
-        description={
-          'Contact you organization administrator for more information.'
-        }
+        title={_`You do not have access to Automation Hub`}
+        description={_`Contact you organization administrator for more information.`}
       />
     );
   }

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -129,6 +129,8 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
         <BaseHeader title='Groups'></BaseHeader>
         {unauthorized ? (
           <EmptyStateUnauthorized />
+        ) : loading ? (
+          <LoadingPageSpinner />
         ) : noData ? (
           <EmptyStateNoData
             title={'No groups yet'}


### PR DESCRIPTION
Backporting #681 manually, without the added test.
Thus, this:

* adds `example.json` to gitignore
* fixes a typo in `EmptyStateUnauthorized`
* fixes the loading state in `group-list`

(there was a conflict in `EmptyStateUnauthorized` because 4.3 doesn't have any l10n changes)

(cherry picked from commit 23e9d36d33bf74b71bbfb9b1a298733a282e87f3)

---

The test themselves turned out to partially fail, see #751.
We should probably wait for tests to settle and then backport all the test changes in bulk.