### PR TITLE
Make changes to be consistent with using redux-promise-middleware 6

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,6 +1,5 @@
 import ReducerRegistry from '@redhat-cloud-services/frontend-components-utilities/files/ReducerRegistry';
-import promiseMiddleware from 'redux-promise-middleware';
-
+import promise from 'redux-promise-middleware';
 let registry;
 
 export function init(...middleware) {
@@ -8,7 +7,7 @@ export function init(...middleware) {
     throw new Error('store already initialized');
   }
 
-  registry = new ReducerRegistry({}, [promiseMiddleware(), ...middleware]);
+  registry = new ReducerRegistry({}, [promise, ...middleware]);
 
   //If you want to register all of your reducers, this is good place.
   /*


### PR DESCRIPTION
Make changes to be consistent with using redux-promise-middleware 6.x according to https://github.com/pburtchaell/redux-promise-middleware/blob/HEAD/docs/upgrading/v6.md

Run Insights mode and see.

Before:
<img width="1670" alt="Screenshot 2021-08-23 at 13 11 45" src="https://user-images.githubusercontent.com/9210860/130438184-952df5f1-3934-4ea7-aade-ce15f3591c44.png">

After:
<img width="1675" alt="Screenshot 2021-08-23 at 13 08 59" src="https://user-images.githubusercontent.com/9210860/130438170-4d698710-602a-4e31-8c60-59886fca5371.png">
