### PR TITLE
Set a default value of 10 for remote download concurrency

### DIFF
--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -73,7 +73,10 @@ export class RemoteForm extends React.Component<IProps, IState> {
      * Shim in a default concurrency value to pass form validation
      * https://issues.redhat.com/browse/AAH-959
      ***************************************************************/
-    if (this.props.remoteType !== 'registry' && this.props.remote.download_concurrency === null) {
+    if (
+      this.props.remoteType !== 'registry' &&
+      this.props.remote.download_concurrency === null
+    ) {
       this.props.remote.download_concurrency = 10;
     }
   }

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -77,7 +77,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
       this.props.remoteType !== 'registry' &&
       this.props.remote.download_concurrency === null
     ) {
-      this.props.remote.download_concurrency = 10;
+      this.updateRemote(10, 'download_concurrency');
     }
   }
 

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -68,6 +68,15 @@ export class RemoteForm extends React.Component<IProps, IState> {
       uploadedClientCertFilename: clientCertFilename,
       uploadedCaCertFilename: caCertFilename,
     };
+
+    /***************************************************************
+     * Shim in a default concurrency value to pass form validation
+     * https://issues.redhat.com/browse/AAH-959
+     ***************************************************************/
+    if (this.props.remote.download_concurrency === null) {
+        this.props.remote.download_concurrency = 1;
+    }
+
   }
 
   render() {

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -74,7 +74,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
      * https://issues.redhat.com/browse/AAH-959
      ***************************************************************/
     if (this.props.remote.download_concurrency === null) {
-        this.props.remote.download_concurrency = 1;
+        this.props.remote.download_concurrency = 10;
     }
 
   }

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -74,9 +74,8 @@ export class RemoteForm extends React.Component<IProps, IState> {
      * https://issues.redhat.com/browse/AAH-959
      ***************************************************************/
     if (this.props.remote.download_concurrency === null) {
-        this.props.remote.download_concurrency = 10;
+      this.props.remote.download_concurrency = 10;
     }
-
   }
 
   render() {

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -73,7 +73,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
      * Shim in a default concurrency value to pass form validation
      * https://issues.redhat.com/browse/AAH-959
      ***************************************************************/
-    if (this.props.remote.download_concurrency === null) {
+    if (this.props.remoteType !== 'registry' && this.props.remote.download_concurrency === null) {
       this.props.remote.download_concurrency = 10;
     }
   }


### PR DESCRIPTION
The edit form for a remote repository has a null value for concurrency even though the validation requires an integer greater than 1. The user does not have any context clues that the value is invalid until they try typing something into the field. Setting a ~~1~~ 10 by default helps eliminate headache.

~~This will be one option to fix this issue, and a second involving a schema migration will follow.~~

Links [Optional]
----------------

* https://issues.redhat.com/browse/AAH-959

Steps for Testing/QA [Optional]
-------------------------------

1) open the hub ui
2) collections
3) repository management
4) click the 3 dots to the far right of "rh-certified"
5) click edit
6) attempt to click save
