### PR TITLE
Fix wrong displaying of username in delete user from group 

### DIFF
--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -562,7 +562,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     const group = this.state.group;
     const user = this.state.showUserRemoveModal as UserType;
 
-    const username = { user };
+    const { username } = user;
     const groupname = group.name;
 
     return (


### PR DESCRIPTION
No Issue

Quick fix of displaying of the username in `DeleteModal` in `GroupDetail` user list.

Before:
![Screenshot from 2021-10-15 14-31-29](https://user-images.githubusercontent.com/19647757/137487626-8d11c4fd-9ea4-4246-a729-d52c5345ad6a.png)

After:
![Screenshot from 2021-10-15 14-31-55](https://user-images.githubusercontent.com/19647757/137487637-6d33c08d-0a02-4fd9-b2fc-29dd8124a285.png)
