### PR TITLE
cypress: update galaxykit

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: "Install galaxykit dependency"
       run: |
-        pip install galaxykit==0.1.0
+        pip install galaxykit
 
     - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |


### PR DESCRIPTION
new galaxykit was released, making sure we're up to date :)

Cc @hendersonreed Does it make sense to just remove the version constraint so we're always up to date?
(I assume no breaking changes? :))

(Looks like we're going from 0.1.0 to 0.5.1. ([pip](https://pypi.org/project/galaxykit/))