### PR TITLE
src/l10n: test_l10n: Fix >>string<< logic to work with strings with params

### DIFF
--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -13,9 +13,17 @@ async function activate(locale: string) {
   const { messages } = await import(`src/../locale/${locale}.js`);
 
   if (window.localStorage.test_l10n === 'true') {
-    Object.keys(messages).forEach(
-      (key) => (messages[key] = '»' + messages[key] + '«'),
-    );
+    Object.keys(messages).forEach((key) => {
+      if (Array.isArray(messages[key])) {
+        // t`Foo ${param}` -> ["Foo ", ['param']] => [">>Foo <<", ['param']]
+        messages[key] = messages[key].map((item) =>
+          Array.isArray(item) ? item : '»' + item + '«',
+        );
+      } else {
+        // simple string
+        messages[key] = '»' + messages[key] + '«';
+      }
+    });
   }
 
   i18n.loadLocaleData(locale, { plurals: plurals[locale] });


### PR DESCRIPTION
when running with `test_l10n = true`, looking at Approval dashboard CompoundFilter placeholder

without this PR it shows `>>Filter by ,0<<`
with this PR it shows `>>Filter by <<>>namespace<<`

strings with params get compiled into `['Foo ', ['param'], ' bar']`, se we need to handle this format as well
(only marking the non-param bits)

(with or without this PR, it works fine when *not* using test_l10n)

Cc @jerabekjiri 