### PR TITLE
Logo - add fallbackToDefault prop, use in NamespaceCard

### DIFF
--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -41,10 +41,11 @@ export class CollectionCard extends React.Component<IProps> {
       <Card className={cx('collection-card-container', className)}>
         <CardHeader className='logo-row'>
           <Logo
+            alt={t`${company} logo`}
+            fallbackToDefault
             image={namespace.avatar_url}
-            alt={company + ' logo'}
             size='40px'
-            unlockWidth={true}
+            unlockWidth
           />
           <TextContent>{this.getCertification(repo)}</TextContent>
         </CardHeader>

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -35,8 +35,9 @@ export class NamespaceCard extends React.Component<IProps, {}> {
             <Logo
               unlockWidth
               image={avatar_url}
-              alt={company + ' logo'}
+              alt={t`${company} logo`}
               size='40px'
+              fallbackToDefault
             />
           </CardHeaderMain>
         </CardHeader>

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -33,11 +33,11 @@ export class NamespaceCard extends React.Component<IProps, {}> {
         <CardHeader>
           <CardHeaderMain>
             <Logo
-              unlockWidth
-              image={avatar_url}
               alt={t`${company} logo`}
-              size='40px'
               fallbackToDefault
+              image={avatar_url}
+              size='40px'
+              unlockWidth
             />
           </CardHeaderMain>
         </CardHeader>

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -54,10 +54,11 @@ export class CollectionListItem extends React.Component<IProps, {}> {
       cells.push(
         <DataListCell isFilled={false} alignRight={false} key='ns'>
           <Logo
-            alt={company + ' logo'}
+            alt={t`${company} logo`}
+            fallbackToDefault
             image={namespace.avatar_url}
             size='40px'
-            unlockWidth={true}
+            unlockWidth
             width='97px'
           />
         </DataListCell>,

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -4,11 +4,10 @@ import cx from 'classnames';
 import './header.scss';
 
 import { Title } from '@patternfly/react-core';
-import { Logo } from 'src/components';
 
 interface IProps {
   title: string;
-  imageURL?: string;
+  logo?: React.ReactNode;
   breadcrumbs?: React.ReactNode;
   pageControls?: React.ReactNode;
   children?: React.ReactNode;
@@ -22,7 +21,7 @@ export class BaseHeader extends React.Component<IProps, {}> {
   render() {
     const {
       title,
-      imageURL,
+      logo,
       pageControls,
       children,
       breadcrumbs,
@@ -43,15 +42,7 @@ export class BaseHeader extends React.Component<IProps, {}> {
 
         <div className='column-section'>
           <div className='title-box'>
-            {imageURL ? (
-              <Logo
-                className='image'
-                alt={t`Page logo`}
-                image={imageURL}
-                size='40px'
-                unlockWidth={true}
-              />
-            ) : null}
+            {logo}
             <div>
               <Title headingLevel='h1' size='2xl'>
                 {title}

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -316,6 +316,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
               <Logo
                 alt={t`${company} logo`}
                 className='image'
+                fallbackToDefault
                 image={collection.namespace.avatar_url}
                 size='40px'
                 unlockWidth

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -26,6 +26,7 @@ import {
   BaseHeader,
   Breadcrumbs,
   LinkTabs,
+  Logo,
   RepoSelector,
   Pagination,
   AlertList,
@@ -155,6 +156,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       }`;
 
     const { name: collectionName } = collection;
+    const company = collection.namespace.company || collection.namespace.name;
 
     if (redirect) return <Redirect push to={redirect} />;
 
@@ -309,7 +311,17 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         <BaseHeader
           className={className}
           title={collection.name}
-          imageURL={collection.namespace.avatar_url}
+          logo={
+            collection.namespace.avatar_url && (
+              <Logo
+                alt={t`${company} logo`}
+                className='image'
+                image={collection.namespace.avatar_url}
+                size='40px'
+                unlockWidth
+              />
+            )
+          }
           contextSelector={
             <RepoSelector
               selectedRepo={this.context.selectedRepo}

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -45,6 +45,7 @@ export class PartnerHeader extends React.Component<IProps, {}> {
             <Logo
               alt={t`${company} logo`}
               className='image'
+              fallbackToDefault
               image={namespace.avatar_url}
               size='40px'
               unlockWidth

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -1,9 +1,10 @@
+import { t } from '@lingui/macro';
 import * as React from 'react';
 import './header.scss';
 
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import { BaseHeader, Tabs, TabsType, Breadcrumbs } from 'src/components';
+import { BaseHeader, Logo, Tabs, TabsType, Breadcrumbs } from 'src/components';
 import { NamespaceType } from 'src/api';
 
 interface IProps {
@@ -33,10 +34,23 @@ export class PartnerHeader extends React.Component<IProps, {}> {
       tabs,
       updateParams,
     } = this.props;
+
+    const company = namespace.company || namespace.name;
+
     return (
       <BaseHeader
-        title={namespace.company || namespace.name}
-        imageURL={namespace.avatar_url}
+        title={company}
+        logo={
+          namespace.avatar_url && (
+            <Logo
+              alt={t`${company} logo`}
+              className='image'
+              image={namespace.avatar_url}
+              size='40px'
+              unlockWidth
+            />
+          )
+        }
         breadcrumbs={<Breadcrumbs links={breadcrumbs} />}
         pageControls={pageControls}
         contextSelector={contextSelector}

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -11,11 +11,30 @@ interface IProps {
   alt: string;
   className?: string;
   unlockWidth?: boolean;
+  fallbackToDefault?: boolean;
 }
 
-export class Logo extends React.Component<IProps> {
+interface IState {
+  failed: boolean;
+}
+
+export class Logo extends React.Component<IProps, IState> {
+  constructor(props) {
+    super(props);
+    this.state = { failed: false };
+  }
+
   render() {
-    const { size, image, alt, className, unlockWidth, width } = this.props;
+    const {
+      alt,
+      className,
+      fallbackToDefault,
+      image,
+      size,
+      unlockWidth,
+      width,
+    } = this.props;
+    const { failed } = this.state;
 
     const style = {
       height: size,
@@ -36,8 +55,13 @@ export class Logo extends React.Component<IProps> {
       <div className={className} style={style}>
         <img
           style={{ objectFit: 'contain', maxHeight: size }}
-          src={image || DefaultLogo}
+          src={failed ? DefaultLogo : image || DefaultLogo}
           alt={alt}
+          onError={
+            fallbackToDefault
+              ? (e) => this.setState({ failed: true })
+              : () => null
+          }
         />
       </div>
     );


### PR DESCRIPTION
allows Logo to detect image load errors and replace the missing image with a default logo

This means we would hide any logo URL errors by treating them as if the logo wasn't defined for the namespace.
(requested by Zvika Sadeh)

After the change:
all colllection/namespace list screen items have a logo (falling back to the default on error or absence)
all colllection/namespace detail screen headers which have a logo set have a logo, falling back to the default on error

Screenshots, with a placekitten.com logo for awcrosby, bad url logo for avd, and no logo for serdigital64:
![20211012004650](https://user-images.githubusercontent.com/289743/136872288-0d166d8c-2c24-4348-8b40-2eed85526c5f.png)
![20211012004703](https://user-images.githubusercontent.com/289743/136872290-8dd6ac4e-5177-408a-af04-76a6ba12f4c9.png)
![20211012004713](https://user-images.githubusercontent.com/289743/136872291-629a442d-0cb3-415a-be3d-f12edb7e6779.png)
![20211012004725](https://user-images.githubusercontent.com/289743/136872293-2074b209-bfee-41ad-99c9-5e0004eff6f2.png)
![20211012004732](https://user-images.githubusercontent.com/289743/136872294-b73faf80-c60c-414c-8a1a-e9d76f8c0cc4.png)
![20211012004741](https://user-images.githubusercontent.com/289743/136872295-68fb85b7-a65a-4c50-9eaf-67d177237a28.png)
![20211012004752](https://user-images.githubusercontent.com/289743/136872296-842167eb-bf66-433d-b69b-7486614bbecb.png)
![20211012004759](https://user-images.githubusercontent.com/289743/136872299-6446ce71-2396-4f3b-aab4-93b2fbb106e5.png)

(also made the alt more consistent)