### PR TITLE
namespace-edit: fix test failure

### DIFF
--- a/test/cypress/integration/namespace-edit.js
+++ b/test/cypress/integration/namespace-edit.js
@@ -87,8 +87,9 @@ describe('Edit a namespace', () => {
       .type('abcde');
     cy.wait('@autocomplete');
     cy.get('.pf-c-select__menu-wrapper').should('contain', 'Not found');
-
     cy.get('.pf-c-button.pf-m-plain.pf-c-select__toggle-clear').click();
+
+    cy.get('.pf-c-form-control.pf-c-select__toggle-typeahead').click();
     cy.wait('@autocomplete');
     cy.contains('namespace-owner-autocomplete').click();
 


### PR DESCRIPTION
it seems the patternfly/react-core update in #765 affects the behaviour of dropdowns,
which now close after an item is selected, or after the clear button is pressed

previously they would stay open, leading to assumptions in tests

---

this fixes `namespace-edit`:

    <testcase name="Edit a namespace tests the namespace owners field" time="0.0000" classname="tests the namespace owners field">
      <failure message="Timed out retrying after 4000ms: Expected to find content: &apos;namespace-owner-autocomplete&apos; but never did." type="AssertionError"><![CDATA[AssertionError: Timed out retrying after 4000ms: Expected to find content: 'namespace-owner-autocomplete' but never did.
    at Context.eval (http://localhost:8002/__cypress/tests?p=cypress/integration/namespace-edit.js:165:8)]]></failure>
    </testcase>

this is related to #784, same cause, different test files

---

(not sure why master is not failing yet, locally I get [5 failures](https://gist.github.com/himdel/83510e21f34c72d3b0af772406504754) (most fixed by #784) but that's a separate issue :) (=> #788))