### PR TITLE
tests: edit local and remote ee

### DIFF
--- a/src/components/execution-environment-header/execution-environment-header.tsx
+++ b/src/components/execution-environment-header/execution-environment-header.tsx
@@ -42,7 +42,9 @@ export class ExecutionEnvironmentHeader extends React.Component<IProps> {
         pageControls={this.props.pageControls}
       >
         <Tooltip content={this.props.container.description}>
-          <p className={'truncated'}>{this.props.container.description}</p>
+          <p data-cy='description' className={'truncated'}>
+            {this.props.container.description}
+          </p>
         </Tooltip>
         {last_sync_task && (
           <p className='truncated'>

--- a/test/cypress/integration/execution_environments_edit.js
+++ b/test/cypress/integration/execution_environments_edit.js
@@ -3,8 +3,57 @@ describe('execution environments', () => {
   let adminPassword = Cypress.env('password');
   let num = (~~(Math.random() * 1000000)).toString();
 
+  function deleteRegistries() {
+    cy.intercept(
+      'GET',
+      Cypress.env('prefix') + '_ui/v1/execution-environments/registries/?*',
+    ).as('registries');
+
+    cy.visit('/ui/registries');
+
+    cy.wait('@registries').then((result) => {
+      var data = result.response.body.data;
+      data.forEach((element) => {
+        cy.get(
+          'tr[aria-labelledby="' +
+            element.name +
+            '"] button[aria-label="Actions"]',
+        ).click();
+        cy.contains('a', 'Delete').click();
+        cy.contains('button', 'Delete').click();
+      });
+    });
+  }
+
+  function deleteContainers() {
+    cy.intercept(
+      'GET',
+      Cypress.env('prefix') + '_ui/v1/execution-environments/repositories/?*',
+    ).as('listLoad');
+
+    cy.visit('/ui/containers');
+
+    cy.wait('@listLoad').then((result) => {
+      var data = result.response.body.data;
+      data.forEach((element) => {
+        cy.get(
+          'tr[aria-labelledby="' +
+            element.name +
+            '"] button[aria-label="Actions"]',
+        ).click();
+        cy.contains('a', 'Delete').click();
+        cy.get('input[id=delete_confirm]').click();
+        cy.contains('button', 'Delete').click();
+        cy.wait('@listLoad', { timeout: 50000 });
+        cy.get('.pf-c-alert__action').click();
+      });
+    });
+  }
+
   before(() => {
     cy.login(adminUsername, adminPassword);
+    deleteRegistries();
+    deleteContainers();
     cy.addRemoteRegistry(`docker${num}`, 'https://registry.hub.docker.com/');
     cy.addRemoteContainer({
       name: `remotepine${num}`,

--- a/test/cypress/integration/execution_environments_edit.js
+++ b/test/cypress/integration/execution_environments_edit.js
@@ -1,0 +1,46 @@
+describe('execution environments', () => {
+  let adminUsername = Cypress.env('username');
+  let adminPassword = Cypress.env('password');
+  let num = (~~(Math.random() * 1000000)).toString();
+
+  before(() => {
+    cy.login(adminUsername, adminPassword);
+    cy.addRemoteRegistry(`docker${num}`, 'https://registry.hub.docker.com/');
+    cy.addRemoteContainer({
+      name: `remotepine${num}`,
+      upstream_name: 'library/alpine',
+      registry: `docker${num}`,
+      include_tags: 'latest',
+    });
+    cy.addLocalContainer(`localpine${num}`, 'alpine');
+  });
+
+  beforeEach(() => {
+    cy.login(adminUsername, adminPassword);
+    cy.menuGo('Execution Environments > Execution Environments');
+  });
+
+  it('edits a remote container', () => {
+    cy.contains('a', `remotepine${num}`).click();
+    cy.get('.pf-c-button.pf-m-primary').contains('Edit').click();
+    cy.get('#description').type('This is the description.');
+    cy.contains('button', 'Save').click();
+    cy.wait(10000); // FIXME have a reload request, wait for it; can't wait for an unspecified number of task requests
+    cy.get('[data-cy=description]').should(
+      'have.text',
+      'This is the description.',
+    );
+  });
+
+  it('edits a local container', () => {
+    cy.contains('a', `localpine${num}`).click();
+    cy.get('.pf-c-button.pf-m-primary').contains('Edit').click();
+    cy.get('#description').type('This is the description.');
+    cy.contains('button', 'Save').click();
+    cy.wait(10000); // FIXME have a reload request, wait for it; can't wait for an unspecified number of task requests
+    cy.get('[data-cy=description]').should(
+      'have.text',
+      'This is the description.',
+    );
+  });
+});


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/AAH-1002

Cypress test for editing local and remote EEs. 

Note: the test `it('edits a local container)` is not correct... I wrote it on the assumption that it would appear in the UI, but now I know that it doesn't...