### PR TITLE
Delete entire collection cypress test

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -86,6 +86,7 @@ jobs:
           RH_ENTITLEMENT_REQUIRED='insights'
           TOKEN_AUTH_DISABLED=True
           X_PULP_CONTENT_HOST='localhost'
+          GALAXY_REQUIRE_CONTENT_APPROVAL=False
         " | sed 's/^\s\+//' | tee settings/settings.py
 
         podman run \

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -166,6 +166,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             <DropdownItem
               key={1}
               onClick={() => this.openDeleteModalWithConfirm()}
+              data-cy='delete-collection-dropdown'
             >
               {t`Delete entire collection`}
             </DropdownItem>
@@ -394,7 +395,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           }
           pageControls={
             dropdownItems.length > 0 ? (
-              <StatefulDropdown items={dropdownItems} />
+              <div data-cy='kebab-toggle'>
+                <StatefulDropdown items={dropdownItems} />
+              </div>
             ) : null
           }
         >

--- a/test/cypress/integration/collection.js
+++ b/test/cypress/integration/collection.js
@@ -20,7 +20,7 @@ describe('collection tests', () => {
 
   it('deletes an entire collection', () => {
     cy.galaxykit('-i collection upload test_namespace test_collection');
-    cy.visit('ui/repo/published/test_namespace/test_collection');
+    cy.visit('/ui/repo/published/test_namespace/test_collection');
 
     cy.get('[data-cy=kebab-toggle]').click();
     cy.get('[data-cy=delete-collection-dropdown]').click();

--- a/test/cypress/integration/collection.js
+++ b/test/cypress/integration/collection.js
@@ -1,0 +1,35 @@
+function waitForTaskToFinish() {
+  cy.wait('@taskStatus').then((res) => {
+    if (res.response.body.state === 'running') {
+      cy.clock();
+      waitForTaskToFinish();
+    }
+
+    if (res.response.body.state === 'completed')
+      cy.get('.pf-c-alert').contains('Successfully deleted collection.');
+  });
+}
+
+describe('collection tests', () => {
+  const adminUsername = Cypress.env('username');
+  const adminPassword = Cypress.env('password');
+
+  before(() => {
+    cy.login(adminUsername, adminPassword);
+  });
+
+  it('deletes an entire collection', () => {
+    cy.galaxykit('-i collection upload test_namespace test_collection');
+    cy.visit('ui/repo/published/test_namespace/test_collection');
+
+    cy.get('[data-cy=kebab-toggle]').click();
+    cy.get('[data-cy=delete-collection-dropdown]').click();
+    cy.get('input[id=delete_confirm]').click();
+
+    cy.intercept('GET', Cypress.env('prefix') + '/v3/tasks/*').as('taskStatus');
+
+    cy.get('button').contains('Delete').click();
+
+    waitForTaskToFinish();
+  });
+});


### PR DESCRIPTION
Issue: [AAH-1007](https://issues.redhat.com/browse/AAH-1007)

Inspired from @ShaiahWren's PR for collection version deletion [#1117](https://github.com/ansible/ansible-hub-ui/pull/1117).

I added a recursive function to wait for the task to finish deleting collection (`state='completed'`).

