### PR TITLE
Additional collection deletion fixes

### DIFF
--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -122,6 +122,7 @@ export class CollectionDetailType {
 
 export class CollectionUsedByDependencies extends CollectionDetailType {
   version: string;
+  repository_list: string[];
 }
 
 export class DependencyType {

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -49,7 +49,6 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
       usedByDependencies,
       itemCount,
       updateParams,
-      repo,
       usedByDependenciesLoading,
     } = this.props;
 
@@ -117,7 +116,7 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
                 <table className='content-table pf-c-table pf-m-compact'>
                   <tbody>
                     {usedByDependencies.map(
-                      ({ name, namespace, version }, i) => (
+                      ({ name, namespace, version, repository_list }, i) => (
                         <tr key={i}>
                           <td>
                             <Link
@@ -126,7 +125,7 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
                                 {
                                   collection: name,
                                   namespace,
-                                  repo,
+                                  repo: repository_list[0],
                                 },
                                 ParamHelper.getReduced(
                                   { version },

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -548,28 +548,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             <>
               <Trans>Dependent collections</Trans>
               <List className='dependent-collections-alert-list'>
-                {dependent_collection_versions.map((d) => {
-                  const { namespace, version, collection } =
-                    this.separateStringDependencies(d);
-                  return (
-                    <ListItem key={d}>
-                      <Link
-                        to={formatPath(
-                          Paths.collectionByRepo,
-                          {
-                            repo: this.context.selectedRepo,
-                            namespace,
-                            collection,
-                          },
-                          { version: version },
-                        )}
-                        onClick={() => this.setState({ alerts: [] })}
-                      >
-                        {d}
-                      </Link>
-                    </ListItem>
-                  );
-                })}
+                {dependent_collection_versions.map((d) => (
+                  <ListItem key={d}>{d}</ListItem>
+                ))}
               </List>
             </>
           );
@@ -679,12 +660,5 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
   get closeAlert() {
     return closeAlertMixin('alerts');
-  }
-
-  private separateStringDependencies(dependency) {
-    const [nsCollection, version] = dependency.split(' ');
-    const [namespace, collection] = nsCollection.split('.');
-
-    return { namespace, collection, version };
   }
 }

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -32,7 +32,7 @@ class CollectionDetail extends React.Component<
   }
 
   componentDidMount() {
-    this.loadCollection(this.context.selectedRepo);
+    this.loadCollection(this.context.selectedRepo, true);
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
No Issue

These fixes are related to the collection's dependencies or collection is being used by collection and resides in a different repository 
- Removed `Link` component from `dependent_collection_versions` list in error alert, because of possible redirection to the wrong repository. Currently, we are unable to track from which repository collection is (collection can be in many repos) and It would be misleading if a user thought it was just in one repo
 
![Screenshot from 2021-10-04 20-42-36](https://user-images.githubusercontent.com/19647757/136059647-6e07b39c-49d8-498e-8d03-36af4bb2124a.png)

- Fixed not found collection if the collection is from a different repository in `usedby dependencies` list in dependencies tab. Right now, I grab the first value from `repository_list` (this might not be ideal if it's in multiple repositories -> misleading for user) 
- @ZitaNemeckova I think I fixed the bug you have been talking about ([#947 screenshot](https://github.com/ansible/ansible-hub-ui/pull/947#issuecomment-923937651)). The problem was on UI, when the repository was changed, collection and its versions weren't reloaded, so what was happening was, no existing collection version in the repository was being deleted, therefore 404 error. Fixed by not caching collection on collection detail page.

I asked @awcrosby about this and he explained to me this issue about the repositories and collections on API and created [AAH-980](https://issues.redhat.com/browse/AAH-980) for improving this to make it more clear for a user. 

CC to @newswangerd @ZitaNemeckova