### PR TITLE
Ux issues in delete modals

### DIFF
--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -267,8 +267,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             isDisabled={!confirmDelete || isDeletionPending}
             title={
               collectionVersion
-                ? t`Permanently delete collection version?`
-                : t`Permanently delete collection?`
+                ? t`Delete collection version`
+                : t`Delete collection`
             }
             confirmButtonTitle={t`Delete`}
           >

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -267,8 +267,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             isDisabled={!confirmDelete || isDeletionPending}
             title={
               collectionVersion
-                ? t`Delete collection version`
-                : t`Delete collection`
+                ? t`Delete collection version?`
+                : t`Delete collection?`
             }
           >
             <>

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -32,8 +32,8 @@ import {
   AlertList,
   AlertType,
   closeAlertMixin,
-  ConfirmModal,
   StatefulDropdown,
+  DeleteModal,
 } from 'src/components';
 
 import { CollectionAPI, CollectionDetailType } from 'src/api';
@@ -254,10 +254,10 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           />
         </Modal>
         {deleteCollection && (
-          <ConfirmModal
+          <DeleteModal
             spinner={isDeletionPending}
             cancelAction={this.closeModal}
-            confirmAction={() =>
+            deleteAction={() =>
               this.setState({ isDeletionPending: true }, () => {
                 !!collectionVersion
                   ? this.deleteCollectionVersion(collectionVersion)
@@ -270,7 +270,6 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                 ? t`Delete collection version`
                 : t`Delete collection`
             }
-            confirmButtonTitle={t`Delete`}
           >
             <>
               <Text style={{ paddingBottom: 'var(--pf-global--spacer--md)' }}>
@@ -309,7 +308,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                 id='delete_confirm'
               />
             </>
-          </ConfirmModal>
+          </DeleteModal>
         )}
         <BaseHeader
           className={className}

--- a/src/containers/execution-environment-detail/execution-environment-detail_images.scss
+++ b/src/containers/execution-environment-detail/execution-environment-detail_images.scss
@@ -7,6 +7,3 @@
   justify-content: space-between;
   align-items: center;
 }
-.delete-image-modal-message {
-  padding-bottom: var(--pf-global--spacer--md);
-}

--- a/src/containers/execution-environment-detail/execution-environment-detail_images.scss
+++ b/src/containers/execution-environment-detail/execution-environment-detail_images.scss
@@ -7,3 +7,6 @@
   justify-content: space-between;
   align-items: center;
 }
+.delete-image-modal-message {
+  padding-bottom: var(--pf-global--spacer--md);
+}

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -205,7 +205,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
         {deleteModalVisible && (
           <DeleteModal
             spinner={isDeletionPending}
-            title={t`Permanently delete image?`}
+            title={t`Delete image`}
             cancelAction={() =>
               this.setState({
                 deleteModalVisible: false,

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -20,6 +20,7 @@ import {
   Checkbox,
   DropdownItem,
   LabelGroup,
+  Text,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
@@ -216,9 +217,13 @@ class ExecutionEnvironmentDetailImages extends React.Component<
             deleteAction={() => this.deleteImage()}
             isDisabled={!confirmDelete || isDeletionPending}
           >
-            <Trans>
-              Deleting <b>{digest}</b> and its data will be lost.
-            </Trans>
+            <>
+              <Text className='delete-image-modal-message'>
+                <Trans>
+                  Deleting <b>{digest}</b> and its data will be lost.
+                </Trans>
+              </Text>
+            </>
             <Checkbox
               isChecked={confirmDelete}
               onChange={(value) => this.setState({ confirmDelete: value })}

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -206,7 +206,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
         {deleteModalVisible && (
           <DeleteModal
             spinner={isDeletionPending}
-            title={t`Delete image`}
+            title={t`Delete image?`}
             cancelAction={() =>
               this.setState({
                 deleteModalVisible: false,

--- a/src/containers/execution-environment-list/execution-environment.scss
+++ b/src/containers/execution-environment-list/execution-environment.scss
@@ -6,3 +6,7 @@
     padding-left: 0px;
   }
 }
+
+.pf-c-check {
+  --pf-c-check__label--LineHeight: 2;
+}

--- a/src/containers/execution-environment-list/execution-environment.scss
+++ b/src/containers/execution-environment-list/execution-environment.scss
@@ -7,6 +7,6 @@
   }
 }
 
-.pf-c-check {
-  --pf-c-check__label--LineHeight: 2;
+.delete-container-modal-message {
+  padding-bottom: var(--pf-global--spacer--md);
 }

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -180,7 +180,7 @@ class ExecutionEnvironmentList extends React.Component<
         {deleteModalVisible && (
           <DeleteModal
             spinner={isDeletionPending}
-            title={'Permanently delete container?'}
+            title={'Delete container'}
             cancelAction={() =>
               this.setState({ deleteModalVisible: false, selectedItem: null })
             }

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -8,6 +8,7 @@ import {
   Checkbox,
   DropdownItem,
   Label,
+  Text,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
@@ -187,9 +188,11 @@ class ExecutionEnvironmentList extends React.Component<
             deleteAction={() => this.deleteContainer()}
             isDisabled={!confirmDelete || isDeletionPending}
           >
-            <Trans>
-              Deleting <b>{name}</b> and its data will be lost.
-            </Trans>
+            <Text className='delete-container-modal-message'>
+              <Trans>
+                Deleting <b>{name}</b> and its data will be lost.
+              </Trans>
+            </Text>
             <Checkbox
               isChecked={confirmDelete}
               onChange={(value) => this.setState({ confirmDelete: value })}

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -181,7 +181,7 @@ class ExecutionEnvironmentList extends React.Component<
         {deleteModalVisible && (
           <DeleteModal
             spinner={isDeletionPending}
-            title={'Delete container'}
+            title={'Delete container?'}
             cancelAction={() =>
               this.setState({ deleteModalVisible: false, selectedItem: null })
             }

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -179,10 +179,10 @@ class ExecutionEnvironmentRegistryList extends React.Component<
               let promise = remoteFormNew
                 ? ExecutionEnvironmentRegistryAPI.create(newRemote)
                 : ExecutionEnvironmentRegistryAPI.smartUpdate(
-                    remoteToEdit.pk,
-                    remoteToEdit,
-                    remoteUnmodified,
-                  );
+                  remoteToEdit.pk,
+                  remoteToEdit,
+                  remoteUnmodified,
+                );
 
               promise
                 .then(() => {
@@ -225,7 +225,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
               <span>
                 <b>
                   {remoteToEdit.name}
-                  {}
+                  {' '}
                 </b>
                 will be deleted.
               </span>

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -221,7 +221,15 @@ class ExecutionEnvironmentRegistryList extends React.Component<
             }
             deleteAction={() => this.deleteRegistry(remoteToEdit)}
             title={t`Delete remote registry?`}
-            children={t`${remoteToEdit.name} will be deleted.`}
+            children={
+              <span>
+                <b>
+                  {remoteToEdit.name}
+                  {}
+                </b>
+                will be deleted.
+              </span>
+            }
           />
         )}
         <BaseHeader title={t`Remote Registries`}></BaseHeader>

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -179,10 +179,10 @@ class ExecutionEnvironmentRegistryList extends React.Component<
               let promise = remoteFormNew
                 ? ExecutionEnvironmentRegistryAPI.create(newRemote)
                 : ExecutionEnvironmentRegistryAPI.smartUpdate(
-                  remoteToEdit.pk,
-                  remoteToEdit,
-                  remoteUnmodified,
-                );
+                    remoteToEdit.pk,
+                    remoteToEdit,
+                    remoteUnmodified,
+                  );
 
               promise
                 .then(() => {
@@ -222,13 +222,9 @@ class ExecutionEnvironmentRegistryList extends React.Component<
             deleteAction={() => this.deleteRegistry(remoteToEdit)}
             title={t`Delete remote registry?`}
             children={
-              <span>
-                <b>
-                  {remoteToEdit.name}
-                  {' '}
-                </b>
-                will be deleted.
-              </span>
+              <Trans>
+                <b>{remoteToEdit.name}</b> will be deleted.
+              </Trans>
             }
           />
         )}
@@ -473,7 +469,8 @@ class ExecutionEnvironmentRegistryList extends React.Component<
       .catch(() =>
         this.addAlert(t`Failed to delete remote registry ${name}`, 'danger'),
       )
-      .then(() =>
+      .then(
+        () => this.queryRegistries(),
         this.setState({ showDeleteModal: false, remoteToEdit: null }),
       );
   }

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -469,10 +469,10 @@ class ExecutionEnvironmentRegistryList extends React.Component<
       .catch(() =>
         this.addAlert(t`Failed to delete remote registry ${name}`, 'danger'),
       )
-      .then(
-        () => this.queryRegistries(),
-        this.setState({ showDeleteModal: false, remoteToEdit: null }),
-      );
+      .then(() => {
+        this.queryRegistries();
+        this.setState({ showDeleteModal: false, remoteToEdit: null });
+      });
   }
 
   private syncRegistry({ pk, name }) {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -204,7 +204,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             spinner={isNamespacePending}
             cancelAction={this.closeModal}
             confirmAction={this.deleteNamespace}
-            title={t`Delete namespace`}
+            title={t`Delete namespace?`}
             confirmButtonTitle={t`Delete`}
             isDisabled={!confirmDelete || isNamespacePending}
           >

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -43,6 +43,7 @@ import {
   ConfirmModal,
   AlertList,
   closeAlertMixin,
+  DeleteModal,
   AlertType,
 } from 'src/components';
 
@@ -200,12 +201,11 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           namespace={namespace.name}
         />
         {isOpenNamespaceModal && (
-          <ConfirmModal
+          <DeleteModal
             spinner={isNamespacePending}
             cancelAction={this.closeModal}
-            confirmAction={this.deleteNamespace}
+            deleteAction={this.deleteNamespace}
             title={t`Delete namespace?`}
-            confirmButtonTitle={t`Delete`}
             isDisabled={!confirmDelete || isNamespacePending}
           >
             <>
@@ -221,7 +221,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                 id='delete_confirm'
               />
             </>
-          </ConfirmModal>
+          </DeleteModal>
         )}
         {warning ? (
           <Alert

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -40,7 +40,6 @@ import {
   RepoSelector,
   StatefulDropdown,
   ClipboardCopy,
-  ConfirmModal,
   AlertList,
   closeAlertMixin,
   DeleteModal,

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -204,7 +204,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             spinner={isNamespacePending}
             cancelAction={this.closeModal}
             confirmAction={this.deleteNamespace}
-            title={t`Permanently delete namespace?`}
+            title={t`Delete namespace`}
             confirmButtonTitle={t`Delete`}
             isDisabled={!confirmDelete || isNamespacePending}
           >

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -623,7 +623,6 @@ Cypress.Commands.add('deleteRegistries', {}, () => {
   cy.wait('@registries').then((result) => {
     var data = result.response.body.data;
     data.forEach((element) => {
-      cy.wait(10000);
       cy.get(
         'tr[aria-labelledby="' +
           element.name +
@@ -631,6 +630,7 @@ Cypress.Commands.add('deleteRegistries', {}, () => {
       ).click();
       cy.contains('a', 'Delete').click();
       cy.contains('button', 'Delete').click();
+      cy.wait('@registries');
     });
   });
 });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -623,6 +623,7 @@ Cypress.Commands.add('deleteRegistries', {}, () => {
   cy.wait('@registries').then((result) => {
     var data = result.response.body.data;
     data.forEach((element) => {
+      cy.wait(10000);
       cy.get(
         'tr[aria-labelledby="' +
           element.name +


### PR DESCRIPTION
This pr addresses UX issues discussed in [AAH-1104](https://issues.redhat.com/browse/AAH-1104)

UI changes:
Execution Environments: 
* add space between line with checkbox and line above it
* title on delete modal does _not_ contain "Permanently"
*
Remote Registries: 
* name of the item is in bold (the translator for this line is removed)
* after hitting delete on the list view page the page reloads -> delete item is not in the list

Collections:
* title on delete modal does _not_ contain "Permanently"

Namespaces:
* title on delete modal does _not_ contain "Permanently"
