### PR TITLE
console-logger: log all console.log args, not only the first one

### DIFF
--- a/test/cypress/plugins/console-logger.js
+++ b/test/cypress/plugins/console-logger.js
@@ -98,9 +98,10 @@ function logConsole(params) {
   const prefixSpacer = ' '.repeat(prefix.length);
 
   if (args) {
-    let formattedMessage = String.prototype.toString(args[0]).trimRight();
-    log(color(`${prefix}${args[0].value}`));
-    recordLogMessage(`${prefix}${args[0].value}`);
+    args.forEach((arg) => {
+      log(color(`${prefix}${arg.value}`));
+      recordLogMessage(`${prefix}${arg.value}`);
+    });
   }
 }
 


### PR DESCRIPTION
When CONSOLE_LOG_TO_TERMINAL=true is used, `console.log('foo', 'bar')` will only log `foo` to the console.
Making sure all args are stringified.

(Or, we could switch to https://github.com/flotwig/cypress-log-to-output which seems related, and uses `JSON.stringify` on args.)
