### PR TITLE
[WIP] Paging for groups, users and namespaces

### DIFF
--- a/test/cypress/integration/group_table.js
+++ b/test/cypress/integration/group_table.js
@@ -1,6 +1,6 @@
 describe('Group Table Tests for Sorting, Paging and Filtering', () => {
   let items = [];
-  let prefix = 'group_table_test';
+  let prefix = 'group_test';
   let selector = '.body:first';
 
   before(() => {

--- a/test/cypress/integration/group_table.js
+++ b/test/cypress/integration/group_table.js
@@ -1,0 +1,40 @@
+describe('Group Table Tests for Sorting, Paging and Filtering', () => {
+  let items = [];
+  let prefix = 'group_table_test';
+  let selector = '.body:first';
+
+  before(() => {
+    cy.deleteTestGroups();
+    cy.deleteTestGroups();
+    cy.deleteTestGroups();
+    cy.deleteTestGroups();
+
+    cy.login('admin', 'admin');
+
+    for (var i = 0; i < 21; i++) {
+      let item = { name: prefix + i };
+      items.push(item);
+      cy.galaxykit('-i group create', item.name);
+    }
+
+    cy.sortBy(items, 'name', true);
+  });
+
+  beforeEach(() => {
+    cy.login('admin', 'admin');
+  });
+
+  it('items are sorted alphabetically and paging is working', () => {
+    var new_items = items.slice(0, 10);
+    cy.visit('/ui/group-list');
+    cy.checkTableItems(selector, new_items, 'name');
+    cy.get('[aria-label="Go to next page"]:first').click();
+
+    new_items = items.slice(10, 20);
+    cy.checkTableItems(selector, new_items, 'name');
+    cy.get('[aria-label="Go to next page"]:first').click();
+
+    new_items = items.slice(20, 21);
+    cy.checkTableItems(selector, new_items, 'name');
+  });
+});

--- a/test/cypress/integration/namespace-edit.js
+++ b/test/cypress/integration/namespace-edit.js
@@ -91,8 +91,15 @@ describe('Edit a namespace', () => {
     cy.get('.pf-c-select__menu-wrapper').should('contain', 'Not found');
     cy.get('.pf-c-button.pf-m-plain.pf-c-select__toggle-clear').click();
 
-    cy.get('.pf-c-form-control.pf-c-select__toggle-typeahead').click();
+    cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/groups/?*').as(
+      'autocomplete',
+    );
+
+    cy.get('.pf-c-form-control.pf-c-select__toggle-typeahead')
+      .click()
+      .type('namespace-owner-autocomplete');
     cy.wait('@autocomplete');
+
     cy.contains('namespace-owner-autocomplete').click();
 
     saveButton().click();

--- a/test/cypress/integration/namespace-edit.js
+++ b/test/cypress/integration/namespace-edit.js
@@ -2,6 +2,8 @@ describe('Edit a namespace', () => {
   let adminUsername = Cypress.env('username');
   let adminPassword = Cypress.env('password');
 
+  let namespace0 = 'namespace_test0';
+
   let kebabToggle = () => {
     return cy.get('button[id^=pf-dropdown-toggle-id-] > svg').parent().click();
   };
@@ -45,9 +47,9 @@ describe('Edit a namespace', () => {
 
   beforeEach(() => {
     cy.login(adminUsername, adminPassword);
-    cy.galaxykit('-i namespace create', 'testns1');
+    cy.galaxykit('-i namespace create', namespace0);
     cy.menuGo('Collections > Namespaces');
-    cy.get('a[href*="ui/repo/published/testns1"]').click();
+    cy.get('a[href*="ui/repo/published/' + namespace0 + '"]').click();
     kebabToggle();
     cy.contains('Edit namespace').click();
   });
@@ -73,7 +75,7 @@ describe('Edit a namespace', () => {
   it('saves a new company name', () => {
     cy.get('#company').clear().type('Company name');
     saveButton().click();
-    cy.url().should('match', /\/ui\/my-namespaces\/testns1/);
+    cy.url().should('match', /\/ui\/my-namespaces\/namespace_test0/);
     cy.get('.pf-c-title').should('contain', 'Company name');
   });
 

--- a/test/cypress/integration/namespace_table.js
+++ b/test/cypress/integration/namespace_table.js
@@ -1,0 +1,31 @@
+describe('Namespaces Table Tests for Sorting, Paging and Filtering', () => {
+  let items = [];
+  let prefix = 'namespace_table_test';
+  let selector = '.namespace-page';
+
+  before(() => {
+    cy.login('admin', 'admin');
+
+    // note - system dont allow to delete namespaces
+    for (var i = 0; i < 21; i++) {
+      let item = { name: prefix + i };
+      items.push(item);
+      cy.galaxykit('-i namespace create', item.name);
+    }
+
+    cy.sortBy(items, 'name', true);
+  });
+
+  beforeEach(() => {
+    cy.login('admin', 'admin');
+  });
+
+  it('items are sorted alphabetically and paging is working', () => {
+    var new_items = items.slice(0, 20);
+    cy.visit('/ui/namespaces');
+    cy.checkTableItems(selector, new_items, 'name');
+    cy.get('[aria-label="Go to next page"]:first').click();
+    new_items = items.slice(20, 21);
+    cy.checkTableItems(selector, new_items, 'name');
+  });
+});

--- a/test/cypress/integration/namespace_table.js
+++ b/test/cypress/integration/namespace_table.js
@@ -1,6 +1,6 @@
 describe('Namespaces Table Tests for Sorting, Paging and Filtering', () => {
   let items = [];
-  let prefix = 'namespace_table_test';
+  let prefix = 'namespace_test';
   let selector = '.namespace-page';
 
   before(() => {

--- a/test/cypress/integration/namespaces.js
+++ b/test/cypress/integration/namespaces.js
@@ -1,4 +1,6 @@
 describe('Namespaces Page Tests', () => {
+  let namespace0 = 'namespace_test0';
+  let namespace1 = 'namespace_test1';
   before(() => {
     cy.deleteTestUsers();
     cy.deleteTestGroups();
@@ -10,18 +12,18 @@ describe('Namespaces Page Tests', () => {
     cy.galaxykit('-i user create', 'testUser2', 'p@ssword1');
     cy.galaxykit('user group add', 'testUser2', 'testGroup2');
 
-    cy.galaxykit('-i namespace create', 'testns1');
-    cy.galaxykit('-i namespace create', 'testns2');
-    cy.galaxykit('namespace addgroup', 'testns1', 'testGroup1');
-    cy.galaxykit('namespace addgroup', 'testns2', 'testGroup2');
+    cy.galaxykit('-i namespace create', namespace0);
+    cy.galaxykit('-i namespace create', namespace1);
+    cy.galaxykit('namespace addgroup', namespace0, 'testGroup1');
+    cy.galaxykit('namespace addgroup', namespace1, 'testGroup2');
   });
 
   it('can navigate to pubic namespace list', () => {
     cy.login('testUser2', 'p@ssword1');
     cy.menuGo('Collections > Namespaces');
 
-    cy.contains('testns2').should('exist');
-    cy.contains('testns1').should('exist');
+    cy.contains(namespace1).should('exist');
+    cy.contains(namespace0).should('exist');
   });
 
   it('can navigate to personal namespace list', () => {
@@ -30,7 +32,7 @@ describe('Namespaces Page Tests', () => {
 
     cy.contains('My namespaces').click();
 
-    cy.contains('testns2').should('exist');
-    cy.contains('testns1').should('not.exist');
+    cy.contains(namespace1).should('exist');
+    cy.contains(namespace0).should('not.exist');
   });
 });

--- a/test/cypress/integration/user_table.js
+++ b/test/cypress/integration/user_table.js
@@ -1,6 +1,6 @@
 describe('User Table Tests for Sorting, Paging and Filtering', () => {
   let items = [];
-  let prefix = 'user_table_test';
+  let prefix = 'user_test';
   let selector = '.body:first';
 
   before(() => {

--- a/test/cypress/integration/user_table.js
+++ b/test/cypress/integration/user_table.js
@@ -1,0 +1,41 @@
+describe('User Table Tests for Sorting, Paging and Filtering', () => {
+  let items = [];
+  let prefix = 'user_table_test';
+  let selector = '.body:first';
+
+  before(() => {
+    cy.deleteTestUsers();
+    cy.deleteTestUsers();
+    cy.deleteTestUsers();
+    cy.deleteTestUsers();
+
+    cy.login('admin', 'admin');
+
+    for (var i = 0; i < 21; i++) {
+      let item = { name: prefix + i };
+      items.push(item);
+      cy.galaxykit('user create', item.name, item.name);
+    }
+
+    items.push({ name: 'admin' });
+    cy.sortBy(items, 'name', true);
+  });
+
+  beforeEach(() => {
+    cy.login('admin', 'admin');
+  });
+
+  it('items are sorted alphabetically and paging is working', () => {
+    var new_items = items.slice(0, 10);
+    cy.visit('/ui/users');
+    cy.checkTableItems(selector, new_items, 'name');
+    cy.get('[aria-label="Go to next page"]:first').click();
+
+    new_items = items.slice(10, 20);
+    cy.checkTableItems(selector, new_items, 'name');
+    cy.get('[aria-label="Go to next page"]:first').click();
+
+    new_items = items.slice(20, 22);
+    cy.checkTableItems(selector, new_items, 'name');
+  });
+});

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -15,6 +15,7 @@
 
 // Import commands.js using ES2015 syntax:
 import './commands';
+import './tableCommands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')

--- a/test/cypress/support/tableCommands.js
+++ b/test/cypress/support/tableCommands.js
@@ -1,42 +1,57 @@
 /*	Checks if all items are visible and in correct order
- * 
- * selector is element selector that surrounds the table
- * 
- * Items are array of {}, where {} is associative array of column name - > value, 
+ *
+ * selector is element selector that surrounds the table - we need to identify the container
+ *
+ * Items are array of {}, where {} is associative array of column name - > value,
  * column input contains column we are looking for
-
+ *
+ * Example
+ *
+ * we have this elements:
+ * <table .class="container">
+ *   <tr>
+ * 		<td>data1</td>
+ *   </tr>
+ *   <tr>
+ *      <td>data2</td>
+ *   </tr>
+ *   <tr>
+ * 		<td>data3</td>
+ *   </tr>
+ * </table>
+ *
+ * checkTableItems(".container", [{name='data1'}, {name='data2'}, {name='data3'}], 'name')
+ *
+ * The command will first select the table element and then look in all elements inside and look for
+ * the items (data1-data3) in correct order in elements.
  */
 Cypress.Commands.add('checkTableItems', {}, (selector, items, column) => {
   // wait for renderer (first item available)
+  // otherwise we may check table that is not loaded yet
   cy.get(selector).contains(items[0][column]);
 
-  // get elements in container
+  // get container and then all elements in the container (get('*'))
   cy.get(selector)
     .get('*')
-    .then((result) => {
-      cy.checkTableElements(result, items, column);
+    .then((elements) => {
+      let itemIndex = 0;
+      elements.each((index) => {
+        let element = elements[index];
+        // we have now all elements in container, but only subset of them has our wanted item
+        // wanted item is in itemIndex position in array
+        // we suppose elements are defined in HTML document in the same order as we want them
+        let text = element.innerHTML;
+
+        // check if element really contains only item and nothing more
+        if (itemIndex < items.length && text == items[itemIndex][column]) {
+          // move to next item, this way we can check all the items in correct order
+          itemIndex++;
+        }
+      });
+
+      // if item index is equal to items length, all items are in container in correct order
+      expect(itemIndex).to.equal(items.length);
     });
-});
-
-// Check if all elements contains items (for input variables, see checkTableItems)
-Cypress.Commands.add('checkTableElements', {}, (elements, items, column) => {
-  let itemIndex = 0;
-  for (var i = 0; i < elements.length; i++) {
-    let element = elements[i];
-    let text = element.innerHTML;
-
-    // if all items were found, quit
-    if (itemIndex >= items.length) break;
-
-    // check if element really contains only entity, the get returns all elements that contains the entity and other HTML
-    // for example it returns main div and etc.
-    if (text == items[itemIndex][column]) {
-      // move to next item, this way we can check all the items in correct order
-      itemIndex++;
-    }
-  }
-
-  expect(itemIndex).to.equal(items.length);
 });
 
 // sorts item of object by column name

--- a/test/cypress/support/tableCommands.js
+++ b/test/cypress/support/tableCommands.js
@@ -1,0 +1,55 @@
+/*	Checks if all items are visible and in correct order
+ * 
+ * selector is element selector that surrounds the table
+ * 
+ * Items are array of {}, where {} is associative array of column name - > value, 
+ * column input contains column we are looking for
+
+ */
+Cypress.Commands.add('checkTableItems', {}, (selector, items, column) => {
+  // wait for renderer (first item available)
+  cy.get(selector).contains(items[0][column]);
+
+  // get elements in container
+  cy.get(selector)
+    .get('*')
+    .then((result) => {
+      cy.checkTableElements(result, items, column);
+    });
+});
+
+// Check if all elements contains items (for input variables, see checkTableItems)
+Cypress.Commands.add('checkTableElements', {}, (elements, items, column) => {
+  let itemIndex = 0;
+  for (var i = 0; i < elements.length; i++) {
+    let element = elements[i];
+    let text = element.innerHTML;
+
+    // if all items were found, quit
+    if (itemIndex >= items.length) break;
+
+    // check if element really contains only entity, the get returns all elements that contains the entity and other HTML
+    // for example it returns main div and etc.
+    if (text == items[itemIndex][column]) {
+      // move to next item, this way we can check all the items in correct order
+      itemIndex++;
+    }
+  }
+
+  expect(itemIndex).to.equal(items.length);
+});
+
+// sorts item of object by column name
+Cypress.Commands.add('sortBy', {}, (items, column, ascending) => {
+  items.sort((a, b) => {
+    let res = 0;
+    if (a[column] > b[column]) {
+      res = 1;
+    } else {
+      res = -1;
+    }
+
+    if (ascending == false) res *= -1;
+    return res;
+  });
+});


### PR DESCRIPTION
Paging for groups, users and namespaces with the usage of new commands in tableCommands.js. Those commands can only test if all wanted data are in some container area in correct order. Another commands and tests for sorting and filtering will be added in future.

Also unification of other namespaces names in other tests, because namespaces cant be deleted, their names must not be in conflict. For example when some other test inserts new namespace, our test fails, because table now contains new element that are not in data we created in this test.