### PR TITLE
Rework of collection version select

### DIFF
--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -1,4 +1,5 @@
 import { t, Trans } from '@lingui/macro';
+import * as moment from 'moment';
 import * as React from 'react';
 import './collection-info.scss';
 

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -2,7 +2,6 @@ import { t, Trans } from '@lingui/macro';
 import * as React from 'react';
 import './collection-info.scss';
 
-import * as moment from 'moment';
 import { Link } from 'react-router-dom';
 
 import {
@@ -10,8 +9,6 @@ import {
   SplitItem,
   Grid,
   GridItem,
-  FormSelect,
-  FormSelectOption,
   Button,
 } from '@patternfly/react-core';
 
@@ -20,7 +17,6 @@ import { DownloadIcon } from '@patternfly/react-icons';
 import { CollectionDetailType, CollectionAPI } from 'src/api';
 import { Tag, ClipboardCopy } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
-import { ParamHelper } from 'src/utilities/param-helper';
 import { AppContext } from 'src/loaders/app-context';
 import { userLanguage } from 'src/l10n';
 
@@ -41,14 +37,7 @@ export class CollectionInfo extends React.Component<IProps> {
   }
 
   render() {
-    const {
-      name,
-      latest_version,
-      namespace,
-      all_versions,
-      params,
-      updateParams,
-    } = this.props;
+    const { name, latest_version, namespace, params } = this.props;
 
     let installCommand = `ansible-galaxy collection install ${namespace.name}.${name}`;
 
@@ -73,34 +62,6 @@ export class CollectionInfo extends React.Component<IProps> {
             <Split hasGutter={true}>
               <SplitItem className='install-title'>{t`License`}</SplitItem>
               <SplitItem isFilled>{latest_version.metadata.license}</SplitItem>
-            </Split>
-          </GridItem>
-          <GridItem>
-            <Split hasGutter={true}>
-              <SplitItem className='install-tile'>{t`Install Version`}</SplitItem>
-              <SplitItem isFilled>
-                <FormSelect
-                  onChange={(val) =>
-                    updateParams(ParamHelper.setParam(params, 'version', val))
-                  }
-                  value={
-                    params.version ? params.version : latest_version.version
-                  }
-                  aria-label={t`Select collection version`}
-                >
-                  {all_versions.map((v) => (
-                    <FormSelectOption
-                      key={v.version}
-                      value={v.version}
-                      label={`${v.version} released ${moment(
-                        v.created,
-                      ).fromNow()} ${
-                        v.version === latest_version.version ? '(latest)' : ''
-                      }`}
-                    />
-                  ))}
-                </FormSelect>
-              </SplitItem>
             </Split>
           </GridItem>
           <GridItem>

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -96,6 +96,13 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     const latestVersion = collection.latest_version.created_at;
 
+    const isLatestVersion = (v) =>
+      `${moment(v.created).fromNow()} ${
+        v.version === all_versions[0].version ? t`(latest)` : ''
+      }`;
+
+    const { name: collectionName } = collection;
+
     return (
       <React.Fragment>
         <Modal
@@ -106,7 +113,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         >
           <List isPlain>
             <Text style={{ paddingBottom: 'var(--pf-global--spacer--md)' }}>
-              {collection.name}'s versions.
+              {t`${collectionName}'s versions.`}
             </Text>
             {all_versions.map((v) => (
               <ListItem key={v.version}>
@@ -126,8 +133,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                 >
                   v{v.version}
                 </Button>{' '}
-                released {moment(v.created).fromNow()}{' '}
-                {v.version === all_versions[0].version ? '(latest)' : ''}
+                {t`released ${isLatestVersion(v)}`}
               </ListItem>
             ))}
           </List>
@@ -174,8 +180,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                         )
                       }
                     >
-                      {v.version} released {moment(v.created).fromNow()}{' '}
-                      {v.version === all_versions[0].version ? '(latest)' : ''}
+                      <Trans>
+                        {v.version} released {isLatestVersion(v)}
+                      </Trans>
                     </SelectOption>
                   ))}
                 </Select>

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -124,7 +124,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           isOpen={isOpenVersionsModal}
           title={t`Collection versions`}
           variant='small'
-          onClose={() => this.onClose('isOpenVersionsModal')}
+          onClose={() => this.setState({ isOpenVersionsModal: false })}
         >
           <List isPlain>
             <div className='versions-modal-header'>
@@ -152,7 +152,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                         v.version.toString(),
                       ),
                     );
-                    this.onClose('isOpenVersionsModal');
+                    this.setState({ isOpenVersionsModal: false });
                   }}
                 >
                   v{v.version}
@@ -192,7 +192,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                     this.setState({ isOpenVersionsSelect })
                   }
                   variant={SelectVariant.single}
-                  onSelect={() => this.onClose('isOpenVersionsSelect')}
+                  onSelect={() =>
+                    this.setState({ isOpenVersionsSelect: false })
+                  }
                   selections={`v${collection.latest_version.version}`}
                   aria-label={t`Select collection version`}
                   loadingVariant={
@@ -256,14 +258,14 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                 <ExternalLinkAltIcon />
               </div>
               {urlKeys.map((link) => {
-                const l = collection.latest_version.metadata[link.key];
-                if (!l) {
+                const url = collection.latest_version.metadata[link.key];
+                if (!url) {
                   return null;
                 }
 
                 return (
                   <div className='link' key={link.key}>
-                    <a href={l} target='_blank'>
+                    <a href={url} target='_blank'>
                       {link.name}
                     </a>
                   </div>
@@ -329,19 +331,11 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   }
 
   private updatePaginationParams = ({ page, page_size }) => {
-    this.setState((prevState) => ({
-      ...prevState,
+    this.setState({
       modalPagination: {
         page: page,
         pageSize: page_size,
       },
-    }));
+    });
   };
-
-  private onClose(key: string) {
-    this.setState((prevState) => ({
-      ...prevState,
-      [key]: false,
-    }));
-  }
 }

--- a/src/components/headers/header.scss
+++ b/src/components/headers/header.scss
@@ -50,6 +50,13 @@
   padding-top: 10px;
 }
 
+.versions-modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-bottom: var(--pf-global--spacer--md);
+}
+
 .tab-link-container {
   display: flex;
   margin-top: 10px;

--- a/src/components/headers/header.scss
+++ b/src/components/headers/header.scss
@@ -25,7 +25,7 @@
 }
 
 .install-version-dropdown {
-  width: 136px;
+  width: 300px;
 }
 
 .last-updated {


### PR DESCRIPTION
Issue: [AAH-907](https://issues.redhat.com/browse/AAH-907)

- Removed collection version select from collection-info.tsx 
- Used Patternfly Select instead of FormSelect for nicer styling

before:
![Screenshot from 2021-09-02 16-48-17](https://user-images.githubusercontent.com/19647757/131865630-5511dcf7-01b2-4835-8f9a-5550276ea6fa.png)
after:
![Screenshot from 2021-09-02 14-36-58](https://user-images.githubusercontent.com/19647757/131865680-9d801adf-a018-4c22-84f6-e2bdc5f7a092.png)



- Added modal for  full list of collections
![Screenshot from 2021-09-02 14-37-25](https://user-images.githubusercontent.com/19647757/131864893-281924d9-2923-477b-ba03-1078df63c06c.png)

Full content screen with removed version select inside install content and with new select component :)
![Screenshot from 2021-09-02 14-37-11](https://user-images.githubusercontent.com/19647757/131866114-8a087395-aeab-437a-bb2f-d03af244eaf7.png)

@ZitaNemeckova  please take a look :)