### PR TITLE
Repair add permission command

### DIFF
--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -184,11 +184,11 @@ Cypress.Commands.add('addPermissions', {}, (groupName, permissions) => {
   permissions.forEach((permissionElement) => {
     permissionElement.permissions.forEach((permission) => {
       // closes previously open dropdowns
-	  cy.get('h1').click();
+      cy.get('h1').click();
       cy.get(
         `.pf-l-flex.pf-m-align-items-center.${permissionElement.group} [aria-label="Options menu"]`,
       ).click();
-	  cy.contains('button', permission).click();
+      cy.contains('button', permission).click();
     });
   });
   // need to click outside dropdown to make save button clickable
@@ -283,7 +283,7 @@ Cypress.Commands.add('addUserToGroup', {}, (groupName, userName) => {
   cy.contains('button', userName).click();
   // closes previously open dropdown
   cy.get('[aria-label="Options menu"]').click();
-  cy.contains('footer > button', 'Add').click({force:true});
+  cy.contains('footer > button', 'Add').click({ force: true });
   cy.get(`[aria-labelledby=${userName}]`).should('exist');
 });
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -182,13 +182,13 @@ Cypress.Commands.add('addPermissions', {}, (groupName, permissions) => {
   cy.wait('@groups');
   cy.contains('button', 'Edit').click();
   permissions.forEach((permissionElement) => {
-    // closes previously open dropdowns
-    cy.get('h1').click();
-    cy.get(
-      `.pf-l-flex.pf-m-align-items-center.${permissionElement.group} [aria-label="Options menu"]`,
-    ).click();
     permissionElement.permissions.forEach((permission) => {
-      cy.contains('button', permission).click();
+      // closes previously open dropdowns
+	  cy.get('h1').click();
+      cy.get(
+        `.pf-l-flex.pf-m-align-items-center.${permissionElement.group} [aria-label="Options menu"]`,
+      ).click();
+	  cy.contains('button', permission).click();
     });
   });
   // need to click outside dropdown to make save button clickable
@@ -283,7 +283,7 @@ Cypress.Commands.add('addUserToGroup', {}, (groupName, userName) => {
   cy.contains('button', userName).click();
   // closes previously open dropdown
   cy.get('[aria-label="Options menu"]').click();
-  cy.contains('footer > button', 'Add').click();
+  cy.contains('footer > button', 'Add').click({force:true});
   cy.get(`[aria-labelledby=${userName}]`).should('exist');
 });
 
@@ -368,6 +368,7 @@ Cypress.Commands.add('galaxykit', {}, (operation, ...args) => {
     operation,
   )} ${args}`;
 
+  cy.log(cmd);
   return cy.exec(cmd, options).then(({ code, stderr, stdout }) => {
     console.log(`RUN ${cmd}`, options, { code, stderr, stdout });
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -281,9 +281,7 @@ Cypress.Commands.add('addUserToGroup', {}, (groupName, userName) => {
   cy.contains('button', 'Add').click();
   cy.get('input.pf-c-select__toggle-typeahead').type(userName);
   cy.contains('button', userName).click();
-  // closes previously open dropdown
-  cy.get('[aria-label="Options menu"]').click();
-  cy.contains('footer > button', 'Add').click({ force: true });
+  cy.contains('footer > button', 'Add').click();
   cy.get(`[aria-labelledby=${userName}]`).should('exist');
 });
 
@@ -368,7 +366,6 @@ Cypress.Commands.add('galaxykit', {}, (operation, ...args) => {
     operation,
   )} ${args}`;
 
-  cy.log(cmd);
   return cy.exec(cmd, options).then(({ code, stderr, stdout }) => {
     console.log(`RUN ${cmd}`, options, { code, stderr, stdout });
 


### PR DESCRIPTION
Add permission had issue, when last permission was selected, list of permissions dissapeared and test failed, because command assumed that list is still here. Now, command always force to view list every time.

Additionaly, some button in addUserToGroup command was overlapped by another element, so force:true fixed it.