### PR TITLE
Fix missing titles in Alert notifications

### DIFF
--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -321,8 +321,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
             ...this.state.alerts,
             {
               variant: 'danger',
-              title: null,
-              description: _`Error editing group.`,
+              title: _`Error editing group.`,
             },
           ],
         }),
@@ -415,8 +414,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
             ...this.state.alerts,
             {
               variant: 'success',
-              title: null,
-              description: _`Successfully deleted group.`,
+              title: _`Successfully deleted group.`,
             },
           ],
         });
@@ -428,8 +426,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
             ...this.state.alerts,
             {
               variant: 'danger',
-              title: null,
-              description: _`Error deleting group.`,
+              title: _`Error deleting group.`,
             },
           ],
         }),


### PR DESCRIPTION
Issue: [AAH-828](https://issues.redhat.com/browse/AAH-828)

Fixed missing titles (null) and replaced them with descriptions. 
I noticed that in some cases alerts don't show like when creating or editing users for example, should this be fixed as well or it's intentional?

before:
![Screenshot from 2021-08-19 12-11-33](https://user-images.githubusercontent.com/19647757/130051243-6932602b-2cf0-4716-9cc5-4a39d38376ff.png)

after:
![Screenshot from 2021-08-19 12-13-19](https://user-images.githubusercontent.com/19647757/130051482-ed7bba97-7e3c-4ba0-89f2-988c5bfdfb5e.png)

