### PR TITLE
Fix cypress failures on master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
       interval: 'weekly'
 
   - package-ecosystem: 'npm'
+    directory: '/test'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'npm'
     directory: '/'
     target-branch: 'stable-4.3'
     schedule:

--- a/test/cypress/integration/group_management.js
+++ b/test/cypress/integration/group_management.js
@@ -5,13 +5,16 @@ describe('Hub Group Management Tests', () => {
   beforeEach(() => {
     cy.deleteTestGroups();
     cy.deleteTestUsers();
+
+    cy.login(adminUsername, adminPassword);
   });
 
   it('admin user can create/delete a group', () => {
     let name = 'testGroup';
-    cy.login(adminUsername, adminPassword);
+
     cy.createGroup(name);
     cy.contains(name).should('exist');
+
     cy.deleteGroup(name);
     cy.contains(name).should('not.exist');
   });
@@ -19,10 +22,11 @@ describe('Hub Group Management Tests', () => {
   it('admin user can add/remove a user to/from a group', () => {
     let groupName = 'testGroup';
     let userName = 'testUser';
-    cy.login(adminUsername, adminPassword);
+
     cy.createGroup(groupName);
     cy.createUser(userName);
     cy.addUserToGroup(groupName, userName);
+
     cy.removeUserFromGroup(groupName, userName);
     cy.deleteGroup(groupName);
     cy.deleteUser(userName);
@@ -37,7 +41,7 @@ describe('Hub Group Management Tests', () => {
       'groups',
       'remotes',
     ];
-    cy.login(adminUsername, adminPassword);
+
     cy.createGroup(name);
     cy.contains(name).should('exist');
 

--- a/test/cypress/integration/group_management.js
+++ b/test/cypress/integration/group_management.js
@@ -1,12 +1,10 @@
 describe('Hub Group Management Tests', () => {
-  var baseUrl = Cypress.config().baseUrl;
   var adminUsername = Cypress.env('username');
   var adminPassword = Cypress.env('password');
 
   beforeEach(() => {
     cy.deleteTestGroups();
     cy.deleteTestUsers();
-    cy.visit(baseUrl);
   });
 
   it('admin user can create/delete a group', () => {

--- a/test/cypress/integration/group_management.js
+++ b/test/cypress/integration/group_management.js
@@ -43,7 +43,6 @@ describe('Hub Group Management Tests', () => {
     ];
 
     cy.createGroup(name);
-    cy.contains(name).should('exist');
 
     cy.addAllPermissions(name);
     permissionTypes.forEach((permGroup) => {
@@ -60,6 +59,5 @@ describe('Hub Group Management Tests', () => {
     });
 
     cy.deleteGroup(name);
-    cy.contains(name).should('not.exist');
   });
 });

--- a/test/cypress/integration/group_permissions.js
+++ b/test/cypress/integration/group_permissions.js
@@ -1,7 +1,6 @@
 describe('Group Permissions Tests', () => {
   let adminUsername = Cypress.env('username');
   let adminPassword = Cypress.env('password');
-  let groupsUrl = '/ui/group-list';
 
   function addTestUser(user, group) {
     cy.galaxykit('user create', user, user + 'Password');
@@ -50,21 +49,18 @@ describe('Group Permissions Tests', () => {
 
   it("it can't view groups", () => {
     // test user without any group at all
-    let user = 'user1';
-    cy.login(user, user + 'Password');
-    cy.visit(groupsUrl);
+    cy.login('user1', 'user1Password');
+    cy.visit('/ui/groups');
     groupsNotVisible();
 
     // test user in group with no privilleges
-    user = 'user2';
-    cy.login(user, user + 'Password');
-    cy.visit(groupsUrl);
+    cy.login('user2', 'user2Password');
+    cy.visit('/ui/groups');
     groupsNotVisible();
   });
 
   it('can view groups, can not change groups, can not add groups, can not delete groups', () => {
-    let user = 'user3';
-    cy.login(user, user + 'Password');
+    cy.login('user3', 'user3Password');
     cy.menuGo('User Access > Groups');
 
     cy.contains('Groups');
@@ -74,14 +70,13 @@ describe('Group Permissions Tests', () => {
   });
 
   it('can add group', () => {
-    let user = 'user4';
-    cy.login(user, user + 'Password');
+    cy.login('user4', 'user4Password');
+
     cy.createGroup('NewGroup');
   });
 
   it('can delete group', () => {
-    let user = 'user4';
-    cy.login(user, user + 'Password');
+    cy.login('user4', 'user4Password');
     cy.menuGo('User Access > Groups');
 
     cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/groups/**').as(
@@ -95,8 +90,8 @@ describe('Group Permissions Tests', () => {
   });
 
   it('can change group', () => {
-    let user = 'user4';
-    cy.login(user, user + 'Password');
+    cy.login('user4', 'user4Password');
+
     cy.removePermissions('group4', [
       { group: 'groups', permissions: ['Change group'] },
     ]);

--- a/test/cypress/integration/group_permissions.js
+++ b/test/cypress/integration/group_permissions.js
@@ -66,12 +66,10 @@ describe('Group Permissions Tests', () => {
     let user = 'user3';
     cy.login(user, user + 'Password');
     cy.menuGo('User Access > Groups');
+
     cy.contains('Groups');
-    cy.menuGo('User Access > Groups');
     cy.contains('button', 'Edit').should('not.exist');
-    cy.menuGo('User Access > Groups');
     cy.contains('button', 'View').should('not.exist');
-    cy.menuGo('User Access > Groups');
     cy.contains('button', 'Delete').should('not.exist');
   });
 
@@ -85,6 +83,7 @@ describe('Group Permissions Tests', () => {
     let user = 'user4';
     cy.login(user, user + 'Password');
     cy.menuGo('User Access > Groups');
+
     cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/groups/**').as(
       'deleteGroup',
     );

--- a/test/cypress/integration/group_permissions.js
+++ b/test/cypress/integration/group_permissions.js
@@ -5,14 +5,16 @@ describe('Group Permissions Tests', () => {
 
   function addTestUser(user, group) {
     cy.galaxykit('user create', user, user + 'Password');
-    if (group != null) {
+    if (group) {
       cy.galaxykit('user group add', user, group);
     }
   }
 
   function addTestGroup(group, permissions) {
     cy.galaxykit('-i group create', group);
-    cy.addPermissions(group, [{ group: 'groups', permissions: permissions }]);
+    if (permissions) {
+      cy.addPermissions(group, [{ group: 'groups', permissions }]);
+    }
   }
 
   function groupsNotVisible() {
@@ -24,8 +26,10 @@ describe('Group Permissions Tests', () => {
   before(() => {
     cy.deleteTestUsers();
     cy.deleteTestGroups();
+
     cy.cookieLogin(adminUsername, adminPassword);
-    addTestGroup('group2', []);
+
+    addTestGroup('group2');
     addTestGroup('group3', ['View group']);
     addTestGroup('group4', [
       'View group',
@@ -36,7 +40,9 @@ describe('Group Permissions Tests', () => {
     cy.addPermissions('group4', [
       { group: 'users', permissions: ['View user'] },
     ]);
-    addTestUser('user1', null);
+    addTestGroup('DeleteGroup');
+
+    addTestUser('user1');
     addTestUser('user2', 'group2');
     addTestUser('user3', 'group3');
     addTestUser('user4', 'group4');
@@ -82,7 +88,7 @@ describe('Group Permissions Tests', () => {
     cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/groups/**').as(
       'deleteGroup',
     );
-    cy.get(`[aria-labelledby=${'NewGroup'}] [aria-label=Delete]`).click();
+    cy.contains('tr', 'DeleteGroup').find('[aria-label=Delete]').click();
     cy.contains('[role=dialog] button', 'Delete').click();
     cy.wait('@deleteGroup').then(({ request, response }) => {
       expect(response.statusCode).to.eq(204);

--- a/test/cypress/integration/group_permissions.js
+++ b/test/cypress/integration/group_permissions.js
@@ -25,6 +25,7 @@ describe('Group Permissions Tests', () => {
   before(() => {
     cy.deleteTestUsers();
     cy.deleteTestGroups();
+    cy.cookieReset();
 
     cy.cookieLogin(adminUsername, adminPassword);
 

--- a/test/cypress/integration/login.js
+++ b/test/cypress/integration/login.js
@@ -6,6 +6,8 @@ describe('Login helpers', () => {
 
   before(() => {
     cy.deleteTestUsers();
+    cy.cookieReset();
+
     cy.galaxykit('user create', username, password);
   });
 
@@ -41,33 +43,6 @@ describe('Login helpers', () => {
     cy.cookieLogin(username, password);
     cy.contains(username);
 
-    cy.cookieLogin(adminUsername, adminPassword);
-    cy.contains(adminUsername);
-  });
-
-  it('can cookieLogin with logout as admin or different user - this will force to login manualy every time', () => {
-    cy.cookieLogin(username, password);
-    cy.contains(username);
-    cy.cookieLogout();
-    cy.getCookies().then((cookies) => {
-      let sessionid = null;
-      let csrftoken = null;
-
-      cookies.forEach((cookie) => {
-        if (cookie.name == 'sessionid') {
-          sessionid = cookie.value;
-        }
-        if (cookie.name == 'csrftoken') {
-          csrftoken = cookie.value;
-        }
-      });
-
-      cy.expect(sessionid).to.be.null;
-      cy.expect(csrftoken).to.be.null;
-    });
-    cy.getUserTokens((user_tokens) => {
-      cy.expect(user_tokens).to.eql({});
-    });
     cy.cookieLogin(adminUsername, adminPassword);
     cy.contains(adminUsername);
   });

--- a/test/cypress/integration/menu.js
+++ b/test/cypress/integration/menu.js
@@ -1,5 +1,4 @@
 describe('Hub Menu Tests', () => {
-  let baseUrl = Cypress.config().baseUrl;
   let adminUsername = Cypress.env('username');
   let adminPassword = Cypress.env('password');
   let menuItems = [

--- a/test/cypress/integration/menu.js
+++ b/test/cypress/integration/menu.js
@@ -1,6 +1,9 @@
 describe('Hub Menu Tests', () => {
   let adminUsername = Cypress.env('username');
   let adminPassword = Cypress.env('password');
+  let username = 'nopermission';
+  let password = 'n0permissi0n';
+
   let menuItems = [
     'Collections > Collections',
     'Collections > Namespaces',
@@ -13,20 +16,20 @@ describe('Hub Menu Tests', () => {
     'User Access > Groups',
   ];
 
+  before(() => {
+    cy.deleteTestUsers();
+    cy.cookieReset();
+
+    cy.galaxykit('user create', username, password);
+  });
+
   it('admin user sees complete menu', () => {
     cy.cookieLogin(adminUsername, adminPassword);
+
     menuItems.forEach((item) => cy.menuPresent(item));
   });
 
   describe('user without permissions', () => {
-    let username = 'nopermission';
-    let password = 'n0permissi0n';
-
-    before(() => {
-      cy.deleteTestUsers();
-      cy.galaxykit('user create', username, password);
-    });
-
     let visibleMenuItems = [
       'Collections > Collections',
       'Collections > Namespaces',
@@ -43,12 +46,14 @@ describe('Hub Menu Tests', () => {
 
     it('sees limited menu', () => {
       cy.cookieLogin(username, password);
+
       visibleMenuItems.forEach((item) => cy.menuPresent(item));
       missingMenuItems.forEach((item) => cy.menuMissing(item));
     });
 
     it('has Documentation tab', () => {
       cy.cookieLogin(username, password);
+
       cy.menuPresent('Documentation').should(
         'have.attr',
         'href',

--- a/test/cypress/integration/menu.js
+++ b/test/cypress/integration/menu.js
@@ -11,6 +11,7 @@ describe('Hub Menu Tests', () => {
     'Collections > API Token',
     'Collections > Approval',
     'Container Registry',
+    'Task Management',
     'Documentation',
     'User Access > Users',
     'User Access > Groups',
@@ -36,6 +37,7 @@ describe('Hub Menu Tests', () => {
       'Collections > Repository Management',
       'Collections > API Token',
       'Container Registry',
+      'Task Management',
       'Documentation',
     ];
     let missingMenuItems = [

--- a/test/cypress/integration/namespace-edit.js
+++ b/test/cypress/integration/namespace-edit.js
@@ -73,7 +73,7 @@ describe('Edit a namespace', () => {
   it('saves a new company name', () => {
     cy.get('#company').clear().type('Company name');
     saveButton().click();
-    cy.url().should('eq', 'http://localhost:8002/ui/my-namespaces/testns1');
+    cy.url().should('match', /\/ui\/my-namespaces\/testns1/);
     cy.get('.pf-c-title').should('contain', 'Company name');
   });
 
@@ -96,20 +96,13 @@ describe('Edit a namespace', () => {
   });
 
   it('tests the Logo URL field', () => {
+    const url = 'https://example.com/';
     cy.get('#avatar_url').clear().type('abcde');
     saveButton().click();
     cy.get('#avatar_url-helper').should('have.text', 'Enter a valid URL.');
-    cy.get('#avatar_url')
-      .clear()
-      .type(
-        'https://www.logotaglines.com/wp-content/uploads/2018/01/IBM-Logo-Tagline.jpg',
-      );
+    cy.get('#avatar_url').clear().type(url);
     saveButton().click();
-    cy.get('div.title-box > div.image > img').should(
-      'have.attr',
-      'src',
-      'https://www.logotaglines.com/wp-content/uploads/2018/01/IBM-Logo-Tagline.jpg',
-    );
+    cy.get('div.title-box > div.image > img').should('have.attr', 'src', url);
   });
 
   it('tests the Description field', () => {
@@ -152,7 +145,7 @@ describe('Edit a namespace', () => {
 
   it('removes a link', () => {
     cy.get(
-      'div.useful-links:first-child > div.link-button > div.link-container > svg > path[d^=M432]',
+      'div.useful-links:first-child > div.link-button > div.link-container > svg',
     ).click();
     saveButton().click();
   });

--- a/test/cypress/integration/namespace-edit.js
+++ b/test/cypress/integration/namespace-edit.js
@@ -1,5 +1,4 @@
 describe('Edit a namespace', () => {
-  let baseUrl = Cypress.config().baseUrl;
   let adminUsername = Cypress.env('username');
   let adminPassword = Cypress.env('password');
 
@@ -45,7 +44,6 @@ describe('Edit a namespace', () => {
   });
 
   beforeEach(() => {
-    cy.visit(baseUrl);
     cy.login(adminUsername, adminPassword);
     cy.galaxykit('-i namespace create', 'testns1');
     cy.menuGo('Collections > Namespaces');

--- a/test/cypress/integration/namespace_form.js
+++ b/test/cypress/integration/namespace_form.js
@@ -1,5 +1,4 @@
 describe('A namespace form', () => {
-  let baseUrl = Cypress.config().baseUrl;
   let adminUsername = Cypress.env('username');
   let adminPassword = Cypress.env('password');
 
@@ -26,7 +25,6 @@ describe('A namespace form', () => {
   };
 
   beforeEach(() => {
-    cy.visit(baseUrl);
     cy.login(adminUsername, adminPassword);
     createNamespace();
     cy.menuGo('Collections > Namespaces');

--- a/test/cypress/integration/namespace_form.js
+++ b/test/cypress/integration/namespace_form.js
@@ -35,30 +35,35 @@ describe('A namespace form', () => {
     getMessage().should('have.text', 'Please, provide the namespace name');
     getCreateButton().should('be.disabled');
   });
+
   it('should give message if input is empty', () => {
     getInputBox().type(' ');
     getMessage().should('have.text', 'Name can only contain [A-Za-z0-9_]');
     getCreateButton().should('be.disabled');
     clearInput();
   });
+
   it('should give message if input has incorrect characters', () => {
     getInputBox().type('!/^[a-zA-Z0-9_]+$/.');
     getMessage().should('have.text', 'Name can only contain [A-Za-z0-9_]');
     getCreateButton().should('be.disabled');
     clearInput();
   });
+
   it('should give message if input is shorter than 3 characters', () => {
     getInputBox().type('na');
     getMessage().should('have.text', 'Name must be longer than 2 characters');
     getCreateButton().should('be.disabled');
     clearInput();
   });
+
   it('should give message if input begins with underscore', () => {
     getInputBox().type('_namespace');
     getMessage().should('have.text', "Name cannot begin with '_'");
     getCreateButton().should('be.disabled');
     clearInput();
   });
+
   it('should give message if name already exists', () => {
     getInputBox().type('testns1');
     getCreateButton().click();
@@ -74,9 +79,6 @@ describe('A namespace form', () => {
     let id = parseInt(Math.random() * 1000000);
     getInputBox().type(`testns_${id}`);
     getCreateButton().click();
-    getUrl().should(
-      'eq',
-      `http://localhost:8002/ui/my-namespaces/testns_${id}`,
-    );
+    getUrl().should('match', /\/ui\/my-namespaces\/testns_/);
   });
 });

--- a/test/cypress/integration/namespaces.js
+++ b/test/cypress/integration/namespaces.js
@@ -1,6 +1,4 @@
 describe('Namespaces Page Tests', () => {
-  var baseUrl = Cypress.config().baseUrl;
-
   before(() => {
     cy.deleteTestUsers();
     cy.deleteTestGroups();

--- a/test/cypress/integration/profile.js
+++ b/test/cypress/integration/profile.js
@@ -1,10 +1,8 @@
 describe('My Profile Tests', () => {
-  var baseUrl = Cypress.config().baseUrl;
   var adminUsername = Cypress.env('username');
   var adminPassword = Cypress.env('password');
 
   beforeEach(() => {
-    cy.visit(baseUrl);
     cy.login(adminUsername, adminPassword);
     // open the dropdown labeled with the username and then...
     cy.get('[aria-label="user-dropdown"] button').click();

--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -1,6 +1,6 @@
 describe('Repo Management tests', () => {
-  let remoteRepoUrl = '/ui/repositories?page_size=10&tab=remote';
-  let localRepoUrl = '/ui/repositories?page_size=10';
+  let remoteRepoUrl = '/ui/repositories?tab=remote';
+  let localRepoUrl = '/ui/repositories';
   let adminUsername = Cypress.env('username');
   let adminPassword = Cypress.env('password');
 

--- a/test/cypress/integration/user_dashboard.js
+++ b/test/cypress/integration/user_dashboard.js
@@ -7,6 +7,7 @@ describe('Hub User Management Tests', () => {
   before(() => {
     cy.deleteTestUsers();
     cy.deleteTestGroups();
+    cy.cookieReset();
 
     cy.cookieLogin(adminUsername, adminPassword);
 
@@ -18,7 +19,6 @@ describe('Hub User Management Tests', () => {
       { group: 'users', permissions: ['View user', 'Delete user'] },
     ]);
     cy.addUserToGroup('delete-user', username);
-    cy.cookieLogout();
   });
 
   describe('basic check of user page', () => {

--- a/test/cypress/integration/user_dashboard.js
+++ b/test/cypress/integration/user_dashboard.js
@@ -1,5 +1,4 @@
 describe('Hub User Management Tests', () => {
-  let baseUrl = Cypress.config().baseUrl;
   let adminUsername = Cypress.env('username');
   let adminPassword = Cypress.env('password');
   let username = 'test';
@@ -9,7 +8,6 @@ describe('Hub User Management Tests', () => {
     cy.deleteTestUsers();
     cy.deleteTestGroups();
 
-    cy.visit(baseUrl);
     cy.cookieLogin(adminUsername, adminPassword);
 
     cy.createUser(username, password, 'Test F', 'Test L', 'test@example.com');
@@ -25,7 +23,6 @@ describe('Hub User Management Tests', () => {
 
   describe('basic check of user page', () => {
     beforeEach(() => {
-      cy.visit(baseUrl);
       cy.cookieLogin(adminUsername, adminPassword);
       cy.menuGo('User Access > Users');
     });
@@ -37,7 +34,6 @@ describe('Hub User Management Tests', () => {
 
   describe('Creation and management of users', () => {
     beforeEach(() => {
-      cy.visit(baseUrl);
       cy.cookieLogin(adminUsername, adminPassword);
       cy.menuGo('User Access > Users');
     });
@@ -52,10 +48,6 @@ describe('Hub User Management Tests', () => {
   });
 
   describe('prevents super-user and self deletion', () => {
-    beforeEach(() => {
-      cy.visit(baseUrl);
-    });
-
     function attemptToDelete(toDelete) {
       cy.menuGo('User Access > Users');
       cy.get(`[aria-labelledby=${toDelete}] [aria-label=Actions]`).click();
@@ -71,6 +63,7 @@ describe('Hub User Management Tests', () => {
       cy.cookieLogin(username, password);
       attemptToDelete(username);
     });
+
     it("an ordinary user can't delete the super-user", () => {
       cy.cookieLogin(username, password);
       attemptToDelete(adminUsername);

--- a/test/cypress/integration/user_filter.js
+++ b/test/cypress/integration/user_filter.js
@@ -4,6 +4,15 @@ describe('Search for users', () => {
   let adminUsername = Cypress.env('username');
   let adminPassword = Cypress.env('password');
 
+  before(() => {
+    cy.deleteTestUsers();
+  });
+
+  beforeEach(() => {
+    cy.login(adminUsername, adminPassword);
+    cy.menuGo('User Access > Users');
+  });
+
   let usernamefilterInput = () => {
     return cy.get('input[aria-label="username__contains"]').click();
   };
@@ -51,27 +60,20 @@ describe('Search for users', () => {
       .should('have.text', 'No results found');
   };
 
-  beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
-    cy.menuGo('User Access > Users');
-  });
-
-  it('should have title', () => {
+  it('filters users', () => {
+    // should have title
     cy.get('.pf-c-title').should('have.text', 'Users');
-  });
 
-  it('creates a new user', () => {
-    cy.get('.pf-c-toolbar__item > a').click();
-    cy.get('#username').type('new_user');
-    cy.get('#first_name').type('first_name');
-    cy.get('#last_name').type('last_name');
-    cy.get('#email').type('new_user@example.com');
-    cy.get('#password').type('veryhardpassword');
-    cy.get('#password-confirm').type('veryhardpassword');
-    cy.get('.pf-c-button.pf-m-primary').contains('Save').click();
-  });
+    // creates a new user
+    cy.createUser(
+      'new_user',
+      'veryhardpassword',
+      'first_name',
+      'last_name',
+      'new_user@example.com',
+    );
 
-  it('filters by username', () => {
+    // filters by username
     usernamefilterInput().type('new_user');
     search();
     checkUserEntry();
@@ -81,9 +83,11 @@ describe('Search for users', () => {
     usernamefilterInput().clear().type('new_userrrrr');
     search();
     emptyState();
-  });
+    cy.contains('.pf-c-chip-group.pf-m-category', 'Username')
+      .get('button[data-ouia-component-id=close]')
+      .click();
 
-  it('filters by first name', () => {
+    // filters by first name
     filterDropdown();
     chooseField().contains('First name').click();
     firstnamefilterInput().type('first_name');
@@ -95,9 +99,11 @@ describe('Search for users', () => {
     firstnamefilterInput().clear().type('first_nammmmm');
     search();
     emptyState();
-  });
+    cy.contains('.pf-c-chip-group.pf-m-category', 'First name')
+      .get('button[data-ouia-component-id=close]')
+      .click();
 
-  it('filters by last name', () => {
+    // filters by last name
     filterDropdown();
     chooseField().contains('Last name').click();
     lastnamefilterInput().type('last_name');
@@ -109,9 +115,11 @@ describe('Search for users', () => {
     lastnamefilterInput().clear().type('last_nammmmm');
     search();
     emptyState();
-  });
+    cy.contains('.pf-c-chip-group.pf-m-category', 'Last name')
+      .get('button[data-ouia-component-id=close]')
+      .click();
 
-  it('filters by email', () => {
+    // filters by email
     filterDropdown();
     chooseField().contains('Email').click();
     emailfilterInput().type('new_user@example.com');
@@ -123,5 +131,8 @@ describe('Search for users', () => {
     emailfilterInput().clear().type('new_user@example.commmm');
     search();
     emptyState();
+    cy.contains('.pf-c-chip-group.pf-m-category', 'Email')
+      .get('button[data-ouia-component-id=close]')
+      .click();
   });
 });

--- a/test/cypress/integration/user_filter.js
+++ b/test/cypress/integration/user_filter.js
@@ -1,7 +1,6 @@
 // This tests the filter on user page. Should apply partial matchMedia.
 
 describe('Search for users', () => {
-  let baseUrl = Cypress.config().baseUrl;
   let adminUsername = Cypress.env('username');
   let adminPassword = Cypress.env('password');
 
@@ -53,7 +52,6 @@ describe('Search for users', () => {
   };
 
   beforeEach(() => {
-    cy.visit(baseUrl);
     cy.login(adminUsername, adminPassword);
     cy.menuGo('User Access > Users');
   });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -55,16 +55,10 @@ Cypress.Commands.add('menuGo', {}, (name) => {
   return cy.contains('#page-sidebar a', last).click({ force: true });
 });
 
-Cypress.Commands.add('cookieLogout', {}, () => {
-  cy.clearCookie('sessionid');
-  cy.clearCookie('csrftoken');
-  user_tokens = {};
-});
-
 let user_tokens = {};
 
-Cypress.Commands.add('getUserTokens', {}, (func) => {
-  func(user_tokens);
+Cypress.Commands.add('cookieReset', {}, () => {
+  user_tokens = {};
 });
 
 Cypress.Commands.add('cookieLogin', {}, (username, password) => {


### PR DESCRIPTION
Master cypress started failing in https://github.com/ansible/ansible-hub-ui/runs/3254310124?check_suite_focus=true,
after merging #681, and I found a couple of more issues locally when testing, and fixed a few more.

The main problem seems to be that `cookieLogin` won't work after the csrf token was used to do a POST, leading to interactions between tests ... adding a separate `cookieReset` call to call in `before` of any tests using it, until this is resolved.

The second problem was that our user/group helpers still don't wait for the last action, aded waits to `createGroup`, `removeGroup`, `addPermissions`, `removePermissions` (and fix tabs in comments).

Also adding a dependabot rule for `test/` so that dependabot keeps cypress up to date.

And adding `Task Management` to the menu test.

Also found 2 places where one `it` depends on data created in a previous `it` - merging the `it`s in `user_filter` test, creating a sepate group for deletion in `group_permissions`.

Other cleanups:

* remove every baseUrl from tests, remove any cy.visit before cy.login, login already visits the login page
* move login to beforeEach where possible
* add missing cleanup when creating users and not deleting them
* remove external links other than redhat, ansible & example.com
* remove a selector matching a pathname inside an SVG icon
* remove a test for the cookieLogout helper (see also https://github.com/ansible/ansible-hub-ui/pull/747#issuecomment-893937569)
* remove any `localhost:8002` hardcoded in tests
* remove `page_size` hardcoded in urls

:crossed_fingers: 