### PR TITLE
Repair Group management sporadic failure

### DIFF
--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -350,6 +350,7 @@ Cypress.Commands.add('deleteUser', {}, (username) => {
 
   // Wait for navigation
   cy.wait('@userList');
+  cy.contains(username).should('not.exist');
 });
 
 Cypress.Commands.add('deleteGroup', {}, (name) => {


### PR DESCRIPTION
Another problem in group management was not waiting good enough for user to be deleted by gui. We added contains at the end of deleteUser command. The app works fine. 

o be honest Im not sure why this exactly works, because without it, galaxykit fails with 403 on select groups (in deleteTestGroups command in beforeEach). 

What was wrong previously:
Before this PR, It fails sometimes in situation after the deleteUser command. It then runs beforeEach which runs deleteTestGroups.
And in deleteTestGroups, there is galaxykit which wants to select groups and this fails with 403.

Removing deleteGroup and deleteUser solves the problem also, but we need to test deletion using GUI. But if we remove only deleteUser, it works. It was maybe because deleteGroup did waited using contains to ensure group is deleted. So we added this contains also to deleteUser and it started working.