### PR TITLE
Add warning and ClipboardCopy to links

### DIFF
--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -219,9 +219,9 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
               {!unsafeLinksSupported && (
                 <ClipboardCopyButton
                   variant={'plain'}
-                  children={href}
+                  children={t`Copy to clipboard`}
                   id={href}
-                  textId={href}
+                  textId={t`Copy to clipboard`}
                   onClick={() => navigator.clipboard.writeText(href)}
                 />
               )}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-1021

Before:
<img width="1072" alt="Screenshot 2021-10-25 at 15 47 19" src="https://user-images.githubusercontent.com/9210860/138707515-4f04337d-bfa0-4888-af1b-8cf66bfb1574.png">
After:

<img width="1087" alt="Screenshot 2021-10-27 at 12 44 47" src="https://user-images.githubusercontent.com/9210860/139052739-8d5d1a68-7ae3-4aa4-b99e-d2175456a56d.png">

