### PR TITLE
EE: Remote Repositories

### DIFF
--- a/src/api/execution-environment-remote.ts
+++ b/src/api/execution-environment-remote.ts
@@ -1,0 +1,16 @@
+import { HubAPI } from './hub';
+
+class API extends HubAPI {
+  apiPath = this.getUIPath('execution-environments/remotes/');
+
+  // list(params?)
+  // create(data)
+  // get(pk)
+  // update(pk, data)
+
+  sync(pk) {
+    return this.http.post(this.apiPath + pk + '/sync/', {});
+  }
+}
+
+export const ExecutionEnvironmentRemoteAPI = new API();

--- a/src/api/execution-environment-remote.ts
+++ b/src/api/execution-environment-remote.ts
@@ -10,7 +10,7 @@ class API extends HubAPI {
 
   sync(name) {
     const apiPath = this.getUIPath('execution-environments/repositories/');
-    return this.http.post(apiPath + name + '/sync/', {});
+    return this.http.post(apiPath + name + '/_content/sync/', {});
   }
 }
 

--- a/src/api/execution-environment-remote.ts
+++ b/src/api/execution-environment-remote.ts
@@ -8,8 +8,9 @@ class API extends HubAPI {
   // get(pk)
   // update(pk, data)
 
-  sync(pk) {
-    return this.http.post(this.apiPath + pk + '/sync/', {});
+  sync(name) {
+    const apiPath = this.getUIPath('execution-environments/repositories/');
+    return this.http.post(apiPath + name + '/sync/', {});
   }
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -45,6 +45,7 @@ export {
   ContainerManifestType,
   ContainerRepositoryType,
 } from './response-types/execution-environment';
+export { ExecutionEnvironmentRemoteAPI } from './execution-environment-remote';
 export { WriteOnlyFieldType } from './response-types/write-only-field';
 export { ActivitiesAPI } from './activities';
 export { ContainerTagAPI } from './container-tag';

--- a/src/api/response-types/execution-environment.ts
+++ b/src/api/response-types/execution-environment.ts
@@ -1,3 +1,5 @@
+import { LastSyncType } from './remote';
+
 export class ExecutionEnvironmentType {
   created: string;
   name: string;
@@ -39,6 +41,7 @@ export class ContainerRepositoryType {
         upstream_name: string;
         include_tags: string[];
         exclude_tags: string[];
+        last_sync_task: LastSyncType;
       };
     };
     distribution: {

--- a/src/api/response-types/execution-environment.ts
+++ b/src/api/response-types/execution-environment.ts
@@ -33,6 +33,13 @@ export class ContainerRepositoryType {
       pulp_created: string;
       last_sync_task: string;
       pulp_labels: object;
+      remote?: {
+        pulp_id: string;
+        registry: string;
+        upstream_name: string;
+        include_tags: string[];
+        exclude_tags: string[];
+      };
     };
     distribution: {
       pulp_id: string;

--- a/src/api/response-types/remote.ts
+++ b/src/api/response-types/remote.ts
@@ -1,7 +1,7 @@
 import { PulpStatus } from './pulp';
 import { WriteOnlyFieldType } from './write-only-field';
 
-class LastSyncType {
+export class LastSyncType {
   state: PulpStatus;
   started_at: string;
   finished_at: string;

--- a/src/components/execution-environment-header/execution-environment-header.tsx
+++ b/src/components/execution-environment-header/execution-environment-header.tsx
@@ -1,9 +1,10 @@
-import { t } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import * as React from 'react';
 import { Tooltip, Button } from '@patternfly/react-core';
 import { Paths } from 'src/paths';
 import { BaseHeader, Breadcrumbs, Tabs } from 'src/components';
 import { ContainerRepositoryType } from 'src/api';
+import { lastSyncStatus, lastSynced } from 'src/utilities';
 
 interface IProps {
   id: string;
@@ -20,6 +21,10 @@ export class ExecutionEnvironmentHeader extends React.Component<IProps> {
       { id: 'activity', name: t`Activity` },
       { id: 'images', name: t`Images` },
     ];
+
+    const last_sync_task =
+      this.props.container.pulp.repository.remote?.last_sync_task;
+
     return (
       <BaseHeader
         title={this.props.container.name}
@@ -39,6 +44,14 @@ export class ExecutionEnvironmentHeader extends React.Component<IProps> {
         <Tooltip content={this.props.container.description}>
           <p className={'truncated'}>{this.props.container.description}</p>
         </Tooltip>
+        {last_sync_task && (
+          <p className='truncated'>
+            <Trans>
+              Last updated from registry {lastSynced({ last_sync_task })}
+            </Trans>{' '}
+            {lastSyncStatus({ last_sync_task })}
+          </p>
+        )}
         <span />
         <div className='tab-link-container'>
           <div className='tabs'>

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -44,7 +44,7 @@ export class RepositoryForm extends React.Component<IProps, IState> {
         variant='large'
         onClose={onCancel}
         isOpen={true}
-        title={t`Edit repository`}
+        title={t`Edit execution environment`}
         actions={[
           <Button
             key='save'

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -92,7 +92,9 @@ export class RepositoryForm extends React.Component<IProps, IState> {
       });
     }
 
-    this.loadSelectedGroups();
+    if (!this.props.isNew) {
+      this.loadSelectedGroups();
+    }
   }
 
   render() {

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -29,7 +29,6 @@ interface IProps {
   name: string;
   namespace: string;
   description: string;
-  selectedGroups: GroupObjectPermissionType[];
   onSave: (Promise) => void;
   onCancel: () => void;
   permissions: string[];
@@ -49,6 +48,7 @@ interface IState {
   name: string;
   description: string;
   selectedGroups: GroupObjectPermissionType[];
+  originalSelectedGroups: GroupObjectPermissionType[];
 
   addTagsInclude: string;
   addTagsExclude: string;
@@ -65,7 +65,8 @@ export class RepositoryForm extends React.Component<IProps, IState> {
     this.state = {
       name: this.props.name,
       description: this.props.description,
-      selectedGroups: cloneDeep(this.props.selectedGroups),
+      selectedGroups: [],
+      originalSelectedGroups: [],
 
       addTagsInclude: '',
       addTagsExclude: '',
@@ -90,6 +91,8 @@ export class RepositoryForm extends React.Component<IProps, IState> {
         }
       });
     }
+
+    this.loadSelectedGroups();
   }
 
   render() {
@@ -348,6 +351,16 @@ export class RepositoryForm extends React.Component<IProps, IState> {
     });
   }
 
+  private loadSelectedGroups() {
+    const { namespace } = this.props;
+    return ExecutionEnvironmentNamespaceAPI.get(namespace).then((result) =>
+      this.setState({
+        selectedGroups: cloneDeep(result.data.groups),
+        originalSelectedGroups: result.data.groups,
+      }),
+    );
+  }
+
   private addTags(tags, key: 'includeTags' | 'excludeTags') {
     const current = new Set(this.state[key]);
     tags.split(/\s+|\s*,\s*/).forEach((tag) => current.add(tag));
@@ -376,7 +389,6 @@ export class RepositoryForm extends React.Component<IProps, IState> {
       name: originalName,
       namespace,
       remotePulpId,
-      selectedGroups: originalSelectedGroups,
     } = this.props;
     const {
       description,
@@ -385,6 +397,7 @@ export class RepositoryForm extends React.Component<IProps, IState> {
       name,
       registrySelection: [{ id: registry } = { id: null }],
       selectedGroups,
+      originalSelectedGroups,
       upstreamName: upstream_name,
     } = this.state;
 

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -35,8 +35,9 @@ import {
   StatefulDropdown,
 } from 'src/components';
 
-import { CollectionAPI, CollectionDetailType, TaskAPI } from 'src/api';
+import { CollectionAPI, CollectionDetailType } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
+import { waitForTask } from 'src/utilities';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { DateComponent } from '../date-component/date-component';
 import { Constants } from 'src/constants';
@@ -494,7 +495,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       .then((res) => {
         const taskId = this.getIdFromTask(res.data.task);
 
-        this.waitForTaskFinish(taskId).then(() => {
+        waitForTask(taskId).then(() => {
           if (deleteCollection.all_versions.length > 1) {
             const topVersion = deleteCollection.all_versions.filter(
               ({ version }) => version !== collectionVersion,
@@ -607,7 +608,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       .then((res) => {
         const taskId = this.getIdFromTask(res.data.task);
 
-        this.waitForTaskFinish(taskId).then(() => {
+        waitForTask(taskId).then(() => {
           this.context.setAlerts([
             ...this.context.alerts,
             {
@@ -667,16 +668,6 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           ],
         }),
       );
-  }
-
-  private waitForTaskFinish(task) {
-    return TaskAPI.get(task).then((result) => {
-      if (result.data.state !== 'completed') {
-        return new Promise((r) => setTimeout(r, 500)).then(() =>
-          this.waitForTaskFinish(task),
-        );
-      }
-    });
   }
 
   private getIdFromTask(task) {

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -177,6 +177,19 @@ export function withContainerRepo(WrappedComponent) {
                 }}
                 onCancel={() => this.setState({ editing: false })}
                 distributionPulpId={this.state.repo.pulp.distribution.pulp_id}
+                isRemote={!!this.state.repo.pulp.repository.remote}
+                isNew={false}
+                upstreamName={
+                  this.state.repo.pulp.repository.remote?.upstream_name
+                }
+                registry={this.state.repo.pulp.repository.remote?.registry}
+                excludeTags={
+                  this.state.repo.pulp.repository.remote?.exclude_tags
+                }
+                includeTags={
+                  this.state.repo.pulp.repository.remote?.include_tags
+                }
+                remotePulpId={this.state.repo.pulp.repository.remote?.pulp_id}
               />
             )}
             <WrappedComponent

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -3,8 +3,9 @@ import * as React from 'react';
 
 import { RouteComponentProps, Redirect } from 'react-router-dom';
 import {
-  ExecutionEnvironmentAPI,
   ContainerRepositoryType,
+  ExecutionEnvironmentAPI,
+  ExecutionEnvironmentRemoteAPI,
   GroupObjectPermissionType,
   TaskAPI,
 } from 'src/api';
@@ -50,9 +51,11 @@ export function withContainerRepo(WrappedComponent) {
         alerts: [],
       };
     }
+
     componentDidMount() {
       this.loadRepo();
     }
+
     render() {
       if (this.state.redirect === 'activity') {
         return (
@@ -94,6 +97,16 @@ export function withContainerRepo(WrappedComponent) {
           'container.namespace_change_containerdistribution',
         ) || permissions.includes('container.change_containernamespace');
       const dropdownItems = [
+        this.state.repo.pulp.repository.remote && (
+          <DropdownItem
+            key='sync'
+            onClick={() =>
+              ExecutionEnvironmentRemoteAPI.sync(this.state.repo.name)
+            }
+          >
+            {t`Sync from registry`}
+          </DropdownItem>
+        ),
         <DropdownItem
           key='publish-to-controller'
           onClick={() => {
@@ -106,7 +119,7 @@ export function withContainerRepo(WrappedComponent) {
         >
           {t`Use in Controller`}
         </DropdownItem>,
-      ];
+      ].filter((truthy) => truthy);
 
       const { publishToController } = this.state;
 

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -5,7 +5,6 @@ import { RouteComponentProps, Redirect } from 'react-router-dom';
 import {
   ExecutionEnvironmentAPI,
   ContainerRepositoryType,
-  ExecutionEnvironmentNamespaceAPI,
   GroupObjectPermissionType,
   TaskAPI,
 } from 'src/api';
@@ -29,7 +28,6 @@ interface IState {
   loading: boolean;
   redirect: string;
   editing: boolean;
-  selectedGroups: GroupObjectPermissionType[];
   alerts: AlertType[];
 }
 
@@ -49,7 +47,6 @@ export function withContainerRepo(WrappedComponent) {
         loading: true,
         redirect: undefined,
         editing: false,
-        selectedGroups: [],
         alerts: [],
       };
     }
@@ -147,7 +144,6 @@ export function withContainerRepo(WrappedComponent) {
               <RepositoryForm
                 name={this.state.repo.name}
                 namespace={this.state.repo.namespace.name}
-                selectedGroups={this.state.selectedGroups}
                 description={this.state.repo.description}
                 permissions={permissions}
                 onSave={(promise) => {
@@ -205,16 +201,10 @@ export function withContainerRepo(WrappedComponent) {
     private loadRepo() {
       ExecutionEnvironmentAPI.get(this.props.match.params['container'])
         .then((result) => {
-          const repo = result;
-          return ExecutionEnvironmentNamespaceAPI.get(
-            result.data.namespace.name,
-          ).then((result) =>
-            this.setState({
-              loading: false,
-              repo: repo.data,
-              selectedGroups: result.data.groups,
-            }),
-          );
+          this.setState({
+            loading: false,
+            repo: result.data,
+          });
         })
         .catch((e) => this.setState({ redirect: 'notFound' }));
     }

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -7,7 +7,6 @@ import {
   ExecutionEnvironmentAPI,
   ExecutionEnvironmentRemoteAPI,
   GroupObjectPermissionType,
-  TaskAPI,
 } from 'src/api';
 import { formatPath, Paths } from '../../paths';
 import { Button, DropdownItem } from '@patternfly/react-core';
@@ -22,6 +21,7 @@ import {
   StatefulDropdown,
   closeAlertMixin,
 } from 'src/components';
+import { waitForTask } from 'src/utilities';
 
 interface IState {
   publishToController: { digest?: string; image: string; tag?: string };
@@ -165,7 +165,7 @@ export function withContainerRepo(WrappedComponent) {
                       let task = results.find((x) => x.data && x.data.task);
                       this.setState({ editing: false, loading: true });
                       if (!!task) {
-                        this.waitForTask(
+                        waitForTask(
                           task.data.task.split('tasks/')[1].replace('/', ''),
                         ).then(() => {
                           this.loadRepo();
@@ -235,15 +235,6 @@ export function withContainerRepo(WrappedComponent) {
       return 'detail';
     }
 
-    private waitForTask(task) {
-      return TaskAPI.get(task).then((result) => {
-        if (result.data.state !== 'completed') {
-          return new Promise((r) => setTimeout(r, 500)).then(() =>
-            this.waitForTask(task),
-          );
-        }
-      });
-    }
     private get closeAlert() {
       return closeAlertMixin('alerts');
     }

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -152,7 +152,7 @@ export function withContainerRepo(WrappedComponent) {
                 selectedGroups={cloneDeep(this.state.selectedGroups)}
                 description={this.state.repo.description}
                 permissions={permissions}
-                onSave={(description, selectedGroups) => {
+                onSave={({ description, selectedGroups }) => {
                   let promises = [];
                   if (description !== this.state.repo.description) {
                     promises.push(

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -3,17 +3,14 @@ import * as React from 'react';
 import './execution-environment-detail.scss';
 
 import { pickBy } from 'lodash';
-import {
-  ExecutionEnvironmentAPI,
-  ContainerManifestType,
-  TaskAPI,
-} from 'src/api';
+import { ExecutionEnvironmentAPI, ContainerManifestType } from 'src/api';
 import { formatPath, Paths } from 'src/paths';
 import {
   ParamHelper,
   filterIsSet,
   getContainersURL,
   getHumanSize,
+  waitForTask,
 } from 'src/utilities';
 
 import { Link, withRouter } from 'react-router-dom';
@@ -458,7 +455,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
           selectedImage: null,
           confirmDelete: false,
         });
-        this.waitForTask(taskId).then(() => {
+        waitForTask(taskId).then(() => {
           this.setState({
             alerts: this.state.alerts.concat([
               {
@@ -480,16 +477,6 @@ class ExecutionEnvironmentDetailImages extends React.Component<
           ]),
         });
       });
-  }
-
-  private waitForTask(task) {
-    return TaskAPI.get(task).then((result) => {
-      if (result.data.state !== 'completed') {
-        return new Promise((r) => setTimeout(r, 500)).then(() =>
-          this.waitForTask(task),
-        );
-      }
-    });
   }
 
   private get updateParams() {

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -180,7 +180,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
       this.props.containerRepository.namespace.my_permissions.includes(
         'container.namespace_modify_content_containerpushrepository',
       );
-    const { digest } = selectedImage;
+    const { digest } = selectedImage || {};
 
     return (
       <section className='body'>

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -346,8 +346,10 @@ class ExecutionEnvironmentDetailImages extends React.Component<
         ? image.digest
         : this.props.match.params['container'] + ':' + image.tags[0];
 
+    const isRemote = !!this.props.containerRepository.pulp.repository.remote;
+
     const dropdownItems = [
-      canEditTags && (
+      canEditTags && !isRemote && (
         <DropdownItem
           key='edit-tags'
           onClick={() => {

--- a/src/containers/execution-environment-detail/tag-manifest-modal.tsx
+++ b/src/containers/execution-environment-detail/tag-manifest-modal.tsx
@@ -171,7 +171,7 @@ export class TagManifestModal extends React.Component<IProps, IState> {
                 onClick={this.verifyAndAddTag}
                 isDisabled={!!tagToVerify || verifyingTag || isSaving}
               >
-                Add {verifyingTag && <Spinner size='sm'></Spinner>}
+                {t`Add`} {verifyingTag && <Spinner size='sm'></Spinner>}
               </Button>
             </InputGroup>
           </FormGroup>

--- a/src/containers/execution-environment-detail/tag-manifest-modal.tsx
+++ b/src/containers/execution-environment-detail/tag-manifest-modal.tsx
@@ -312,6 +312,7 @@ export class TagManifestModal extends React.Component<IProps, IState> {
     });
   }
 
+  // FIXME merge with waitForTask from utilities
   private waitForTasks(taskUrls: ITaskUrls[]) {
     const pending = new Set(taskUrls.map((i) => i.task));
 

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -14,6 +14,7 @@ import {
 } from '@patternfly/react-core';
 import {
   ExecutionEnvironmentAPI,
+  ExecutionEnvironmentRemoteAPI,
   ExecutionEnvironmentType,
   TaskAPI,
 } from 'src/api';
@@ -292,6 +293,18 @@ class ExecutionEnvironmentList extends React.Component<
   private renderTableRow(item: any, index: number) {
     const description = item.description;
     const dropdownItems = [
+      item.pulp.repository.remote && (
+        <DropdownItem
+          key='sync'
+          onClick={() =>
+            ExecutionEnvironmentRemoteAPI.sync(
+              item.pulp.repository.remote.pulp_id,
+            )
+          }
+        >
+          {t`Sync from registry`}
+        </DropdownItem>
+      ),
       <DropdownItem
         key='publish-to-controller'
         onClick={() => {

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -137,6 +137,20 @@ class ExecutionEnvironmentList extends React.Component<
         <Trans>Push container images</Trans> <ExternalLinkAltIcon />
       </Button>
     );
+    const addRemoteButton = (
+      <Button
+        onClick={() =>
+          this.setState({
+            showRemoteModal: true,
+            itemToEdit: {} as ExecutionEnvironmentType,
+          })
+        }
+        variant='primary'
+      >
+        <Trans>Add execution environment</Trans>
+      </Button>
+    );
+
     const name = !!selectedItem ? selectedItem.name : '';
 
     return (
@@ -180,7 +194,12 @@ class ExecutionEnvironmentList extends React.Component<
           <EmptyStateNoData
             title={t`No container repositories yet`}
             description={t`You currently have no container repositories. Add a container repository via the CLI to get started.`}
-            button={pushImagesButton}
+            button={
+              <>
+                {addRemoteButton}
+                {pushImagesButton}
+              </>
+            }
           />
         ) : (
           <Main>
@@ -209,19 +228,7 @@ class ExecutionEnvironmentList extends React.Component<
                             ]}
                           />
                         </ToolbarItem>
-                        <ToolbarItem>
-                          <Button
-                            onClick={() =>
-                              this.setState({
-                                showRemoteModal: true,
-                                itemToEdit: {} as ExecutionEnvironmentType,
-                              })
-                            }
-                            variant='primary'
-                          >
-                            <Trans>Add execution environment</Trans>
-                          </Button>
-                        </ToolbarItem>
+                        <ToolbarItem>{addRemoteButton}</ToolbarItem>
                         <ToolbarItem>{pushImagesButton}</ToolbarItem>
                       </ToolbarGroup>
                     </ToolbarContent>

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Checkbox,
   DropdownItem,
+  Label,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
@@ -44,15 +45,17 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { DeleteModal } from 'src/components/delete-modal/delete-modal';
 
 interface IState {
+  alerts: AlertType[];
+  itemCount: number;
+  itemToEdit?: ExecutionEnvironmentType;
+  items: ExecutionEnvironmentType[];
+  loading: boolean;
   params: {
     page?: number;
     page_size?: number;
   };
   publishToController: { digest?: string; image: string; tag?: string };
-  loading: boolean;
-  items: ExecutionEnvironmentType[];
-  itemCount: number;
-  alerts: AlertType[];
+  showRemoteModal: boolean;
   unauthorized: boolean;
   deleteModalVisible: boolean;
   selectedItem: ExecutionEnvironmentType;
@@ -80,12 +83,14 @@ class ExecutionEnvironmentList extends React.Component<
     }
 
     this.state = {
-      params: params,
-      publishToController: null,
+      alerts: [],
+      itemCount: 0,
+      itemToEdit: null,
       items: [],
       loading: true,
-      itemCount: 0,
-      alerts: [],
+      params,
+      publishToController: null,
+      showRemoteModal: false,
       unauthorized: false,
       deleteModalVisible: false,
       selectedItem: null,
@@ -103,17 +108,20 @@ class ExecutionEnvironmentList extends React.Component<
 
   render() {
     const {
+      alerts,
+      itemCount,
+      itemToEdit,
+      items,
+      loading,
       params,
       publishToController,
-      itemCount,
-      loading,
-      alerts,
-      items,
+      showRemoteModal,
       unauthorized,
       deleteModalVisible,
       selectedItem,
       confirmDelete,
     } = this.state;
+
     const noData = items.length === 0 && !filterIsSet(params, ['name']);
     const pushImagesButton = (
       <Button
@@ -125,7 +133,7 @@ class ExecutionEnvironmentList extends React.Component<
           )
         }
       >
-        Push container images <ExternalLinkAltIcon />
+        <Trans>Push container images</Trans> <ExternalLinkAltIcon />
       </Button>
     );
     const name = !!selectedItem ? selectedItem.name : '';
@@ -143,6 +151,7 @@ class ExecutionEnvironmentList extends React.Component<
           onClose={() => this.setState({ publishToController: null })}
           tag={publishToController?.tag}
         />
+        {showRemoteModal && this.renderRemoteModal(itemToEdit)}
         <BaseHeader title={t`Execution Environments`}></BaseHeader>
         {deleteModalVisible && (
           <DeleteModal
@@ -198,6 +207,19 @@ class ExecutionEnvironmentList extends React.Component<
                               },
                             ]}
                           />
+                        </ToolbarItem>
+                        <ToolbarItem>
+                          <Button
+                            onClick={() =>
+                              this.setState({
+                                showRemoteModal: true,
+                                itemToEdit: null,
+                              })
+                            }
+                            variant='primary'
+                          >
+                            <Trans>Add execution environment</Trans>
+                          </Button>
                         </ToolbarItem>
                         <ToolbarItem>{pushImagesButton}</ToolbarItem>
                       </ToolbarGroup>
@@ -300,6 +322,19 @@ class ExecutionEnvironmentList extends React.Component<
     const dropdownItems = [
       item.pulp.repository.remote && (
         <DropdownItem
+          key='edit'
+          onClick={() =>
+            this.setState({
+              showRemoteModal: true,
+              itemToEdit: item,
+            })
+          }
+        >
+          {t`Edit`}
+        </DropdownItem>
+      ),
+      item.pulp.repository.remote && (
+        <DropdownItem
           key='sync'
           onClick={() =>
             ExecutionEnvironmentRemoteAPI.sync(
@@ -364,6 +399,10 @@ class ExecutionEnvironmentList extends React.Component<
         </td>
       </tr>
     );
+  }
+
+  private renderRemoteModal(itemToEdit) {
+    return <div>TODO</div>;
   }
 
   private queryEnvironments() {

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -418,11 +418,6 @@ class ExecutionEnvironmentList extends React.Component<
         excludeTags={exclude_tags || []}
         includeTags={include_tags || []}
         permissions={namespace?.my_permissions || []}
-        selectedGroups={
-          [
-            /*TODO*/
-          ]
-        }
         remotePulpId={pulp_id}
         distributionPulpId={distributionPulpId}
         onSave={(promise) => {

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -269,6 +269,11 @@ class ExecutionEnvironmentList extends React.Component<
           id: 'updated',
         },
         {
+          title: t`Container registry type`,
+          type: 'none',
+          id: 'type',
+        },
+        {
           title: '',
           type: 'none',
           id: 'controls',
@@ -350,6 +355,9 @@ class ExecutionEnvironmentList extends React.Component<
         </td>
         <td>
           <DateComponent date={item.updated} />
+        </td>
+        <td>
+          <Label>{item.pulp.repository.remote ? t`Remote` : t`Local`}</Label>
         </td>
         <td style={{ paddingRight: '0px', textAlign: 'right' }}>
           {!!dropdownItems.length && <StatefulDropdown items={dropdownItems} />}

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -17,9 +17,8 @@ import {
   ExecutionEnvironmentAPI,
   ExecutionEnvironmentRemoteAPI,
   ExecutionEnvironmentType,
-  TaskAPI,
 } from 'src/api';
-import { filterIsSet, ParamHelper } from 'src/utilities';
+import { filterIsSet, waitForTask, ParamHelper } from 'src/utilities';
 import {
   AlertList,
   AlertType,
@@ -479,7 +478,7 @@ class ExecutionEnvironmentList extends React.Component<
           selectedItem: null,
           confirmDelete: false,
         });
-        this.waitForTask(taskId).then(() => {
+        waitForTask(taskId).then(() => {
           this.setState({
             alerts: this.state.alerts.concat([
               {
@@ -501,16 +500,6 @@ class ExecutionEnvironmentList extends React.Component<
           ]),
         });
       });
-  }
-
-  private waitForTask(task) {
-    return TaskAPI.get(task).then((result) => {
-      if (result.data.state !== 'completed') {
-        return new Promise((r) => setTimeout(r, 500)).then(() =>
-          this.waitForTask(task),
-        );
-      }
-    });
   }
 
   private get updateParams() {

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -404,6 +404,7 @@ class ExecutionEnvironmentList extends React.Component<
       pulp?.repository?.remote || {};
     const remote = pulp?.repository ? !!pulp?.repository?.remote : true; // add only supports remote
     const isNew = !pulp?.repository; // only exists in real data
+    const distributionPulpId = pulp?.distribution?.pulp_id;
 
     return (
       <RepositoryForm
@@ -422,56 +423,27 @@ class ExecutionEnvironmentList extends React.Component<
             /*TODO*/
           ]
         }
-        onSave={(item) => {
-          if (isNew) {
-            const {
-              name,
-              upstreamName: upstream_name,
-              registry,
-              includeTags: include_tags,
-              excludeTags: exclude_tags,
-            } = item;
-            ExecutionEnvironmentRemoteAPI.create({
-              name,
-              upstream_name,
-              registry,
-              include_tags,
-              exclude_tags,
-            }).then(() =>
+        remotePulpId={pulp_id}
+        distributionPulpId={distributionPulpId}
+        onSave={(promise) => {
+          promise
+            .then(() => {
               this.setState(
                 {
                   showRemoteModal: false,
                   itemToEdit: null,
                 },
                 () => this.queryEnvironments(),
-              ),
-            );
-          } else {
-            const {
-              upstreamName: upstream_name,
-              registry,
-              includeTags: include_tags,
-              excludeTags: exclude_tags,
-              description,
-              selectedGroups,
-            } = item;
-            ExecutionEnvironmentRemoteAPI.update(pulp_id, {
-              name,
-              upstream_name,
-              registry,
-              include_tags,
-              exclude_tags,
-            }).then(() =>
-              //TODO description, selectedGroups
-              this.setState(
-                {
-                  showRemoteModal: false,
-                  itemToEdit: null,
-                },
-                () => this.queryEnvironments(),
-              ),
-            );
-          }
+              );
+            })
+            .catch(() => {
+              this.setState({
+                alerts: this.state.alerts.concat({
+                  variant: 'danger',
+                  title: t`Error: changes weren't saved`,
+                }),
+              });
+            });
         }}
         onCancel={() =>
           this.setState({

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -321,19 +321,17 @@ class ExecutionEnvironmentList extends React.Component<
   private renderTableRow(item: any, index: number) {
     const description = item.description;
     const dropdownItems = [
-      item.pulp.repository.remote && (
-        <DropdownItem
-          key='edit'
-          onClick={() =>
-            this.setState({
-              showRemoteModal: true,
-              itemToEdit: { ...item },
-            })
-          }
-        >
-          {t`Edit`}
-        </DropdownItem>
-      ),
+      <DropdownItem
+        key='edit'
+        onClick={() =>
+          this.setState({
+            showRemoteModal: true,
+            itemToEdit: { ...item },
+          })
+        }
+      >
+        {t`Edit`}
+      </DropdownItem>,
       item.pulp.repository.remote && (
         <DropdownItem
           key='sync'

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -336,11 +336,7 @@ class ExecutionEnvironmentList extends React.Component<
       item.pulp.repository.remote && (
         <DropdownItem
           key='sync'
-          onClick={() =>
-            ExecutionEnvironmentRemoteAPI.sync(
-              item.pulp.repository.remote.pulp_id,
-            )
-          }
+          onClick={() => ExecutionEnvironmentRemoteAPI.sync(item.name)}
         >
           {t`Sync from registry`}
         </DropdownItem>

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -14,3 +14,4 @@ export { truncateSha } from './truncate_sha';
 export { getHumanSize } from './get_human_size';
 export { parsePulpIDFromURL } from './parse-pulp-id';
 export { lastSynced, lastSyncStatus } from './last-sync-task';
+export { waitForTask } from './wait-for-task';

--- a/src/utilities/wait-for-task.ts
+++ b/src/utilities/wait-for-task.ts
@@ -1,10 +1,17 @@
+import { t } from '@lingui/macro';
 import { TaskAPI } from 'src/api';
 
-export function waitForTask(task) {
+export function waitForTask(task, bailAfter = 10) {
   return TaskAPI.get(task).then((result) => {
     if (result.data.state !== 'completed') {
+      if (!bailAfter) {
+        return Promise.reject(
+          new Error(t`Giving up waiting for task after 10 attempts.`),
+        );
+      }
+
       return new Promise((r) => setTimeout(r, 5000)).then(() =>
-        waitForTask(task),
+        waitForTask(task, bailAfter - 1),
       );
     }
   });

--- a/src/utilities/wait-for-task.ts
+++ b/src/utilities/wait-for-task.ts
@@ -1,0 +1,11 @@
+import { TaskAPI } from 'src/api';
+
+export function waitForTask(task) {
+  return TaskAPI.get(task).then((result) => {
+    if (result.data.state !== 'completed') {
+      return new Promise((r) => setTimeout(r, 5000)).then(() =>
+        waitForTask(task),
+      );
+    }
+  });
+}


### PR DESCRIPTION
Fixes [AAH-437](https://issues.redhat.com/browse/AAH-437) (with #873)
API: https://github.com/ansible/galaxy_ng/pull/935 (merged), https://github.com/ansible/galaxy_ng/pull/985 (merged), https://github.com/ansible/galaxy_ng/pull/988
Design https://marvelapp.com/prototype/27ee1cd6/screen/82150243 
Soft-depends on #873 for Remote Registry crud (merged)

This allows adding, editing and syncing remote repositories in Execution Environments. These new remote container repos act like local ones, except only local ones can have tags managed while only remote ones can sync, and show sync status.

* EE list:
  * [x] Add button to sync EE if it is a remote EE.
  * [x] Add option to edit an EE’s remote.
  * [x] Add button to create new remote EE.
  * [x] Add if container registry is remote or not

![20210922234654](https://user-images.githubusercontent.com/289743/134436473-c1f8938a-971d-4384-938c-3b71e2bf9446.png)

* EE detail:
  * [x] last updated from registry
  * [x] edit merge
  * [x] disallow editing tags on remotes
  * [x] dropdown with sync&edit(&use)

![20210924172413](https://user-images.githubusercontent.com/289743/134716058-03a0dd95-61d7-4498-ab0c-a371a44cd1d3.png)

* the form itself:
  * [x] Create new remote repository: Allows the user to specify an upstream image name, registry and image name. Creates a new remote execution environment that can be synced
  * [x] Edit remote form. Allows updating a remotes upstream name and registry BUT NOT THE REMOTE’S NAME.
  * [x] rename from Edit repository to Edit execution environment

| ![20210924011502](https://user-images.githubusercontent.com/289743/134603644-10f5add9-bca6-41b1-847a-5117328abf05.png) | ![20210924011617](https://user-images.githubusercontent.com/289743/134603729-2858bce3-3b8d-4516-bc66-96a5a397d9e2.png) |
|-|-|