### PR TITLE
EE delete modal: don't hide name while still waiting for task

### DIFF
--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -487,15 +487,13 @@ class ExecutionEnvironmentList extends React.Component<
     this.setState({ isDeletionPending: true }, () =>
       ExecutionEnvironmentAPI.deleteExecutionEnvironment(selectedItem.name)
         .then((result) => {
-          let taskId = result.data.task.split('tasks/')[1].replace('/', '');
-          this.setState({
-            selectedItem: null,
-          });
+          const taskId = result.data.task.split('tasks/')[1].replace('/', '');
           waitForTask(taskId).then(() => {
             this.setState({
-              isDeletionPending: false,
               confirmDelete: false,
               deleteModalVisible: false,
+              isDeletionPending: false,
+              selectedItem: null,
               alerts: this.state.alerts.concat([
                 {
                   variant: 'success',


### PR DESCRIPTION
the modal shows the name of the EE to remove, but only until we reset `selectedItem` (where we're taking the name from), which was happening before `waitForTask` is done, making the name disappear mid-delete.

Unset `selectedItem` only when closing the modal instead.