### PR TITLE
dev-release: git push -f --tags

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -29,7 +29,7 @@ jobs:
         git config --local user.name "Dev release workflow"
         git config --local user.email "ansible-hub-ui+dev@example.com"
         git tag -f dev
-        git push --tags
+        git push -f --tags
 
     - name: "Cache ~/.npm"
       uses: actions/cache@v2


### PR DESCRIPTION
Follow-up to #943 

the action now [fails](https://github.com/ansible/ansible-hub-ui/runs/3622942619?check_suite_focus=true#step:4:12):

> To https://github.com/ansible/ansible-hub-ui
>  ! [rejected]        dev -> dev (already exists)
> error: failed to push some refs to 'https://github.com/ansible/ansible-hub-ui'
> hint: Updates were rejected because the tag already exists in the remote.

because the dev tag already exists, we need `-f` to rewrite it.

(But the good news is that the pushing to our repo still works without extra users :).)
