### PR TITLE
Add check that EE name is correct when typed in

### DIFF
--- a/CHANGES/968.misc
+++ b/CHANGES/968.misc
@@ -1,0 +1,1 @@
+add check that EE name is correct when typed in

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -46,8 +46,8 @@ interface IProps {
   registry?: string; // pk
   upstreamName?: string;
   remotePulpId?: string;
-
   addAlert?: (variant, title, description?) => void;
+  formError: { title: string; detail: string }[];
 }
 
 interface IState {
@@ -125,7 +125,8 @@ export class RepositoryForm extends React.Component<IProps, IState> {
   }
 
   render() {
-    const { onSave, onCancel, namespace, isNew, isRemote } = this.props;
+    const { onSave, onCancel, namespace, isNew, isRemote, formError } =
+      this.props;
     const {
       name,
       description,
@@ -151,13 +152,8 @@ export class RepositoryForm extends React.Component<IProps, IState> {
           <Button
             key='save'
             variant='primary'
+            isDisabled={!this.formIsValid()}
             onClick={() => onSave(this.onSave())}
-            isDisabled={
-              (this.state.name.length === 0 ||
-                this.state.upstreamName.length === 0 ||
-                this.state.registrySelection.length === 0) &&
-              isRemote
-            }
           >
             {t`Save`}
           </Button>,
@@ -198,12 +194,15 @@ export class RepositoryForm extends React.Component<IProps, IState> {
                 key='name'
                 fieldId='name'
                 label={t`Name`}
+                helperTextInvalid={t`Container names can only contain alphanumeric characters, ".", "_", "-" and a up to one "/".`}
+                validated={this.validateName(name)}
               >
                 <TextInput
                   id='name'
                   value={name}
                   isDisabled={!isNew}
                   onChange={(value) => this.setState({ name: value })}
+                  validated={this.validateName(name)}
                 />
               </FormGroup>
 
@@ -374,53 +373,80 @@ export class RepositoryForm extends React.Component<IProps, IState> {
               autoResize={true}
             />
           </FormGroup>
-          <FormGroup
-            key='groups'
-            fieldId='groups'
-            label={t`Groups with access`}
-            className='hub-formgroup-groups'
-          >
-            {formErrors?.groups ? (
-              <Alert title={formErrors.groups.title} variant='danger' isInline>
-                {formErrors.groups.description}
-              </Alert>
-            ) : (
-              <>
-                <div className='pf-c-form__helper-text'>
-                  {t`Adding groups provides access to all repositories in the
+          {formErrors?.groups ? (
+            <Alert title={formErrors.groups.title} variant='danger' isInline>
+              {formErrors.groups.description}
+            </Alert>
+          ) : (
+            <FormGroup
+              key='groups'
+              fieldId='groups'
+              label={t`Groups with access`}
+              className='hub-formgroup-groups'
+            >
+              <div className='pf-c-form__helper-text'>
+                {t`Adding groups provides access to all repositories in the
                     "${namespace}" container namespace.`}
-                </div>
-                <ObjectPermissionField
-                  groups={this.state.selectedGroups}
-                  availablePermissions={
-                    Constants.CONTAINER_NAMESPACE_PERMISSIONS
-                  }
-                  setGroups={(g) => this.setState({ selectedGroups: g })}
-                  menuAppendTo='parent'
-                  isDisabled={
-                    !this.props.permissions.includes(
-                      'container.change_containernamespace',
-                    )
-                  }
-                  onError={(err) =>
-                    this.setState({
-                      formErrors: {
-                        ...this.state.formErrors,
-                        groups: {
-                          title: t`Error loading groups.`,
-                          description: err,
-                          variant: 'danger',
-                        },
+              </div>
+              <ObjectPermissionField
+                groups={this.state.selectedGroups}
+                availablePermissions={Constants.CONTAINER_NAMESPACE_PERMISSIONS}
+                setGroups={(g) => this.setState({ selectedGroups: g })}
+                menuAppendTo='parent'
+                isDisabled={
+                  !this.props.permissions.includes(
+                    'container.change_containernamespace',
+                  )
+                }
+                onError={(err) =>
+                  this.setState({
+                    formErrors: {
+                      ...this.state.formErrors,
+                      groups: {
+                        title: t`Error loading groups.`,
+                        description: err,
+                        variant: 'danger',
                       },
-                    })
-                  }
-                ></ObjectPermissionField>
-              </>
-            )}
-          </FormGroup>
+                    },
+                  })
+                }
+              ></ObjectPermissionField>
+              {!!formError &&
+                formError.length > 0 &&
+                formError.map((error) => (
+                  <Alert
+                    title={error.title}
+                    variant='danger'
+                    isInline
+                    key={error.title}
+                  >
+                    {error.detail}
+                  </Alert>
+                ))}
+            </FormGroup>
+          )}
         </Form>
       </Modal>
     );
+  }
+
+  private validateName(name) {
+    const regex = /^([0-9A-Za-z._-]+\/)?[0-9A-Za-z._-]+$/;
+    if (name === '' || regex.test(name)) {
+      return 'default';
+    } else {
+      return 'error';
+    }
+  }
+
+  private formIsValid() {
+    const { name, upstreamName, registrySelection } = this.state;
+    if (!this.props.isRemote) {
+      // no validation for local
+      return true;
+    }
+    const nameValid = name && this.validateName(name) === 'default';
+    return nameValid && upstreamName && registrySelection.length;
   }
 
   private loadRegistries(name?) {

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -34,6 +34,7 @@ interface IState {
   editing: boolean;
   alerts: AlertType[];
   showDeleteModal: boolean;
+  formError: { title: string; detail: string }[];
 }
 
 export interface IDetailSharedProps extends RouteComponentProps {
@@ -57,6 +58,7 @@ export function withContainerRepo(WrappedComponent) {
         editing: false,
         alerts: [],
         showDeleteModal: false,
+        formError: [],
       };
     }
 
@@ -200,6 +202,7 @@ export function withContainerRepo(WrappedComponent) {
                 namespace={this.state.repo.namespace.name}
                 description={this.state.repo.description}
                 permissions={permissions}
+                formError={this.state.formError}
                 onSave={(promise) => {
                   promise
                     .then((results) => {
@@ -215,12 +218,14 @@ export function withContainerRepo(WrappedComponent) {
                         this.loadRepo();
                       }
                     })
-                    .catch(() =>
+                    .catch((err) =>
                       this.setState({
-                        editing: false,
-                        alerts: this.state.alerts.concat({
-                          variant: 'danger',
-                          title: t`Error: changes weren't saved`,
+                        formError: err.response.data.errors.map((error) => {
+                          return {
+                            title: error.title,
+                            detail:
+                              error.source.parameter + ': ' + error.detail,
+                          };
                         }),
                       }),
                     );

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -60,6 +60,7 @@ interface IState {
   showDeleteModal: boolean;
   selectedItem: ExecutionEnvironmentType;
   inputText: string;
+  formError: { title: string; detail: string }[];
 }
 
 class ExecutionEnvironmentList extends React.Component<
@@ -95,6 +96,7 @@ class ExecutionEnvironmentList extends React.Component<
       showDeleteModal: false,
       selectedItem: null,
       inputText: '',
+      formError: [],
     };
   }
 
@@ -429,6 +431,7 @@ class ExecutionEnvironmentList extends React.Component<
         permissions={namespace?.my_permissions || []}
         remotePulpId={pulp_id}
         distributionPulpId={distributionPulpId}
+        formError={this.state.formError}
         onSave={(promise) => {
           promise
             .then(() => {
@@ -436,15 +439,23 @@ class ExecutionEnvironmentList extends React.Component<
                 {
                   showRemoteModal: false,
                   itemToEdit: null,
+                  alerts: this.state.alerts.concat({
+                    variant: 'success',
+                    title: isNew
+                      ? t`Execution environment added.`
+                      : t`Execution environment saved.`,
+                  }),
                 },
                 () => this.queryEnvironments(),
               );
             })
-            .catch(() => {
+            .catch((err) => {
               this.setState({
-                alerts: this.state.alerts.concat({
-                  variant: 'danger',
-                  title: t`Error: changes weren't saved`,
+                formError: err.response.data.errors.map((error) => {
+                  return {
+                    title: error.title,
+                    detail: error.source.parameter + ': ' + error.detail,
+                  };
                 }),
               });
             });


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/AAH-968

Steps to reproduce:

- go to http://localhost:8002/ui/containers
- click "Add execution environment" button
- set the name to something invalid like "i/am/an/invalid/container/name"
- click save

(Screenshots are in French because I'm looking for possible problems with translation)
Before:
<img width="1090" alt="Screenshot 2021-11-09 at 12 23 36" src="https://user-images.githubusercontent.com/9210860/140915528-7e5d7d69-98f2-41e9-b8d0-88d8b6b6fd9a.png">

After:
<img width="1091" alt="Screenshot 2021-11-09 at 12 22 11" src="https://user-images.githubusercontent.com/9210860/140915440-0c6998b3-10da-458f-a1bb-a6d151bc64e4.png">

<img width="1105" alt="Screenshot 2021-11-11 at 11 39 11" src="https://user-images.githubusercontent.com/9210860/141284583-1b391a84-d5d7-42dc-b9df-51ae401e1f0c.png">

This is not fixed in https://github.com/ansible/ansible-hub-ui/pull/1115 and is not related to that PR. 

@himdel please have a look, thanks :)