### PR TITLE
EE list, EE detail - alert on sync success/error

### DIFF
--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -18,7 +18,12 @@ import {
   ExecutionEnvironmentRemoteAPI,
   ExecutionEnvironmentType,
 } from 'src/api';
-import { filterIsSet, waitForTask, ParamHelper } from 'src/utilities';
+import {
+  filterIsSet,
+  parsePulpIDFromURL,
+  waitForTask,
+  ParamHelper,
+} from 'src/utilities';
 import {
   AlertList,
   AlertType,
@@ -339,10 +344,7 @@ class ExecutionEnvironmentList extends React.Component<
         {t`Edit`}
       </DropdownItem>,
       item.pulp.repository.remote && (
-        <DropdownItem
-          key='sync'
-          onClick={() => ExecutionEnvironmentRemoteAPI.sync(item.name)}
-        >
+        <DropdownItem key='sync' onClick={() => this.sync(item.name)}>
           {t`Sync from registry`}
         </DropdownItem>
       ),
@@ -508,6 +510,40 @@ class ExecutionEnvironmentList extends React.Component<
 
   private get closeAlert() {
     return closeAlertMixin('alerts');
+  }
+
+  private addAlert(title, variant, description?) {
+    this.setState({
+      alerts: [
+        ...this.state.alerts,
+        {
+          description,
+          title,
+          variant,
+        },
+      ],
+    });
+  }
+
+  private sync(name) {
+    ExecutionEnvironmentRemoteAPI.sync(name)
+      .then((result) => {
+        const task_id = parsePulpIDFromURL(result.data.task);
+        this.addAlert(
+          t`Sync initiated for ${name}`,
+          'success',
+          <span>
+            <Trans>
+              View the task{' '}
+              <Link to={formatPath(Paths.taskDetail, { task: task_id })}>
+                here
+              </Link>
+              .
+            </Trans>
+          </span>,
+        );
+      })
+      .catch(() => this.addAlert(t`Sync failed for ${name}`, 'danger'));
   }
 }
 


### PR DESCRIPTION
Fixes [AAH-967](https://issues.redhat.com/browse/AAH-967)

This just adds an alert on sync success/failure on both the EE list and EE detail screens.

The logic is copied from Remote Registries sync, I verified this does show an error alert nicely :).
(There seems to be an API issue where sync 500s now, but theoretically it should show the task link on success :) .. fixed in https://github.com/ansible/galaxy_ng/pull/1006)