### PR TITLE
Collection dependencies tab

### DIFF
--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -166,9 +166,10 @@ export class API extends HubAPI {
     });
   }
 
-  getDependencies(namespace, collection) {
+  getUsedDependenciesByCollection(namespace, collection, params?) {
     return this.http.get(
       `/_ui/v1/collection-versions/?dependency=${namespace}.${collection}`,
+      { params },
     );
   }
 }

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -169,7 +169,7 @@ export class API extends HubAPI {
   getUsedDependenciesByCollection(namespace, collection, params?) {
     return this.http.get(
       `/_ui/v1/collection-versions/?dependency=${namespace}.${collection}`,
-      { params },
+      { params: this.mapPageToOffset(params) },
     );
   }
 }

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -168,7 +168,9 @@ export class API extends HubAPI {
 
   getUsedDependenciesByCollection(namespace, collection, params?) {
     return this.http.get(
-      `/_ui/v1/collection-versions/?dependency=${namespace}.${collection}`,
+      this.getUIPath(
+        `collection-versions/?dependency=${namespace}.${collection}`,
+      ),
       { params: this.mapPageToOffset(params) },
     );
   }

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -165,6 +165,12 @@ export class API extends HubAPI {
         .catch((err) => reject(err));
     });
   }
+
+  getDependencies(namespace, collection) {
+    return this.http.get(
+      `/_ui/v1/collection-versions/?dependency=${namespace}.${collection}`,
+    );
+  }
 }
 
 export const CollectionAPI = new API();

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,6 +8,7 @@ export {
 export {
   CollectionListType,
   CollectionDetailType,
+  CollectionUsedByDependencies,
   DocsBlobType,
   PluginContentType,
   CollectionUploadType,

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -11,6 +11,7 @@ export class CollectionVersion {
     contents: ContentSummaryType[];
     description: string;
     tags: string[];
+    dependencies: any; //FIXME: any for testing
   };
   created_at: string;
   // contents: ContentSummaryType[]; // deprecated
@@ -35,6 +36,7 @@ export class CollectionVersionDetail extends CollectionVersion {
     documentation: string;
     issues: string;
     repository: string;
+    dependencies: any;
   };
   requires_ansible?: string;
   docs_blob: DocsBlobType;

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -11,7 +11,7 @@ export class CollectionVersion {
     contents: ContentSummaryType[];
     description: string;
     tags: string[];
-    dependencies: any; //FIXME: any for testing
+    dependencies: DependencyType[];
   };
   created_at: string;
   // contents: ContentSummaryType[]; // deprecated
@@ -36,7 +36,7 @@ export class CollectionVersionDetail extends CollectionVersion {
     documentation: string;
     issues: string;
     repository: string;
-    dependencies: any;
+    dependencies: DependencyType[];
   };
   requires_ansible?: string;
   docs_blob: DocsBlobType;
@@ -122,4 +122,8 @@ export class CollectionDetailType {
 
 export class CollectionUsedByDependencies extends CollectionDetailType {
   version: string;
+}
+
+export class DependencyType {
+  [namespaceCollection: string]: string;
 }

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -119,3 +119,7 @@ export class CollectionDetailType {
     company: string;
   };
 }
+
+export class CollectionUsedByDependencies extends CollectionDetailType {
+  version: string;
+}

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -115,7 +115,12 @@ export class CollectionCard extends React.Component<IProps> {
           <NumericLabel number={count} />
         </div>
         <div className='type-label'>
-          <NumericLabel number={count} hideNumber={true} label={type} />
+          <NumericLabel
+            number={count}
+            hideNumber={true}
+            label={type}
+            pluralLabels={Constants.COLLECTION_PLURAL_LABELS[type]}
+          />
         </div>
       </div>
     );

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -35,9 +35,7 @@ export class CollectionCard extends React.Component<IProps> {
       this.props;
 
     const company = namespace.company || namespace.name;
-    const contentSummary = convertContentSummaryCounts(
-      latest_version.metadata.contents,
-    );
+    const contentSummary = convertContentSummaryCounts(latest_version.metadata);
 
     return (
       <Card className={cx('collection-card-container', className)}>

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -1,27 +1,39 @@
+import { t } from '@lingui/macro';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 import { List, ListItem, ListVariant } from '@patternfly/react-core';
 
-import { CollectionDetailType } from 'src/api';
+import { EmptyStateNoData } from 'src/components';
 
+import { CollectionDetailType } from 'src/api';
 import { formatPath, Paths } from 'src/paths';
 
 import 'src/containers/collection-detail/collection-dependencies.scss';
+
 interface IProps {
   collection: CollectionDetailType;
   repo: string;
 }
+
 export class CollectionDependenciesList extends React.Component<IProps> {
   render() {
     const { collection, repo } = this.props;
 
     const { dependencies } = collection.latest_version.metadata;
 
+    if (!Object.keys(dependencies).length)
+      return (
+        <EmptyStateNoData
+          title={t`No dependencies`}
+          description={t`Collection does not have dependencies.`}
+        />
+      );
+
     return (
-      <List variant={ListVariant.inline}>
+      <List variant={ListVariant.inline} className='dependencies-list'>
         {Object.keys(dependencies).map((dependency, i) => (
-          <ListItem key={i}>
+          <ListItem key={i} style={{ marginRight: '70px' }}>
             <Link
               to={formatPath(
                 Paths.collectionByRepo,

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -42,7 +42,7 @@ export class CollectionDependenciesList extends React.Component<IProps> {
                   namespace: this.splitDependencyName(dependency).namespace,
                   repo,
                 },
-                { version: this.separateVersion(dependencies[dependency]) },
+                this.separateVersion(dependencies[dependency]),
               )}
             >
               {this.splitDependencyName(dependency).collection}
@@ -59,6 +59,7 @@ export class CollectionDependenciesList extends React.Component<IProps> {
   }
 
   private separateVersion(version) {
-    return version.split(/(\d+.*)/)[1];
+    const v = version.match(/((\d+\.*)+)/);
+    return v ? { version: v[0] } : {};
   }
 }

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+import { List, ListItem, ListVariant } from '@patternfly/react-core';
+
+import { CollectionDetailType } from 'src/api';
+
+import { formatPath, Paths } from 'src/paths';
+
+import 'src/containers/collection-detail/collection-dependencies.scss';
+interface IProps {
+  collection: CollectionDetailType;
+  repo: string;
+}
+export class CollectionDependenciesList extends React.Component<IProps> {
+  render() {
+    const { collection, repo } = this.props;
+
+    const { dependencies } = collection.latest_version.metadata;
+
+    return (
+      <List variant={ListVariant.inline}>
+        {Object.keys(dependencies).map((dependency, i) => (
+          <ListItem key={i}>
+            <Link
+              to={formatPath(
+                Paths.collectionByRepo,
+                {
+                  collection: this.splitDependencyName(dependency).collection,
+                  namespace: this.splitDependencyName(dependency).namespace,
+                  repo,
+                },
+                { version: this.separateVersion(dependencies[dependency]) },
+              )}
+            >
+              {this.splitDependencyName(dependency).collection}
+            </Link>
+          </ListItem>
+        ))}
+      </List>
+    );
+  }
+
+  private splitDependencyName(dependency) {
+    const [namespace, collection] = dependency.split('.');
+    return { namespace, collection };
+  }
+
+  private separateVersion(version) {
+    return version.split(/(\d+.*)/)[1];
+  }
+}

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -4,9 +4,14 @@ import { Link } from 'react-router-dom';
 
 import { CollectionUsedByDependencies } from 'src/api';
 
-import { Pagination, Toolbar } from 'src/components';
+import {
+  Pagination,
+  Toolbar,
+  EmptyStateNoData,
+  EmptyStateFilter,
+} from 'src/components';
 
-import { ParamHelper } from 'src/utilities/param-helper';
+import { ParamHelper, filterIsSet } from 'src/utilities';
 import { formatPath, Paths } from 'src/paths';
 
 import 'src/containers/collection-detail/collection-dependencies.scss';
@@ -35,6 +40,14 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
 
     const { name, ...rest } = params;
 
+    if (!itemCount && !filterIsSet(params, ['name']))
+      return (
+        <EmptyStateNoData
+          title={t`No collection is using this dependency`}
+          description={t`Collection is not being used by any collection.`}
+        />
+      );
+
     return (
       <>
         <div className='usedby-dependencies-header'>
@@ -59,34 +72,43 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
           />
         </div>
 
-        <table className='content-table pf-c-table pf-m-compact'>
-          <tbody>
-            {usedByDependencies.map(({ name, namespace, version }, i) => (
-              <tr key={i}>
-                <td>
-                  <Link
-                    to={formatPath(
-                      Paths.collectionByRepo,
-                      {
-                        collection: name,
-                        namespace: namespace,
-                        repo,
-                      },
-                      ParamHelper.getReduced({ version }, this.ignoredParams),
-                    )}
-                  >
-                    {name}
-                  </Link>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-        <Pagination
-          params={params}
-          updateParams={(params) => updateParams(params)}
-          count={itemCount}
-        />
+        {!itemCount ? (
+          <EmptyStateFilter />
+        ) : (
+          <>
+            <table className='content-table pf-c-table pf-m-compact'>
+              <tbody>
+                {usedByDependencies.map(({ name, namespace, version }, i) => (
+                  <tr key={i}>
+                    <td>
+                      <Link
+                        to={formatPath(
+                          Paths.collectionByRepo,
+                          {
+                            collection: name,
+                            namespace: namespace,
+                            repo,
+                          },
+                          ParamHelper.getReduced(
+                            { version },
+                            this.ignoredParams,
+                          ),
+                        )}
+                      >
+                        {name}
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <Pagination
+              params={params}
+              updateParams={(params) => updateParams(params)}
+              count={itemCount}
+            />
+          </>
+        )}
       </>
     );
   }

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -27,10 +27,7 @@ interface IProps {
 }
 
 export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
-  private ignoredParams = ['page_size', 'page', 'sort', 'collection'];
-  constructor(props) {
-    super(props);
-  }
+  private ignoredParams = ['page_size', 'page', 'sort', 'name'];
 
   render() {
     const { params, usedByDependencies, itemCount, updateParams, repo } =

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -5,10 +5,17 @@ import { Link } from 'react-router-dom';
 import { CollectionUsedByDependencies } from 'src/api';
 
 import {
-  Pagination,
   Toolbar,
+  ToolbarItem,
+  ToolbarGroup,
+  SearchInput,
+} from '@patternfly/react-core';
+
+import {
+  Pagination,
   EmptyStateNoData,
   EmptyStateFilter,
+  Sort,
 } from 'src/components';
 
 import { ParamHelper, filterIsSet } from 'src/utilities';
@@ -38,8 +45,6 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
     const { params, usedByDependencies, itemCount, updateParams, repo } =
       this.props;
 
-    const { name, ...rest } = params;
-
     if (!itemCount && !filterIsSet(params, ['name']))
       return (
         <EmptyStateNoData
@@ -51,21 +56,34 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
     return (
       <>
         <div className='usedby-dependencies-header'>
-          <Toolbar
-            params={{ ...rest, keywords: name }}
-            sortOptions={
-              !!itemCount && [
-                { title: t`Collection`, id: 'collection', type: 'alpha' },
-              ]
-            }
-            searchPlaceholder={t`Filter collection name`}
-            updateParams={(p) => {
-              const { keywords, ...rest } = p;
-              'keywords' in p
-                ? updateParams({ ...rest, name: keywords })
-                : updateParams(p);
-            }}
-          />
+          <Toolbar>
+            <ToolbarGroup>
+              <ToolbarItem>
+                <SearchInput
+                  value={params.name || ''}
+                  onChange={(val) =>
+                    updateParams(ParamHelper.setParam(params, 'name', val))
+                  }
+                  onClear={() =>
+                    updateParams(ParamHelper.setParam(params, 'name', ''))
+                  }
+                  aria-label='filter-collection-name'
+                  placeholder={t`Filter collection name`}
+                />
+              </ToolbarItem>
+              <ToolbarItem>
+                <Sort
+                  options={[
+                    { title: t`Collection`, id: 'collection', type: 'alpha' },
+                  ]}
+                  params={params}
+                  updateParams={({ sort }) =>
+                    updateParams(ParamHelper.setParam(params, 'sort', sort))
+                  }
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
+          </Toolbar>
           {!!itemCount && (
             <Pagination
               params={params}

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -53,9 +53,11 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
         <div className='usedby-dependencies-header'>
           <Toolbar
             params={{ ...rest, keywords: name }}
-            sortOptions={[
-              { title: t`Collection`, id: 'collection', type: 'alpha' },
-            ]}
+            sortOptions={
+              !!itemCount && [
+                { title: t`Collection`, id: 'collection', type: 'alpha' },
+              ]
+            }
             searchPlaceholder={t`Filter collection name`}
             updateParams={(p) => {
               const { keywords, ...rest } = p;
@@ -64,12 +66,14 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
                 : updateParams(p);
             }}
           />
-          <Pagination
-            params={params}
-            updateParams={(p) => updateParams(p)}
-            count={itemCount}
-            isTop
-          />
+          {!!itemCount && (
+            <Pagination
+              params={params}
+              updateParams={(p) => updateParams(p)}
+              count={itemCount}
+              isTop
+            />
+          )}
         </div>
 
         {!itemCount ? (

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -16,6 +16,7 @@ import {
   EmptyStateNoData,
   EmptyStateFilter,
   Sort,
+  LoadingPageSpinner,
 } from 'src/components';
 
 import { ParamHelper, filterIsSet } from 'src/utilities';
@@ -25,6 +26,7 @@ import 'src/containers/collection-detail/collection-dependencies.scss';
 
 interface IProps {
   usedByDependencies: CollectionUsedByDependencies[];
+  usedByDependenciesLoading: boolean;
   repo: string;
   itemCount: number;
   params: {
@@ -42,8 +44,14 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
   private ignoredParams = ['page_size', 'page', 'sort', 'name'];
 
   render() {
-    const { params, usedByDependencies, itemCount, updateParams, repo } =
-      this.props;
+    const {
+      params,
+      usedByDependencies,
+      itemCount,
+      updateParams,
+      repo,
+      usedByDependenciesLoading,
+    } = this.props;
 
     if (!itemCount && !filterIsSet(params, ['name']))
       return (
@@ -68,7 +76,7 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
                     updateParams(ParamHelper.setParam(params, 'name', ''))
                   }
                   aria-label='filter-collection-name'
-                  placeholder={t`Filter collection name`}
+                  placeholder={t`Filter by name`}
                 />
               </ToolbarItem>
               <ToolbarItem>
@@ -94,41 +102,49 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
           )}
         </div>
 
-        {!itemCount ? (
-          <EmptyStateFilter />
+        {usedByDependenciesLoading ? (
+          <LoadingPageSpinner />
         ) : (
           <>
-            <table className='content-table pf-c-table pf-m-compact'>
-              <tbody>
-                {usedByDependencies.map(({ name, namespace, version }, i) => (
-                  <tr key={i}>
-                    <td>
-                      <Link
-                        to={formatPath(
-                          Paths.collectionByRepo,
-                          {
-                            collection: name,
-                            namespace: namespace,
-                            repo,
-                          },
-                          ParamHelper.getReduced(
-                            { version },
-                            this.ignoredParams,
-                          ),
-                        )}
-                      >
-                        {name}
-                      </Link>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-            <Pagination
-              params={params}
-              updateParams={(params) => updateParams(params)}
-              count={itemCount}
-            />
+            {!itemCount ? (
+              <EmptyStateFilter />
+            ) : (
+              <>
+                <table className='content-table pf-c-table pf-m-compact'>
+                  <tbody>
+                    {usedByDependencies.map(
+                      ({ name, namespace, version }, i) => (
+                        <tr key={i}>
+                          <td>
+                            <Link
+                              to={formatPath(
+                                Paths.collectionByRepo,
+                                {
+                                  collection: name,
+                                  namespace: namespace,
+                                  repo,
+                                },
+                                ParamHelper.getReduced(
+                                  { version },
+                                  this.ignoredParams,
+                                ),
+                              )}
+                            >
+                              {name}
+                            </Link>
+                          </td>
+                        </tr>
+                      ),
+                    )}
+                  </tbody>
+                </table>
+                <Pagination
+                  params={params}
+                  updateParams={(params) => updateParams(params)}
+                  count={itemCount}
+                />
+              </>
+            )}
           </>
         )}
       </>

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -1,0 +1,96 @@
+import { t } from '@lingui/macro';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+
+import { CollectionUsedByDependencies } from 'src/api';
+
+import { Pagination, Toolbar } from 'src/components';
+
+import { ParamHelper } from 'src/utilities/param-helper';
+import { formatPath, Paths } from 'src/paths';
+
+import 'src/containers/collection-detail/collection-dependencies.scss';
+
+interface IProps {
+  usedByDependencies: CollectionUsedByDependencies[];
+  repo: string;
+  itemCount: number;
+  params: {
+    page?: number;
+    page_size?: number;
+    collection?: string;
+    sort?: string;
+    version?: string;
+    name?: string;
+  };
+  updateParams: (params) => void;
+}
+
+export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
+  private ignoredParams = ['page_size', 'page', 'sort', 'collection'];
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    const { params, usedByDependencies, itemCount, updateParams, repo } =
+      this.props;
+
+    const { name, ...rest } = params;
+
+    return (
+      <>
+        <div className='usedby-dependencies-header'>
+          <Toolbar
+            params={{ ...rest, keywords: name }}
+            sortOptions={[
+              { title: t`Collection`, id: 'collection', type: 'alpha' },
+            ]}
+            searchPlaceholder={t`Filter collection name`}
+            updateParams={(p) => {
+              const { keywords, ...rest } = p;
+              'keywords' in p
+                ? updateParams({ ...rest, name: keywords })
+                : updateParams(p);
+            }}
+          />
+          <Pagination
+            params={params}
+            updateParams={(p) => updateParams(p)}
+            count={itemCount}
+            isTop
+          />
+        </div>
+
+        <table className='content-table pf-c-table pf-m-compact'>
+          <tbody>
+            {usedByDependencies.map(({ name, namespace, version }, i) => (
+              <tr key={i}>
+                <td>
+                  <Link
+                    to={formatPath(
+                      Paths.collectionByRepo,
+                      {
+                        collection: name,
+                        namespace: namespace,
+                        repo,
+                      },
+                      ParamHelper.getReduced({ version }, this.ignoredParams),
+                    )}
+                  >
+                    {name}
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <Pagination
+          params={params}
+          updateParams={(params) => updateParams(params)}
+          count={itemCount}
+        />
+      </>
+    );
+  }
+}

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -56,7 +56,7 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
     if (!itemCount && !filterIsSet(params, ['name']))
       return (
         <EmptyStateNoData
-          title={t`No collection is using this dependency`}
+          title={t`Not required for use by other collections`}
           description={t`Collection is not being used by any collection.`}
         />
       );

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -63,9 +63,15 @@ export class CollectionListItem extends React.Component<IProps, {}> {
       );
     }
 
-    const contentSummary = convertContentSummaryCounts(
-      latest_version.metadata.contents,
-    );
+    let contentSummary = convertContentSummaryCounts(latest_version.metadata);
+
+    const plural = {
+      dependency: {
+        '0': 'dependencies',
+        '1': 'dependency',
+        other: 'dependencies',
+      },
+    };
 
     cells.push(
       <DataListCell key='content'>
@@ -96,6 +102,7 @@ export class CollectionListItem extends React.Component<IProps, {}> {
                 className='numeric-label-capitalize-text'
                 label={k}
                 number={contentSummary.contents[k]}
+                pluralLabels={plural[k]}
               />
             </div>
           ))}

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -25,6 +25,7 @@ import {
 } from 'src/components';
 import { CollectionListType } from 'src/api';
 import { convertContentSummaryCounts } from 'src/utilities';
+import { Constants } from 'src/constants';
 
 interface IProps extends CollectionListType {
   showNamespace?: boolean;
@@ -65,14 +66,6 @@ export class CollectionListItem extends React.Component<IProps, {}> {
 
     let contentSummary = convertContentSummaryCounts(latest_version.metadata);
 
-    const plural = {
-      dependency: {
-        '0': 'dependencies',
-        '1': 'dependency',
-        other: 'dependencies',
-      },
-    };
-
     cells.push(
       <DataListCell key='content'>
         <div>
@@ -102,7 +95,7 @@ export class CollectionListItem extends React.Component<IProps, {}> {
                 className='numeric-label-capitalize-text'
                 label={k}
                 number={contentSummary.contents[k]}
-                pluralLabels={plural[k]}
+                pluralLabels={Constants.COLLECTION_PLURAL_LABELS[k]}
               />
             </div>
           ))}

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -313,6 +313,15 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         title: t`Import log`,
         link: formatPath(Paths.collectionImportLogByRepo, pathParams, reduced),
       },
+      {
+        active: active === 'dependencies',
+        title: t`Dependencies`,
+        link: formatPath(
+          Paths.collectionDependenciesByRepo,
+          pathParams,
+          reduced,
+        ),
+      },
     ];
 
     return <LinkTabs tabs={tabs} />;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -16,6 +16,8 @@ export { CollectionFilter } from './collection-list/collection-filter';
 export { CollectionList } from './collection-list/collection-list';
 export { CollectionListItem } from './collection-list/collection-list-item';
 export { ConfirmModal } from './confirm-modal/confirm-modal';
+export { CollectionDependenciesList } from './collection-dependencies-list/collection-dependencies-list';
+export { CollectionUsedbyDependenciesList } from './collection-dependencies-list/collection-usedby-dependencies-list';
 export { CompoundFilter } from './patternfly-wrappers/compound-filter';
 export { DateComponent } from './date-component/date-component';
 export { DeprecatedTag } from './tags/deprecated-tag';

--- a/src/components/numeric-label/numeric-label.tsx
+++ b/src/components/numeric-label/numeric-label.tsx
@@ -5,11 +5,18 @@ interface IProps {
   number: number | string;
   label?: string;
   hideNumber?: boolean;
+  pluralLabels?: {
+    [key: string]: {
+      '0': string;
+      '1': string;
+      other: string;
+    }[];
+  };
 }
 
 export class NumericLabel extends React.Component<IProps, {}> {
   render() {
-    const { className, number, label, hideNumber } = this.props;
+    const { className, number, label, hideNumber, pluralLabels } = this.props;
     let convertedNum: number;
 
     if (typeof number === 'string') {
@@ -25,7 +32,13 @@ export class NumericLabel extends React.Component<IProps, {}> {
         <span>
           {hideNumber ? null : NumericLabel.roundNumber(convertedNum)}{' '}
         </span>
-        <span className={className}>{label ? label + plural : null}</span>
+        <span className={className}>
+          {pluralLabels ? (
+            <>{this.setPluralLabel(pluralLabels, number)}</>
+          ) : (
+            <> {label ? label + plural : null} </>
+          )}
+        </span>
       </div>
     );
   }
@@ -51,5 +64,9 @@ export class NumericLabel extends React.Component<IProps, {}> {
 
     // If larger than a billion, don't even bother.
     return '1B+';
+  }
+
+  private setPluralLabel(plurals, number) {
+    return number === 0 || number === 1 ? plurals[number] : plurals['other'];
   }
 }

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -202,6 +202,14 @@ export class Constants {
     'windows',
   ];
 
+  static COLLECTION_PLURAL_LABELS = {
+    dependency: {
+      '0': 'dependencies',
+      '1': 'dependency',
+      other: 'dependencies',
+    },
+  };
+
   static TASK_NAMES = {
     'galaxy_ng.app.tasks.promotion._remove_content_from_repository': t`Remove content from repository`,
     'galaxy_ng.app.tasks.publishing.import_and_auto_approve': t`Import and auto approve`,

--- a/src/containers/collection-detail/collection-dependencies.scss
+++ b/src/containers/collection-detail/collection-dependencies.scss
@@ -1,0 +1,5 @@
+.usedby-dependencies-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/src/containers/collection-detail/collection-dependencies.scss
+++ b/src/containers/collection-detail/collection-dependencies.scss
@@ -5,8 +5,12 @@
 }
 
 // resets to default, possible bug pagination shows disc list-style-type with 'pf-c-content' className
-.pf-c-content ul {
-  padding-left: 0;
-  margin-left: 0;
-  list-style: none;
+.pf-c-options-menu__menu {
+  padding-left: 0 !important;
+  margin-left: 0 !important;
+  list-style: none !important;
+}
+
+.dependencies-list li {
+  list-style: disc;
 }

--- a/src/containers/collection-detail/collection-dependencies.scss
+++ b/src/containers/collection-detail/collection-dependencies.scss
@@ -3,3 +3,10 @@
   justify-content: space-between;
   align-items: center;
 }
+
+// resets to default, possible bug pagination shows disc list-style-type with 'pf-c-content' className
+.pf-c-content ul {
+  padding-left: 0;
+  margin-left: 0;
+  list-style: none;
+}

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -139,7 +139,7 @@ class CollectionDependencies extends React.Component<
                 />
               ) : (
                 <>
-                  <p>{t`This collection is dependent on the following collections`}</p>
+                  <p>{t`This collections requires the following collections for use`}</p>
                   {noDependencies ? (
                     <EmptyStateNoData
                       title={t`No dependencies`}

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -1,27 +1,51 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
+import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 
-import { withRouter, RouteComponentProps } from 'react-router-dom';
+import {
+  List,
+  ListItem,
+  ListVariant,
+  SearchInput,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
 
-import { Link } from 'react-router-dom';
-
-import { ImportAPI, ImportDetailType, ImportListType } from 'src/api';
+import {
+  CollectionDetailType,
+  ImportAPI,
+  ImportDetailType,
+  ImportListType,
+} from 'src/api';
 import {
   CollectionHeader,
   LoadingPageWithHeader,
   ImportConsole,
   Main,
+  Pagination,
+  Sort,
 } from 'src/components';
 
-import { loadCollection, IBaseCollectionState } from './base';
+import { IBaseCollectionState } from './base';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
 
 import { CollectionAPI } from 'src/api/';
 
-interface IState extends IBaseCollectionState {
-  dependencies: any[];
+import './collection-dependencies.scss';
+interface IState {
+  collection: IBaseCollectionState['collection'];
+  //dependencies: any[];
+  headerParams: IBaseCollectionState['params'];
+  params: {
+    page?: number;
+    page_size?: number;
+    keywords?: string;
+    sort?: string;
+  };
+  usedByDependencies: any[];
 }
 
 class CollectionDependencies extends React.Component<
@@ -31,34 +55,78 @@ class CollectionDependencies extends React.Component<
   constructor(props) {
     super(props);
 
-    const params = ParamHelper.parseParamString(props.location.search);
+    const headerParams =
+      {}; /* ParamHelper.parseParamString(props.location.search, [
+      'version',
+      'showing',
+      'keywords',
+    ]);
+    */
+
+    const params = ParamHelper.parseParamString(props.location.search); /*, [
+      'keywords',
+      'page',
+      'page_size',
+    ]*/
+
+    if (!params['page']) {
+      params['page'] = 1;
+    }
+
+    if (!params['page_size']) {
+      params['page_size'] = 10;
+    }
+
+    if (!params['sort']) {
+      params['sort'] = 'name';
+    }
 
     this.state = {
       collection: undefined,
-      params: params,
-      dependencies: [],
+      headerParams: headerParams,
+      params,
+      usedByDependencies: [],
     };
   }
 
   componentDidMount() {
     this.loadData();
-
-    const namespace = 'jiricollectionsoxrttpna';
-    const collection = 'jiricollectionserregzmzdv';
-    CollectionAPI.getDependencies(namespace, collection).then(
-      (dependencies) => {
-        this.setState({ dependencies: dependencies.data.data });
-        console.log(dependencies.data.data);
-      },
-    );
   }
 
   render() {
-    const { collection, params } = this.state;
+    const { collection, params, headerParams, usedByDependencies } = this.state;
 
     if (!collection) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
+
+    let { dependencies } = collection.latest_version.metadata;
+
+    dependencies = {
+      ...dependencies,
+      'mytestcollsdtpvoomv.mytestcollsevpzzbuhof': '>=2.5.9',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi1': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi2': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi3': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi4': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi5': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi6': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi11': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi21': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi31': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi41': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi51': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi61': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi12': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi22': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi32': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi42': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi52': '<=3.6.2',
+      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi62': '<=3.6.2',
+    };
+
+    const usedByDependenciesCount = usedByDependencies.length;
 
     const breadcrumbs = [
       namespaceBreadcrumb,
@@ -80,14 +148,24 @@ class CollectionDependencies extends React.Component<
       { name: t`Dependencies` },
     ];
 
+    let toShow: any[] = [];
+    //const summary = {};
+    const keywords = params.keywords || '';
+
+    for (let c of usedByDependencies) {
+      if (c.name.match(keywords)) {
+        toShow.push(c);
+      }
+    }
+    // console.log(keywords, toShow)
+
     return (
       <React.Fragment>
         <CollectionHeader
           collection={collection}
-          params={params}
-          updateParams={
-            (params) => {}
-            //this.updateParams(params, () => this.loadData(true))
+          params={headerParams}
+          updateParams={(params) =>
+            this.updateParams(params, () => this.loadData())
           }
           breadcrumbs={breadcrumbs}
           activeTab='dependencies'
@@ -95,37 +173,99 @@ class CollectionDependencies extends React.Component<
         />
         <Main>
           <section className='body'>
-            <div className='pf-c-content info-panel'>
+            <div className='pf-c-content collection-dependencies'>
               <h1>{t`Dependencies`}</h1>
               <p>{t`This collection is dependent on the following collections`}</p>
-              ...List here...
+              <List variant={ListVariant.inline}>
+                {Object.keys(dependencies).map((dependency) => (
+                  <ListItem key={dependency}>
+                    <Link to={'/test'}>
+                      {this.separateCollectionByDependency(dependency)}
+                    </Link>
+                  </ListItem>
+                ))}
+              </List>
               <p>{t`This collection is being used by `}</p>
+              <div className='usedby-dependencies-header'>
+                <Toolbar>
+                  <ToolbarContent>
+                    <ToolbarItem>
+                      <SearchInput
+                        style={{ width: '211px' }}
+                        value={params.keywords || ''}
+                        onChange={(val) =>
+                          this.updateParams(
+                            ParamHelper.setParam(params, 'keywords', val),
+                          )
+                        }
+                        onClear={() =>
+                          this.updateParams(
+                            ParamHelper.setParam(params, 'keywords', ''),
+                            () => this.loadData(),
+                          )
+                        }
+                        aria-label='filter-content'
+                        placeholder={t`Filter collection name`}
+                      />
+                    </ToolbarItem>
+                    <ToolbarItem>
+                      <Sort
+                        options={[
+                          { title: t`Name`, id: 'name', type: 'alpha' },
+                        ]}
+                        params={params}
+                        updateParams={(p) =>
+                          this.updateParams(p /*() => this.loadData()*/)
+                        }
+                      />
+                    </ToolbarItem>
+                  </ToolbarContent>
+                </Toolbar>
+                <Pagination
+                  params={params}
+                  updateParams={(params) =>
+                    this.updateParams(params, () => this.setState({ params }))
+                  }
+                  count={usedByDependenciesCount}
+                  isTop
+                />
+              </div>
+
               <table className='content-table pf-c-table pf-m-compact'>
                 <tbody>
-                  {this.state.dependencies.map((dependency) => (
-                    <tr key={dependency.name}>
-                      <td>
-                        <Link
-                          to={formatPath(
-                            Paths.collectionContentDocsByRepo,
-                            {
-                              /*collection: collection,
+                  {this.filterUsedByDependencies(usedByDependencies).map(
+                    ({ name }) => (
+                      <tr key={name}>
+                        <td>
+                          <Link
+                            to={formatPath(
+                              Paths.collectionContentDocsByRepo,
+                              {
+                                /*collection: collection,
                                           namespace: namespace,
                                           type: content.content_type,
                                           name: content.name,
                                           repo: this.context.selectedRepo,
                                           */
-                            },
-                            //ParamHelper.getReduced(params, this.ignoredParams),
-                          )}
-                        >
-                          {dependency.name}
-                        </Link>
-                      </td>
-                    </tr>
-                  ))}
+                              },
+                              //ParamHelper.getReduced(params, this.ignoredParams),
+                            )}
+                          >
+                            {name}
+                          </Link>
+                        </td>
+                      </tr>
+                    ),
+                  )}
                 </tbody>
               </table>
+              <Pagination
+                params={params}
+                updateParams={(params) =>
+                  this.updateParams(params, () => this.setState({ params }))
+                }
+                count={usedByDependenciesCount}
+              />
             </div>
           </section>
         </Main>
@@ -134,17 +274,218 @@ class CollectionDependencies extends React.Component<
   }
 
   private loadData() {
-    this.loadCollection(this.context.selectedRepo, false, () => {
-      console.log('called after');
+    this.loadCollection(() => {
+      this.loadUsedByDependencies();
     });
   }
 
-  get loadCollection() {
-    return loadCollection;
+  private loadUsedByDependencies() {
+    const {
+      name: collection,
+      namespace: { name: namespace },
+    } = this.state.collection;
+    CollectionAPI.getUsedDependenciesByCollection(namespace, collection).then(
+      (dependencies) => {
+        const mockedDependencies = [
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollsevpzzbuhof1',
+            version: '2.5.9',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollswfnzropnhv2',
+            version: '0.4.3',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollshoqyrcukgc3',
+            version: '0.9.6',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollsevpzzbuhof4',
+            version: '2.5.9',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollswfnzropnhv5',
+            version: '0.4.3',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollshoqyrcukgc6',
+            version: '0.9.6',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollsevpzzbuhof7',
+            version: '2.5.9',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollswfnzropnhv8',
+            version: '0.4.3',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollshoqyrcukgc9',
+            version: '0.9.6',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollshoqyrcukgc10',
+            version: '0.9.6',
+          },
+
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollsevpzzbuhof1x',
+            version: '2.5.9',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollswfnzropnhv2x',
+            version: '0.4.3',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollshoqyrcukgc3x',
+            version: '0.9.6',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollsevpzzbuhof4x',
+            version: '2.5.9',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollswfnzropnhv5x',
+            version: '0.4.3',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollshoqyrcukgc6x',
+            version: '0.9.6',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollsevpzzbuhof7x',
+            version: '2.5.9',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollswfnzropnhv8x',
+            version: '0.4.3',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollshoqyrcukgc9x',
+            version: '0.9.6',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollshoqyrcukgc10x',
+            version: '0.9.6',
+          },
+
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollsevpzzbuhof1z',
+            version: '2.5.9',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollswfnzropnhv2z',
+            version: '0.4.3',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollshoqyrcukgc3z',
+            version: '0.9.6',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollsevpzzbuhof4z',
+            version: '2.5.9',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollswfnzropnhv5z',
+            version: '0.4.3',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollshoqyrcukgc6z',
+            version: '0.9.6',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollsevpzzbuhof7z',
+            version: '2.5.9',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollswfnzropnhv8z',
+            version: '0.4.3',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollshoqyrcukgc9z',
+            version: '0.9.6',
+          },
+          {
+            namespace: 'mytestcollsdtpvoomv',
+            name: 'mytestcollshoqyrcukgc10z',
+            version: '0.9.6',
+          },
+        ];
+
+        this.setState({
+          usedByDependencies: [
+            ...dependencies.data.data,
+            ...mockedDependencies,
+          ],
+        });
+      },
+    );
+  }
+
+  private filterUsedByDependencies(dependencies) {
+    const { page, page_size, keywords, sort } = this.state.params;
+
+    return dependencies
+      .filter((d) => d.name.match(keywords))
+      .sort((a, b) =>
+        sort === '-name'
+          ? a.name.localeCompare(b.name)
+          : b.name.localeCompare(a.name),
+      )
+      .slice(page_size * (page - 1), page_size * page);
+  }
+
+  private loadCollection(callback = null) {
+    CollectionAPI.getCached(
+      this.props.match.params['namespace'],
+      this.props.match.params['collection'],
+      this.context.selectedRepo,
+      {},
+      false,
+    )
+      .then((result) => {
+        this.setState({ collection: result }, callback);
+      })
+      .catch((result) => {
+        this.props.history.push(Paths.notFound);
+      });
   }
 
   get updateParams() {
     return ParamHelper.updateParamsMixin();
+  }
+
+  private separateCollectionByDependency(dependency) {
+    return dependency.split('.')[1];
   }
 }
 

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -48,6 +48,8 @@ class CollectionDependencies extends React.Component<
       'page_size',
     ]);
 
+    params['sort'] = !params['sort'] ? '-collection' : 'collection';
+
     this.state = {
       collection: undefined,
       params: params,

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -18,7 +18,11 @@ import { ParamHelper } from 'src/utilities/param-helper';
 import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
 
-interface IState extends IBaseCollectionState {}
+import { CollectionAPI } from 'src/api/';
+
+interface IState extends IBaseCollectionState {
+  dependencies: any[];
+}
 
 class CollectionDependencies extends React.Component<
   RouteComponentProps,
@@ -32,11 +36,21 @@ class CollectionDependencies extends React.Component<
     this.state = {
       collection: undefined,
       params: params,
+      dependencies: [],
     };
   }
 
   componentDidMount() {
     this.loadData();
+
+    const namespace = 'jiricollectionsoxrttpna';
+    const collection = 'jiricollectionserregzmzdv';
+    CollectionAPI.getDependencies(namespace, collection).then(
+      (dependencies) => {
+        this.setState({ dependencies: dependencies.data.data });
+        console.log(dependencies.data.data);
+      },
+    );
   }
 
   render() {
@@ -88,26 +102,28 @@ class CollectionDependencies extends React.Component<
               <p>{t`This collection is being used by `}</p>
               <table className='content-table pf-c-table pf-m-compact'>
                 <tbody>
-                  <tr>
-                    <td>
-                      <Link
-                        to={formatPath(
-                          Paths.collectionContentDocsByRepo,
-                          {
-                            /*collection: collection,
-                                        namespace: namespace,
-                                        type: content.content_type,
-                                        name: content.name,
-                                        repo: this.context.selectedRepo,
-                                        */
-                          },
-                          //ParamHelper.getReduced(params, this.ignoredParams),
-                        )}
-                      >
-                        Depended
-                      </Link>
-                    </td>
-                  </tr>
+                  {this.state.dependencies.map((dependency) => (
+                    <tr key={dependency.name}>
+                      <td>
+                        <Link
+                          to={formatPath(
+                            Paths.collectionContentDocsByRepo,
+                            {
+                              /*collection: collection,
+                                          namespace: namespace,
+                                          type: content.content_type,
+                                          name: content.name,
+                                          repo: this.context.selectedRepo,
+                                          */
+                            },
+                            //ParamHelper.getReduced(params, this.ignoredParams),
+                          )}
+                        >
+                          {dependency.name}
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
                 </tbody>
               </table>
             </div>

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -3,91 +3,54 @@ import * as React from 'react';
 import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 
 import {
-  List,
-  ListItem,
-  ListVariant,
-  SearchInput,
-  Toolbar,
-  ToolbarContent,
-  ToolbarItem,
-  Text,
-} from '@patternfly/react-core';
-
-import {
+  CollectionAPI,
   CollectionDetailType,
-  ImportAPI,
-  ImportDetailType,
-  ImportListType,
+  CollectionUsedByDependencies,
 } from 'src/api';
 import {
   CollectionHeader,
   LoadingPageWithHeader,
-  ImportConsole,
   Main,
-  Pagination,
-  Sort,
+  CollectionDependenciesList,
+  CollectionUsedbyDependenciesList,
 } from 'src/components';
 
-import { IBaseCollectionState } from './base';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
 
-import { CollectionAPI } from 'src/api/';
-
 import './collection-dependencies.scss';
 interface IState {
-  collection: IBaseCollectionState['collection'];
-  //dependencies: any[];
-  headerParams: IBaseCollectionState['params'];
+  collection: CollectionDetailType;
   params: {
     page?: number;
     page_size?: number;
-    keywords?: string;
+    collection?: string;
     sort?: string;
+    version?: string;
   };
-  usedByDependencies: any[];
+  usedByDependencies: CollectionUsedByDependencies[];
+  usedByDependenciesCount: number;
 }
 
 class CollectionDependencies extends React.Component<
   RouteComponentProps,
   IState
 > {
-  private ignoredParams = ['page_size', 'page', 'sort', 'keywords'];
+  private ignoredParams = ['page_size', 'page', 'sort', 'name'];
   constructor(props) {
     super(props);
 
-    const headerParams =
-      {}; /* ParamHelper.parseParamString(props.location.search, [
-      'version',
-      'showing',
-      'keywords',
-    ]);
-    */
-
-    const params = ParamHelper.parseParamString(props.location.search); /*, [
-      'keywords',
+    const params = ParamHelper.parseParamString(props.location.search, [
       'page',
       'page_size',
-    ]*/
-
-    if (!params['page']) {
-      params['page'] = 1;
-    }
-
-    if (!params['page_size']) {
-      params['page_size'] = 10;
-    }
-
-    if (!params['sort']) {
-      params['sort'] = 'name';
-    }
+    ]);
 
     this.state = {
       collection: undefined,
-      headerParams: headerParams,
-      params,
+      params: params,
       usedByDependencies: [],
+      usedByDependenciesCount: 0,
     };
   }
 
@@ -96,39 +59,12 @@ class CollectionDependencies extends React.Component<
   }
 
   render() {
-    const { collection, params, headerParams, usedByDependencies } = this.state;
+    const { collection, params, usedByDependencies, usedByDependenciesCount } =
+      this.state;
 
     if (!collection) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
-
-    let { dependencies } = collection.latest_version.metadata;
-
-    dependencies = {
-      ...dependencies,
-      'mytestcollsdtpvoomv.mytestcollsevpzzbuhof': '>=2.5.9',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi1': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi2': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi3': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi4': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi5': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi6': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi11': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi21': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi31': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi41': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi51': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi61': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi12': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi22': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi32': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi42': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi52': '<=3.6.2',
-      'mytestcollsdtpvoomv.mytestcollsojfmqxigvi62': '<=3.6.2',
-    };
-
-    const usedByDependenciesCount = usedByDependencies.length;
 
     const breadcrumbs = [
       namespaceBreadcrumb,
@@ -150,25 +86,20 @@ class CollectionDependencies extends React.Component<
       { name: t`Dependencies` },
     ];
 
-    let toShow: any[] = [];
-    //const summary = {};
-    const keywords = params.keywords || '';
+    const headerParams = ParamHelper.getReduced(params, this.ignoredParams);
 
-    for (let c of usedByDependencies) {
-      if (c.name.match(keywords)) {
-        toShow.push(c);
-      }
-    }
-    // console.log(keywords, toShow)
+    const dependenciesParams = ParamHelper.getReduced(params, ['version']);
 
     return (
       <React.Fragment>
         <CollectionHeader
           collection={collection}
           params={headerParams}
-          updateParams={(params) =>
-            this.updateParams(params, () => this.loadData())
-          }
+          updateParams={(p) => {
+            this.updateParams(this.combineParams(this.state.params, p), () =>
+              this.loadData(true),
+            );
+          }}
           breadcrumbs={breadcrumbs}
           activeTab='dependencies'
           repo={this.context.selectedRepo}
@@ -176,109 +107,24 @@ class CollectionDependencies extends React.Component<
         <Main>
           <section className='body'>
             <div className='pf-c-content collection-dependencies'>
-              <Text>{t`Dependencies`}</Text>
+              <h1>{t`Dependencies`}</h1>
               <p>{t`This collection is dependent on the following collections`}</p>
-              <List variant={ListVariant.inline}>
-                {Object.keys(dependencies).map((dependency) => (
-                  <ListItem key={dependency}>
-                    <Link
-                      to={formatPath(
-                        Paths.collectionByRepo,
-                        {
-                          collection:
-                            this.separateCollectionByDependency(dependency)[1],
-                          namespace:
-                            this.separateCollectionByDependency(dependency)[0],
-                          repo: this.context.selectedRepo,
-                        },
-                        ParamHelper.getReduced(params, this.ignoredParams),
-                      )}
-                    >
-                      {this.separateCollectionByDependency(dependency)[1]}
-                    </Link>
-                  </ListItem>
-                ))}
-              </List>
+              <CollectionDependenciesList
+                collection={this.state.collection}
+                repo={this.context.selectedRepo}
+              />
               <p>{t`This collection is being used by `}</p>
-              <div className='usedby-dependencies-header'>
-                <Toolbar>
-                  <ToolbarContent>
-                    <ToolbarItem>
-                      <SearchInput
-                        style={{ width: '211px' }}
-                        value={params.keywords || ''}
-                        onChange={(val) =>
-                          this.updateParams(
-                            ParamHelper.setParam(params, 'keywords', val),
-                          )
-                        }
-                        onClear={() =>
-                          this.updateParams(
-                            ParamHelper.setParam(params, 'keywords', ''),
-                            () => this.loadData(),
-                          )
-                        }
-                        aria-label='filter-content'
-                        placeholder={t`Filter collection name`}
-                      />
-                    </ToolbarItem>
-                    <ToolbarItem>
-                      <Sort
-                        options={[
-                          { title: t`Name`, id: 'name', type: 'alpha' },
-                        ]}
-                        params={params}
-                        updateParams={(p) =>
-                          this.updateParams(p /*() => this.loadData()*/)
-                        }
-                      />
-                    </ToolbarItem>
-                  </ToolbarContent>
-                </Toolbar>
-                <Pagination
-                  params={params}
-                  updateParams={(params) =>
-                    this.updateParams(params, () => this.setState({ params }))
-                  }
-                  count={usedByDependenciesCount}
-                  isTop
-                />
-              </div>
-
-              <table className='content-table pf-c-table pf-m-compact'>
-                <tbody>
-                  {this.filterUsedByDependencies(usedByDependencies).map(
-                    ({ name, namespace }) => (
-                      <tr key={name}>
-                        <td>
-                          <Link
-                            to={formatPath(
-                              Paths.collectionByRepo,
-                              {
-                                collection: name,
-                                namespace: namespace,
-                                repo: this.context.selectedRepo,
-                              },
-                              ParamHelper.getReduced(
-                                params,
-                                this.ignoredParams,
-                              ),
-                            )}
-                          >
-                            {name}
-                          </Link>
-                        </td>
-                      </tr>
-                    ),
-                  )}
-                </tbody>
-              </table>
-              <Pagination
-                params={params}
-                updateParams={(params) =>
-                  this.updateParams(params, () => this.setState({ params }))
+              <CollectionUsedbyDependenciesList
+                repo={this.context.selectedRepo}
+                usedByDependencies={usedByDependencies}
+                itemCount={usedByDependenciesCount}
+                params={dependenciesParams}
+                updateParams={(p) =>
+                  this.updateParams(
+                    this.combineParams(this.state.params, p),
+                    () => this.loadUsedByDependencies(),
+                  )
                 }
-                count={usedByDependenciesCount}
               />
             </div>
           </section>
@@ -287,209 +133,35 @@ class CollectionDependencies extends React.Component<
     );
   }
 
-  private loadData() {
-    this.loadCollection(() => {
-      this.loadUsedByDependencies();
-    });
+  private loadData(forceReload = false) {
+    this.loadCollection(forceReload, () => this.loadUsedByDependencies());
   }
 
   private loadUsedByDependencies() {
-    const {
-      name: collection,
-      namespace: { name: namespace },
-    } = this.state.collection;
-    CollectionAPI.getUsedDependenciesByCollection(namespace, collection).then(
-      (dependencies) => {
-        const mockedDependencies = [
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollsevpzzbuhof1',
-            version: '2.5.9',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollswfnzropnhv2',
-            version: '0.4.3',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollshoqyrcukgc3',
-            version: '0.9.6',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollsevpzzbuhof4',
-            version: '2.5.9',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollswfnzropnhv5',
-            version: '0.4.3',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollshoqyrcukgc6',
-            version: '0.9.6',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollsevpzzbuhof7',
-            version: '2.5.9',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollswfnzropnhv8',
-            version: '0.4.3',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollshoqyrcukgc9',
-            version: '0.9.6',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollshoqyrcukgc10',
-            version: '0.9.6',
-          },
-
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollsevpzzbuhof1x',
-            version: '2.5.9',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollswfnzropnhv2x',
-            version: '0.4.3',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollshoqyrcukgc3x',
-            version: '0.9.6',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollsevpzzbuhof4x',
-            version: '2.5.9',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollswfnzropnhv5x',
-            version: '0.4.3',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollshoqyrcukgc6x',
-            version: '0.9.6',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollsevpzzbuhof7x',
-            version: '2.5.9',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollswfnzropnhv8x',
-            version: '0.4.3',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollshoqyrcukgc9x',
-            version: '0.9.6',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollshoqyrcukgc10x',
-            version: '0.9.6',
-          },
-
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollsevpzzbuhof1z',
-            version: '2.5.9',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollswfnzropnhv2z',
-            version: '0.4.3',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollshoqyrcukgc3z',
-            version: '0.9.6',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollsevpzzbuhof4z',
-            version: '2.5.9',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollswfnzropnhv5z',
-            version: '0.4.3',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollshoqyrcukgc6z',
-            version: '0.9.6',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollsevpzzbuhof7z',
-            version: '2.5.9',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollswfnzropnhv8z',
-            version: '0.4.3',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollshoqyrcukgc9z',
-            version: '0.9.6',
-          },
-          {
-            namespace: 'mytestcollsdtpvoomv',
-            name: 'mytestcollshoqyrcukgc10z',
-            version: '0.9.6',
-          },
-        ];
-
-        this.setState({
-          usedByDependencies: [
-            ...dependencies.data.data,
-            ...mockedDependencies,
-          ],
-        });
-      },
-    );
+    CollectionAPI.getUsedDependenciesByCollection(
+      this.state.collection.namespace.name,
+      this.state.collection.name,
+      ParamHelper.getReduced(this.state.params, ['version']),
+    ).then(({ data }) => {
+      this.setState({
+        usedByDependencies: data.data,
+        usedByDependenciesCount: data.meta.count,
+      });
+    });
   }
 
-  private filterUsedByDependencies(dependencies) {
-    const { page, page_size, keywords, sort } = this.state.params;
-
-    return dependencies
-      .filter((d) => d.name.match(keywords))
-      .sort((a, b) =>
-        sort === '-name'
-          ? a.name.localeCompare(b.name)
-          : b.name.localeCompare(a.name),
-      )
-      .slice(page_size * (page - 1), page_size * page);
-  }
-
-  private loadCollection(callback = null) {
+  private loadCollection(forceReload, callback) {
     CollectionAPI.getCached(
       this.props.match.params['namespace'],
       this.props.match.params['collection'],
       this.context.selectedRepo,
-      {},
-      false,
+      this.state.params.version ? { version: this.state.params.version } : {},
+      forceReload,
     )
       .then((result) => {
         this.setState({ collection: result }, callback);
       })
-      .catch((result) => {
+      .catch(() => {
         this.props.history.push(Paths.notFound);
       });
   }
@@ -498,8 +170,8 @@ class CollectionDependencies extends React.Component<
     return ParamHelper.updateParamsMixin();
   }
 
-  private separateCollectionByDependency(dependency) {
-    return dependency.split('.');
+  private combineParams(...params) {
+    return params.reduce((acc, cur) => ({ ...acc, ...cur }));
   }
 }
 

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -10,6 +10,7 @@ import {
   Toolbar,
   ToolbarContent,
   ToolbarItem,
+  Text,
 } from '@patternfly/react-core';
 
 import {
@@ -52,6 +53,7 @@ class CollectionDependencies extends React.Component<
   RouteComponentProps,
   IState
 > {
+  private ignoredParams = ['page_size', 'page', 'sort', 'keywords'];
   constructor(props) {
     super(props);
 
@@ -174,13 +176,25 @@ class CollectionDependencies extends React.Component<
         <Main>
           <section className='body'>
             <div className='pf-c-content collection-dependencies'>
-              <h1>{t`Dependencies`}</h1>
+              <Text>{t`Dependencies`}</Text>
               <p>{t`This collection is dependent on the following collections`}</p>
               <List variant={ListVariant.inline}>
                 {Object.keys(dependencies).map((dependency) => (
                   <ListItem key={dependency}>
-                    <Link to={'/test'}>
-                      {this.separateCollectionByDependency(dependency)}
+                    <Link
+                      to={formatPath(
+                        Paths.collectionByRepo,
+                        {
+                          collection:
+                            this.separateCollectionByDependency(dependency)[1],
+                          namespace:
+                            this.separateCollectionByDependency(dependency)[0],
+                          repo: this.context.selectedRepo,
+                        },
+                        ParamHelper.getReduced(params, this.ignoredParams),
+                      )}
+                    >
+                      {this.separateCollectionByDependency(dependency)[1]}
                     </Link>
                   </ListItem>
                 ))}
@@ -234,21 +248,21 @@ class CollectionDependencies extends React.Component<
               <table className='content-table pf-c-table pf-m-compact'>
                 <tbody>
                   {this.filterUsedByDependencies(usedByDependencies).map(
-                    ({ name }) => (
+                    ({ name, namespace }) => (
                       <tr key={name}>
                         <td>
                           <Link
                             to={formatPath(
-                              Paths.collectionContentDocsByRepo,
+                              Paths.collectionByRepo,
                               {
-                                /*collection: collection,
-                                          namespace: namespace,
-                                          type: content.content_type,
-                                          name: content.name,
-                                          repo: this.context.selectedRepo,
-                                          */
+                                collection: name,
+                                namespace: namespace,
+                                repo: this.context.selectedRepo,
                               },
-                              //ParamHelper.getReduced(params, this.ignoredParams),
+                              ParamHelper.getReduced(
+                                params,
+                                this.ignoredParams,
+                              ),
                             )}
                           >
                             {name}
@@ -485,7 +499,7 @@ class CollectionDependencies extends React.Component<
   }
 
   private separateCollectionByDependency(dependency) {
-    return dependency.split('.')[1];
+    return dependency.split('.');
   }
 }
 

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -119,7 +119,7 @@ class CollectionDependencies extends React.Component<
               !filterIsSet(params, ['name']) ? (
                 <EmptyStateNoData
                   title={t`No dependencies`}
-                  description={t`Collection does not have any dependencies`}
+                  description={t`Collection does not have any dependencies.`}
                 />
               ) : (
                 <>
@@ -127,7 +127,7 @@ class CollectionDependencies extends React.Component<
                   {noDependencies ? (
                     <EmptyStateNoData
                       title={t`No dependencies`}
-                      description={t`Collection has no dependencies.`}
+                      description={t`Collection does not have any dependencies.`}
                     />
                   ) : (
                     <CollectionDependenciesList

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import {
   CollectionAPI,
@@ -13,13 +13,15 @@ import {
   Main,
   CollectionDependenciesList,
   CollectionUsedbyDependenciesList,
+  EmptyStateNoData,
 } from 'src/components';
 
-import { ParamHelper } from 'src/utilities/param-helper';
+import { filterIsSet, ParamHelper } from 'src/utilities';
 import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
 
 import './collection-dependencies.scss';
+
 interface IState {
   collection: CollectionDetailType;
   params: {
@@ -90,6 +92,10 @@ class CollectionDependencies extends React.Component<
 
     const dependenciesParams = ParamHelper.getReduced(params, ['version']);
 
+    const noDependencies: boolean = !Object.keys(
+      collection.latest_version.metadata.dependencies,
+    ).length;
+
     return (
       <React.Fragment>
         <CollectionHeader
@@ -108,24 +114,42 @@ class CollectionDependencies extends React.Component<
           <section className='body'>
             <div className='pf-c-content collection-dependencies'>
               <h1>{t`Dependencies`}</h1>
-              <p>{t`This collection is dependent on the following collections`}</p>
-              <CollectionDependenciesList
-                collection={this.state.collection}
-                repo={this.context.selectedRepo}
-              />
-              <p>{t`This collection is being used by `}</p>
-              <CollectionUsedbyDependenciesList
-                repo={this.context.selectedRepo}
-                usedByDependencies={usedByDependencies}
-                itemCount={usedByDependenciesCount}
-                params={dependenciesParams}
-                updateParams={(p) =>
-                  this.updateParams(
-                    this.combineParams(this.state.params, p),
-                    () => this.loadUsedByDependencies(),
-                  )
-                }
-              />
+              {noDependencies &&
+              !usedByDependenciesCount &&
+              !filterIsSet(params, ['name']) ? (
+                <EmptyStateNoData
+                  title={t`No dependencies`}
+                  description={t`Collection does not have any dependencies`}
+                />
+              ) : (
+                <>
+                  <p>{t`This collection is dependent on the following collections`}</p>
+                  {noDependencies ? (
+                    <EmptyStateNoData
+                      title={t`No dependencies`}
+                      description={t`Collection has no dependencies.`}
+                    />
+                  ) : (
+                    <CollectionDependenciesList
+                      collection={this.state.collection}
+                      repo={this.context.selectedRepo}
+                    />
+                  )}
+                  <p>{t`This collection is being used by`}</p>
+                  <CollectionUsedbyDependenciesList
+                    repo={this.context.selectedRepo}
+                    usedByDependencies={usedByDependencies}
+                    itemCount={usedByDependenciesCount}
+                    params={dependenciesParams}
+                    updateParams={(p) =>
+                      this.updateParams(
+                        this.combineParams(this.state.params, p),
+                        () => this.loadUsedByDependencies(),
+                      )
+                    }
+                  />
+                </>
+              )}
             </div>
           </section>
         </Main>

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -1,0 +1,137 @@
+import { t } from '@lingui/macro';
+import * as React from 'react';
+
+import { withRouter, RouteComponentProps } from 'react-router-dom';
+
+import { Link } from 'react-router-dom';
+
+import { ImportAPI, ImportDetailType, ImportListType } from 'src/api';
+import {
+  CollectionHeader,
+  LoadingPageWithHeader,
+  ImportConsole,
+  Main,
+} from 'src/components';
+
+import { loadCollection, IBaseCollectionState } from './base';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
+import { AppContext } from 'src/loaders/app-context';
+
+interface IState extends IBaseCollectionState {}
+
+class CollectionDependencies extends React.Component<
+  RouteComponentProps,
+  IState
+> {
+  constructor(props) {
+    super(props);
+
+    const params = ParamHelper.parseParamString(props.location.search);
+
+    this.state = {
+      collection: undefined,
+      params: params,
+    };
+  }
+
+  componentDidMount() {
+    this.loadData();
+  }
+
+  render() {
+    const { collection, params } = this.state;
+
+    if (!collection) {
+      return <LoadingPageWithHeader></LoadingPageWithHeader>;
+    }
+
+    const breadcrumbs = [
+      namespaceBreadcrumb,
+      {
+        url: formatPath(Paths.namespaceByRepo, {
+          namespace: collection.namespace.name,
+          repo: this.context.selectedRepo,
+        }),
+        name: collection.namespace.name,
+      },
+      {
+        url: formatPath(Paths.collectionByRepo, {
+          namespace: collection.namespace.name,
+          collection: collection.name,
+          repo: this.context.selectedRepo,
+        }),
+        name: collection.name,
+      },
+      { name: t`Dependencies` },
+    ];
+
+    return (
+      <React.Fragment>
+        <CollectionHeader
+          collection={collection}
+          params={params}
+          updateParams={
+            (params) => {}
+            //this.updateParams(params, () => this.loadData(true))
+          }
+          breadcrumbs={breadcrumbs}
+          activeTab='dependencies'
+          repo={this.context.selectedRepo}
+        />
+        <Main>
+          <section className='body'>
+            <div className='pf-c-content info-panel'>
+              <h1>{t`Dependencies`}</h1>
+              <p>{t`This collection is dependent on the following collections`}</p>
+              ...List here...
+              <p>{t`This collection is being used by `}</p>
+              <table className='content-table pf-c-table pf-m-compact'>
+                <tbody>
+                  <tr>
+                    <td>
+                      <Link
+                        to={formatPath(
+                          Paths.collectionContentDocsByRepo,
+                          {
+                            /*collection: collection,
+                                        namespace: namespace,
+                                        type: content.content_type,
+                                        name: content.name,
+                                        repo: this.context.selectedRepo,
+                                        */
+                          },
+                          //ParamHelper.getReduced(params, this.ignoredParams),
+                        )}
+                      >
+                        Depended
+                      </Link>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </Main>
+      </React.Fragment>
+    );
+  }
+
+  private loadData() {
+    this.loadCollection(this.context.selectedRepo, false, () => {
+      console.log('called after');
+    });
+  }
+
+  get loadCollection() {
+    return loadCollection;
+  }
+
+  get updateParams() {
+    return ParamHelper.updateParamsMixin();
+  }
+}
+
+export default withRouter(CollectionDependencies);
+
+CollectionDependencies.contextType = AppContext;

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -3,6 +3,7 @@ export { default as CollectionContent } from './collection-detail/collection-con
 export { default as CollectionDetail } from './collection-detail/collection-detail';
 export { default as CollectionDocs } from './collection-detail/collection-docs';
 export { default as CollectionImportLog } from './collection-detail/collection-import-log';
+export { default as CollectionDependencies } from './collection-detail/collection-dependencies';
 export { default as EditNamespace } from './edit-namespace/edit-namespace';
 export { default as LoginPage } from './login/login';
 export { default as MyImports } from './my-imports/my-imports';

--- a/src/loaders/insights/Routes.js
+++ b/src/loaders/insights/Routes.js
@@ -54,6 +54,13 @@ const CollectionImportLog = asyncComponent(() =>
   ),
 );
 
+const CollectionDependencies = asyncComponent(() =>
+  import(
+    /* webpackChunkName: "collection_detail" */
+    '../../containers/collection-detail/collection-dependencies'
+  ),
+);
+
 const NotFound = asyncComponent(() =>
   import(
     /* webpackChunkName: "not_found" */
@@ -219,6 +226,11 @@ export const Routes = (props) => {
       <InsightsRoute
         path={Paths.collectionImportLogByRepo}
         component={CollectionImportLog}
+        rootClass='root'
+      />
+      <InsightsRoute
+        path={Paths.collectionDependenciesByRepo}
+        component={CollectionDependencies}
         rootClass='root'
       />
       <InsightsRoute

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -7,6 +7,7 @@ import {
   CollectionDetail,
   CollectionDocs,
   CollectionImportLog,
+  CollectionDependencies,
   EditNamespace,
   LoginPage,
   MyImports,
@@ -206,6 +207,10 @@ export class Routes extends React.Component<IRoutesProps> {
       { comp: CollectionDocs, path: Paths.collectionContentDocsByRepo },
       { comp: CollectionContent, path: Paths.collectionContentListByRepo },
       { comp: CollectionImportLog, path: Paths.collectionImportLogByRepo },
+      {
+        comp: CollectionDependencies,
+        path: Paths.collectionDependenciesByRepo,
+      },
       { comp: CollectionDetail, path: Paths.collectionByRepo },
       { comp: NamespaceDetail, path: Paths.namespaceByRepo },
       { comp: Search, path: Paths.searchByRepo },

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -44,6 +44,7 @@ export enum Paths {
   collectionContentDocsByRepo = '/repo/:repo/:namespace/:collection/content/:type/:name',
   collectionContentListByRepo = '/repo/:repo/:namespace/:collection/content',
   collectionImportLogByRepo = '/repo/:repo/:namespace/:collection/import-log',
+  collectionDependenciesByRepo = '/repo/:repo/:namespace/:collection/dependencies',
   namespaceByRepo = '/repo/:repo/:namespace',
   collection = '/:namespace/:collection',
   namespace = '/:namespace',

--- a/src/utilities/content-summary.ts
+++ b/src/utilities/content-summary.ts
@@ -1,4 +1,4 @@
-import { ContentSummaryType } from 'src/api';
+import { CollectionVersion } from 'src/api';
 
 class Summary {
   total_count: number;
@@ -6,16 +6,23 @@ class Summary {
     module: number;
     role: number;
     plugin: number;
+    dependency: number;
     // playbook: number;
   };
 }
 
 export function convertContentSummaryCounts(
-  content: ContentSummaryType[],
+  metadata: CollectionVersion['metadata'],
 ): Summary {
+  const { contents: content, dependencies } = metadata;
   const summary: Summary = {
     total_count: content.length,
-    contents: { module: 0, role: 0, plugin: 0 },
+    contents: {
+      module: 0,
+      role: 0,
+      plugin: 0,
+      dependency: Object.keys(dependencies).length,
+    },
   };
 
   for (let c of content) {


### PR DESCRIPTION
Issue: [AAH-752](https://issues.redhat.com/browse/AAH-752)

- Added displaying the number of dependencies in the `CollectionList` page. I had to add a plural option for the `NumericLabel` component. It was implemented just to put `s` at the end of the keyword, so what was happening => `123 Dependencys` and what we needed `2 Dependencies` (`2 Dependencys` => `2 Dependencies`).
![Screenshot from 2021-09-15 01-56-48](https://user-images.githubusercontent.com/19647757/133349131-ecb4e42d-27be-4d44-8723-e8507fc1558b.png)

### Dependencies page
- added `CollectionDependenciesList` component to display list of dependencies
- added `CollectionUsedbyDependenciesList` component to show all collections that are using this collection. 

![Screenshot from 2021-09-14 23-03-58](https://user-images.githubusercontent.com/19647757/133349207-97ecaf88-1ed5-4bea-a801-93ab4de9a2a7.png)

- Should we show an empty state on no `dependencies` or `usedby dependencies` list?
- Now, when I'm thinking about it, maybe `reverseDependencies` would be a better variable name than `usedByDependencies`? :smile:

To generate test collections run `make api/create-test-collections`. More here [#936](https://github.com/ansible/galaxy_ng/pull/936)

I still have some issues with generating test collections and therefore `Filter collection name` Input that uses `/collection-versions/?dependency=namespace.collection&name?=test_dependency` doesn't seem to be working on my end (pagination and sort works though), so I'll test this more when I figure it out. 