### PR TITLE
create single  'Get Token' button for all local repos

### DIFF
--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -72,11 +72,6 @@ export class LocalRepositoryTable extends React.Component<IProps> {
           type: 'none',
           id: 'cli_config',
         },
-        {
-          title: '',
-          type: 'none',
-          id: 'kebab',
-        },
       ],
     };
 
@@ -139,22 +134,6 @@ export class LocalRepositoryTable extends React.Component<IProps> {
             </ClipboardCopy>
           </td>
         )}
-        <td style={{ paddingRight: '0px', textAlign: 'right' }}>
-          <span>
-            <StatefulDropdown
-              items={[
-                <DropdownItem
-                  key='2'
-                  component={
-                    <Link to={formatPath(Paths.token, {})} target='_blank'>
-                      {t`Get token`}
-                    </Link>
-                  }
-                />,
-              ]}
-            />
-          </span>
-        </td>
       </tr>
     );
   }

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -1,7 +1,6 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-
-import { withRouter, RouteComponentProps } from 'react-router-dom';
+import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 
 import {
   BaseHeader,
@@ -24,6 +23,8 @@ import {
   DistributionType,
 } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
+import { Button, ToolbarItem } from '@patternfly/react-core';
+import { Paths } from 'src/paths';
 
 export class Repository {
   name: string;
@@ -159,7 +160,10 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
             }
           />
         )}
-        <BaseHeader title={t`Repo Management`}>
+        <BaseHeader
+          title={t`Repo Management`}
+          pageControls={this.renderControls()}
+        >
           {DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE &&
           !loading &&
           !unauthorised ? (
@@ -284,6 +288,18 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
       }
     });
   };
+
+  private renderControls() {
+    if (this.state.params.tab == 'local') {
+      return (
+        <ToolbarItem>
+          <Link to={Paths.token}>
+            <Button>{t`Get token`}</Button>
+          </Link>
+        </ToolbarItem>
+      );
+    }
+  }
 
   private get updateParams() {
     return ParamHelper.updateParamsMixin(this.nonQueryStringParams);


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/AAH-903

Assignment:

1. Only one "Get Token" button for the list view in the header. Only when 'local' repos tab is selected
2. Button does not redirect to a new tab

Before: 
![Screen Shot 2021-11-18 at 4 09 15 PM](https://user-images.githubusercontent.com/64337863/142497208-640aa4d1-fdc7-47e9-bdf2-af4d6fb24498.png)

After:  
![Screen Shot 2021-11-30 at 4 16 16 PM](https://user-images.githubusercontent.com/64337863/144129415-0b734da1-50db-40f4-ac83-bafdda67dc32.png)




