### PR TITLE
Cypress: add view-only tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -86,6 +86,7 @@ jobs:
           RH_ENTITLEMENT_REQUIRED='insights'
           TOKEN_AUTH_DISABLED=True
           X_PULP_CONTENT_HOST='localhost'
+          GALAXY_REQUIRE_CONTENT_APPROVAL=False
         " | sed 's/^\s\+//' | tee settings/settings.py
 
         podman run \

--- a/test/README.md
+++ b/test/README.md
@@ -42,12 +42,15 @@ The tests need to know details about the instance of Automation Hub that it's ru
         "username": "<your username here>",
         "password": "<your password here>",
         "settings": "../../galaxy_ng/galaxy_ng/app/settings.py",
-        "restart": "true"
+        "restart": "true",
+        "containers": "localhost:5001"
     }
 
 *note*: the api root for the docker development environment of ansible/galaxy\_ng is `/api/automation-hub/`, while pulp-oci-images uses `/api/galaxy/`.
 
 *note*: `settings` should point to galaxy\_ng `settings.py` relative to the `test/` folder, `restart` is a command to restart the server, true works in development because the server is watching for changes.
+
+*note*: `containers` is what you would use with `docker push`/`podman push` to add a local container
 
 ## Run the Tests Directly
 

--- a/test/README.md
+++ b/test/README.md
@@ -34,16 +34,20 @@ These are separate from the project's own dependencies. Run the following from t
 
 ### Prepare your `cypress.env.json`
 
-The tests need to know details about the instance of Automation Hub that it's running against. Create a file named `cypress.env.json` in the test/ directory, and use the below example as a template.
+The tests need to know details about the instance of Automation Hub that it's running against. Create a file named `cypress.env.json` in the test/ directory, and use the below example as a template or start by copying `cypress.env.json.template`.
 
     {
-        "baseUrl":"http://localhost:8002/",
-        "prefix":"<api root>",
+        "baseUrl": "http://localhost:8002/",
+        "prefix": "<api root>",
         "username": "<your username here>",
-        "password": "<your password here>"
+        "password": "<your password here>",
+        "settings": "../../galaxy_ng/galaxy_ng/app/settings.py",
+        "restart": "true"
     }
 
-*note*: the api root for the docker development environment of ansible/galaxy_ng is `api/automation-hub/`.
+*note*: the api root for the docker development environment of ansible/galaxy\_ng is `/api/automation-hub/`, while pulp-oci-images uses `/api/galaxy/`.
+
+*note*: `settings` should point to galaxy\_ng `settings.py` relative to the `test/` folder, `restart` is a command to restart the server, true works in development because the server is watching for changes.
 
 ## Run the Tests Directly
 
@@ -128,3 +132,5 @@ You may use these commands:
 * cy.galaxykit("namespace create", name, [initial group])
 * cy.galaxykit("namespace addgroup", namespace, group)
 * cy.galaxykit("namespace removegroup", namespace, group)
+
+see [command.py](https://github.com/ansible/galaxykit/blob/main/galaxykit/command.py) for more.

--- a/test/cypress/integration/menu.js
+++ b/test/cypress/integration/menu.js
@@ -32,6 +32,7 @@ describe('Hub Menu Tests', () => {
   });
 
   describe('user without permissions', () => {
+    // one more similar test in view-only
     let visibleMenuItems = [
       'Collections > Collections',
       'Collections > Namespaces',

--- a/test/cypress/integration/view-only.js
+++ b/test/cypress/integration/view-only.js
@@ -53,7 +53,8 @@ describe('view-only mode', () => {
       cy.contains('.pf-c-tabs__item a', 'My namespaces').should('not.exist');
 
       // go to a (namespace) detail screen
-      cy.contains('a', 'View collections');
+      cy.contains('a', 'View collections').click();
+      cy.contains('.pf-c-title', 'admin');
 
       cy.contains('button', 'Upload collection').should('not.exist');
       cy.contains('button', 'Upload new version').should('not.exist');

--- a/test/cypress/integration/view-only.js
+++ b/test/cypress/integration/view-only.js
@@ -1,4 +1,8 @@
 describe('view-only mode', () => {
+  before(() => {
+    cy.galaxykit('collection upload');
+  });
+
   describe('with download', () => {
     before(() => {
       cy.settings({

--- a/test/cypress/integration/view-only.js
+++ b/test/cypress/integration/view-only.js
@@ -1,0 +1,16 @@
+describe('view-only mode', () => {
+  before(() => {
+    cy.settings({
+      GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS: true,
+    });
+  });
+
+  it('can load Collections', () => {
+    cy.visit('/');
+    cy.contains('.pf-c-title', 'Collections');
+  });
+
+  after(() => {
+    cy.settings(); // reset
+  });
+});

--- a/test/cypress/integration/view-only.js
+++ b/test/cypress/integration/view-only.js
@@ -1,13 +1,88 @@
 describe('view-only mode', () => {
-  before(() => {
-    cy.settings({
-      GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS: true,
+  describe('with download', () => {
+    before(() => {
+      cy.settings({
+        GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS: true,
+        GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD: true,
+      });
+    });
+
+    it('has limited menu, nav', () => {
+      cy.visit('/');
+
+      [
+        'Collections > Collections',
+        'Collections > Namespaces',
+        'Documentation',
+      ].forEach((item) => cy.menuPresent(item));
+
+      [
+        'Collections > Repository Management',
+        'Collections > API Token',
+        'Collections > Approval',
+        'Execution Environments > Execution Environments',
+        'Execution Environments > Remote Registries',
+        'Task Management',
+        'User Access > Users',
+        'User Access > Groups',
+      ].forEach((item) => cy.menuMissing(item));
+
+      // login button in top right nav
+      cy.contains('.pf-c-page__header-tools a', 'Login');
+    });
+
+    it('can load Collections', () => {
+      cy.visit('/');
+      cy.contains('.pf-c-title', 'Collections');
+
+      // go to a detail screen
+      cy.get('.pf-c-card__header .name a').first().click();
+
+      cy.contains('.pf-c-button', 'Download tarball');
+    });
+
+    it('can load Namespaces', () => {
+      cy.visit('/ui/namespaces');
+      cy.contains('.pf-c-title', 'Namespaces');
+
+      cy.contains('button', 'Create').should('not.exist');
+      cy.contains('.pf-c-tabs__item a', 'My namespaces').should('not.exist');
+
+      // go to a (namespace) detail screen
+      cy.contains('a', 'View collections');
+
+      cy.contains('button', 'Upload collection').should('not.exist');
+      cy.contains('button', 'Upload new version').should('not.exist');
+    });
+
+    it('gets Unauthorized elsewhere', () => {
+      cy.visit('/ui/repositories');
+      cy.contains('You do not have access to Automation Hub');
+      cy.contains('.pf-c-button', 'Login');
     });
   });
 
-  it('can load Collections', () => {
-    cy.visit('/');
-    cy.contains('.pf-c-title', 'Collections');
+  describe('without download', () => {
+    before(() => {
+      cy.settings({
+        GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS: true,
+        GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD: false,
+      });
+    });
+
+    it("can't download collections", () => {
+      cy.visit('/');
+      cy.contains('.pf-c-title', 'Collections');
+
+      // go to a detail screen
+      cy.get('.pf-c-card__header .name a').first().click();
+
+      cy.contains(
+        '.pf-c-alert.pf-m-warning',
+        'You have to be logged in to be able to download the tarball',
+      );
+      cy.contains('.pf-c-button', 'Download tarball').should('not.exist');
+    });
   });
 
   after(() => {


### PR DESCRIPTION
Fixes [AAH-997](https://issues.redhat.com/browse/AAH-997)

A `cy.settings` Cypress command was added in https://github.com/ansible/ansible-hub-ui/pull/1116.
(It also added `cypress.env.json.template` but didn't document it, fixing here.)

Adding a test for view-only mode, using `cy.settings` to change the server settings for the duration.

With `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS` & `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD`, test that Collections, Namespaces and Documentation are in the menu, we can see the list & detail screens, and no Add/Upload/Create buttons, as well as Unauthorized elsewhere.

With just `GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS`: check that collection detail screen has the alert instead of a download button.

**And** changing the settings for github actions to `GALAXY_REQUIRE_CONTENT_APPROVAL=False`, so that `galaxykit collection upload` doesn't require approvals everywhere ([AAH-628](https://issues.redhat.com/browse/AAH-628) will deal with enabling it back for approval tests). This should unblock #1117 & #1137.

---

:grey_exclamation: Note: when testing locally, most likely you first need to:

* update galaxykit to 0.5.2+: `python -m pip install --user galaxykit --upgrade`
* add `settings` and `restart` to your `test/cypress.env.json` (see `test/cypress.env.json.template` and `test/README.md`)