### PR TITLE
Cypress: ensure we're serving the freshly built UI, not an older version

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -126,9 +126,16 @@ jobs:
       run: |
         npm install
         npm run build-standalone
+
+        # save the App.*.js hash for later verification
+        BUILD_HASH=`ls dist/js/App*js | cut -d. -f2`
+        echo "BUILD_HASH=${BUILD_HASH}" >> $GITHUB_ENV
+
         rm -rf ../pulp_galaxy_ng/static/galaxy_ng/ || true
         mv -v dist/ ../pulp_galaxy_ng/static/galaxy_ng
-        podman exec pulp bash -c "s6-svc -r /var/run/s6/services/pulpcore-api" # apply changes, api also serves static assets
+
+        # apply changes, runs collectstatic and serves static assets
+        podman exec pulp bash -c "s6-svc -r /var/run/s6/services/pulpcore-api"
 
     - name: "Finish up and run cypress"
       working-directory: 'ansible-hub-ui/test'
@@ -140,13 +147,8 @@ jobs:
         npm install
         echo -e '{\n  "prefix": "/api/galaxy/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
 
-        echo;echo index.html
-        curl http://localhost:8002/static/galaxy_ng/index.html
-        echo;echo App-good
-        curl http://localhost:8002/static/galaxy_ng/js/App.e400d1830cf70196db07.js
-        echo;echo App-bad
-        curl http://localhost:8002/static/galaxy_ng/js/App.fbd114cdb000ec6fd762.js
-        echo
+        # ensure index.html uses the new js
+        curl http://localhost:8002/static/galaxy_ng/index.html | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
 
         npm run cypress:chrome
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: pulp_galaxy_ng/image
-        key: ${{ runner.os }}-container-${{ env.GALAXY_NG_COMMIT }}-788
+        key: ${{ runner.os }}-container-${{ env.GALAXY_NG_COMMIT }}-post788
 
     - name: "Build pulp-galaxy-ng"
       if: steps.cache-container.outputs.cache-hit != 'true'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -59,7 +59,7 @@ jobs:
           RUN ln /usr/local/lib/python*/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
 
           RUN rm -rf /usr/local/lib/python*/site-packages/galaxy_ng/app/static/
-          RUN ln -sv /galaxy_ng_static /usr/local/lib/python*/site-packages/galaxy_ng/app/static
+          RUN ln -sv /galaxy_ng_static `ls -d /usr/local/lib/python*/site-packages/galaxy_ng/app/`static
         ' | tee Containerfile
 
         buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -124,6 +124,9 @@ jobs:
         npm run build-standalone
         rm -rf ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng/
         mv -v dist/ ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng
+        podman exec pulp bash -c "ls -l /var/run/s6/services/pulpcore-api/"
+        podman exec pulp bash -c "cat /var/run/s6/services/pulpcore-api/run"
+        podman exec pulp bash -c "sed -i 's/collectstatic --clear/collectstatic/' /var/run/s6/services/pulpcore-api/run"
         podman exec pulp bash -c "s6-svc -r /var/run/s6/services/pulpcore-api" # apply changes, api also serves static assets
 
     - name: "Finish up and run cypress"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -134,6 +134,7 @@ jobs:
       run: |
         # podman exec pulp pip install django_extensions
         podman exec pulp pulpcore-manager reset-admin-password --password admin
+        podman exec pulp pulpcore-manager findstatic galaxy_ng/index.html --verbosity=2
 
         npm install
         echo -e '{\n  "prefix": "/api/galaxy/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -140,6 +140,14 @@ jobs:
 
         npm run cypress:chrome
 
+        echo;echo index.html
+        curl http://localhost:8002/static/galaxy_ng/index.html
+        echo;echo App-good
+        curl http://localhost:8002/static/galaxy_ng/js/App.e400d1830cf70196db07.js
+        echo;echo App-bad
+        curl http://localhost:8002/static/galaxy_ng/js/App.fbd114cdb000ec6fd762.js
+        echo
+
     - uses: actions/upload-artifact@v2
       if: failure()
       with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -39,7 +39,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: pulp_galaxy_ng/image
-        key: ${{ runner.os }}-container-${{ env.GALAXY_NG_COMMIT }}
+        key: ${{ runner.os }}-container-${{ env.GALAXY_NG_COMMIT }}-788
 
     - name: "Build pulp-galaxy-ng"
       if: steps.cache-container.outputs.cache-hit != 'true'
@@ -57,6 +57,9 @@ jobs:
           RUN ln /usr/local/lib/python*/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
           RUN ln /usr/local/lib/python*/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
           RUN ln /usr/local/lib/python*/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
+
+          RUN rm -rf /usr/local/lib/python*/site-packages/galaxy_ng/app/static/
+          RUN ln -sv /galaxy_ng_static /usr/local/lib/python3.8/site-packages/galaxy_ng/app/static
         ' | tee Containerfile
 
         buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .
@@ -90,7 +93,7 @@ jobs:
              --publish 8002:80 \
              --name pulp \
              --volume "$(pwd)/settings":/etc/pulp \
-             --volume "$(pwd)/static":/usr/local/lib/python3.8/site-packages/galaxy_ng/app/static \
+             --volume "$(pwd)/static":/galaxy_ng_static \
              --tmpfs /var/lib/pulp \
              --tmpfs /var/lib/pgsql \
              --tmpfs /var/lib/containers \
@@ -125,9 +128,6 @@ jobs:
         npm run build-standalone
         rm -rf ../pulp_galaxy_ng/static/galaxy_ng/ || true
         mv -v dist/ ../pulp_galaxy_ng/static/galaxy_ng
-        #podman exec pulp bash -c "ls -l /var/run/s6/services/pulpcore-api/"
-        #podman exec pulp bash -c "cat /var/run/s6/services/pulpcore-api/run"
-        #podman exec pulp bash -c "sed -i 's/collectstatic --clear/collectstatic/' /var/run/s6/services/pulpcore-api/run"
         podman exec pulp bash -c "s6-svc -r /var/run/s6/services/pulpcore-api" # apply changes, api also serves static assets
 
     - name: "Finish up and run cypress"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -59,7 +59,7 @@ jobs:
           RUN ln /usr/local/lib/python*/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
 
           RUN rm -rf /usr/local/lib/python*/site-packages/galaxy_ng/app/static/
-          RUN ln -sv /galaxy_ng_static /usr/local/lib/python3.8/site-packages/galaxy_ng/app/static
+          RUN ln -sv /galaxy_ng_static /usr/local/lib/python*/site-packages/galaxy_ng/app/static
         ' | tee Containerfile
 
         buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .
@@ -142,7 +142,6 @@ jobs:
       run: |
         # podman exec pulp pip install django_extensions
         podman exec pulp pulpcore-manager reset-admin-password --password admin
-        podman exec pulp pulpcore-manager findstatic galaxy_ng/index.html --verbosity=2
 
         npm install
         echo -e '{\n  "prefix": "/api/galaxy/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -138,8 +138,6 @@ jobs:
         npm install
         echo -e '{\n  "prefix": "/api/galaxy/",\n  "username": "admin",\n  "password": "admin"\n}' > cypress.env.json
 
-        npm run cypress:chrome
-
         echo;echo index.html
         curl http://localhost:8002/static/galaxy_ng/index.html
         echo;echo App-good
@@ -147,6 +145,8 @@ jobs:
         echo;echo App-bad
         curl http://localhost:8002/static/galaxy_ng/js/App.fbd114cdb000ec6fd762.js
         echo
+
+        npm run cypress:chrome
 
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -70,7 +70,7 @@ jobs:
     - name: "Configure and run pulp-galaxy-ng"
       working-directory: 'pulp_galaxy_ng'
       run: |
-        mkdir settings pulp_storage pgsql containers
+        mkdir settings static
         echo '# settings/settings.py'
         echo "\
           ANSIBLE_API_HOSTNAME='http://localhost:8002'
@@ -90,9 +90,10 @@ jobs:
              --publish 8002:80 \
              --name pulp \
              --volume "$(pwd)/settings":/etc/pulp \
-             --volume "$(pwd)/pulp_storage":/var/lib/pulp \
-             --volume "$(pwd)/pgsql":/var/lib/pgsql \
-             --volume "$(pwd)/containers":/var/lib/containers \
+             --volume "$(pwd)/static":/usr/local/lib/python3.8/site-packages/galaxy_ng/app/static \
+             --tmpfs /var/lib/pulp \
+             --tmpfs /var/lib/pgsql \
+             --tmpfs /var/lib/containers \
              --device /dev/fuse \
              localhost/pulp/pulp-galaxy-ng:latest
 
@@ -122,11 +123,11 @@ jobs:
       run: |
         npm install
         npm run build-standalone
-        rm -rf ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng/
-        mv -v dist/ ../pulp_galaxy_ng/pulp_storage/assets/galaxy_ng
-        podman exec pulp bash -c "ls -l /var/run/s6/services/pulpcore-api/"
-        podman exec pulp bash -c "cat /var/run/s6/services/pulpcore-api/run"
-        podman exec pulp bash -c "sed -i 's/collectstatic --clear/collectstatic/' /var/run/s6/services/pulpcore-api/run"
+        rm -rf ../pulp_galaxy_ng/static/galaxy_ng/ || true
+        mv -v dist/ ../pulp_galaxy_ng/static/galaxy_ng
+        #podman exec pulp bash -c "ls -l /var/run/s6/services/pulpcore-api/"
+        #podman exec pulp bash -c "cat /var/run/s6/services/pulpcore-api/run"
+        #podman exec pulp bash -c "sed -i 's/collectstatic --clear/collectstatic/' /var/run/s6/services/pulpcore-api/run"
         podman exec pulp bash -c "s6-svc -r /var/run/s6/services/pulpcore-api" # apply changes, api also serves static assets
 
     - name: "Finish up and run cypress"


### PR DESCRIPTION
This fixes Cypress on Github Actions to run against the UI changes in the PR, instead of an older UI version.

The problem:
* we build a new version of the assets
* copy to `pulp_storage/` ( = `/var/lib/pulp` on the container)
* then restart the API service in order to start serving the new assets
  * which runs `collectstatic` which removes our new assets (`--clear`), but still replaces `index.html` even without the `--clear`.
  * the files it uses to replace the new ones come from `/usr/local/lib/python3.8/site-packages/galaxy_ng/app/static/galaxy_ng/`

Solution:

Since restarting the API replaces files in `/var/lib/pulp/assets/galaxy_ng` by files from `/usr/local/lib/python3.8/site-packages/galaxy_ng/app/static/galaxy_ng/`, we have to make sure our new files end up in that second location.
=> Updating the container build to replace `/usr/local/lib/python*/site-packages/galaxy_ng/app/static` with a symlink to `/galaxy_ng_static`
=> Updating the UI build to put these files in the new `/galaxy_ng_static` volume.

And adding a check to ensure the `index.html` served by the container actually contains a link to the `App.*.js` with the right hash, to make sure we'd notice if this happened again :).

Cc @jerabekjiri @fao89, thanks both of you :)
