### PR TITLE
Bump react-markdown to 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4229,6 +4229,14 @@
             "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.4.tgz",
             "integrity": "sha512-9SEVY3nsz+uMN2DwDocftB5TAgZe7D0cOzxxRhpotWs6T4QFqRaTXpXbOSzbk31/7iYcfCkJJPwWGzTxyuGhCg=="
         },
+        "@types/debug": {
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+            "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+            "requires": {
+                "@types/ms": "*"
+            }
+        },
         "@types/eslint": {
             "version": "7.28.2",
             "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.2.tgz",
@@ -4266,9 +4274,9 @@
             }
         },
         "@types/hast": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.2.tgz",
-            "integrity": "sha512-Op5W7jYgZI7AWKY5wQ0/QNMzQM7dGQPyW1rXKNiymVCy5iTfdPuGu4HhYNOM2sIv8gUfIuIdcYlXmAepwaowow==",
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
+            "integrity": "sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==",
             "requires": {
                 "@types/unist": "*"
             }
@@ -4340,6 +4348,11 @@
                 "@types/unist": "*"
             }
         },
+        "@types/mdurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
+            "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
+        },
         "@types/minimatch": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -4351,6 +4364,11 @@
             "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
             "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
             "dev": true
+        },
+        "@types/ms": {
+            "version": "0.7.31",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+            "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
         },
         "@types/node": {
             "version": "14.17.15",
@@ -5145,7 +5163,8 @@
         "bail": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-            "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
+            "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
+            "dev": true
         },
         "balanced-match": {
             "version": "1.0.2",
@@ -5433,17 +5452,20 @@
         "character-entities": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-            "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
+            "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
+            "dev": true
         },
         "character-entities-legacy": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-            "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
+            "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
+            "dev": true
         },
         "character-reference-invalid": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-            "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
+            "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
+            "dev": true
         },
         "chardet": {
             "version": "0.7.0",
@@ -5612,9 +5634,9 @@
             "dev": true
         },
         "comma-separated-tokens": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
-            "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.2.tgz",
+            "integrity": "sha512-G5yTt3KQN4Yn7Yk4ed73hlZ1evrFKXeUW3086p3PRFNp7m2vIjI6Pg+Kgb+oyzhd9F2qdcoj67+y3SdxL5XWsg=="
         },
         "commander": {
             "version": "8.1.0",
@@ -6101,6 +6123,11 @@
             "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
             "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
             "dev": true
+        },
+        "dequal": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+            "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
         },
         "destroy": {
             "version": "1.0.4",
@@ -7473,6 +7500,11 @@
                 "has-symbols": "^1.0.2"
             }
         },
+        "hast-util-whitespace": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-2.0.0.tgz",
+            "integrity": "sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg=="
+        },
         "he": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -8100,12 +8132,14 @@
         "is-alphabetical": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-            "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
+            "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+            "dev": true
         },
         "is-alphanumerical": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
             "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+            "dev": true,
             "requires": {
                 "is-alphabetical": "^1.0.0",
                 "is-decimal": "^1.0.0"
@@ -8192,7 +8226,8 @@
         "is-decimal": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-            "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
+            "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+            "dev": true
         },
         "is-docker": {
             "version": "2.2.1",
@@ -8233,7 +8268,8 @@
         "is-hexadecimal": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-            "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
+            "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
+            "dev": true
         },
         "is-interactive": {
             "version": "1.0.0",
@@ -8308,7 +8344,8 @@
         "is-plain-obj": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -8635,6 +8672,11 @@
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
         },
+        "kleur": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+            "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA=="
+        },
         "klona": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
@@ -8905,17 +8947,37 @@
             "dev": true
         },
         "mdast-util-definitions": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz",
-            "integrity": "sha512-k8AJ6aNnUkB7IE+5azR9h81O5EQ/cTDXtWdMq9Kk5KcEW/8ritU5CeLg/9HhOC++nALHBlaogJ5jz0Ybk3kPMQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-5.1.0.tgz",
+            "integrity": "sha512-5hcR7FL2EuZ4q6lLMUK5w4lHT2H3vqL9quPvYZ/Ku5iifrirfMHiGdhxdXMUbUkDmz5I+TYMd7nbaxUhbQkfpQ==",
             "requires": {
-                "unist-util-visit": "^2.0.0"
+                "@types/mdast": "^3.0.0",
+                "@types/unist": "^2.0.0",
+                "unist-util-visit": "^3.0.0"
+            },
+            "dependencies": {
+                "unist-util-is": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+                    "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
+                },
+                "unist-util-visit": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-3.1.0.tgz",
+                    "integrity": "sha512-Szoh+R/Ll68QWAyQyZZpQzZQm2UPbxibDvaY8Xc9SUtYgPsDzx5AWSk++UUt2hJuow8mvwR+rG+LQLw+KsuAKA==",
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "unist-util-is": "^5.0.0",
+                        "unist-util-visit-parents": "^4.0.0"
+                    }
+                }
             }
         },
         "mdast-util-from-markdown": {
             "version": "0.8.5",
             "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
             "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
+            "dev": true,
             "requires": {
                 "@types/mdast": "^3.0.0",
                 "mdast-util-to-string": "^2.0.0",
@@ -8925,18 +8987,19 @@
             }
         },
         "mdast-util-to-hast": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-10.2.0.tgz",
-            "integrity": "sha512-JoPBfJ3gBnHZ18icCwHR50orC9kNH81tiR1gs01D8Q5YpV6adHNO9nKNuFBCJQ941/32PT1a63UF/DitmS3amQ==",
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-11.3.0.tgz",
+            "integrity": "sha512-4o3Cli3hXPmm1LhB+6rqhfsIUBjnKFlIUZvudaermXB+4/KONdd/W4saWWkC+LBLbPMqhFSSTSRgafHsT5fVJw==",
             "requires": {
+                "@types/hast": "^2.0.0",
                 "@types/mdast": "^3.0.0",
-                "@types/unist": "^2.0.0",
-                "mdast-util-definitions": "^4.0.0",
+                "@types/mdurl": "^1.0.0",
+                "mdast-util-definitions": "^5.0.0",
                 "mdurl": "^1.0.0",
-                "unist-builder": "^2.0.0",
-                "unist-util-generated": "^1.0.0",
-                "unist-util-position": "^3.0.0",
-                "unist-util-visit": "^2.0.0"
+                "unist-builder": "^3.0.0",
+                "unist-util-generated": "^2.0.0",
+                "unist-util-position": "^4.0.0",
+                "unist-util-visit": "^4.0.0"
             }
         },
         "mdast-util-to-markdown": {
@@ -8956,7 +9019,8 @@
         "mdast-util-to-string": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-            "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w=="
+            "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
+            "dev": true
         },
         "mdurl": {
             "version": "1.0.1",
@@ -9123,10 +9187,309 @@
             "version": "2.11.4",
             "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
             "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
+            "dev": true,
             "requires": {
                 "debug": "^4.0.0",
                 "parse-entities": "^2.0.0"
             }
+        },
+        "micromark-core-commonmark": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-1.0.4.tgz",
+            "integrity": "sha512-HAtoZisp1M/sQFuw2zoUKGo1pMKod7GSvdM6B2oBU0U2CEN5/C6Tmydmi1rmvEieEhGQsjMyiiSoYgxISNxGFA==",
+            "requires": {
+                "micromark-factory-destination": "^1.0.0",
+                "micromark-factory-label": "^1.0.0",
+                "micromark-factory-space": "^1.0.0",
+                "micromark-factory-title": "^1.0.0",
+                "micromark-factory-whitespace": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-classify-character": "^1.0.0",
+                "micromark-util-html-tag-name": "^1.0.0",
+                "micromark-util-normalize-identifier": "^1.0.0",
+                "micromark-util-resolve-all": "^1.0.0",
+                "micromark-util-subtokenize": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.1",
+                "parse-entities": "^3.0.0",
+                "uvu": "^0.5.0"
+            },
+            "dependencies": {
+                "character-entities": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.1.tgz",
+                    "integrity": "sha512-OzmutCf2Kmc+6DrFrrPS8/tDh2+DpnrfzdICHWhcVC9eOd0N1PXmQEE1a8iM4IziIAG+8tmTq3K+oo0ubH6RRQ=="
+                },
+                "character-entities-legacy": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+                    "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
+                },
+                "character-reference-invalid": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+                    "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
+                },
+                "is-alphabetical": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+                    "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
+                },
+                "is-alphanumerical": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+                    "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+                    "requires": {
+                        "is-alphabetical": "^2.0.0",
+                        "is-decimal": "^2.0.0"
+                    }
+                },
+                "is-decimal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+                    "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="
+                },
+                "is-hexadecimal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+                    "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="
+                },
+                "parse-entities": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.1.0.tgz",
+                    "integrity": "sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==",
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "character-entities": "^2.0.0",
+                        "character-entities-legacy": "^3.0.0",
+                        "character-reference-invalid": "^2.0.0",
+                        "is-alphanumerical": "^2.0.0",
+                        "is-decimal": "^2.0.0",
+                        "is-hexadecimal": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "micromark-factory-destination": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-1.0.0.tgz",
+            "integrity": "sha512-eUBA7Rs1/xtTVun9TmV3gjfPz2wEwgK5R5xcbIM5ZYAtvGF6JkyaDsj0agx8urXnO31tEO6Ug83iVH3tdedLnw==",
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-factory-label": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-1.0.2.tgz",
+            "integrity": "sha512-CTIwxlOnU7dEshXDQ+dsr2n+yxpP0+fn271pu0bwDIS8uqfFcumXpj5mLn3hSC8iw2MUr6Gx8EcKng1dD7i6hg==",
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "uvu": "^0.5.0"
+            }
+        },
+        "micromark-factory-space": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-1.0.0.tgz",
+            "integrity": "sha512-qUmqs4kj9a5yBnk3JMLyjtWYN6Mzfcx8uJfi5XAveBniDevmZasdGBba5b4QsvRcAkmvGo5ACmSUmyGiKTLZew==",
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-factory-title": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-1.0.2.tgz",
+            "integrity": "sha512-zily+Nr4yFqgMGRKLpTVsNl5L4PMu485fGFDOQJQBl2NFpjGte1e86zC0da93wf97jrc4+2G2GQudFMHn3IX+A==",
+            "requires": {
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "uvu": "^0.5.0"
+            }
+        },
+        "micromark-factory-whitespace": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-1.0.0.tgz",
+            "integrity": "sha512-Qx7uEyahU1lt1RnsECBiuEbfr9INjQTGa6Err+gF3g0Tx4YEviPbqqGKNv/NrBaE7dVHdn1bVZKM/n5I/Bak7A==",
+            "requires": {
+                "micromark-factory-space": "^1.0.0",
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-character": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-1.1.0.tgz",
+            "integrity": "sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==",
+            "requires": {
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-chunked": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-1.0.0.tgz",
+            "integrity": "sha512-5e8xTis5tEZKgesfbQMKRCyzvffRRUX+lK/y+DvsMFdabAicPkkZV6gO+FEWi9RfuKKoxxPwNL+dFF0SMImc1g==",
+            "requires": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-classify-character": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-1.0.0.tgz",
+            "integrity": "sha512-F8oW2KKrQRb3vS5ud5HIqBVkCqQi224Nm55o5wYLzY/9PwHGXC01tr3d7+TqHHz6zrKQ72Okwtvm/xQm6OVNZA==",
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-combine-extensions": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-1.0.0.tgz",
+            "integrity": "sha512-J8H058vFBdo/6+AsjHp2NF7AJ02SZtWaVUjsayNFeAiydTxUwViQPxN0Hf8dp4FmCQi0UUFovFsEyRSUmFH3MA==",
+            "requires": {
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-decode-numeric-character-reference": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-1.0.0.tgz",
+            "integrity": "sha512-OzO9AI5VUtrTD7KSdagf4MWgHMtET17Ua1fIpXTpuhclCqD8egFWo85GxSGvxgkGS74bEahvtM0WP0HjvV0e4w==",
+            "requires": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-decode-string": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-1.0.1.tgz",
+            "integrity": "sha512-Wf3H6jLaO3iIlHEvblESXaKAr72nK7JtBbLLICPwuZc3eJkMcp4j8rJ5Xv1VbQWMCWWDvKUbVUbE2MfQNznwTA==",
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "parse-entities": "^3.0.0"
+            },
+            "dependencies": {
+                "character-entities": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.1.tgz",
+                    "integrity": "sha512-OzmutCf2Kmc+6DrFrrPS8/tDh2+DpnrfzdICHWhcVC9eOd0N1PXmQEE1a8iM4IziIAG+8tmTq3K+oo0ubH6RRQ=="
+                },
+                "character-entities-legacy": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+                    "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
+                },
+                "character-reference-invalid": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+                    "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
+                },
+                "is-alphabetical": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+                    "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
+                },
+                "is-alphanumerical": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+                    "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+                    "requires": {
+                        "is-alphabetical": "^2.0.0",
+                        "is-decimal": "^2.0.0"
+                    }
+                },
+                "is-decimal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+                    "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="
+                },
+                "is-hexadecimal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+                    "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="
+                },
+                "parse-entities": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.1.0.tgz",
+                    "integrity": "sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==",
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "character-entities": "^2.0.0",
+                        "character-entities-legacy": "^3.0.0",
+                        "character-reference-invalid": "^2.0.0",
+                        "is-alphanumerical": "^2.0.0",
+                        "is-decimal": "^2.0.0",
+                        "is-hexadecimal": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "micromark-util-encode": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-1.0.0.tgz",
+            "integrity": "sha512-cJpFVM768h6zkd8qJ1LNRrITfY4gwFt+tziPcIf71Ui8yFzY9wG3snZQqiWVq93PG4Sw6YOtcNiKJfVIs9qfGg=="
+        },
+        "micromark-util-html-tag-name": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-1.0.0.tgz",
+            "integrity": "sha512-NenEKIshW2ZI/ERv9HtFNsrn3llSPZtY337LID/24WeLqMzeZhBEE6BQ0vS2ZBjshm5n40chKtJ3qjAbVV8S0g=="
+        },
+        "micromark-util-normalize-identifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-1.0.0.tgz",
+            "integrity": "sha512-yg+zrL14bBTFrQ7n35CmByWUTFsgst5JhA4gJYoty4Dqzj4Z4Fr/DHekSS5aLfH9bdlfnSvKAWsAgJhIbogyBg==",
+            "requires": {
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-resolve-all": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-1.0.0.tgz",
+            "integrity": "sha512-CB/AGk98u50k42kvgaMM94wzBqozSzDDaonKU7P7jwQIuH2RU0TeBqGYJz2WY1UdihhjweivStrJ2JdkdEmcfw==",
+            "requires": {
+                "micromark-util-types": "^1.0.0"
+            }
+        },
+        "micromark-util-sanitize-uri": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-1.0.0.tgz",
+            "integrity": "sha512-cCxvBKlmac4rxCGx6ejlIviRaMKZc0fWm5HdCHEeDWRSkn44l6NdYVRyU+0nT1XC72EQJMZV8IPHF+jTr56lAg==",
+            "requires": {
+                "micromark-util-character": "^1.0.0",
+                "micromark-util-encode": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0"
+            }
+        },
+        "micromark-util-subtokenize": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-1.0.2.tgz",
+            "integrity": "sha512-d90uqCnXp/cy4G881Ub4psE57Sf8YD0pim9QdjCRNjfas2M1u6Lbt+XZK9gnHL2XFhnozZiEdCa9CNfXSfQ6xA==",
+            "requires": {
+                "micromark-util-chunked": "^1.0.0",
+                "micromark-util-symbol": "^1.0.0",
+                "micromark-util-types": "^1.0.0",
+                "uvu": "^0.5.0"
+            }
+        },
+        "micromark-util-symbol": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-1.0.0.tgz",
+            "integrity": "sha512-NZA01jHRNCt4KlOROn8/bGi6vvpEmlXld7EHcRH+aYWUfL3Wc8JLUNNlqUMKa0hhz6GrpUWsHtzPmKof57v0gQ=="
+        },
+        "micromark-util-types": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-1.0.1.tgz",
+            "integrity": "sha512-UT0ylWEEy80RFYzK9pEaugTqaxoD/j0Y9WhHpSyitxd99zjoQz7JJ+iKuhPAgOW2MiPSUAx+c09dcqokeyaROA=="
         },
         "micromatch": {
             "version": "4.0.4",
@@ -9264,6 +9627,11 @@
             "version": "2.29.1",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
             "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+        },
+        "mri": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+            "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="
         },
         "ms": {
             "version": "2.1.2",
@@ -9905,6 +10273,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
             "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
+            "dev": true,
             "requires": {
                 "character-entities": "^1.0.0",
                 "character-entities-legacy": "^1.0.0",
@@ -10577,12 +10946,9 @@
             }
         },
         "property-information": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
-            "integrity": "sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==",
-            "requires": {
-                "xtend": "^4.0.0"
-            }
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.1.1.tgz",
+            "integrity": "sha512-hrzC564QIl0r0vy4l6MvRLhafmUowhO/O3KgVSoXIbbA2Sz4j8HGpJc6T2cubRVwMwpdiG/vKGfhT4IixmKN9w=="
         },
         "proxy-addr": {
             "version": "2.0.7",
@@ -10743,29 +11109,198 @@
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "react-markdown": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-6.0.3.tgz",
-            "integrity": "sha512-kQbpWiMoBHnj9myLlmZG9T1JdoT/OEyHK7hqM6CqFT14MAkgWiWBUYijLyBmxbntaN6dCDicPcUhWhci1QYodg==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-7.1.0.tgz",
+            "integrity": "sha512-hL8cLLkTydyoKlZWZOjlU6TvMYIw9qKLh1CCzVfnhKt/R/SnKVAqiyugetXY61CkjhBqJl2C5FdU3OwHYo7SrQ==",
             "requires": {
                 "@types/hast": "^2.0.0",
-                "@types/unist": "^2.0.3",
-                "comma-separated-tokens": "^1.0.0",
-                "prop-types": "^15.7.2",
-                "property-information": "^5.3.0",
+                "@types/unist": "^2.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "hast-util-whitespace": "^2.0.0",
+                "prop-types": "^15.0.0",
+                "property-information": "^6.0.0",
                 "react-is": "^17.0.0",
-                "remark-parse": "^9.0.0",
-                "remark-rehype": "^8.0.0",
-                "space-separated-tokens": "^1.1.0",
+                "remark-parse": "^10.0.0",
+                "remark-rehype": "^9.0.0",
+                "space-separated-tokens": "^2.0.0",
                 "style-to-object": "^0.3.0",
-                "unified": "^9.0.0",
-                "unist-util-visit": "^2.0.0",
-                "vfile": "^4.0.0"
+                "unified": "^10.0.0",
+                "unist-util-visit": "^4.0.0",
+                "vfile": "^5.0.0"
             },
             "dependencies": {
+                "bail": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+                    "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+                },
+                "character-entities": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.1.tgz",
+                    "integrity": "sha512-OzmutCf2Kmc+6DrFrrPS8/tDh2+DpnrfzdICHWhcVC9eOd0N1PXmQEE1a8iM4IziIAG+8tmTq3K+oo0ubH6RRQ=="
+                },
+                "character-entities-legacy": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+                    "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
+                },
+                "character-reference-invalid": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+                    "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="
+                },
+                "is-alphabetical": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+                    "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="
+                },
+                "is-alphanumerical": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+                    "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+                    "requires": {
+                        "is-alphabetical": "^2.0.0",
+                        "is-decimal": "^2.0.0"
+                    }
+                },
+                "is-decimal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+                    "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="
+                },
+                "is-hexadecimal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+                    "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="
+                },
+                "is-plain-obj": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+                    "integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw=="
+                },
+                "mdast-util-from-markdown": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.1.0.tgz",
+                    "integrity": "sha512-Mex7IIeIKRpGYNNywpxTfPhfFBTxBL5IVacPMU6GjYF+EkIvy++19cBgxVFyHVd2JpC/chG2IKGqZLffoo7Q1g==",
+                    "requires": {
+                        "@types/mdast": "^3.0.0",
+                        "@types/unist": "^2.0.0",
+                        "mdast-util-to-string": "^3.1.0",
+                        "micromark": "^3.0.0",
+                        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                        "micromark-util-decode-string": "^1.0.0",
+                        "micromark-util-normalize-identifier": "^1.0.0",
+                        "micromark-util-symbol": "^1.0.0",
+                        "micromark-util-types": "^1.0.0",
+                        "parse-entities": "^3.0.0",
+                        "unist-util-stringify-position": "^3.0.0",
+                        "uvu": "^0.5.0"
+                    }
+                },
+                "mdast-util-to-string": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-3.1.0.tgz",
+                    "integrity": "sha512-n4Vypz/DZgwo0iMHLQL49dJzlp7YtAJP+N07MZHpjPf/5XJuHUWstviF4Mn2jEiR/GNmtnRRqnwsXExk3igfFA=="
+                },
+                "micromark": {
+                    "version": "3.0.7",
+                    "resolved": "https://registry.npmjs.org/micromark/-/micromark-3.0.7.tgz",
+                    "integrity": "sha512-67ipZ2CzQVsDyH1kqNLh7dLwe5QMPJwjFBGppW7JCLByaSc6ZufV0ywPOxt13MIDAzzmj3wctDL6Ov5w0fOHXw==",
+                    "requires": {
+                        "@types/debug": "^4.0.0",
+                        "debug": "^4.0.0",
+                        "micromark-core-commonmark": "^1.0.1",
+                        "micromark-factory-space": "^1.0.0",
+                        "micromark-util-character": "^1.0.0",
+                        "micromark-util-chunked": "^1.0.0",
+                        "micromark-util-combine-extensions": "^1.0.0",
+                        "micromark-util-decode-numeric-character-reference": "^1.0.0",
+                        "micromark-util-encode": "^1.0.0",
+                        "micromark-util-normalize-identifier": "^1.0.0",
+                        "micromark-util-resolve-all": "^1.0.0",
+                        "micromark-util-sanitize-uri": "^1.0.0",
+                        "micromark-util-subtokenize": "^1.0.0",
+                        "micromark-util-symbol": "^1.0.0",
+                        "micromark-util-types": "^1.0.1",
+                        "parse-entities": "^3.0.0",
+                        "uvu": "^0.5.0"
+                    }
+                },
+                "parse-entities": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-3.1.0.tgz",
+                    "integrity": "sha512-xf2yeHbsfg1vJySsQelVwgtI/67eAndVU05skrr/XN6KFMoVVA95BYrW8y78OfW4jqcuHwB7tlMlLkvbq4WbHQ==",
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "character-entities": "^2.0.0",
+                        "character-entities-legacy": "^3.0.0",
+                        "character-reference-invalid": "^2.0.0",
+                        "is-alphanumerical": "^2.0.0",
+                        "is-decimal": "^2.0.0",
+                        "is-hexadecimal": "^2.0.0"
+                    }
+                },
                 "react-is": {
                     "version": "17.0.2",
                     "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
                     "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+                },
+                "remark-parse": {
+                    "version": "10.0.0",
+                    "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.0.tgz",
+                    "integrity": "sha512-07ei47p2Xl7Bqbn9H2VYQYirnAFJPwdMuypdozWsSbnmrkgA2e2sZLZdnDNrrsxR4onmIzH/J6KXqKxCuqHtPQ==",
+                    "requires": {
+                        "@types/mdast": "^3.0.0",
+                        "mdast-util-from-markdown": "^1.0.0",
+                        "unified": "^10.0.0"
+                    }
+                },
+                "trough": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/trough/-/trough-2.0.2.tgz",
+                    "integrity": "sha512-FnHq5sTMxC0sk957wHDzRnemFnNBvt/gSY99HzK8F7UP5WAbvP70yX5bd7CjEQkN+TjdxwI7g7lJ6podqrG2/w=="
+                },
+                "unified": {
+                    "version": "10.1.0",
+                    "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.0.tgz",
+                    "integrity": "sha512-4U3ru/BRXYYhKbwXV6lU6bufLikoAavTwev89H5UxY8enDFaAT2VXmIXYNm6hb5oHPng/EXr77PVyDFcptbk5g==",
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "bail": "^2.0.0",
+                        "extend": "^3.0.0",
+                        "is-buffer": "^2.0.0",
+                        "is-plain-obj": "^4.0.0",
+                        "trough": "^2.0.0",
+                        "vfile": "^5.0.0"
+                    }
+                },
+                "unist-util-stringify-position": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz",
+                    "integrity": "sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==",
+                    "requires": {
+                        "@types/unist": "^2.0.0"
+                    }
+                },
+                "vfile": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.2.0.tgz",
+                    "integrity": "sha512-ftCpb6pU8Jrzcqku8zE6N3Gi4/RkDhRwEXSWudzZzA2eEOn/cBpsfk9aulCUR+j1raRSAykYQap9u6j6rhUaCA==",
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "is-buffer": "^2.0.0",
+                        "unist-util-stringify-position": "^3.0.0",
+                        "vfile-message": "^3.0.0"
+                    }
+                },
+                "vfile-message": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.0.2.tgz",
+                    "integrity": "sha512-UUjZYIOg9lDRwwiBAuezLIsu9KlXntdxwG+nXnjuQAHvBpcX3x0eN8h+I7TkY5nkCXj+cWVp4ZqebtGBvok8ww==",
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "unist-util-stringify-position": "^3.0.0"
+                    }
                 }
             }
         },
@@ -11058,16 +11593,79 @@
             "version": "9.0.0",
             "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
             "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
+            "dev": true,
             "requires": {
                 "mdast-util-from-markdown": "^0.8.0"
             }
         },
         "remark-rehype": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-8.1.0.tgz",
-            "integrity": "sha512-EbCu9kHgAxKmW1yEYjx3QafMyGY3q8noUbNUI5xyKbaFP89wbhDrKxyIQNukNYthzjNHZu6J7hwFg7hRm1svYA==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-9.1.0.tgz",
+            "integrity": "sha512-oLa6YmgAYg19zb0ZrBACh40hpBLteYROaPLhBXzLgjqyHQrN+gVP9N/FJvfzuNNuzCutktkroXEZBrxAxKhh7Q==",
             "requires": {
-                "mdast-util-to-hast": "^10.2.0"
+                "@types/hast": "^2.0.0",
+                "@types/mdast": "^3.0.0",
+                "mdast-util-to-hast": "^11.0.0",
+                "unified": "^10.0.0"
+            },
+            "dependencies": {
+                "bail": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+                    "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+                },
+                "is-plain-obj": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.0.0.tgz",
+                    "integrity": "sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw=="
+                },
+                "trough": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/trough/-/trough-2.0.2.tgz",
+                    "integrity": "sha512-FnHq5sTMxC0sk957wHDzRnemFnNBvt/gSY99HzK8F7UP5WAbvP70yX5bd7CjEQkN+TjdxwI7g7lJ6podqrG2/w=="
+                },
+                "unified": {
+                    "version": "10.1.0",
+                    "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.0.tgz",
+                    "integrity": "sha512-4U3ru/BRXYYhKbwXV6lU6bufLikoAavTwev89H5UxY8enDFaAT2VXmIXYNm6hb5oHPng/EXr77PVyDFcptbk5g==",
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "bail": "^2.0.0",
+                        "extend": "^3.0.0",
+                        "is-buffer": "^2.0.0",
+                        "is-plain-obj": "^4.0.0",
+                        "trough": "^2.0.0",
+                        "vfile": "^5.0.0"
+                    }
+                },
+                "unist-util-stringify-position": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.0.tgz",
+                    "integrity": "sha512-SdfAl8fsDclywZpfMDTVDxA2V7LjtRDTOFd44wUJamgl6OlVngsqWjxvermMYf60elWHbxhuRCZml7AnuXCaSA==",
+                    "requires": {
+                        "@types/unist": "^2.0.0"
+                    }
+                },
+                "vfile": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.2.0.tgz",
+                    "integrity": "sha512-ftCpb6pU8Jrzcqku8zE6N3Gi4/RkDhRwEXSWudzZzA2eEOn/cBpsfk9aulCUR+j1raRSAykYQap9u6j6rhUaCA==",
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "is-buffer": "^2.0.0",
+                        "unist-util-stringify-position": "^3.0.0",
+                        "vfile-message": "^3.0.0"
+                    }
+                },
+                "vfile-message": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.0.2.tgz",
+                    "integrity": "sha512-UUjZYIOg9lDRwwiBAuezLIsu9KlXntdxwG+nXnjuQAHvBpcX3x0eN8h+I7TkY5nkCXj+cWVp4ZqebtGBvok8ww==",
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "unist-util-stringify-position": "^3.0.0"
+                    }
+                }
             }
         },
         "remark-stringify": {
@@ -11205,6 +11803,14 @@
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
+            }
+        },
+        "sade": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
+            "integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+            "requires": {
+                "mri": "^1.1.0"
             }
         },
         "safe-buffer": {
@@ -11581,9 +12187,9 @@
             }
         },
         "space-separated-tokens": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
-            "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.1.tgz",
+            "integrity": "sha512-ekwEbFp5aqSPKaqeY1PGrlGQxPNaq+Cnx4+bE2D8sciBQrHpbwoBbawqTN2+6jPs9IdWxxiUcN0K2pkczD3zmw=="
         },
         "spawn-command": {
             "version": "0.0.2-1",
@@ -12427,6 +13033,11 @@
             "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
             "dev": true
         },
+        "totalist": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
+            "integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ=="
+        },
         "tree-kill": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -12442,7 +13053,8 @@
         "trough": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-            "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
+            "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
+            "dev": true
         },
         "ts-loader": {
             "version": "8.3.0",
@@ -12631,6 +13243,7 @@
             "version": "9.2.2",
             "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
             "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
+            "dev": true,
             "requires": {
                 "bail": "^1.0.0",
                 "extend": "^3.0.0",
@@ -12650,9 +13263,12 @@
             }
         },
         "unist-builder": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
-            "integrity": "sha512-f98yt5pnlMWlzP539tPc4grGMsFaQQlP/vM396b00jngsiINumNmsY8rkXjfoi1c6QaM8nQ3vaGDuoKWbe/1Uw=="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-3.0.0.tgz",
+            "integrity": "sha512-GFxmfEAa0vi9i5sd0R2kcrI9ks0r82NasRq5QHh2ysGngrc6GiqD5CDf1FjPenY4vApmFASBIIlk/jj5J5YbmQ==",
+            "requires": {
+                "@types/unist": "^2.0.0"
+            }
         },
         "unist-util-find-all-after": {
             "version": "3.0.2",
@@ -12664,45 +13280,70 @@
             }
         },
         "unist-util-generated": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-1.1.6.tgz",
-            "integrity": "sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg=="
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.0.tgz",
+            "integrity": "sha512-TiWE6DVtVe7Ye2QxOVW9kqybs6cZexNwTwSMVgkfjEReqy/xwGpAXb99OxktoWwmL+Z+Epb0Dn8/GNDYP1wnUw=="
         },
         "unist-util-is": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-            "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg=="
+            "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+            "dev": true
         },
         "unist-util-position": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-3.1.0.tgz",
-            "integrity": "sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA=="
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.1.tgz",
+            "integrity": "sha512-mgy/zI9fQ2HlbOtTdr2w9lhVaiFUHWQnZrFF2EUoVOqtAUdzqMtNiD99qA5a1IcjWVR8O6aVYE9u7Z2z1v0SQA=="
         },
         "unist-util-stringify-position": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
             "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
+            "dev": true,
             "requires": {
                 "@types/unist": "^2.0.2"
             }
         },
         "unist-util-visit": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
-            "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.0.tgz",
+            "integrity": "sha512-n7lyhFKJfVZ9MnKtqbsqkQEk5P1KShj0+//V7mAcoI6bpbUjh3C/OG8HVD+pBihfh6Ovl01m8dkcv9HNqYajmQ==",
             "requires": {
                 "@types/unist": "^2.0.0",
-                "unist-util-is": "^4.0.0",
-                "unist-util-visit-parents": "^3.0.0"
+                "unist-util-is": "^5.0.0",
+                "unist-util-visit-parents": "^5.0.0"
+            },
+            "dependencies": {
+                "unist-util-is": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+                    "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
+                },
+                "unist-util-visit-parents": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.0.tgz",
+                    "integrity": "sha512-y+QVLcY5eR/YVpqDsLf/xh9R3Q2Y4HxkZTp7ViLDU6WtJCEcPmRzW1gpdWDCDIqIlhuPDXOgttqPlykrHYDekg==",
+                    "requires": {
+                        "@types/unist": "^2.0.0",
+                        "unist-util-is": "^5.0.0"
+                    }
+                }
             }
         },
         "unist-util-visit-parents": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
-            "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-4.1.1.tgz",
+            "integrity": "sha512-1xAFJXAKpnnJl8G7K5KgU7FY55y3GcLIXqkzUj5QF/QVP7biUm0K0O2oqVkYsdjzJKifYeWn9+o6piAK2hGSHw==",
             "requires": {
                 "@types/unist": "^2.0.0",
-                "unist-util-is": "^4.0.0"
+                "unist-util-is": "^5.0.0"
+            },
+            "dependencies": {
+                "unist-util-is": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+                    "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
+                }
             }
         },
         "universalify": {
@@ -12788,6 +13429,25 @@
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
             "dev": true
         },
+        "uvu": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.2.tgz",
+            "integrity": "sha512-m2hLe7I2eROhh+tm3WE5cTo/Cv3WQA7Oc9f7JB6uWv+/zVKvfAm53bMyOoGOSZeQ7Ov2Fu9pLhFr7p07bnT20w==",
+            "requires": {
+                "dequal": "^2.0.0",
+                "diff": "^5.0.0",
+                "kleur": "^4.0.3",
+                "sade": "^1.7.3",
+                "totalist": "^2.0.0"
+            },
+            "dependencies": {
+                "diff": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+                    "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w=="
+                }
+            }
+        },
         "v8-compile-cache": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -12819,6 +13479,7 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
             "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
+            "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0",
                 "is-buffer": "^2.0.0",
@@ -12830,6 +13491,7 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
             "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
+            "dev": true,
             "requires": {
                 "@types/unist": "^2.0.0",
                 "unist-util-stringify-position": "^2.0.0"
@@ -13325,11 +13987,6 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
             "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
             "dev": true
-        },
-        "xtend": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
         },
         "y18n": {
             "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "prop-types": "^15.7.2",
         "react": "^16.14.0",
         "react-dom": "^16.14.0",
-        "react-markdown": "^6.0.3",
+        "react-markdown": "^7.1.0",
         "react-redux": "^7.2.6",
         "react-router-dom": "^5.3.0",
         "react-router-hash-link": "^2.4.3",

--- a/src/components/markdown-editor/markdown-editor.tsx
+++ b/src/components/markdown-editor/markdown-editor.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import './markdown-editor.scss';
 
 import { Form, FormGroup, TextArea } from '@patternfly/react-core';
-import * as ReactMarkdown from 'react-markdown';
+import ReactMarkdown from 'react-markdown';
 
 interface IProps {
   text: string;
@@ -37,11 +37,7 @@ export class MarkdownEditor extends React.Component<IProps, {}> {
           <div className='column preview-container'>
             {editing && t`Preview`}
             <div className={editing ? 'pf-c-content preview' : 'pf-c-content'}>
-              {text ? (
-                <ReactMarkdown children={text} />
-              ) : (
-                <ReactMarkdown children={placeholder} />
-              )}
+              <ReactMarkdown>{text || placeholder}</ReactMarkdown>
             </div>
           </div>
         </div>

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -18,7 +18,7 @@ import {
   Checkbox,
 } from '@patternfly/react-core';
 
-import * as ReactMarkdown from 'react-markdown';
+import ReactMarkdown from 'react-markdown';
 
 import {
   CollectionListType,
@@ -362,7 +362,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
   private renderResources(namespace: NamespaceType) {
     return (
       <div className='pf-c-content preview'>
-        <ReactMarkdown source={namespace.resources} />
+        <ReactMarkdown>{namespace.resources}</ReactMarkdown>
       </div>
     );
   }


### PR DESCRIPTION
Replaces #1229

`ReactMarkdown` [changelog](https://github.com/remarkjs/react-markdown/blob/main/changelog.md#change-source-to-children)

The bump PR caused namespace detail tests to go red, as ReactMarkdown failed to instantiate because of a bad import.
Fixing by using the default import.

Also `source` throws a warning, using children instead.

