### PR TITLE
[stable-4.2] Collection detail - make both version selects affect the download tarball version

### DIFF
--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -27,7 +27,7 @@ interface IProps extends CollectionDetailType {
   params: {
     version?: string;
   };
-  updateParams: (params) => void;
+  setVersion: (version: string) => void;
 }
 
 export class CollectionInfo extends React.Component<IProps> {
@@ -46,7 +46,7 @@ export class CollectionInfo extends React.Component<IProps> {
       namespace,
       all_versions,
       params,
-      updateParams,
+      setVersion,
     } = this.props;
 
     let installCommand = `ansible-galaxy collection install ${namespace.name}.${name}`;
@@ -107,12 +107,8 @@ export class CollectionInfo extends React.Component<IProps> {
               <SplitItem className='install-tile'>Install Version</SplitItem>
               <SplitItem isFilled>
                 <FormSelect
-                  onChange={val =>
-                    updateParams(ParamHelper.setParam(params, 'version', val))
-                  }
-                  value={
-                    params.version ? params.version : latest_version.version
-                  }
+                  onChange={val => setVersion(val)}
+                  value={params.version || latest_version.version}
                   aria-label='Select collection version'
                 >
                   {all_versions.map(v => (

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -92,7 +92,7 @@ export class CollectionInfo extends React.Component<IProps> {
                         this.context.selectedRepo,
                         namespace,
                         name,
-                        latest_version,
+                        params.version || latest_version.version,
                       )
                     }
                   >
@@ -162,20 +162,17 @@ export class CollectionInfo extends React.Component<IProps> {
     );
   }
 
-  private download(reponame, namespace, name, latest_version) {
-    CollectionAPI.getDownloadURL(
-      reponame,
-      namespace.name,
-      name,
-      latest_version.version,
-    ).then((downloadURL: string) => {
-      // By getting a reference to a hidden <a> tag, setting the href and
-      // programmatically clicking it, we can hold off on making the api
-      // calls to get the download URL until it's actually needed. Clicking
-      // the <a> tag also gets around all the problems using a popup with
-      // window.open() causes.
-      this.downloadLinkRef.current.href = downloadURL;
-      this.downloadLinkRef.current.click();
-    });
+  private download(reponame, namespace, name, version) {
+    CollectionAPI.getDownloadURL(reponame, namespace.name, name, version).then(
+      (downloadURL: string) => {
+        // By getting a reference to a hidden <a> tag, setting the href and
+        // programmatically clicking it, we can hold off on making the api
+        // calls to get the download URL until it's actually needed. Clicking
+        // the <a> tag also gets around all the problems using a popup with
+        // window.open() causes.
+        this.downloadLinkRef.current.href = downloadURL;
+        this.downloadLinkRef.current.click();
+      },
+    );
   }
 }

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -16,7 +16,6 @@ interface IProps {
   params: {
     version?: string;
   };
-  updateParams: (params) => void;
   breadcrumbs: {
     url?: string;
     name: string;
@@ -24,6 +23,7 @@ interface IProps {
   activeTab: string;
   className?: string;
   repo?: string;
+  setVersion: (version: string) => void;
 }
 
 export class CollectionHeader extends React.Component<IProps> {
@@ -33,10 +33,10 @@ export class CollectionHeader extends React.Component<IProps> {
     const {
       collection,
       params,
-      updateParams,
       breadcrumbs,
       activeTab,
       className,
+      setVersion,
     } = this.props;
 
     const all_versions = [...collection.all_versions];
@@ -70,9 +70,7 @@ export class CollectionHeader extends React.Component<IProps> {
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <APIButton style={{ marginRight: '8px' }} />
             <FormSelect
-              onChange={val =>
-                updateParams(ParamHelper.setParam(params, 'version', val))
-              }
+              onChange={val => setVersion(val)}
               value={collection.latest_version.version}
               aria-label='Select collection version'
             >

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -68,8 +68,8 @@ class CollectionContent extends React.Component<
         <CollectionHeader
           collection={collection}
           params={params}
-          updateParams={params =>
-            this.updateParams(params, () =>
+          setVersion={version =>
+            this.updateParams({ ...params, version }, () =>
               this.loadCollection(this.context.selectedRepo, true),
             )
           }

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -57,26 +57,27 @@ class CollectionDetail extends React.Component<
       },
     ];
 
+    const setVersion = version =>
+      this.updateParams({ ...params, version }, () =>
+        this.loadCollection(this.context.selectedRepo, true),
+      );
+
     return (
       <React.Fragment>
         <CollectionHeader
           collection={collection}
           params={params}
-          updateParams={p =>
-            this.updateParams(p, () =>
-              this.loadCollection(this.context.selectedRepo, true),
-            )
-          }
           breadcrumbs={breadcrumbs}
           activeTab='details'
           repo={this.context.selectedRepo}
+          setVersion={setVersion}
         />
         <Main>
           <Section className='body'>
             <CollectionInfo
               {...collection}
-              updateParams={p => this.updateParams(p)}
-              params={this.state.params}
+              params={params}
+              setVersion={setVersion}
             />
           </Section>
         </Main>

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -133,8 +133,8 @@ class CollectionDocs extends React.Component<
         <CollectionHeader
           collection={collection}
           params={params}
-          updateParams={p =>
-            this.updateParams(p, () =>
+          setVersion={version =>
+            this.updateParams({ ...params, version }, () =>
               this.loadCollection(this.context.selectedRepo, true),
             )
           }

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -84,8 +84,8 @@ class CollectionImportLog extends React.Component<RouteComponentProps, IState> {
         <CollectionHeader
           collection={collection}
           params={params}
-          updateParams={params =>
-            this.updateParams(params, () => this.loadData(true))
+          setVersion={version =>
+            this.updateParams({ ...params, version }, () => this.loadData(true))
           }
           breadcrumbs={breadcrumbs}
           activeTab='import-log'


### PR DESCRIPTION
Fixes AAH-1067 for stable-4.3 and stable-4.2, by making the "Download tarball" button default to `params.version` instead of `latest_version.version`.

(while for stable-4.4+, this was fixed in https://github.com/ansible/ansible-hub-ui/pull/870/, by removing the non-header selector, and latest_version is actually the selected version)

And adding a `setVersion` prop to `CollectionInfo`, `CollectionHeader` & having `CollectionDetail` share `setVersion` between both allows the bottom version selector to update the top one when changed.

![20211122235433](https://user-images.githubusercontent.com/289743/142952371-13d8d07e-4587-4ec8-837b-980563ed338b.png)


