### PR TITLE
cypress test delete collection version

### DIFF
--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -188,14 +188,16 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             </Tooltip>
           ),
       this.context.user.model_permissions.delete_collection && (
-        <DropdownItem
-          key='2'
-          onClick={() =>
-            this.openDeleteModalWithConfirm(collection.latest_version.version)
-          }
-        >
-          {t`Delete version ${collection.latest_version.version}`}
-        </DropdownItem>
+        <div data-cy='delete-version-dropdown'>
+          <DropdownItem
+            key='2'
+            onClick={() =>
+              this.openDeleteModalWithConfirm(collection.latest_version.version)
+            }
+          >
+            {t`Delete version ${collection.latest_version.version}`}
+          </DropdownItem>
+        </div>
       ),
     ].filter(Boolean);
 

--- a/test/cypress/integration/collection.js
+++ b/test/cypress/integration/collection.js
@@ -28,7 +28,7 @@ describe('collection tests', () => {
     cy.intercept(
       'DELETE',
       Cypress.env('prefix') +
-        '/content/published/v3/collections/test_namespace/test_collection',
+      '/content/published/v3/collections/test_namespace/test_collection',
     ).as('deleteCollection');
     cy.intercept('GET', Cypress.env('prefix') + '/v3/tasks/*').as('taskStatus');
 
@@ -40,5 +40,24 @@ describe('collection tests', () => {
     cy.get('@taskStatus.last').then((res) => {
       cy.get('.pf-c-alert').contains('Successfully deleted collection.');
     });
-  });
+
+    it('deletes a collection version', () => {
+      cy.galaxykit('-i collection upload my_namespace my_collection');
+      cy.menuGo('Collections > Collections');
+      cy.intercept(
+        'GET',
+        Cypress.env('prefix') + '_ui/v1/namespaces/my_namespace/',
+      ).as('reload');
+      cy.get('a[href*="ui/repo/published/my_namespace/my_collection"]').click();
+      cy.get('[data-cy=kebab-toggle]').click();
+      cy.get('[data-cy=delete-version-dropdown]').click();
+      cy.get('input[id=delete_confirm]').click();
+      cy.get('button').contains('Delete').click();
+      cy.wait('@reload', { timeout: 50000 });
+      cy.get('h4[class=pf-c-alert__title]').should(
+        'have.text',
+        'Success alert:Successfully deleted collection.',
+      );
+    });
+  })
 });

--- a/test/cypress/integration/collection.js
+++ b/test/cypress/integration/collection.js
@@ -13,7 +13,7 @@ describe('collection tests', () => {
   const adminUsername = Cypress.env('username');
   const adminPassword = Cypress.env('password');
 
-  before(() => {
+  beforeEach(() => {
     cy.login(adminUsername, adminPassword);
   });
 

--- a/test/cypress/integration/collection.js
+++ b/test/cypress/integration/collection.js
@@ -28,7 +28,7 @@ describe('collection tests', () => {
     cy.intercept(
       'DELETE',
       Cypress.env('prefix') +
-      '/content/published/v3/collections/test_namespace/test_collection',
+        '/content/published/v3/collections/test_namespace/test_collection',
     ).as('deleteCollection');
     cy.intercept('GET', Cypress.env('prefix') + '/v3/tasks/*').as('taskStatus');
 
@@ -40,24 +40,24 @@ describe('collection tests', () => {
     cy.get('@taskStatus.last').then((res) => {
       cy.get('.pf-c-alert').contains('Successfully deleted collection.');
     });
+  });
 
-    it('deletes a collection version', () => {
-      cy.galaxykit('-i collection upload my_namespace my_collection');
-      cy.menuGo('Collections > Collections');
-      cy.intercept(
-        'GET',
-        Cypress.env('prefix') + '_ui/v1/namespaces/my_namespace/',
-      ).as('reload');
-      cy.get('a[href*="ui/repo/published/my_namespace/my_collection"]').click();
-      cy.get('[data-cy=kebab-toggle]').click();
-      cy.get('[data-cy=delete-version-dropdown]').click();
-      cy.get('input[id=delete_confirm]').click();
-      cy.get('button').contains('Delete').click();
-      cy.wait('@reload', { timeout: 50000 });
-      cy.get('h4[class=pf-c-alert__title]').should(
-        'have.text',
-        'Success alert:Successfully deleted collection.',
-      );
-    });
-  })
+  it('deletes a collection version', () => {
+    cy.galaxykit('-i collection upload my_namespace my_collection');
+    cy.menuGo('Collections > Collections');
+    cy.intercept(
+      'GET',
+      Cypress.env('prefix') + '_ui/v1/namespaces/my_namespace/',
+    ).as('reload');
+    cy.get('a[href*="ui/repo/published/my_namespace/my_collection"]').click();
+    cy.get('[data-cy=kebab-toggle]').click();
+    cy.get('[data-cy=delete-version-dropdown]').click();
+    cy.get('input[id=delete_confirm]').click();
+    cy.get('button').contains('Delete').click();
+    cy.wait('@reload', { timeout: 50000 });
+    cy.get('h4[class=pf-c-alert__title]').should(
+      'have.text',
+      'Success alert:Successfully deleted collection.',
+    );
+  });
 });


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/AAH-1008

Assignment: Cypress test for deleting a collection version. 

Note: I tried putting a `data-cy` attribute on the StatefulDropdown in /collection-header.tsx but it does not appear in the file tree. So I used a className instead, for now...