### PR TITLE
webpack: don't remove patternfly from non-insights builds

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -71,6 +71,9 @@ module.exports = (inputConfigs) => {
 
     // defines port for dev server
     port: customConfigs.UI_PORT,
+
+    // frontend-components-config 4.5.0+: don't remove patternfly from non-insights builds
+    bundlePfModules: customConfigs.DEPLOYMENT_MODE !== 'insights',
   });
 
   // Override sections of the webpack config to work with TypeScript


### PR DESCRIPTION
As of `@redhat-cloud-services/frontend-components-config` 4.5.0+, patternfly is removed from the build so as not to clash with other patternfly versions in cloud.

This is not desirable for standalone/standalone-keycloak, disabling for non-insights builds.

https://github.com/RedHatInsights/frontend-components/blob/f4633d4f8927f46d5a259bed1cf573c0410785f6/packages/config/README.md#include-pf-css-modules-in-your-bundle

(waiting for the Bump pr first, we're on 4.3.2)