### PR TITLE
Tests for EE Use in Controller

### DIFF
--- a/test/cypress/integration/execution_environments.js
+++ b/test/cypress/integration/execution_environments.js
@@ -3,57 +3,12 @@ describe('execution environments', () => {
   let adminPassword = Cypress.env('password');
   let num = (~~(Math.random() * 1000000)).toString();
 
-  function deleteRegistries() {
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') + '_ui/v1/execution-environments/registries/?*',
-    ).as('registries');
-
-    cy.visit('/ui/registries');
-
-    cy.wait('@registries').then((result) => {
-      var data = result.response.body.data;
-      data.forEach((element) => {
-        cy.get(
-          'tr[aria-labelledby="' +
-            element.name +
-            '"] button[aria-label="Actions"]',
-        ).click();
-        cy.contains('a', 'Delete').click();
-        cy.contains('button', 'Delete').click();
-      });
-    });
-  }
-
-  function deleteContainers() {
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') + '_ui/v1/execution-environments/repositories/?*',
-    ).as('listLoad');
-
-    cy.visit('/ui/containers');
-
-    cy.wait('@listLoad').then((result) => {
-      var data = result.response.body.data;
-      data.forEach((element) => {
-        cy.get(
-          'tr[aria-labelledby="' +
-            element.name +
-            '"] button[aria-label="Actions"]',
-        ).click();
-        cy.contains('a', 'Delete').click();
-        cy.get('input[id=delete_confirm]').click();
-        cy.contains('button', 'Delete').click();
-        cy.wait('@listLoad', { timeout: 50000 });
-        cy.get('.pf-c-alert__action').click();
-      });
-    });
-  }
-
   before(() => {
     cy.login(adminUsername, adminPassword);
-    deleteRegistries();
-    deleteContainers();
+
+    cy.deleteRegistries();
+    cy.deleteContainers();
+
     cy.addRemoteRegistry(`docker${num}`, 'https://registry.hub.docker.com/');
     cy.addRemoteContainer({
       name: `remotepine${num}`,

--- a/test/cypress/integration/execution_environments_edit.js
+++ b/test/cypress/integration/execution_environments_edit.js
@@ -3,57 +3,12 @@ describe('execution environments', () => {
   let adminPassword = Cypress.env('password');
   let num = (~~(Math.random() * 1000000)).toString();
 
-  function deleteRegistries() {
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') + '_ui/v1/execution-environments/registries/?*',
-    ).as('registries');
-
-    cy.visit('/ui/registries');
-
-    cy.wait('@registries').then((result) => {
-      var data = result.response.body.data;
-      data.forEach((element) => {
-        cy.get(
-          'tr[aria-labelledby="' +
-            element.name +
-            '"] button[aria-label="Actions"]',
-        ).click();
-        cy.contains('a', 'Delete').click();
-        cy.contains('button', 'Delete').click();
-      });
-    });
-  }
-
-  function deleteContainers() {
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') + '_ui/v1/execution-environments/repositories/?*',
-    ).as('listLoad');
-
-    cy.visit('/ui/containers');
-
-    cy.wait('@listLoad').then((result) => {
-      var data = result.response.body.data;
-      data.forEach((element) => {
-        cy.get(
-          'tr[aria-labelledby="' +
-            element.name +
-            '"] button[aria-label="Actions"]',
-        ).click();
-        cy.contains('a', 'Delete').click();
-        cy.get('input[id=delete_confirm]').click();
-        cy.contains('button', 'Delete').click();
-        cy.wait('@listLoad', { timeout: 50000 });
-        cy.get('.pf-c-alert__action').click();
-      });
-    });
-  }
-
   before(() => {
     cy.login(adminUsername, adminPassword);
-    deleteRegistries();
-    deleteContainers();
+
+    cy.deleteRegistries();
+    cy.deleteContainers();
+
     cy.addRemoteRegistry(`docker${num}`, 'https://registry.hub.docker.com/');
     cy.addRemoteContainer({
       name: `remotepine${num}`,

--- a/test/cypress/integration/execution_environments_use_in_controller.js
+++ b/test/cypress/integration/execution_environments_use_in_controller.js
@@ -92,14 +92,14 @@ describe('Execution Environments - Use in Controller', () => {
             /^https:\/\/www\.example\.com\/#\/execution_environments\/add\?image=.*latest$/,
           );
         cy.contains('a', 'https://another.example.com');
-        cy.get('button[aria-label="Copyable input"]').should('have.length', 2);
+        cy.get('ul.pf-c-list > li > a').should('have.length', 2);
 
         // filter controllers
         cy.get('input[placeholder="Filter by controller name"]')
           .click()
           .type('another{enter}');
         cy.contains('a', 'https://another.example.com');
-        cy.get('button[aria-label="Copyable input"]').should('have.length', 1);
+        cy.get('ul.pf-c-list > li > a').should('have.length', 1);
         cy.contains('a', 'https://www.example.com').should('not.exist');
 
         // unset tag, see digest
@@ -123,7 +123,7 @@ describe('Execution Environments - Use in Controller', () => {
 
         // unfilter controllers
         cy.contains('Clear all filters').click();
-        cy.get('button[aria-label="Copyable input"]').should('have.length', 2);
+        cy.get('ul.pf-c-list > li > a').should('have.length', 2);
 
         // leave
         cy.get('button[aria-label="Close"]').click();

--- a/test/cypress/integration/execution_environments_use_in_controller.js
+++ b/test/cypress/integration/execution_environments_use_in_controller.js
@@ -1,0 +1,137 @@
+describe('Execution Environments - Use in Controller', () => {
+  const adminUsername = Cypress.env('username');
+  const adminPassword = Cypress.env('password');
+  let num = (~~(Math.random() * 1000000)).toString(); // FIXME: maybe drop everywhere once AAH-1095 is fixed
+
+  before(() => {
+    cy.settings({
+      CONNECTED_ANSIBLE_CONTROLLERS: [
+        'https://www.example.com',
+        'https://another.example.com',
+      ],
+    });
+
+    cy.login(adminUsername, adminPassword);
+
+    cy.deleteRegistries();
+    cy.deleteContainers();
+
+    // FIXME: add galaxykit support for remote registries
+    cy.addRemoteRegistry(`docker${num}`, 'https://registry.hub.docker.com/');
+
+    cy.addRemoteContainer({
+      name: `remotepine${num}`,
+      upstream_name: 'library/alpine',
+      registry: `docker${num}`,
+      include_tags: 'latest',
+    });
+    cy.syncRemoteContainer(`remotepine${num}`);
+
+    cy.addLocalContainer(`localpine${num}`, 'alpine');
+  });
+
+  beforeEach(() => {
+    cy.login(adminUsername, adminPassword);
+    cy.menuGo('Execution Environments > Execution Environments');
+  });
+
+  it('admin sees containers', () => {
+    // table headers
+    [
+      'Container repository name',
+      'Description',
+      'Created',
+      'Last modified',
+      'Container registry type',
+    ].forEach((header) =>
+      cy.get('tr[aria-labelledby="headers"] th').contains(header),
+    );
+
+    // one row of each type available
+    cy.contains('.content-table .pf-c-label', 'Remote');
+    cy.contains('.content-table .pf-c-label', 'Local');
+  });
+
+  const list = (type) =>
+    cy
+      .contains('.content-table .pf-c-label', type)
+      .parents('tr')
+      .find('button[aria-label="Actions"]')
+      .click()
+      .parents('tr')
+      .contains('.pf-c-dropdown__menu-item', 'Use in Controller')
+      .click();
+
+  const detail = (type) => {
+    cy.contains('.content-table .pf-c-label', type)
+      .parents('tr')
+      .find('td a')
+      .click();
+
+    ['Detail', 'Activity', 'Images'].forEach((tab) =>
+      cy.contains('.pf-c-tabs__item', tab),
+    );
+
+    cy.get('button[aria-label="Actions"]')
+      .click()
+      .parent()
+      .contains('.pf-c-dropdown__menu-item', 'Use in Controller')
+      .click();
+  };
+
+  ['Remote', 'Local'].forEach((type) => {
+    [list, detail].forEach((opener) => {
+      it(`Use in Controller - ${type} ${opener.name}`, () => {
+        opener(type);
+
+        // shows links
+        cy.contains('a', 'https://www.example.com')
+          .should('have.attr', 'href')
+          .and(
+            'match',
+            /^https:\/\/www\.example\.com\/#\/execution_environments\/add\?image=.*latest$/,
+          );
+        cy.contains('a', 'https://another.example.com');
+        cy.get('button[aria-label="Copyable input"]').should('have.length', 2);
+
+        // filter controllers
+        cy.get('input[placeholder="Filter by controller name"]')
+          .click()
+          .type('another{enter}');
+        cy.contains('a', 'https://another.example.com');
+        cy.get('button[aria-label="Copyable input"]').should('have.length', 1);
+        cy.contains('a', 'https://www.example.com').should('not.exist');
+
+        // unset tag, see digest
+        cy.get('.pf-m-typeahead .pf-c-select__toggle-clear').click();
+        cy.contains('a', 'https://another.example.com')
+          .should('have.attr', 'href')
+          .and(
+            'match',
+            /^https:\/\/another\.example\.com\/#\/execution_environments\/add\?image=.*sha256.*$/,
+          );
+
+        // search tag
+        cy.get('input.pf-c-select__toggle-typeahead').click();
+        cy.contains('.pf-c-select__menu', 'latest').click();
+        cy.contains('a', 'https://another.example.com')
+          .should('have.attr', 'href')
+          .and(
+            'match',
+            /^https:\/\/another\.example\.com\/#\/execution_environments\/add\?image=.*latest$/,
+          );
+
+        // unfilter controllers
+        cy.contains('Clear all filters').click();
+        cy.get('button[aria-label="Copyable input"]').should('have.length', 2);
+
+        // leave
+        cy.get('button[aria-label="Close"]').click();
+      });
+    });
+  });
+
+  after(() => {
+    cy.settings(); // reset
+  });
+});

--- a/test/cypress/integration/remote_registry.js
+++ b/test/cypress/integration/remote_registry.js
@@ -2,32 +2,10 @@ describe('Remote Registry Tests', () => {
   const adminUsername = Cypress.env('username');
   const adminPassword = Cypress.env('password');
 
-  function deleteData() {
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') + '_ui/v1/execution-environments/registries/?*',
-    ).as('registries');
-
-    cy.visit('/ui/registries');
-
-    cy.wait('@registries').then((result) => {
-      var data = result.response.body.data;
-      data.forEach((element) => {
-        cy.get(
-          'tr[aria-labelledby="' +
-            element.name +
-            '"] button[aria-label="Actions"]',
-        ).click();
-        cy.contains('a', 'Delete').click();
-        cy.contains('button', 'Delete').click();
-      });
-    });
-  }
-
   before(() => {
     cy.visit('/');
     cy.login(adminUsername, adminPassword);
-    deleteData();
+    cy.deleteRegistries();
   });
 
   beforeEach(() => {
@@ -98,6 +76,6 @@ describe('Remote Registry Tests', () => {
   });
 
   it('admin can delete data', () => {
-    deleteData();
+    cy.deleteRegistries();
   });
 });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -582,3 +582,50 @@ Cypress.Commands.add('syncRemoteContainer', {}, (name) => {
 
   cy.contains('.pf-c-alert__title', `Sync initiated for ${name}`);
 });
+
+Cypress.Commands.add('deleteRegistries', {}, () => {
+  cy.intercept(
+    'GET',
+    Cypress.env('prefix') + '_ui/v1/execution-environments/registries/?*',
+  ).as('registries');
+
+  cy.visit('/ui/registries');
+
+  cy.wait('@registries').then((result) => {
+    var data = result.response.body.data;
+    data.forEach((element) => {
+      cy.get(
+        'tr[aria-labelledby="' +
+          element.name +
+          '"] button[aria-label="Actions"]',
+      ).click();
+      cy.contains('a', 'Delete').click();
+      cy.contains('button', 'Delete').click();
+    });
+  });
+});
+
+Cypress.Commands.add('deleteContainers', {}, () => {
+  cy.intercept(
+    'GET',
+    Cypress.env('prefix') + '_ui/v1/execution-environments/repositories/?*',
+  ).as('listLoad');
+
+  cy.visit('/ui/containers');
+
+  cy.wait('@listLoad').then((result) => {
+    var data = result.response.body.data;
+    data.forEach((element) => {
+      cy.get(
+        'tr[aria-labelledby="' +
+          element.name +
+          '"] button[aria-label="Actions"]',
+      ).click();
+      cy.contains('a', 'Delete').click();
+      cy.get('input[id=delete_confirm]').click();
+      cy.contains('button', 'Delete').click();
+      cy.wait('@listLoad', { timeout: 50000 });
+      cy.get('.pf-c-alert__action').click();
+    });
+  });
+});

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -580,7 +580,8 @@ Cypress.Commands.add('syncRemoteContainer', {}, (name) => {
     .contains('.pf-c-dropdown__menu-item', 'Sync from registry')
     .click();
 
-  cy.contains('.pf-c-alert__title', `Sync initiated for ${name}`);
+  // FIXME: `Sync initiated for ${name}` after AAH-972 is fixed (shows `Sync initiated for {name}` on GH)
+  cy.contains('.pf-c-alert__title', `Sync initiated for`);
 });
 
 Cypress.Commands.add('deleteRegistries', {}, () => {


### PR DESCRIPTION
Follow-up to #872 .. tests.
Fixes [AAH-889](https://issues.redhat.com/browse/AAH-889)

Depends on #1116 which adds these relevant helpers (merged)
* `cy.addRemoteRegistry` - add a remote registry via the UI
* `cy.addRemoteContainer` - add a remote container via the UI
* `cy.addLocalContainer` - exec podman pull/push to add a local container

Depends on #1142 which fixes `addLocalContainer` on github actions (merged)

Creates `cy.deleteContainers` and `cy.deleteRegistries` helpers, from functions introduced in #1027, #1138 and #1141.

Adjusts `cy.syncRemoteContainer` to NOT check for the container name in the task alert - AAH-982, the alert is literally `Sync initiated for {name}` on github

---

Adding tests for the "Use in Controller" feature on local and remote containers, from both the detail and list screens.