### PR TITLE
In Use in controller modal in the note change "links" to "external links"

### DIFF
--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -357,7 +357,7 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
             {!unsafeLinksSupported && (
               <Trans>
                 <b>Note:</b> The following links may be blocked by your browser.
-                Copy and paste the link manually.
+                Copy and paste the external link manually.
               </Trans>
             )}
             <Spacer />


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-1112

Problem Description: In Use in controller modal in the note change "links" to "external links"

QA Criteria: In Use in controller modal in the note has "external links" insteaad of "links"

Proposed Solution: In Use in controller modal in the note change "links" to "external links"

Reminder: Set the affected Component(s): [API, UI, Infrastructure, Importer, Installer, Sync, Docs, pulp_ansible, pulpcore]
