### PR TITLE
EE detail page: README is in a Card component as is its Edit button 

### DIFF
--- a/src/containers/execution-environment-detail/execution_environment_detail.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail.tsx
@@ -6,7 +6,14 @@ import {
   MarkdownEditor,
   ClipboardCopy,
 } from 'src/components';
-import { FlexItem, Flex, Title, Button } from '@patternfly/react-core';
+import {
+  FlexItem,
+  Flex,
+  Title,
+  Button,
+  Card,
+  CardBody,
+} from '@patternfly/react-core';
 import { withContainerRepo, IDetailSharedProps } from './base';
 import { ExecutionEnvironmentAPI, GroupObjectPermissionType } from 'src/api';
 import { getContainersURL } from 'src/utilities';
@@ -80,78 +87,84 @@ class ExecutionEnvironmentDetail extends React.Component<
         </FlexItem>
         <FlexItem>
           <section className='body pf-c-content'>
-            <Title headingLevel='h2' size='lg'>
-              {!this.state.markdownEditing && this.state.readme && canEdit && (
-                <Button
-                  className={'edit-button'}
-                  variant={'primary'}
-                  onClick={() => {
-                    this.setState({ markdownEditing: true });
-                  }}
-                >
-                  {t`Edit`}
-                </Button>
-              )}
-            </Title>
-            {!this.state.markdownEditing && !this.state.readme ? (
-              <EmptyStateNoData
-                title={t`No README`}
-                description={t`Add a README with instructions for using this container.`}
-                button={
-                  canEdit ? (
-                    <div data-cy='add-readme'>
+            <Card>
+              <CardBody>
+                <Title headingLevel='h2' size='lg'>
+                  {!this.state.markdownEditing && this.state.readme && canEdit && (
+                    <Button
+                      className={'edit-button'}
+                      variant={'primary'}
+                      onClick={() => {
+                        this.setState({ markdownEditing: true });
+                      }}
+                    >
+                      {t`Edit`}
+                    </Button>
+                  )}
+                </Title>
+                {!this.state.markdownEditing && !this.state.readme ? (
+                  <EmptyStateNoData
+                    title={t`No README`}
+                    description={t`Add a README with instructions for using this container.`}
+                    button={
+                      canEdit ? (
+                        <div data-cy='add-readme'>
+                          <Button
+                            variant='primary'
+                            onClick={() =>
+                              this.setState({ markdownEditing: true })
+                            }
+                          >
+                            {t`Add`}
+                          </Button>
+                        </div>
+                      ) : null
+                    }
+                  />
+                ) : (
+                  <MarkdownEditor
+                    text={this.state.readme}
+                    placeholder={''}
+                    helperText={''}
+                    updateText={(value) =>
+                      this.setState({
+                        readme: value,
+                      })
+                    }
+                    editing={this.state.markdownEditing}
+                  />
+                )}
+
+                {this.state.markdownEditing && (
+                  <React.Fragment>
+                    <div data-cy='save-readme'>
                       <Button
-                        variant='primary'
-                        onClick={() => this.setState({ markdownEditing: true })}
+                        variant={'primary'}
+                        onClick={() =>
+                          this.saveReadme(
+                            this.props.containerRepository.name,
+                            this.state.readme,
+                          )
+                        }
                       >
-                        {t`Add`}
+                        {t`Save`}
                       </Button>
                     </div>
-                  ) : null
-                }
-              />
-            ) : (
-              <MarkdownEditor
-                text={this.state.readme}
-                placeholder={''}
-                helperText={''}
-                updateText={(value) =>
-                  this.setState({
-                    readme: value,
-                  })
-                }
-                editing={this.state.markdownEditing}
-              />
-            )}
-
-            {this.state.markdownEditing && (
-              <React.Fragment>
-                <div data-cy='save-readme'>
-                  <Button
-                    variant={'primary'}
-                    onClick={() =>
-                      this.saveReadme(
-                        this.props.containerRepository.name,
-                        this.state.readme,
-                      )
-                    }
-                  >
-                    {t`Save`}
-                  </Button>
-                </div>
-                <Button
-                  variant={'link'}
-                  onClick={() => {
-                    this.setState({
-                      markdownEditing: false,
-                    });
-                    this.queryReadme(this.props.containerRepository.name);
-                  }}
-                >
-                  {t`Cancel`}
-                </Button>
-              </React.Fragment>
-            )}
+                    <Button
+                      variant={'link'}
+                      onClick={() => {
+                        this.setState({
+                          markdownEditing: false,
+                        });
+                        this.queryReadme(this.props.containerRepository.name);
+                      }}
+                    >
+                      {t`Cancel`}
+                    </Button>
+                  </React.Fragment>
+                )}
+              </CardBody>
+            </Card>
           </section>
         </FlexItem>
       </Flex>


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-1113

Problem Description: EE detail page: README is not in a Card component as isn't its Edit button

QA Criteria: README has white background and its Edit button is in that background.

Proposed Solution: Use Card component and move README and Edit button to it. This goes for README Empty state as well. Ask Susan if you have any questions.
