### PR TITLE
EE: Remote Registries

### DIFF
--- a/src/api/execution-environment-registry.ts
+++ b/src/api/execution-environment-registry.ts
@@ -1,0 +1,7 @@
+import { HubAPI } from './hub';
+
+class API extends HubAPI {
+  apiPath = this.getUIPath('execution-environments/registries/');
+}
+
+export const ExecutionEnvironmentRegistryAPI = new API();

--- a/src/api/execution-environment-registry.ts
+++ b/src/api/execution-environment-registry.ts
@@ -1,7 +1,27 @@
 import { HubAPI } from './hub';
+import { RemoteType } from '.';
+import { smartUpdate } from './remotes';
 
 class API extends HubAPI {
   apiPath = this.getUIPath('execution-environments/registries/');
+
+  // list(params?)
+  // create(data)
+  // get(name)
+  // delete(name)
+
+  smartUpdate(pk, newValue: RemoteType, oldValue: RemoteType) {
+    const reducedData = smartUpdate(newValue, oldValue);
+    return super.update(pk, reducedData);
+  }
+
+  update(id, obj) {
+    throw 'use smartUpdate()';
+  }
+
+  sync(name) {
+    return this.http.post(this.apiPath + name + '/sync/', {});
+  }
 }
 
 export const ExecutionEnvironmentRegistryAPI = new API();

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -39,6 +39,7 @@ export { DistributionAPI } from './distribution';
 export { MyDistributionAPI } from './my-distribution';
 export { DistributionType } from './response-types/distribution';
 export { ExecutionEnvironmentAPI } from './execution-environment';
+export { ExecutionEnvironmentRegistryAPI } from './execution-environment-registry';
 export {
   ExecutionEnvironmentType,
   ContainerManifestType,

--- a/src/api/remotes.ts
+++ b/src/api/remotes.ts
@@ -2,41 +2,42 @@ import { HubAPI } from './hub';
 import { RemoteType } from '.';
 import { clearSetFieldsFromRequest } from 'src/utilities';
 
+// removes unchanged values and write only fields before updating
+export function smartUpdate(remote: RemoteType, unmodifiedRemote: RemoteType) {
+  // Deletes any write only fields from the object that are market as is_set.
+  // This is to prevent accidentally clearing fields that weren't updated.
+
+  // TODO: clearing set fields from the response will be unnecesary if the API
+  // stops returning field: null on write only fields
+  const reducedData: RemoteType = clearSetFieldsFromRequest(
+    remote,
+    remote.write_only_fields,
+  ) as RemoteType;
+
+  // Pulp complains if auth_url gets sent with a request that doesn't include a
+  // valid token, even if the token exists in the database and isn't being changed.
+  // To solve this issue, simply delete auth_url from the request if it hasn't
+  // been updated by the user.
+  if (reducedData.auth_url === unmodifiedRemote.auth_url) {
+    delete reducedData['auth_url'];
+  }
+
+  for (const field of Object.keys(reducedData)) {
+    if (reducedData[field] === '') {
+      reducedData[field] = null;
+    }
+  }
+
+  return reducedData;
+}
+
 class API extends HubAPI {
   apiPath = this.getUIPath('remotes/');
 
-  constructor() {
-    super();
-  }
-
-  // removes unchanged values and write only fields before
   // can't override the base class update method because this function takes a
   // third parameter and update only takes 2
-  smartUpdate(distribution, remote: RemoteType, unModifiedRemote: RemoteType) {
-    // Deletes any write only fields from the object that are market as is_set.
-    // This is to prevent accidentally clearing fields that weren't updated.
-
-    // TODO: clearing set fields from the response will be unnecesary if the API
-    // stops returning field: null on write only fields
-    const reducedData: RemoteType = clearSetFieldsFromRequest(
-      remote,
-      remote.write_only_fields,
-    ) as RemoteType;
-
-    // Pulp complains if auth_url gets sent with a request that doesn't include a
-    // valid token, even if the token exists in the database and isn't being changed.
-    // To solve this issue, simply delete auth_url from the request if it hasn't
-    // been updated by the user.
-    if (reducedData.auth_url === unModifiedRemote.auth_url) {
-      delete reducedData['auth_url'];
-    }
-
-    for (const field of Object.keys(reducedData)) {
-      if (reducedData[field] === '') {
-        reducedData[field] = null;
-      }
-    }
-
+  smartUpdate(distribution, remote: RemoteType, unmodifiedRemote: RemoteType) {
+    const reducedData = smartUpdate(remote, unmodifiedRemote);
     return this.http.put(
       `content/${distribution}/v3/sync/config/`,
       reducedData,

--- a/src/api/response-types/remote.ts
+++ b/src/api/response-types/remote.ts
@@ -12,6 +12,7 @@ class LastSyncType {
 }
 
 export class RemoteType {
+  pk: string;
   name: string;
   url: string;
   auth_url: string;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -27,6 +27,7 @@ export { EmptyStateNoData } from './empty-state/empty-state-no-data';
 export { EmptyStateUnauthorized } from './empty-state/empty-state-unauthorized';
 export { ExecutionEnvironmentHeader } from './execution-environment-header/execution-environment-header';
 export { GroupModal } from './group-management/group-modal';
+export { DeleteModal } from './delete-modal/delete-modal';
 export { HelperText } from './helper-text/helper-text';
 export { ImportConsole } from './my-imports/import-console';
 export { ImportList } from './my-imports/import-list';

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -107,7 +107,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
         onClose={() => this.props.closeModal()}
         actions={[
           <Button
-            isDisabled={!this.isValid(requiredFields)}
+            isDisabled={!this.isValid(requiredFields, remoteType)}
             key='confirm'
             variant='primary'
             onClick={() => this.props.saveRemote()}
@@ -647,7 +647,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
     );
   }
 
-  private isValid(requiredFields) {
+  private isValid(requiredFields, remoteType) {
     const { remote } = this.props;
 
     for (const field of requiredFields) {
@@ -655,9 +655,14 @@ export class RemoteForm extends React.Component<IProps, IState> {
         return false;
       }
     }
-    if (remote.download_concurrency < 1) {
-      return false;
+
+    if (['community', 'certified', 'none'].includes(remoteType)) {
+      // only required in remotes, not registries
+      if (remote.download_concurrency < 1) {
+        return false;
+      }
     }
+
     return true;
   }
 

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -288,70 +288,70 @@ export class RemoteForm extends React.Component<IProps, IState> {
           </FormGroup>
         )}
 
+        <FormGroup
+          fieldId={'username'}
+          label={t`Username`}
+          labelIcon={
+            <HelperText
+              content={t`The username to be used for authentication when syncing. This is not required when using a token.`}
+            />
+          }
+          isRequired={requiredFields.includes('username')}
+          validated={this.toError(!('username' in errorMessages))}
+          helperTextInvalid={errorMessages['username']}
+        >
+          <WriteOnlyField
+            isValueSet={
+              isWriteOnly('username', remote.write_only_fields) &&
+              isFieldSet('username', remote.write_only_fields)
+            }
+            onClear={() => this.updateIsSet('username', false)}
+          >
+            <TextInput
+              validated={this.toError(!('username' in errorMessages))}
+              isRequired={requiredFields.includes('username')}
+              isDisabled={disabledFields.includes('username')}
+              id='username'
+              type='text'
+              value={remote.username || ''}
+              onChange={(value) => this.updateRemote(value, 'username')}
+            />
+          </WriteOnlyField>
+        </FormGroup>
+
+        <FormGroup
+          fieldId={'password'}
+          label={t`Password`}
+          labelIcon={
+            <HelperText
+              content={t`The password to be used for authentication when syncing. This is not required when using a token.`}
+            />
+          }
+          isRequired={requiredFields.includes('password')}
+          validated={this.toError(!('password' in errorMessages))}
+          helperTextInvalid={errorMessages['password']}
+        >
+          <WriteOnlyField
+            isValueSet={isFieldSet('password', remote.write_only_fields)}
+            onClear={() => this.updateIsSet('password', false)}
+          >
+            <TextInput
+              validated={this.toError(!('password' in errorMessages))}
+              isRequired={requiredFields.includes('password')}
+              isDisabled={disabledFields.includes('password')}
+              id='password'
+              type='password'
+              value={remote.password || ''}
+              onChange={(value) => this.updateRemote(value, 'password')}
+            />
+          </WriteOnlyField>
+        </FormGroup>
+
         <ExpandableSection
           toggleTextExpanded={t`Hide advanced options`}
           toggleTextCollapsed={t`Show advanced options`}
         >
           <div className='pf-c-form'>
-            <FormGroup
-              fieldId={'username'}
-              label={t`Username`}
-              labelIcon={
-                <HelperText
-                  content={t`The username to be used for authentication when syncing. This is not required when using a token.`}
-                />
-              }
-              isRequired={requiredFields.includes('username')}
-              validated={this.toError(!('username' in errorMessages))}
-              helperTextInvalid={errorMessages['username']}
-            >
-              <WriteOnlyField
-                isValueSet={
-                  isWriteOnly('username', remote.write_only_fields) &&
-                  isFieldSet('username', remote.write_only_fields)
-                }
-                onClear={() => this.updateIsSet('username', false)}
-              >
-                <TextInput
-                  validated={this.toError(!('username' in errorMessages))}
-                  isRequired={requiredFields.includes('username')}
-                  isDisabled={disabledFields.includes('username')}
-                  id='username'
-                  type='text'
-                  value={remote.username || ''}
-                  onChange={(value) => this.updateRemote(value, 'username')}
-                />
-              </WriteOnlyField>
-            </FormGroup>
-
-            <FormGroup
-              fieldId={'password'}
-              label={t`Password`}
-              labelIcon={
-                <HelperText
-                  content={t`The password to be used for authentication when syncing. This is not required when using a token.`}
-                />
-              }
-              isRequired={requiredFields.includes('password')}
-              validated={this.toError(!('password' in errorMessages))}
-              helperTextInvalid={errorMessages['password']}
-            >
-              <WriteOnlyField
-                isValueSet={isFieldSet('password', remote.write_only_fields)}
-                onClear={() => this.updateIsSet('password', false)}
-              >
-                <TextInput
-                  validated={this.toError(!('password' in errorMessages))}
-                  isRequired={requiredFields.includes('password')}
-                  isDisabled={disabledFields.includes('password')}
-                  id='password'
-                  type='password'
-                  value={remote.password || ''}
-                  onChange={(value) => this.updateRemote(value, 'password')}
-                />
-              </WriteOnlyField>
-            </FormGroup>
-
             <FormGroup
               fieldId={'proxy_url'}
               label={t`Proxy URL`}

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -20,7 +20,7 @@ import { DownloadIcon } from '@patternfly/react-icons';
 
 import { RemoteType, WriteOnlyFieldType } from 'src/api';
 import { Constants } from 'src/constants';
-import { isFieldSet } from 'src/utilities';
+import { isFieldSet, isWriteOnly } from 'src/utilities';
 
 interface IProps {
   updateRemote: (remote) => void;
@@ -289,15 +289,23 @@ export class RemoteForm extends React.Component<IProps, IState> {
               validated={this.toError(!('username' in errorMessages))}
               helperTextInvalid={errorMessages['username']}
             >
-              <TextInput
-                validated={this.toError(!('username' in errorMessages))}
-                isRequired={requiredFields.includes('username')}
-                isDisabled={disabledFields.includes('username')}
-                id='username'
-                type='text'
-                value={remote.username || ''}
-                onChange={(value) => this.updateRemote(value, 'username')}
-              />
+              <WriteOnlyField
+                isValueSet={
+                  isWriteOnly('username', remote.write_only_fields) &&
+                  isFieldSet('username', remote.write_only_fields)
+                }
+                onClear={() => this.updateIsSet('username', false)}
+              >
+                <TextInput
+                  validated={this.toError(!('username' in errorMessages))}
+                  isRequired={requiredFields.includes('username')}
+                  isDisabled={disabledFields.includes('username')}
+                  id='username'
+                  type='text'
+                  value={remote.username || ''}
+                  onChange={(value) => this.updateRemote(value, 'username')}
+                />
+              </WriteOnlyField>
             </FormGroup>
             <FormGroup
               fieldId={'password'}
@@ -351,15 +359,25 @@ export class RemoteForm extends React.Component<IProps, IState> {
               validated={this.toError(!('proxy_username' in errorMessages))}
               helperTextInvalid={errorMessages['proxy_username']}
             >
-              <TextInput
-                validated={this.toError(!('proxy_username' in errorMessages))}
-                isRequired={requiredFields.includes('proxy_username')}
-                isDisabled={disabledFields.includes('proxy_username')}
-                id='proxy_username'
-                type='text'
-                value={remote.proxy_username || ''}
-                onChange={(value) => this.updateRemote(value, 'proxy_username')}
-              />
+              <WriteOnlyField
+                isValueSet={
+                  isWriteOnly('proxy_username', remote.write_only_fields) &&
+                  isFieldSet('proxy_username', remote.write_only_fields)
+                }
+                onClear={() => this.updateIsSet('proxy_username', false)}
+              >
+                <TextInput
+                  validated={this.toError(!('proxy_username' in errorMessages))}
+                  isRequired={requiredFields.includes('proxy_username')}
+                  isDisabled={disabledFields.includes('proxy_username')}
+                  id='proxy_username'
+                  type='text'
+                  value={remote.proxy_username || ''}
+                  onChange={(value) =>
+                    this.updateRemote(value, 'proxy_username')
+                  }
+                />
+              </WriteOnlyField>
             </FormGroup>
 
             <FormGroup

--- a/src/components/repositories/remote-repository-table.tsx
+++ b/src/components/repositories/remote-repository-table.tsx
@@ -5,10 +5,9 @@ import { Button, DropdownItem, Tooltip } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import { RemoteType, UserType, PulpStatus } from 'src/api';
-import { DateComponent, HelperText, SortTable, StatefulDropdown } from '..';
-import { StatusIndicator } from 'src/components';
-
+import { DateComponent, SortTable, StatefulDropdown } from 'src/components';
 import { Constants } from 'src/constants';
+import { lastSynced, lastSyncStatus } from 'src/utilities';
 
 interface IProps {
   remotes: RemoteType[];
@@ -123,14 +122,8 @@ export class RemoteRepositoryTable extends React.Component<IProps> {
         ) : (
           <td>{'---'}</td>
         )}
-        {!!remote.last_sync_task && !!remote.last_sync_task.finished_at ? (
-          <td>
-            <DateComponent date={remote.last_sync_task.finished_at} />
-          </td>
-        ) : (
-          <td>{'---'}</td>
-        )}
-        <td>{this.renderStatus(remote)}</td>
+        <td>{lastSynced(remote) || '---'}</td>
+        <td>{lastSyncStatus(remote) || '---'}</td>
         <td>
           {remote.repositories.length === 0 ? (
             <Tooltip
@@ -162,25 +155,6 @@ export class RemoteRepositoryTable extends React.Component<IProps> {
           )}
         </td>
       </tr>
-    );
-  }
-
-  private renderStatus(remote) {
-    if (!remote.last_sync_task) {
-      return '---';
-    }
-
-    let errorMessage = null;
-    if (remote['last_sync_task']['error']) {
-      errorMessage = (
-        <HelperText content={remote.last_sync_task.error['description']} />
-      );
-    }
-
-    return (
-      <>
-        <StatusIndicator status={remote.last_sync_task.state} /> {errorMessage}
-      </>
     );
   }
 

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -111,7 +111,7 @@ class ExecutionEnvironmentList extends React.Component<
           onClose={() => this.setState({ publishToController: null })}
           tag={publishToController?.tag}
         />
-        <BaseHeader title={t`Container Registry`}></BaseHeader>
+        <BaseHeader title={t`Execution Environments`}></BaseHeader>
         {noData && !loading ? (
           <EmptyStateNoData
             title={t`No container repositories yet`}

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -251,7 +251,7 @@ class ExecutionEnvironmentList extends React.Component<
       >
         {t`Use in Controller`}
       </DropdownItem>,
-    ];
+    ].filter((truthy) => truthy);
 
     return (
       <tr aria-labelledby={item.name} key={index}>
@@ -278,7 +278,7 @@ class ExecutionEnvironmentList extends React.Component<
           <DateComponent date={item.updated} />
         </td>
         <td>
-          <StatefulDropdown items={dropdownItems}></StatefulDropdown>
+          {!!dropdownItems.length && <StatefulDropdown items={dropdownItems} />}
         </td>
       </tr>
     );

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -195,7 +195,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
             }
             allowEditName={remoteFormNew}
             title={
-              remoteFormNew ? t`New remote registry` : t`Edit remote registry`
+              remoteFormNew ? t`Add remote registry` : t`Edit remote registry`
             }
           />
         )}
@@ -357,7 +357,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
 
         <td>
           <Button variant='secondary' onClick={() => this.syncRegistry(item)}>
-            <Trans>Sync all remotes</Trans>
+            <Trans>Sync from registry</Trans>
           </Button>{' '}
           <StatefulDropdown
             items={[

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -1,0 +1,431 @@
+import * as React from 'react';
+import { t, Trans } from '@lingui/macro';
+
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+import {
+  Button,
+  DropdownItem,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { ExecutionEnvironmentRegistryAPI, RemoteType } from 'src/api';
+import {
+  ParamHelper,
+  filterIsSet,
+  lastSyncStatus,
+  lastSynced,
+  mapErrorMessages,
+} from 'src/utilities';
+import {
+  AlertList,
+  AlertType,
+  AppliedFilters,
+  BaseHeader,
+  CompoundFilter,
+  DateComponent,
+  DeleteModal,
+  EmptyStateFilter,
+  EmptyStateNoData,
+  LoadingPageSpinner,
+  Main,
+  Pagination,
+  RemoteForm,
+  SortTable,
+  StatefulDropdown,
+  closeAlertMixin,
+} from 'src/components';
+
+interface IState {
+  alerts: AlertType[];
+  itemCount: number;
+  items: RemoteType[];
+  loading: boolean;
+  params: {
+    page?: number;
+    page_size?: number;
+  };
+  remoteFormErrors: Object;
+  remoteFormNew: boolean;
+  remoteToEdit?: RemoteType;
+  remoteUnmodified?: RemoteType;
+  showDeleteModal: boolean;
+  showRemoteFormModal: boolean;
+}
+
+class ExecutionEnvironmentRegistryList extends React.Component<
+  RouteComponentProps,
+  IState
+> {
+  constructor(props) {
+    super(props);
+
+    const params = ParamHelper.parseParamString(props.location.search, [
+      'page',
+      'page_size',
+    ]);
+
+    if (!params['page_size']) {
+      params['page_size'] = 10;
+    }
+
+    if (!params['sort']) {
+      params['sort'] = 'name';
+    }
+
+    this.state = {
+      alerts: [],
+      itemCount: 0,
+      items: [],
+      loading: true,
+      params,
+      remoteFormErrors: {},
+      remoteFormNew: false,
+      remoteToEdit: null,
+      remoteUnmodified: null,
+      showDeleteModal: false,
+      showRemoteFormModal: false,
+    };
+  }
+
+  componentDidMount() {
+    this.queryRegistries();
+  }
+
+  render() {
+    const {
+      alerts,
+      itemCount,
+      items,
+      loading,
+      params,
+      remoteFormErrors,
+      remoteFormNew,
+      remoteToEdit,
+      remoteUnmodified,
+      showDeleteModal,
+      showRemoteFormModal,
+    } = this.state;
+    const noData = items.length === 0 && !filterIsSet(params, ['name']);
+
+    const addButton = (
+      <Button
+        onClick={() =>
+          this.setState({
+            remoteFormErrors: {},
+            remoteFormNew: true,
+            remoteToEdit: {
+              name: '',
+              // API defaults to true when not sending anything, make the UI fits
+              tls_validation: true,
+              write_only_fields: [
+                { name: 'username', is_set: false },
+                { name: 'password', is_set: false },
+                { name: 'proxy_username', is_set: false },
+                { name: 'proxy_password', is_set: false },
+                { name: 'client_key', is_set: false },
+              ],
+            } as any,
+            remoteUnmodified: null,
+            showRemoteFormModal: true,
+          })
+        }
+      >
+        <Trans>Add remote registry</Trans>
+      </Button>
+    );
+
+    return (
+      <React.Fragment>
+        <AlertList
+          alerts={alerts}
+          closeAlert={(i) => this.closeAlert(i)}
+        ></AlertList>
+        {showRemoteFormModal && (
+          <RemoteForm
+            remote={remoteToEdit}
+            remoteType='registry'
+            updateRemote={(r: RemoteType) => this.setState({ remoteToEdit: r })}
+            saveRemote={() => {
+              const { remoteFormNew, remoteToEdit } = this.state;
+              let newRemote = { ...remoteToEdit };
+
+              if (remoteFormNew) {
+                // prevent "This field may not be blank." when writing in and then deleting username/password/etc
+                // only when creating, edit diffs with remoteUnmodified
+                Object.keys(newRemote).forEach((k) => {
+                  if (newRemote[k] === '' || newRemote[k] == null) {
+                    delete newRemote[k];
+                  }
+                });
+              }
+
+              let promise = remoteFormNew
+                ? ExecutionEnvironmentRegistryAPI.create(newRemote)
+                : ExecutionEnvironmentRegistryAPI.smartUpdate(
+                    remoteToEdit.pk,
+                    remoteToEdit,
+                    remoteUnmodified,
+                  );
+
+              promise
+                .then((r) => {
+                  this.setState(
+                    {
+                      remoteToEdit: null,
+                      remoteUnmodified: null,
+                      showRemoteFormModal: false,
+                    },
+                    () => this.queryRegistries(),
+                  );
+                })
+                .catch((err) =>
+                  this.setState({ remoteFormErrors: mapErrorMessages(err) }),
+                );
+            }}
+            errorMessages={remoteFormErrors}
+            showModal={showRemoteFormModal}
+            closeModal={() =>
+              this.setState({
+                remoteToEdit: null,
+                remoteUnmodified: null,
+                showRemoteFormModal: false,
+              })
+            }
+            allowEditName={remoteFormNew}
+            title={
+              remoteFormNew ? t`New remote registry` : t`Edit remote registry`
+            }
+          />
+        )}
+        {showDeleteModal && remoteToEdit && (
+          <DeleteModal
+            cancelAction={() =>
+              this.setState({ showDeleteModal: false, remoteToEdit: null })
+            }
+            deleteAction={() => this.deleteRegistry(remoteToEdit)}
+            title={t`Delete remote registry?`}
+            children={t`${remoteToEdit.name} will be deleted.`}
+          />
+        )}
+        <BaseHeader title={t`Remote Registries`}></BaseHeader>
+        {noData && !loading ? (
+          <EmptyStateNoData
+            title={t`No remote registries yet`}
+            description={t`You currently have no remote registries.`}
+            button={addButton}
+          />
+        ) : (
+          <Main>
+            {loading ? (
+              <LoadingPageSpinner />
+            ) : (
+              <section className='body'>
+                <div className='container-list-toolbar'>
+                  <Toolbar>
+                    <ToolbarContent>
+                      <ToolbarGroup>
+                        <ToolbarItem>
+                          <CompoundFilter
+                            updateParams={(p) => {
+                              p['page'] = 1;
+                              this.updateParams(p, () =>
+                                this.queryRegistries(),
+                              );
+                            }}
+                            params={params}
+                            filterConfig={[
+                              {
+                                id: 'name',
+                                title: t`Name`,
+                              },
+                            ]}
+                          />
+                        </ToolbarItem>
+                        <ToolbarItem>{addButton}</ToolbarItem>
+                      </ToolbarGroup>
+                    </ToolbarContent>
+                  </Toolbar>
+
+                  <Pagination
+                    params={params}
+                    updateParams={(p) =>
+                      this.updateParams(p, () => this.queryRegistries())
+                    }
+                    count={itemCount}
+                    isTop
+                  />
+                </div>
+                <div>
+                  <AppliedFilters
+                    updateParams={(p) =>
+                      this.updateParams(p, () => this.queryRegistries())
+                    }
+                    params={params}
+                    ignoredParams={['page_size', 'page', 'sort']}
+                  />
+                </div>
+                {this.renderTable(params)}
+                <div style={{ paddingTop: '24px', paddingBottom: '8px' }}>
+                  <Pagination
+                    params={params}
+                    updateParams={(p) =>
+                      this.updateParams(p, () => this.queryRegistries())
+                    }
+                    count={itemCount}
+                  />
+                </div>
+              </section>
+            )}
+          </Main>
+        )}
+      </React.Fragment>
+    );
+  }
+
+  private renderTable(params) {
+    const { items } = this.state;
+    if (items.length === 0) {
+      return <EmptyStateFilter />;
+    }
+
+    let sortTableOptions = {
+      headers: [
+        {
+          title: t`Name`,
+          type: 'alpha',
+          id: 'name',
+        },
+        {
+          title: t`Created`,
+          type: 'alpha',
+          id: 'created_at',
+        },
+        {
+          title: t`Last updated`,
+          type: 'alpha',
+          id: 'updated_at',
+        },
+        {
+          title: t`Registry URL`,
+          type: 'alpha',
+          id: 'url',
+        },
+        {
+          title: t`Registry sync status`,
+          type: 'none',
+          id: 'last_sync_task',
+        },
+        {
+          title: '',
+          type: 'none',
+          id: 'controls',
+        },
+      ],
+    };
+
+    return (
+      <table className='content-table pf-c-table'>
+        <SortTable
+          options={sortTableOptions}
+          params={params}
+          updateParams={(p) =>
+            this.updateParams(p, () => this.queryRegistries())
+          }
+        />
+        <tbody>{items.map((user, i) => this.renderTableRow(user, i))}</tbody>
+      </table>
+    );
+  }
+
+  private renderTableRow(item: any, index: number) {
+    return (
+      <tr aria-labelledby={item.name} key={index}>
+        <td>{item.name}</td>
+        <td>
+          <DateComponent date={item.created_at} />
+        </td>
+        <td>
+          <DateComponent date={item.updated_at} />
+        </td>
+        <td>{item.url}</td>
+        <td>
+          {lastSyncStatus(item) || '---'}
+          {lastSynced(item)}
+        </td>
+
+        <td>
+          <Button variant='secondary' onClick={() => this.syncRegistry(item)}>
+            <Trans>Sync all remotes</Trans>
+          </Button>{' '}
+          <StatefulDropdown
+            items={[
+              <DropdownItem
+                key='edit'
+                onClick={() =>
+                  this.setState({
+                    remoteFormErrors: {},
+                    remoteFormNew: false,
+                    remoteToEdit: { ...item },
+                    remoteUnmodified: { ...item },
+                    showRemoteFormModal: true,
+                  })
+                }
+              >
+                <Trans>Edit</Trans>
+              </DropdownItem>,
+              <DropdownItem
+                key='delete'
+                onClick={() =>
+                  this.setState({
+                    showDeleteModal: true,
+                    remoteToEdit: item,
+                  })
+                }
+              >
+                <Trans>Delete</Trans>
+              </DropdownItem>,
+            ]}
+          />
+        </td>
+      </tr>
+    );
+  }
+
+  private queryRegistries() {
+    this.setState({ loading: true }, () =>
+      ExecutionEnvironmentRegistryAPI.list(this.state.params).then((result) =>
+        this.setState({
+          items: result.data.data,
+          itemCount: result.data.meta.count,
+          loading: false,
+        }),
+      ),
+    );
+  }
+
+  private deleteRegistry(item) {
+    ExecutionEnvironmentRegistryAPI.delete(item.name)
+      .then((r) => console.log('TODO delete success/error'))
+      .then(() =>
+        this.setState({ showDeleteModal: false, remoteToEdit: null }),
+      );
+  }
+
+  private syncRegistry(item) {
+    ExecutionEnvironmentRegistryAPI.sync(item.name).then((r) =>
+      console.log('TODO sync success/error'),
+    );
+  }
+
+  private get updateParams() {
+    return ParamHelper.updateParamsMixin();
+  }
+
+  private get closeAlert() {
+    return closeAlertMixin('alerts');
+  }
+}
+
+export default withRouter(ExecutionEnvironmentRegistryList);

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -117,7 +117,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
             remoteFormNew: true,
             remoteToEdit: {
               name: '',
-              // API defaults to true when not sending anything, make the UI fits
+              // API defaults to true when not sending anything, make the UI fit
               tls_validation: true,
               write_only_fields: [
                 { name: 'username', is_set: false },
@@ -126,7 +126,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
                 { name: 'proxy_password', is_set: false },
                 { name: 'client_key', is_set: false },
               ],
-            } as any,
+            } as RemoteType,
             remoteUnmodified: null,
             showRemoteFormModal: true,
           })
@@ -405,18 +405,39 @@ class ExecutionEnvironmentRegistryList extends React.Component<
     );
   }
 
-  private deleteRegistry(item) {
-    ExecutionEnvironmentRegistryAPI.delete(item.name)
-      .then((r) => console.log('TODO delete success/error'))
+  private deleteRegistry({ name }) {
+    ExecutionEnvironmentRegistryAPI.delete(name)
+      .then(() =>
+        this.addAlert(
+          t`Successfully deleted remote registry ${name}`,
+          'success',
+        ),
+      )
+      .catch(() =>
+        this.addAlert(t`Failed to delete remote registry ${name}`, 'danger'),
+      )
       .then(() =>
         this.setState({ showDeleteModal: false, remoteToEdit: null }),
       );
   }
 
-  private syncRegistry(item) {
-    ExecutionEnvironmentRegistryAPI.sync(item.name).then((r) =>
-      console.log('TODO sync success/error'),
-    );
+  private syncRegistry({ name }) {
+    ExecutionEnvironmentRegistryAPI.sync(name)
+      .then(() => this.addAlert(t`Sync initiated for ${name}`, 'success'))
+      .catch(() => this.addAlert(t`Sync failed for ${name}`, 'danger'));
+  }
+
+  private addAlert(title, variant, description?) {
+    this.setState({
+      alerts: [
+        ...this.state.alerts,
+        {
+          description,
+          title,
+          variant,
+        },
+      ],
+    });
   }
 
   private get updateParams() {

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -107,7 +107,8 @@ class ExecutionEnvironmentRegistryList extends React.Component<
       showDeleteModal,
       showRemoteFormModal,
     } = this.state;
-    const noData = items.length === 0 && !filterIsSet(params, ['name']);
+    const noData =
+      items.length === 0 && !filterIsSet(params, ['name__icontains']);
 
     const addButton = (
       <Button
@@ -237,7 +238,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
                             params={params}
                             filterConfig={[
                               {
-                                id: 'name',
+                                id: 'name__icontains',
                                 title: t`Name`,
                               },
                             ]}
@@ -264,6 +265,9 @@ class ExecutionEnvironmentRegistryList extends React.Component<
                     }
                     params={params}
                     ignoredParams={['page_size', 'page', 'sort']}
+                    niceNames={{
+                      name__icontains: t`Name`,
+                    }}
                   />
                 </div>
                 {this.renderTable(params)}

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -23,6 +23,7 @@ export { default as GroupList } from './group-management/group-list';
 export { default as GroupDetail } from './group-management/group-detail';
 export { default as RepositoryList } from './repositories/repository-list';
 export { default as ExecutionEnvironmentList } from './execution-environment-list/execution_environment_list';
+export { default as ExecutionEnvironmentRegistryList } from './execution-environment/registry-list';
 export { default as ExecutionEnvironmentDetail } from './execution-environment-detail/execution_environment_detail';
 export { default as ExecutionEnvironmentDetailActivities } from './execution-environment-detail/execution_environment_detail_activities';
 export { default as ExecutionEnvironmentDetailImages } from './execution-environment-detail/execution_environment_detail_images';

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -42,7 +42,7 @@ interface IState {
   itemCount: number;
   loading: boolean;
   showRemoteFormModal: boolean;
-  errorMessages: Object;
+  errorMessages: Object; // RemoteForm modal messages
 
   content: RemoteType[] | DistributionType[];
   remoteToEdit: RemoteType;

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -26,6 +26,7 @@ import {
   GroupDetail,
   RepositoryList,
   ExecutionEnvironmentList,
+  ExecutionEnvironmentRegistryList,
   ExecutionEnvironmentDetail,
   ExecutionEnvironmentDetailActivities,
   ExecutionEnvironmentDetailImages,
@@ -174,6 +175,11 @@ export class Routes extends React.Component<IRoutesProps> {
       {
         comp: ExecutionEnvironmentList,
         path: Paths.executionEnvironments,
+        isDisabled: isContainerDisabled,
+      },
+      {
+        comp: ExecutionEnvironmentRegistryList,
+        path: Paths.executionEnvironmentsRegistries,
         isDisabled: isContainerDisabled,
       },
       {

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -345,10 +345,17 @@ class App extends React.Component<RouteComponentProps, IState> {
           url: Paths.approvalDashboard,
         }),
       ]),
-      menuItem(t`Container Registry`, {
-        condition: ({ featureFlags }) => featureFlags.execution_environments,
-        url: Paths.executionEnvironments,
-      }),
+      menuSection(
+        t`Execution Environments`,
+        {
+          condition: ({ featureFlags }) => featureFlags.execution_environments,
+        },
+        [
+          menuItem(t`Execution Environments`, {
+            url: Paths.executionEnvironments,
+          }),
+        ],
+      ),
       menuItem(t`Task Management`, {
         url: Paths.taskList,
       }),

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -354,6 +354,9 @@ class App extends React.Component<RouteComponentProps, IState> {
           menuItem(t`Execution Environments`, {
             url: Paths.executionEnvironments,
           }),
+          menuItem(t`Remote Registries`, {
+            url: Paths.executionEnvironmentsRegistries,
+          }),
         ],
       ),
       menuItem(t`Task Management`, {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -21,6 +21,7 @@ export enum Paths {
   executionEnvironmentDetail = '/containers/:container+',
   executionEnvironments = '/containers',
   executionEnvironmentManifest = '/containers/:container+/_content/images/:digest',
+  executionEnvironmentsRegistries = '/registries',
   groupList = '/group-list',
   groupDetail = '/group/:group',
   taskDetail = '/task/:task',

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -9,3 +9,4 @@ export { filterIsSet } from './filter-is-set';
 export { truncateSha } from './truncate_sha';
 export { getHumanSize } from './get_human_size';
 export { parsePulpIDFromURL } from './parse-pulp-id';
+export { lastSynced, lastSyncStatus } from './last-sync-task';

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -4,7 +4,11 @@ export { sanitizeDocsUrls } from './sanitize-docs-urls';
 export { mapErrorMessages } from './map-error-messages';
 export { getRepoUrl, getContainersURL } from './get-repo-url';
 export { twoWayMapper } from './two-way-mapper';
-export { isFieldSet, clearSetFieldsFromRequest } from './write-only-fields';
+export {
+  clearSetFieldsFromRequest,
+  isFieldSet,
+  isWriteOnly,
+} from './write-only-fields';
 export { filterIsSet } from './filter-is-set';
 export { truncateSha } from './truncate_sha';
 export { getHumanSize } from './get_human_size';

--- a/src/utilities/last-sync-task.tsx
+++ b/src/utilities/last-sync-task.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { DateComponent, HelperText, StatusIndicator } from 'src/components';
+
+export function lastSynced(entity) {
+  if (!entity.last_sync_task || !entity.last_sync_task.finished_at) {
+    return null;
+  }
+
+  return (
+    <>
+      <DateComponent date={entity.last_sync_task.finished_at} />
+    </>
+  );
+}
+
+export function lastSyncStatus(entity) {
+  if (!entity.last_sync_task) {
+    return null;
+  }
+
+  let errorMessage = null;
+  if (entity.last_sync_task.error) {
+    errorMessage = (
+      <HelperText content={entity.last_sync_task.error['description']} />
+    );
+  }
+
+  return (
+    <>
+      <StatusIndicator status={entity.last_sync_task.state} /> {errorMessage}
+    </>
+  );
+}

--- a/src/utilities/write-only-fields.ts
+++ b/src/utilities/write-only-fields.ts
@@ -1,5 +1,13 @@
 import { WriteOnlyFieldType } from 'src/api';
 
+export function isWriteOnly(
+  name: string,
+  writeOnlyFields: WriteOnlyFieldType[],
+) {
+  const field = writeOnlyFields.find((el) => el.name === name);
+  return !!field;
+}
+
 export function isFieldSet(
   name: string,
   writeOnlyFields: WriteOnlyFieldType[],

--- a/src/utilities/write-only-fields.ts
+++ b/src/utilities/write-only-fields.ts
@@ -14,7 +14,6 @@ export function isFieldSet(
 ) {
   const field = writeOnlyFields.find((el) => el.name === name);
   if (field) {
-    console.log(field);
     return field.is_set;
   } else {
     throw 'Field ${name} is not in writeOnlyFields';

--- a/test/cypress/integration/menu.js
+++ b/test/cypress/integration/menu.js
@@ -10,7 +10,7 @@ describe('Hub Menu Tests', () => {
     'Collections > Repository Management',
     'Collections > API Token',
     'Collections > Approval',
-    'Container Registry',
+    'Execution Environments > Execution Environments',
     'Task Management',
     'Documentation',
     'User Access > Users',
@@ -36,7 +36,7 @@ describe('Hub Menu Tests', () => {
       'Collections > Namespaces',
       'Collections > Repository Management',
       'Collections > API Token',
-      'Container Registry',
+      'Execution Environments > Execution Environments',
       'Task Management',
       'Documentation',
     ];

--- a/test/cypress/integration/menu.js
+++ b/test/cypress/integration/menu.js
@@ -11,6 +11,7 @@ describe('Hub Menu Tests', () => {
     'Collections > API Token',
     'Collections > Approval',
     'Execution Environments > Execution Environments',
+    'Execution Environments > Remote Registries',
     'Task Management',
     'Documentation',
     'User Access > Users',
@@ -37,6 +38,7 @@ describe('Hub Menu Tests', () => {
       'Collections > Repository Management',
       'Collections > API Token',
       'Execution Environments > Execution Environments',
+      'Execution Environments > Remote Registries',
       'Task Management',
       'Documentation',
     ];


### PR DESCRIPTION
Fixes [AAH-437](https://issues.redhat.com/browse/AAH-437) (with #898)
API https://github.com/ansible/galaxy_ng/pull/898 (crud; merged), https://github.com/ansible/galaxy_ng/pull/944 (filtering; merged), https://github.com/ansible/galaxy_ng/pull/965 (sorting; merged)

Updates menu & title from Container Registry to Execution Environments > Execution Environments,
and adds a new Execution Environments > Remote registries screen, allowing the user to create, list, update, delete and sync container registries.

The form is shared with collection repository management, but extended to allow creation, allow some fields to be optionally write-only, allow editing name, and the Username & Password fields are moved from advanced options in both versions of the form.

![Untitled](https://user-images.githubusercontent.com/289743/132783786-266219da-5fe2-43ac-95d2-b0b30168bc1f.png)

![20210922002211](https://user-images.githubusercontent.com/289743/134264444-7b0a33ba-495e-4f5c-933d-0d221c42173a.png)

| | | |
|-|-|-|
| ![20210922002329](https://user-images.githubusercontent.com/289743/134264624-765e9f9b-2066-4b3b-9be3-eee36e6a39c8.png) ![20210922002612](https://user-images.githubusercontent.com/289743/134264705-1dcea326-2e36-4096-954a-b5b232565127.png) | ![20210922002350](https://user-images.githubusercontent.com/289743/134264625-fa109e4a-d3cd-4fd8-b483-927ae771d402.png) | ![20210922002420](https://user-images.githubusercontent.com/289743/134264626-499c9f68-0399-49e5-b8e9-c26b0ae7c9bd.png) |

![Untitled](https://user-images.githubusercontent.com/289743/132783889-f92a6f5e-d995-4089-b5c5-d371fd82ea1c.png)

(TODO APIs for delete & sync are not yet merged, so these operations fail with an alert now.)