### PR TITLE
Update registries sync status after sync from registry action

### DIFF
--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -447,6 +447,22 @@ class ExecutionEnvironmentRegistryList extends React.Component<
     );
   }
 
+  private updateRegistries() {
+    ExecutionEnvironmentRegistryAPI.list(this.state.params).then((result) => {
+      const isAllCompleted = result.data.data.every(
+        (task) => task.last_sync_task.state === 'completed',
+      );
+
+      if (!isAllCompleted) setTimeout(() => this.updateRegistries(), 500);
+
+      this.setState({
+        items: result.data.data,
+        itemCount: result.data.meta.count,
+        loading: false,
+      });
+    });
+  }
+
   private deleteRegistry({ pk, name }) {
     ExecutionEnvironmentRegistryAPI.delete(pk)
       .then(() =>
@@ -480,6 +496,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
             </Trans>
           </span>,
         );
+        this.updateRegistries();
       })
       .catch(() => this.addAlert(t`Sync failed for ${name}`, 'danger'));
   }


### PR DESCRIPTION
Issue: [AAH-1094](https://issues.redhat.com/browse/AAH-1094)

UI part of issue AAH-1094. Fixed backend here [#1056](https://github.com/ansible/galaxy_ng/pull/1056) (merged). 

With fixed backend `registry sync status` is now showing correctly, but it doesn't get updated after the `sync from registry` action. We have to manually reload the page to see the result. This PR fixes the status and keeps fetching registries until the status is completed.  