### PR TITLE
alert SSO user of token expiration

### DIFF
--- a/src/containers/token/token-standalone.tsx
+++ b/src/containers/token/token-standalone.tsx
@@ -9,6 +9,7 @@ import {
   Main,
   ClipboardCopy,
   EmptyStateUnauthorized,
+  DateComponent,
 } from 'src/components';
 import { ActiveUserAPI } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
@@ -29,6 +30,8 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
   render() {
     const { token } = this.state;
     let unauthorised = !this.context.user || this.context.user.is_anonymous;
+    const expiration = this.context.settings.GALAXY_TOKEN_EXPIRATION;
+    const expirationDate = new Date(Date.now() + 1000 * 60 * expiration);
 
     return (
       <React.Fragment>
@@ -45,6 +48,17 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
                   client.
                 </Trans>
               </p>
+              {!this.context.user.auth_provider.includes('django') && (
+                <div>
+                  <h2>{t`Expiration`}</h2>
+                  <p>
+                    <Trans>
+                      You are an SSO user. Your token will expire{' '}
+                      <DateComponent date={expirationDate.toISOString()} />.
+                    </Trans>
+                  </p>
+                </div>
+              )}
               <div className='pf-c-content'>
                 <Trans>
                   <b>WARNING</b> loading a new token will delete your old token.


### PR DESCRIPTION
Issue: [AAH-952](https://issues.redhat.com/browse/AAH-952?_sscc=t)

Assignment: Warn SSO users of token expiration.

Note: Since I am not able to access the UI as a _Keycloak_ user, I wasn't able to test the UI properly. If `user.auth_provider` returns `['django']` then the message will not appear. 