### PR TITLE
Empty search correct

### DIFF
--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -78,8 +78,6 @@ export class CompoundFilter extends React.Component<IProps, IState> {
       </DropdownItem>
     ));
 
-   
-
     return (
       <InputGroup>
         <StatefulDropdown
@@ -106,7 +104,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
       </InputGroup>
     );
   }
-  
+
   private renderInput(selectedFilter: FilterOption) {
     switch (selectedFilter.inputType) {
       case 'multiple':

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -78,6 +78,8 @@ export class CompoundFilter extends React.Component<IProps, IState> {
       </DropdownItem>
     ));
 
+   
+
     return (
       <InputGroup>
         <StatefulDropdown
@@ -97,14 +99,14 @@ export class CompoundFilter extends React.Component<IProps, IState> {
         <Button
           onClick={() => this.submitFilter()}
           variant={ButtonVariant.control}
-          isDisabled={!this.props.inputText}
+          isDisabled={!this.props.inputText.trim().length}
         >
           <SearchIcon></SearchIcon>
         </Button>
       </InputGroup>
     );
   }
-
+  
   private renderInput(selectedFilter: FilterOption) {
     switch (selectedFilter.inputType) {
       case 'multiple':


### PR DESCRIPTION
Compound filter had problem that it accepted blank string (string with only empty spaces). This PR disables filter button in this situation. This corrects the issue for many containers that uses compound filter.