### PR TITLE
Fix create namespace modal

### DIFF
--- a/src/components/helper-text/helper-text.tsx
+++ b/src/components/helper-text/helper-text.tsx
@@ -11,11 +11,13 @@ interface IProps {
 
 export class HelperText extends React.Component<IProps, {}> {
   render() {
+    let div = <div style={{ height: '10px' }}></div>;
     return (
       <Popover
         aria-label={t`popover example`}
         position={PopoverPosition.top}
         bodyContent={this.props.content}
+        headerContent={div}
       >
         <Button iconPosition={'left'} variant={'plain'} className={'helper'}>
           <OutlinedQuestionCircleIcon />

--- a/src/components/helper-text/helper-text.tsx
+++ b/src/components/helper-text/helper-text.tsx
@@ -7,17 +7,17 @@ import './helper-text.scss';
 interface IProps {
   /** Value to display in the tag */
   content: React.ReactNode;
+  header?: React.ReactNode;
 }
 
 export class HelperText extends React.Component<IProps, {}> {
   render() {
-    let div = <div style={{ height: '10px' }}></div>;
     return (
       <Popover
         aria-label={t`popover example`}
         position={PopoverPosition.top}
         bodyContent={this.props.content}
-        headerContent={div}
+        headerContent={this.props.header}
       >
         <Button iconPosition={'left'} variant={'plain'} className={'helper'}>
           <OutlinedQuestionCircleIcon />

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -118,6 +118,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
             labelIcon={
               <HelperText
                 content={t`Namespace names are limited to alphanumeric characters and underscores, must have a minimum length of 2 characters and cannot start with an ‘_’.`}
+                header={t`Namespace name`}
               />
             }
           >

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -147,6 +147,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
               groups={newGroups}
               setGroups={(g) => this.setState({ newGroups: g })}
               menuAppendTo='parent'
+              selectPermissionCaption={t`Select namespace owner permissions`}
             />
           </FormGroup>
         </Form>

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -43,7 +43,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
     if (name == '') {
       error['name'] = t`Please, provide the namespace name`;
     } else if (!/^[a-zA-Z0-9_]+$/.test(name)) {
-      error['name'] = t`Name can only contain [A-Za-z0-9_]`;
+      error['name'] = t`Name can only contain letters and numbers`;
     } else if (name.length <= 2) {
       error['name'] = t`Name must be longer than 2 characters`;
     } else if (name.startsWith('_')) {
@@ -90,7 +90,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
     const { newNamespaceName, newGroups, newNamespaceNameValid } = this.state;
     return (
       <Modal
-        variant='large'
+        variant='small'
         title={t`Create a new namespace`}
         isOpen={this.props.isOpen}
         onClose={this.toggleModal}
@@ -113,7 +113,6 @@ export class NamespaceModal extends React.Component<IProps, IState> {
             label={t`Name`}
             isRequired
             fieldId='name'
-            helperText={t`Please, provide the namespace name`}
             helperTextInvalid={this.state.errorMessages['name']}
             validated={this.toError(this.state.newNamespaceNameValid)}
             labelIcon={

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -39,7 +39,10 @@ export class NamespaceModal extends React.Component<IProps, IState> {
   private newNamespaceNameIsValid() {
     const error: any = this.state.errorMessages;
     const name: string = this.state.newNamespaceName;
-    if (!/^[a-zA-Z0-9_]+$/.test(name)) {
+
+    if (name == '') {
+      error['name'] = t`Please, provide the namespace name`;
+    } else if (!/^[a-zA-Z0-9_]+$/.test(name)) {
       error['name'] = t`Name can only contain letters and numbers`;
     } else if (name.length <= 2) {
       error['name'] = t`Name must be longer than 2 characters`;
@@ -87,7 +90,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
     const { newNamespaceName, newGroups, newNamespaceNameValid } = this.state;
     return (
       <Modal
-        variant='small'
+        variant='medium'
         title={t`Create a new namespace`}
         isOpen={this.props.isOpen}
         onClose={this.toggleModal}
@@ -139,12 +142,12 @@ export class NamespaceModal extends React.Component<IProps, IState> {
             fieldId='groups'
             helperTextInvalid={this.state.errorMessages['groups']}
           >
+            {t`Select namespace owner permissions`}
             <ObjectPermissionField
               availablePermissions={['change_namespace', 'upload_to_namespace']}
               groups={newGroups}
               setGroups={(g) => this.setState({ newGroups: g })}
               menuAppendTo='parent'
-              selectPermissionCaption={t`Select namespace owner permissions`}
             />
           </FormGroup>
         </Form>

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -39,10 +39,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
   private newNamespaceNameIsValid() {
     const error: any = this.state.errorMessages;
     const name: string = this.state.newNamespaceName;
-
-    if (name == '') {
-      error['name'] = t`Please, provide the namespace name`;
-    } else if (!/^[a-zA-Z0-9_]+$/.test(name)) {
+    if (!/^[a-zA-Z0-9_]+$/.test(name)) {
       error['name'] = t`Name can only contain letters and numbers`;
     } else if (name.length <= 2) {
       error['name'] = t`Name must be longer than 2 characters`;

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -143,7 +143,6 @@ export class NamespaceModal extends React.Component<IProps, IState> {
             fieldId='groups'
             helperTextInvalid={this.state.errorMessages['groups']}
           >
-            {t`Select namespace owner permissions`}
             <ObjectPermissionField
               availablePermissions={['change_namespace', 'upload_to_namespace']}
               groups={newGroups}

--- a/src/components/permissions/obect-permission-field.tsx
+++ b/src/components/permissions/obect-permission-field.tsx
@@ -15,7 +15,6 @@ interface IProps {
   setGroups: (groups: GroupObjectPermissionType[]) => void;
   isDisabled?: boolean;
   menuAppendTo?: 'parent' | 'inline';
-  selectPermissionCaption?: string;
 }
 
 interface IState {
@@ -67,7 +66,6 @@ export class ObjectPermissionField extends React.Component<IProps, IState> {
                   )}
                   setSelected={(perms) => this.setPermissions(perms, group)}
                   menuAppendTo={this.props.menuAppendTo}
-                  selectPermissionCaption={this.props.selectPermissionCaption}
                 />
               </FlexItem>
               <FlexItem>

--- a/src/components/permissions/obect-permission-field.tsx
+++ b/src/components/permissions/obect-permission-field.tsx
@@ -15,6 +15,7 @@ interface IProps {
   setGroups: (groups: GroupObjectPermissionType[]) => void;
   isDisabled?: boolean;
   menuAppendTo?: 'parent' | 'inline';
+  selectPermissionCaption?: string;
 }
 
 interface IState {
@@ -66,6 +67,7 @@ export class ObjectPermissionField extends React.Component<IProps, IState> {
                   )}
                   setSelected={(perms) => this.setPermissions(perms, group)}
                   menuAppendTo={this.props.menuAppendTo}
+                  selectPermissionCaption={this.props.selectPermissionCaption}
                 />
               </FlexItem>
               <FlexItem>

--- a/src/components/permissions/obect-permission-field.tsx
+++ b/src/components/permissions/obect-permission-field.tsx
@@ -43,7 +43,7 @@ export class ObjectPermissionField extends React.Component<IProps, IState> {
           results={this.state.searchGroups}
           loadResults={this.loadGroups}
           onSelect={this.onSelect}
-          placeholderText={t`Find a group`}
+          placeholderText={t`Select a group`}
           menuAppendTo={this.props.menuAppendTo}
           isDisabled={!!this.props.isDisabled}
         />

--- a/src/components/permissions/permission-chip-selector.tsx
+++ b/src/components/permissions/permission-chip-selector.tsx
@@ -17,7 +17,6 @@ interface IProps {
   onSelect?: (event, selection) => void;
   onClear?: () => void;
   menuAppendTo?: 'parent' | 'inline';
-  selectPermissionCaption?: string;
 }
 
 interface IState {
@@ -31,13 +30,10 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
   }
 
   render() {
-    let selectPermissionCaption =
-      this.props.selectPermissionCaption || t`Select permissions`;
-
     if (this.props.isViewOnly) {
       const items = this.props.selectedPermissions.length
         ? this.props.selectedPermissions
-        : [this.placeholderText(selectPermissionCaption)];
+        : [this.placeholderText()];
       return (
         <LabelGroup>
           {items.map((text) => (
@@ -51,7 +47,7 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
       <Select
         menuAppendTo={this.props.menuAppendTo}
         variant={SelectVariant.typeaheadMulti}
-        typeAheadAriaLabel={selectPermissionCaption}
+        typeAheadAriaLabel={t`Select permissions`}
         onToggle={this.onToggle}
         onSelect={!!this.props.onSelect ? this.props.onSelect : this.onSelect}
         onClear={
@@ -59,7 +55,7 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
         }
         selections={this.props.selectedPermissions}
         isOpen={this.state.isOpen}
-        placeholderText={this.placeholderText(selectPermissionCaption)}
+        placeholderText={this.placeholderText()}
         isDisabled={!!this.props.isDisabled}
       >
         {this.props.availablePermissions.length === 0
@@ -77,9 +73,9 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
     );
   }
 
-  private placeholderText(selectPermissionCaption) {
+  private placeholderText() {
     if (!this.props.isDisabled && !this.props.isViewOnly) {
-      return selectPermissionCaption;
+      return t`Select permissions`;
     }
     return this.props.selectedPermissions.length === 0 ? t`No permission` : '';
   }

--- a/src/components/permissions/permission-chip-selector.tsx
+++ b/src/components/permissions/permission-chip-selector.tsx
@@ -17,6 +17,7 @@ interface IProps {
   onSelect?: (event, selection) => void;
   onClear?: () => void;
   menuAppendTo?: 'parent' | 'inline';
+  selectPermissionCaption?: string;
 }
 
 interface IState {
@@ -30,10 +31,15 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
   }
 
   render() {
+    let selectPermissionCaption = this.props.selectPermissionCaption;
+    if (!this.props.selectPermissionCaption) {
+      selectPermissionCaption = t`Select permissions`;
+    }
+
     if (this.props.isViewOnly) {
       const items = this.props.selectedPermissions.length
         ? this.props.selectedPermissions
-        : [this.placeholderText()];
+        : [this.placeholderText(selectPermissionCaption)];
       return (
         <LabelGroup>
           {items.map((text) => (
@@ -47,7 +53,7 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
       <Select
         menuAppendTo={this.props.menuAppendTo}
         variant={SelectVariant.typeaheadMulti}
-        typeAheadAriaLabel={t`Select permissions`}
+        typeAheadAriaLabel={selectPermissionCaption}
         onToggle={this.onToggle}
         onSelect={!!this.props.onSelect ? this.props.onSelect : this.onSelect}
         onClear={
@@ -55,7 +61,7 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
         }
         selections={this.props.selectedPermissions}
         isOpen={this.state.isOpen}
-        placeholderText={this.placeholderText()}
+        placeholderText={this.placeholderText(selectPermissionCaption)}
         isDisabled={!!this.props.isDisabled}
       >
         {this.props.availablePermissions.length === 0
@@ -73,9 +79,9 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
     );
   }
 
-  private placeholderText() {
+  private placeholderText(selectPermissionCaption) {
     if (!this.props.isDisabled && !this.props.isViewOnly) {
-      return t`Select permissions`;
+      return selectPermissionCaption;
     }
     return this.props.selectedPermissions.length === 0 ? t`No permission` : '';
   }

--- a/src/components/permissions/permission-chip-selector.tsx
+++ b/src/components/permissions/permission-chip-selector.tsx
@@ -31,10 +31,8 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
   }
 
   render() {
-    let selectPermissionCaption = this.props.selectPermissionCaption;
-    if (!this.props.selectPermissionCaption) {
-      selectPermissionCaption = t`Select permissions`;
-    }
+    let selectPermissionCaption =
+      this.props.selectPermissionCaption || t`Select permissions`;
 
     if (this.props.isViewOnly) {
       const items = this.props.selectedPermissions.length

--- a/test/cypress/integration/namespace_form.js
+++ b/test/cypress/integration/namespace_form.js
@@ -32,6 +32,8 @@ describe('A namespace form', () => {
   });
 
   it('should give message before typing', () => {
+    // error is shown only when start typing and then left empty
+    getInputBox().type('A{backspace}');
     getMessage().should('have.text', 'Please, provide the namespace name');
     getCreateButton().should('be.disabled');
   });

--- a/test/cypress/integration/namespace_form.js
+++ b/test/cypress/integration/namespace_form.js
@@ -38,14 +38,14 @@ describe('A namespace form', () => {
 
   it('should give message if input is empty', () => {
     getInputBox().type(' ');
-    getMessage().should('have.text', 'Name can only contain [A-Za-z0-9_]');
+    getMessage().should('have.text', 'Name can only contain letters and numbers');
     getCreateButton().should('be.disabled');
     clearInput();
   });
 
   it('should give message if input has incorrect characters', () => {
     getInputBox().type('!/^[a-zA-Z0-9_]+$/.');
-    getMessage().should('have.text', 'Name can only contain [A-Za-z0-9_]');
+    getMessage().should('have.text', 'Name can only contain letters and numbers');
     getCreateButton().should('be.disabled');
     clearInput();
   });

--- a/test/cypress/integration/namespace_form.js
+++ b/test/cypress/integration/namespace_form.js
@@ -38,14 +38,20 @@ describe('A namespace form', () => {
 
   it('should give message if input is empty', () => {
     getInputBox().type(' ');
-    getMessage().should('have.text', 'Name can only contain letters and numbers');
+    getMessage().should(
+      'have.text',
+      'Name can only contain letters and numbers',
+    );
     getCreateButton().should('be.disabled');
     clearInput();
   });
 
   it('should give message if input has incorrect characters', () => {
     getInputBox().type('!/^[a-zA-Z0-9_]+$/.');
-    getMessage().should('have.text', 'Name can only contain letters and numbers');
+    getMessage().should(
+      'have.text',
+      'Name can only contain letters and numbers',
+    );
     getCreateButton().should('be.disabled');
     clearInput();
   });

--- a/test/cypress/integration/namespace_form.js
+++ b/test/cypress/integration/namespace_form.js
@@ -31,11 +31,6 @@ describe('A namespace form', () => {
     getCreateNamespace().click();
   });
 
-  it('should give message before typing', () => {
-    getMessage().should('have.text', 'Please, provide the namespace name');
-    getCreateButton().should('be.disabled');
-  });
-
   it('should give message if input is empty', () => {
     getInputBox().type(' ');
     getMessage().should(

--- a/test/cypress/integration/namespace_form.js
+++ b/test/cypress/integration/namespace_form.js
@@ -31,7 +31,7 @@ describe('A namespace form', () => {
     getCreateNamespace().click();
   });
 
-  it('should give message before typing', () => {
+  it('should give message if input has no characters', () => {
     // error is shown only when start typing and then left empty
     getInputBox().type('A{backspace}');
     getMessage().should('have.text', 'Please, provide the namespace name');

--- a/test/cypress/integration/namespace_form.js
+++ b/test/cypress/integration/namespace_form.js
@@ -31,6 +31,11 @@ describe('A namespace form', () => {
     getCreateNamespace().click();
   });
 
+  it('should give message before typing', () => {
+    getMessage().should('have.text', 'Please, provide the namespace name');
+    getCreateButton().should('be.disabled');
+  });
+
   it('should give message if input is empty', () => {
     getInputBox().type(' ');
     getMessage().should(


### PR DESCRIPTION
From Issue AAH-824:

- [x]  Resize modal to standard (shorter width)

- [x] Remove "please, provide a namespace" text under "name" field 

- [x]  Move popover question mark (input group) to form (next to field label) 

- [x]  Reword "name" field alert message from "Name can only contain [A-Za-z0-9_]" to "Name can only contain letters and numbers" 

- [x] Remove popover extra right padding 

- [x] Change "namespace owners" select prompt from "find a group" to "select a group", let selected groups appear in field as chips 

- [x] Add "Select namespace owner permissions" title above permissions section

Completed: 1, 2, 4, 6 (partialy), 7

I was not sure what 3, 5 and part of 6 ment to be, maybe it is already corrected.