### PR TITLE
Fix documenttioon link

### DIFF
--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -232,8 +232,8 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
       tagSelection,
     } = this.state;
 
-    // FIXME: installer docs link
-    const docsLink = 'https://fixme.example.com';
+    const docsLink =
+      'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1';
 
     const noData =
       controllers?.length === 0 &&


### PR DESCRIPTION
Using default link to documentation because it was advised by the docs team not to use specific ones.

Fixes https://issues.redhat.com/browse/AAH-1022

Steps to reproduce:
Execution Environments -> Execution Environments -> kebab next to one of EE -> Use in Controller -> see "If the Controller is not listed in the table, check settings.py. Learn more " line

Before:
link went to www.example.com
After:
link goes to documentation