### PR TITLE
Fix context alerts error in insights loader

### DIFF
--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -18,6 +18,7 @@ class App extends Component {
       user: null,
       activeUser: null,
       selectedRepo: DEFAULT_REPO,
+      alerts: [],
     };
   }
 
@@ -117,6 +118,8 @@ class App extends Component {
             user: this.state.activeUser,
             setUser: this.setActiveUser,
             selectedRepo: this.state.selectedRepo,
+            alerts: this.state.alerts,
+            setAlerts: this.setAlerts,
           }}
         >
           <Routes childProps={this.props} />
@@ -126,6 +129,10 @@ class App extends Component {
   }
   setActiveUser = (user) => {
     this.setState({ activeUser: user });
+  };
+
+  setAlerts = (alerts) => {
+    this.setState({ alerts });
   };
 
   isRepoURL = (location) => {


### PR DESCRIPTION
No issue

This fixes missing context state alerts and `setAlerts` function in the insights version. Partners page is working now with this fix.