### PR TITLE
CollectionsFilter / Roles filter: use /_ui/v1/tags/{collections,roles} API to populate filter tags

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -67,7 +67,7 @@ export class BaseAPI {
     return this.http.patch(this.getPath(apiPath) + id + '/', data);
   }
 
-  getPath(apiPath: string) {
+  getPath(apiPath?: string) {
     return apiPath || this.apiPath;
   }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -85,6 +85,7 @@ export { SettingsAPI } from './settings';
 export { SignCollectionAPI } from './sign-collections';
 export { SignContainersAPI } from './sign-containers';
 export { SigningServiceAPI, SigningServiceType } from './signing-service';
+export { TagAPI } from './tag';
 export { TaskAPI } from './task';
 export { TaskManagementAPI } from './task-management';
 export { UserAPI } from './user';

--- a/src/api/tag.ts
+++ b/src/api/tag.ts
@@ -1,0 +1,15 @@
+import { HubAPI } from './hub';
+
+export class API extends HubAPI {
+  apiPath = this.getUIPath('tags/');
+
+  listCollections(params) {
+    return this.list(params, this.getPath() + 'collections/');
+  }
+
+  listRoles(params) {
+    return this.list(params, this.getPath() + 'roles/');
+  }
+}
+
+export const TagAPI = new API();

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -32,22 +32,6 @@ export class Constants {
     'rejected',
   ];
 
-  // FIXME: replace with API call or free form input
-  static COLLECTION_FILTER_TAGS = [
-    'application',
-    'cloud',
-    'database',
-    'eda',
-    'infrastructure',
-    'linux',
-    'monitoring',
-    'networking',
-    'security',
-    'storage',
-    'tools',
-    'windows',
-  ];
-
   static TASK_NAMES = {
     'galaxy_ng.app.tasks.curate_all_synclist_repository': msg`Curate all synclist repository`,
     'galaxy_ng.app.tasks.curate_synclist_repository': msg`Curate synclist repository`,

--- a/src/containers/ansible-role/namespace-detail.tsx
+++ b/src/containers/ansible-role/namespace-detail.tsx
@@ -14,6 +14,7 @@ import {
   LegacyNamespaceListType,
   LegacyRoleAPI,
   LegacyRoleListType,
+  TagAPI,
 } from 'src/api';
 import {
   AlertList,
@@ -119,11 +120,24 @@ class NamespaceRoles extends React.Component<
       );
   }
 
+  loadTags(inputText) {
+    return TagAPI.listRoles({ name__icontains: inputText, sort: '-count' })
+      .then(({ data: { data } }) =>
+        data.map(({ name, count }) => ({
+          id: name,
+          title: count === undefined ? name : t`${name} (${count})`,
+        })),
+      )
+      .catch(() => []);
+  }
+
   private get updateParams() {
     return ParamHelper.updateParamsMixin();
   }
 
   render() {
+    const { count, loading, params, roles } = this.state;
+
     const updateParams = (params) =>
       this.updateParams(params, () => this.query(params));
 
@@ -135,6 +149,8 @@ class NamespaceRoles extends React.Component<
       {
         id: 'tags',
         title: t`Tags`,
+        inputType: 'typeahead' as const,
+        // options handled by `typeaheads`
       },
     ];
 
@@ -151,8 +167,6 @@ class NamespaceRoles extends React.Component<
         type: 'numeric' as const,
       },
     ];
-
-    const { count, loading, params, roles } = this.state;
 
     const noData =
       count === 0 &&
@@ -178,6 +192,7 @@ class NamespaceRoles extends React.Component<
               ignoredParams={['page', 'page_size', 'sort']}
               params={params}
               sortOptions={sortOptions}
+              typeaheads={{ tags: this.loadTags }}
               updateParams={updateParams}
             />
             {!count ? (

--- a/src/containers/ansible-role/role-list.tsx
+++ b/src/containers/ansible-role/role-list.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { DataList } from '@patternfly/react-core';
 import React from 'react';
-import { LegacyRoleAPI, LegacyRoleListType } from 'src/api';
+import { LegacyRoleAPI, LegacyRoleListType, TagAPI } from 'src/api';
 import {
   AlertList,
   AlertType,
@@ -80,6 +80,17 @@ class AnsibleRoleList extends React.Component<RouteProps, RolesState> {
       );
   }
 
+  loadTags(inputText) {
+    return TagAPI.listRoles({ name__icontains: inputText, sort: '-count' })
+      .then(({ data: { data } }) =>
+        data.map(({ name, count }) => ({
+          id: name,
+          title: count === undefined ? name : t`${name} (${count})`,
+        })),
+      )
+      .catch(() => []);
+  }
+
   private get updateParams() {
     return ParamHelper.updateParamsMixin();
   }
@@ -95,6 +106,8 @@ class AnsibleRoleList extends React.Component<RouteProps, RolesState> {
   }
 
   render() {
+    const { alerts, count, loading, params, roles } = this.state;
+
     const updateParams = (params) =>
       this.updateParams(params, () => this.query(params));
 
@@ -110,6 +123,8 @@ class AnsibleRoleList extends React.Component<RouteProps, RolesState> {
       {
         id: 'tags',
         title: t`Tags`,
+        inputType: 'typeahead' as const,
+        // options handled by `typeaheads`
       },
     ];
 
@@ -126,8 +141,6 @@ class AnsibleRoleList extends React.Component<RouteProps, RolesState> {
         type: 'numeric' as const,
       },
     ];
-
-    const { alerts, count, loading, params, roles } = this.state;
 
     const noData =
       count === 0 &&
@@ -155,6 +168,7 @@ class AnsibleRoleList extends React.Component<RouteProps, RolesState> {
               ignoredParams={['page', 'page_size', 'sort']}
               params={params}
               sortOptions={sortOptions}
+              typeaheads={{ tags: this.loadTags }}
               updateParams={updateParams}
             />
 


### PR DESCRIPTION
Depends on https://github.com/ansible/galaxy_ng/pull/1931

role list:
![20231106201834](https://github.com/ansible/ansible-hub-ui/assets/289743/acacd949-0d24-4c59-a072-1ade4149e253)

![20231106201855](https://github.com/ansible/ansible-hub-ui/assets/289743/1e4f749b-23a0-4424-b488-8e8f27850eb4)
(typeahead in filter steals focus from input field when typing - fixing as separate issue, unrelated to tags)

role namespace role list:
![20231106201941](https://github.com/ansible/ansible-hub-ui/assets/289743/d2ccec4c-c16a-4def-a73b-bafe1c7cec62)
(tags counts are NOT scoped to the namespace)

collections:
![20231106202038](https://github.com/ansible/ansible-hub-ui/assets/289743/b785ad74-0415-4884-bdb3-03f596a96e3a)
(tag counts will appear with newer pulp_ansible - the ui can display them as long as the api serves them)