### PR TITLE
cypress reporter: use spec for output, junit for test/results/

### DIFF
--- a/test/cypress.json
+++ b/test/cypress.json
@@ -2,9 +2,8 @@
   "viewportWidth": 1200,
   "viewportHeight": 800,
   "baseUrl":"http://localhost:8002",
-  "reporter": "junit",
+  "reporter": "cypress-multi-reporters",
   "reporterOptions": {
-    "mochaFile": "results/cypress-report-[hash].xml",
-    "toConsole": true
+    "configFile": "reporter-config.json"
   }
 }

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -529,6 +529,16 @@
         "chrome-remote-interface": "^0.27.1"
       }
     },
+    "cypress-multi-reporters": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cypress-multi-reporters/-/cypress-multi-reporters-1.5.0.tgz",
+      "integrity": "sha512-6rJ1rk1RpjZwTeydCDc8r3iOmWj2ZEYo++oDTJHNEu7eetb3W1cYDNo5CdxF/r0bo7TLQsOEpBHOCYBZfPVt/g==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",

--- a/test/package.json
+++ b/test/package.json
@@ -14,7 +14,8 @@
   "license": "ISC",
   "devDependencies": {
     "cypress": "^8.3.1",
-    "cypress-log-to-output": "^1.1.2"
+    "cypress-log-to-output": "^1.1.2",
+    "cypress-multi-reporters": "^1.5.0"
   },
   "dependencies": {
     "shell-escape-tag": "^2.0.2",

--- a/test/reporter-config.json
+++ b/test/reporter-config.json
@@ -1,0 +1,7 @@
+{
+  "reporterEnabled": "spec, mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "results/cypress-report-[hash].xml",
+    "toConsole": false
+  }
+}


### PR DESCRIPTION
changes the cypress standard output from XML to

  Token Management Tests
    ✓ user can open docs dropdown menu (2065ms)
    ✓ user can toggle about modal (2260ms)

(while keeping `test/results/` in junit format - I'm assuming it's there for a reason? :))