### PR TITLE
Fix create namespace problem

### DIFF
--- a/src/components/permissions/obect-permission-field.tsx
+++ b/src/components/permissions/obect-permission-field.tsx
@@ -88,6 +88,7 @@ export class ObjectPermissionField extends React.Component<IProps, IState> {
         newGroups.push(g);
       }
     }
+
     this.props.setGroups(newGroups);
 
     const newSearchGroups = [...this.state.searchGroups];

--- a/src/components/permissions/obect-permission-field.tsx
+++ b/src/components/permissions/obect-permission-field.tsx
@@ -91,8 +91,7 @@ export class ObjectPermissionField extends React.Component<IProps, IState> {
 
     this.props.setGroups(newGroups);
 
-    const newSearchGroups = [...this.state.searchGroups];
-    newSearchGroups.push(group);
+    const newSearchGroups = [...this.state.searchGroups, group];
     this.setState({ searchGroups: newSearchGroups });
   }
 

--- a/src/components/permissions/obect-permission-field.tsx
+++ b/src/components/permissions/obect-permission-field.tsx
@@ -88,8 +88,11 @@ export class ObjectPermissionField extends React.Component<IProps, IState> {
         newGroups.push(g);
       }
     }
-
     this.props.setGroups(newGroups);
+
+    const newSearchGroups = [...this.state.searchGroups];
+    newSearchGroups.push(group);
+    this.setState({ searchGroups: newSearchGroups });
   }
 
   private setPermissions(perms, group) {


### PR DESCRIPTION
When creating namespace, there is search dropdown list. Before this PR, it worked this way:

In dropdown list, there is list of available groups. When one group is selected, it appears in bottom of the drop down in selected group permission area and it dissapears from the search drop down. This is fine. But when the group is removed, it is not available in search drop down again. This PR fixed this by adding the removed group back to drop down.

No Issue.