### PR TITLE
Fix `cy.addLocalContainer` on github actions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -149,7 +149,8 @@ jobs:
           "username": "admin",
           "password": "admin",
           "settings": "../../pulp_galaxy_ng/settings/settings.py",
-          "restart": "podman exec pulp bash -c \"s6-svc -r /var/run/s6/services/pulpcore-api\"; sleep 10"
+          "restart": "podman exec pulp bash -c \"s6-svc -r /var/run/s6/services/pulpcore-api\"; sleep 10",
+          "containers": "localhost:8002"
         }' > cypress.env.json
 
         # ensure index.html uses the new js

--- a/test/cypress.env.json.template
+++ b/test/cypress.env.json.template
@@ -3,5 +3,6 @@
     "username": "admin",
     "password": "admin",
     "settings": "../../galaxy_ng/galaxy_ng/app/settings.py",
-    "restart": "true"
+    "restart": "true",
+    "containers": "localhost:5001"
 }

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -543,26 +543,27 @@ Cypress.Commands.add(
       console.log(arr);
       return Promise.reject(...arr);
     };
+    const server = Cypress.env('containers');
 
     return cy
       .exec(shell`podman pull ${registry + remoteName}`)
       .then(log, logFail)
       .then(() =>
         cy.exec(
-          shell`podman image tag ${remoteName} localhost:8002/${localName}:latest`,
+          shell`podman image tag ${remoteName} ${server}/${localName}:latest`,
         ),
       )
       .then(log, logFail)
       .then(() =>
         cy.exec(
-          shell`podman login localhost:8002 --tls-verify=false --username=admin --password=admin`,
+          shell`podman login ${server} --tls-verify=false --username=admin --password=admin`,
           { failOnNonZeroExit: false },
         ),
       )
       .then(log, logFail)
       .then(() =>
         cy.exec(
-          shell`podman push localhost:8002/${localName}:latest --tls-verify=false`,
+          shell`podman push ${server}/${localName}:latest --tls-verify=false`,
           { failOnNonZeroExit: false },
         ),
       )

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -537,22 +537,36 @@ Cypress.Commands.add(
   'addLocalContainer',
   {},
   (localName, remoteName, registry = 'docker.io/') => {
+    const log = ({ code, stderr, stdout }) =>
+      console.log(`CODE=${code} ERR=${stderr} OUT=${stdout}`);
+    const logFail = (...arr) => {
+      console.log(arr);
+      return Promise.reject(...arr);
+    };
+
     return cy
-      .exec(
-        shell`
-    podman pull ${registry + remoteName} ;
-    podman image tag ${remoteName} localhost:5001/${localName}:latest ;
-    podman push localhost:5001/${localName}:latest --tls-verify=false
-  `,
+      .exec(shell`podman pull ${registry + remoteName}`)
+      .then(log, logFail)
+      .then(() =>
+        cy.exec(
+          shell`podman image tag ${remoteName} localhost:8002/${localName}:latest`,
+        ),
       )
-      .then(({ code, stderr, stdout }) => {
-        console.log(`c${code} ERR=${stderr} OUT=${stdout}`);
-        if (code) {
-          return Promise.reject(
-            new Error(`podman pull/push failed (code ${code}): ${stderr}`),
-          );
-        }
-      });
+      .then(log, logFail)
+      .then(() =>
+        cy.exec(
+          shell`podman login localhost:8002 --tls-verify=false --username=admin --password=admin`,
+          { failOnNonZeroExit: false },
+        ),
+      )
+      .then(log, logFail)
+      .then(() =>
+        cy.exec(
+          shell`podman push localhost:8002/${localName}:latest --tls-verify=false`,
+          { failOnNonZeroExit: false },
+        ),
+      )
+      .then(log, logFail);
   },
 );
 


### PR DESCRIPTION
Follow-up to https://github.com/ansible/ansible-hub-ui/pull/1116, which adds the helper

Successful run using the container: https://github.com/ansible/ansible-hub-ui/runs/4053371839?check_suite_focus=true (had an extra commit with a version of the test being added in #1141)

Without this, the command fails on `podman push` for 2 reasons:
* needs `podman login` first
* pushing to `localhost:5001` works in dev, but not with pulp-oci-images, and vice versa
  * => switching to configurable `localhost:8002` on pulp-oci-images while keeping `localhost:5001` in `cypress.env.json.template`

This also switches from running one shell to run 3 commands, to running 4 commands separately in a row, to better catch error codes and stdout/stderr of each command. This should mean better error messages if something breaks again.

Should unblock: #1113, #1141

---

:grey_exclamation: Note: when testing locally, most likely you first need to add `"containers": "localhost:5001"` to your `test/cypress.env.json` (see `test/cypress.env.json.template`) (documented in https://github.com/ansible/ansible-hub-ui/pull/1082, to prevent conflicts)