### PR TITLE
cypress test for empty state remote registries

### DIFF
--- a/test/cypress/integration/remote_registry.js
+++ b/test/cypress/integration/remote_registry.js
@@ -58,6 +58,18 @@ describe('Remote Registry Tests', () => {
     cy.login(adminUsername, adminPassword);
   });
 
+  it('checks for empty state', () => {
+    cy.menuGo('Execution Enviroments > Remote Registries');
+    cy.get('.pf-c-empty-state__content > .pf-c-title').should(
+      'have.text',
+      'No remote registries yet',
+    );
+    cy.get('.pf-c-empty-state__content > .pf-c-empty-state__body').should(
+      'have.text',
+      'You currently have no remote registries.',
+    );
+  });
+
   it('admin can add new remote registry', () => {
     cy.menuGo('Execution Enviroments > Remote Registries');
     addData('New remote registry1', 'some url1');


### PR DESCRIPTION
Good afternoon :)

Issue: https://issues.redhat.com/browse/AAH-998

This pr adds an additional cypress test to `/integration/remote_registries.js` that checks for an empty state message before remote registries are added. Hopefully this is the appropriate place to put it. Feedback welcomed. :)