### PR TITLE
display backend authentication provider on user detail page

### DIFF
--- a/src/api/response-types/user.ts
+++ b/src/api/response-types/user.ts
@@ -42,6 +42,7 @@ export class UserType {
   last_name?: string;
   email?: string;
   groups: { id: number; name: string }[];
+  auth_provider?: [];
   date_joined?: string;
   password?: string;
   model_permissions?: Permissions;

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -120,6 +120,19 @@ export class UserForm extends React.Component<IProps, IState> {
       </FormGroup>
     );
 
+    const readonlyAuth = () => (
+      <FormGroup
+        fieldId='auth_provider'
+        key='readonlyAuth'
+        label={t`Authentication provider`}
+        aria-labelledby='readonly-auth'
+      >
+        {user.auth_provider.map((provider) => (
+          <Label key={provider}>{provider}</Label>
+        ))}
+      </FormGroup>
+    );
+
     const readonlyGroups = () => (
       <FormGroup
         fieldId='groups'
@@ -203,6 +216,7 @@ export class UserForm extends React.Component<IProps, IState> {
     const formSuffix = [
       !isReadonly && passwordConfirmGroup(),
       isMe || isReadonly ? readonlyGroups() : editGroups(),
+      isMe && isReadonly && readonlyAuth(),
       superuserLabel,
       !isReadonly && formButtons(),
     ];


### PR DESCRIPTION
Good morning Zita && Martin :)

Issue: [AAH-952](https://issues.redhat.com/browse/AAH-952)

Assignment: Display the backend authentication provider on the user detail page. If user is not an SSO user this should return 'django,' if user _is_ SSO user, that auth provider should be displayed. 

Note: Testing should be done with someone who has Keycloak working. 

Before:
![Screen Shot 2021-10-06 at 10 37 05 AM](https://user-images.githubusercontent.com/64337863/136225177-a15941e6-d422-4bc6-a67c-d9396c462480.png)

After:
![Screen Shot 2021-10-06 at 10 36 30 AM](https://user-images.githubusercontent.com/64337863/136225221-633aa639-8f1e-497f-8ecd-45f8e2d62885.png)

Have a nice day :)