### PR TITLE
group_manager - more test fixes

### DIFF
--- a/test/cypress/integration/group_management.js
+++ b/test/cypress/integration/group_management.js
@@ -2,10 +2,12 @@ describe('Hub Group Management Tests', () => {
   var adminUsername = Cypress.env('username');
   var adminPassword = Cypress.env('password');
 
-  beforeEach(() => {
+  before(() => {
     cy.deleteTestGroups();
     cy.deleteTestUsers();
+  });
 
+  beforeEach(() => {
     cy.login(adminUsername, adminPassword);
   });
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -327,14 +327,7 @@ Cypress.Commands.add('removeUserFromGroup', {}, (groupName, userName) => {
   cy.contains(userName).should('not.exist');
 });
 
-// FIXME: createUser doesn't change logins, deleteUser does => TODO consistency
 Cypress.Commands.add('deleteUser', {}, (username) => {
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
-
-  cy.logout();
-  cy.login(adminUsername, adminPassword);
-
   cy.menuGo('User Access > Users');
   cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/users/**').as(
     'deleteUser',
@@ -358,12 +351,6 @@ Cypress.Commands.add('deleteUser', {}, (username) => {
 });
 
 Cypress.Commands.add('deleteGroup', {}, (name) => {
-  var adminUsername = Cypress.env('username');
-  var adminPassword = Cypress.env('password');
-
-  cy.logout();
-  cy.login(adminUsername, adminPassword);
-
   cy.menuGo('User Access > Groups');
   cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/groups/**').as(
     'deleteGroup',

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -329,7 +329,7 @@ Cypress.Commands.add('removeUserFromGroup', {}, (groupName, userName) => {
 
 Cypress.Commands.add('deleteUser', {}, (username) => {
   cy.menuGo('User Access > Users');
-  cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/users/**').as(
+  cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/users/*').as(
     'deleteUser',
   );
   cy.get(`[aria-labelledby=${username}] [aria-label=Actions]`).click();
@@ -352,10 +352,10 @@ Cypress.Commands.add('deleteUser', {}, (username) => {
 
 Cypress.Commands.add('deleteGroup', {}, (name) => {
   cy.menuGo('User Access > Groups');
-  cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/groups/**').as(
+  cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/groups/*').as(
     'deleteGroup',
   );
-  cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/groups/**').as(
+  cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/groups/?*').as(
     'listGroups',
   );
   cy.get(`[aria-labelledby=${name}] [aria-label=Delete]`).click();


### PR DESCRIPTION
Follow-up to #833,

`cy.deleteUser` and `cy.deleteGroup` are now used only in `group_management`, which is always logged in as admin => we no longer need to logout & login as admin (previously changing the login to admin was needed for uses replaced by `deleteTestUsers`). Removing, no other helpers change login :).

`group_management` is doing `deleteTestUsers` & `deleteTestGroups` cleanup in `beforeEach`, instead of doing it just once in `before` - fixing for consistency as well :). The individual tests in group_management actually do their own cleanup.

`deleteUser` and `deleteGroup` have over-eager intercepts, intercepting `DELETE .../group/123/model_permission/456` when expecting to intercept `DELETE .../group/123` => changed `**` to `?*` or `*` to be more specific

---

This *may* fix a ~6% sporadic failure in group_management, as described in https://github.com/ansible/ansible-hub-ui/pull/833#issuecomment-908633723:
https://gist.github.com/himdel/7dc3e4d342494ebd195894f80e4390c6
`api/automation-hub/_ui/v1/auth/login/ ... 400: Bad Request`

(but not sure, as I can't test this reliably, seems like the model_permission request storm from `addAllPermissions` kills the pulp worker)