### PR TITLE
Additional fixes in collection deletion and collection dependencies page

### DIFF
--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -178,12 +178,17 @@ export class API extends HubAPI {
     );
   }
 
-  getUsedDependenciesByCollection(namespace, collection, params?) {
+  getUsedDependenciesByCollection(
+    namespace,
+    collection,
+    params = {},
+    cancelToken = undefined,
+  ) {
     return this.http.get(
       this.getUIPath(
         `collection-versions/?dependency=${namespace}.${collection}`,
       ),
-      { params: this.mapPageToOffset(params) },
+      { params: this.mapPageToOffset(params), cancelToken: cancelToken?.token },
     );
   }
 }

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -35,13 +35,13 @@ interface IProps {
     collection?: string;
     sort?: string;
     version?: string;
-    name?: string;
+    name__icontains?: string;
   };
   updateParams: (params) => void;
 }
 
 export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
-  private ignoredParams = ['page_size', 'page', 'sort', 'name'];
+  private ignoredParams = ['page_size', 'page', 'sort', 'name__icontains'];
 
   render() {
     const {
@@ -53,7 +53,7 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
       usedByDependenciesLoading,
     } = this.props;
 
-    if (!itemCount && !filterIsSet(params, ['name']))
+    if (!itemCount && !filterIsSet(params, ['name__icontains']))
       return (
         <EmptyStateNoData
           title={t`Not required for use by other collections`}
@@ -68,12 +68,16 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
             <ToolbarGroup>
               <ToolbarItem>
                 <SearchInput
-                  value={params.name || ''}
+                  value={params.name__icontains || ''}
                   onChange={(val) =>
-                    updateParams(ParamHelper.setParam(params, 'name', val))
+                    updateParams(
+                      ParamHelper.setParam(params, 'name__icontains', val),
+                    )
                   }
                   onClear={() =>
-                    updateParams(ParamHelper.setParam(params, 'name', ''))
+                    updateParams(
+                      ParamHelper.setParam(params, 'name__icontains', ''),
+                    )
                   }
                   aria-label='filter-collection-name'
                   placeholder={t`Filter by name`}
@@ -121,7 +125,7 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
                                 Paths.collectionByRepo,
                                 {
                                   collection: name,
-                                  namespace: namespace,
+                                  namespace,
                                   repo,
                                 },
                                 ParamHelper.getReduced(

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -134,7 +134,7 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
                                 ),
                               )}
                             >
-                              {name}
+                              {name} v{version}
                             </Link>
                           </td>
                         </tr>

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -547,7 +547,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           const dependencies = (
             <>
               <Trans>Dependent collections</Trans>
-              <List>
+              <List className='dependent-collections-alert-list'>
                 {dependent_collection_versions.map((d) => {
                   const { namespace, version, collection } =
                     this.separateStringDependencies(d);

--- a/src/components/headers/header.scss
+++ b/src/components/headers/header.scss
@@ -57,6 +57,10 @@
   padding-bottom: var(--pf-global--spacer--md);
 }
 
+.dependent-collections-alert-list {
+  margin-top: var(--pf-global--spacer--sm);
+}
+
 .tab-link-container {
   display: flex;
   margin-top: 10px;

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -44,7 +44,7 @@ class CollectionDependencies extends React.Component<
   RouteComponentProps,
   IState
 > {
-  private ignoredParams = ['page_size', 'page', 'sort', 'name'];
+  private ignoredParams = ['page_size', 'page', 'sort', 'name__icontains'];
   constructor(props) {
     super(props);
 
@@ -60,7 +60,7 @@ class CollectionDependencies extends React.Component<
       params: params,
       usedByDependencies: [],
       usedByDependenciesCount: 0,
-      usedByDependenciesLoading: false,
+      usedByDependenciesLoading: true,
       alerts: [],
     };
   }
@@ -132,7 +132,7 @@ class CollectionDependencies extends React.Component<
               <h1>{t`Dependencies`}</h1>
               {noDependencies &&
               !usedByDependenciesCount &&
-              !filterIsSet(params, ['name']) ? (
+              !filterIsSet(params, ['name__icontains']) ? (
                 <EmptyStateNoData
                   title={t`No dependencies`}
                   description={t`Collection does not have any dependencies.`}

--- a/src/containers/namespace-detail/namespace-detail.scss
+++ b/src/containers/namespace-detail/namespace-detail.scss
@@ -3,3 +3,19 @@
     padding-left: 0px;
   }
 }
+
+.delete-namespace-modal-message {
+  padding-bottom: var(--pf-global--spacer--md);
+}
+
+.namespace-page-controls {
+  display: flex;
+  align-items: center;
+}
+
+.namespace-warning-alert {
+  position: fixed;
+  right: 5px;
+  top: 80px;
+  z-index: 300;
+}

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -200,7 +200,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             isDisabled={!confirmDelete}
           >
             <>
-              <Text style={{ paddingBottom: 'var(--pf-global--spacer--md)' }}>
+              <Text className='delete-namespace-modal-message'>
                 <Trans>
                   Deleting <b>{namespace.name}</b> and its data will be lost.
                 </Trans>
@@ -220,12 +220,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
         />
         {warning ? (
           <Alert
-            style={{
-              position: 'fixed',
-              right: '5px',
-              top: '80px',
-              zIndex: 300,
-            }}
+            className='namespace-warning-alert'
             variant='warning'
             title={warning}
             actionClose={
@@ -462,10 +457,10 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
   private renderPageControls() {
     const { collections } = this.state;
     if (!this.state.showControls) {
-      return <div style={{ display: 'flex', alignItems: 'center' }}></div>;
+      return <div className='namespace-page-controls'></div>;
     }
     return (
-      <div style={{ display: 'flex', alignItems: 'center' }}>
+      <div className='namespace-page-controls'>
         {' '}
         {collections.length !== 0 && (
           <Button onClick={() => this.setState({ showImportModal: true })}>


### PR DESCRIPTION
No Issue

PR for additional fixes from content deletion (collection deletion, namespace deletion, collection dependencies tab)

- *namespace-detail*: moved from inline styles to classes (moved all inline styles in `namespace-detail.tsx` to `namespace-detail.scss` ) [#871 comment](https://github.com/ansible/ansible-hub-ui/pull/871#pullrequestreview-762178022)
- *error alert in collection dependencies tab*: added space between list and text
before: 
![Screenshot from 2021-09-24 13-33-42](https://user-images.githubusercontent.com/19647757/135124722-e75f6d35-ef7c-4212-95bf-9e790746a062.png)

after:
![Screenshot from 2021-09-27 17-49-07](https://user-images.githubusercontent.com/19647757/135124733-ee73e53c-95bc-4de6-9ad0-5e8e875cab06.png)

- *collection dependencies tab*: added partial match filter for `used by collections` list (on API already merged on master, thanks to David, [#995](https://github.com/ansible/galaxy_ng/pull/995))

- Bug was happening with a lot of collections loading on typing quickly, so I added  canceling of older requests

- added version to the list to distinguish collections better 
![Screenshot from 2021-09-29 17-41-10](https://user-images.githubusercontent.com/19647757/135306370-c0284fcd-7770-41f4-9f05-ded97f5dc7ea.png)


I'm still investigating this bug [#947 comment](https://github.com/ansible/ansible-hub-ui/pull/947#issuecomment-923937651)