### PR TITLE
Correct Redirect Push in multiline situation

### DIFF
--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -58,6 +58,7 @@ export function withContainerRepo(WrappedComponent) {
       if (this.state.redirect === 'activity') {
         return (
           <Redirect
+            push
             to={formatPath(Paths.executionEnvironmentDetailActivities, {
               container: this.props.match.params['container'],
             })}
@@ -66,6 +67,7 @@ export function withContainerRepo(WrappedComponent) {
       } else if (this.state.redirect === 'detail') {
         return (
           <Redirect
+            push
             to={formatPath(Paths.executionEnvironmentDetail, {
               container: this.props.match.params['container'],
             })}
@@ -74,6 +76,7 @@ export function withContainerRepo(WrappedComponent) {
       } else if (this.state.redirect === 'images') {
         return (
           <Redirect
+            push
             to={formatPath(Paths.executionEnvironmentDetailImages, {
               container: this.props.match.params['container'],
             })}

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -120,6 +120,7 @@ class AuthHandler extends React.Component<
       }
       return (
         <Redirect
+          push
           to={formatPath(Paths.login, {}, { next: props.location.pathname })}
         ></Redirect>
       );


### PR DESCRIPTION
Correct Redirect Push in multiline situation. Push is needed for history - in order to go back and further.