### PR TITLE
EE Detail page tab Images - fix cards to have proper spacing

### DIFF
--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -144,62 +144,58 @@ class ExecutionEnvironmentManifest extends React.Component<
 
         <Main>
           {error ? (
-            <section className='body'>
-              <Trans>
-                Manifest lists are not currently supported on this screen,
-                please use the{' '}
-                <Link
-                  to={formatPath(Paths.executionEnvironmentDetailImages, {
-                    container: container.name,
-                  })}
-                >
-                  Images
-                </Link>{' '}
-                tab to see manifest list details.
-              </Trans>
-            </section>
+            <Trans>
+              Manifest lists are not currently supported on this screen, please
+              use the{' '}
+              <Link
+                to={formatPath(Paths.executionEnvironmentDetailImages, {
+                  container: container.name,
+                })}
+              >
+                Images
+              </Link>{' '}
+              tab to see manifest list details.
+            </Trans>
           ) : (
             <Flex>
               <FlexItem className='layers-max-width'>
                 <Card>
-                  <section className='body'>
-                    <CardTitle>
-                      <Title headingLevel='h2' size='lg'>
-                        {t`Image layers`}
-                      </Title>
-                    </CardTitle>
-                    <CardBody>
-                      <DataList
-                        aria-label={t`Image layers`}
-                        onSelectDataListItem={(id) =>
-                          this.setState({ selectedLayer: id })
-                        }
-                        selectedDataListItemId={selectedLayer}
-                      >
-                        {layers.map(({ text, size }, index) => (
-                          <DataListItem key={index} id={`layer-${index}`}>
-                            <DataListItemRow>
-                              <DataListItemCells
-                                dataListCells={[
-                                  <DataListCell
-                                    key='primary content'
-                                    className='single-line-ellipsis'
-                                  >
-                                    <code>{text}</code>
-                                  </DataListCell>,
-                                  size && (
-                                    <DataListCell key='secondary content'>
-                                      {size}
-                                    </DataListCell>
-                                  ),
-                                ]}
-                              />
-                            </DataListItemRow>
-                          </DataListItem>
-                        ))}
-                      </DataList>
-                    </CardBody>
-                  </section>
+                  <CardTitle>
+                    <Title headingLevel='h2' size='lg'>
+                      {t`Image layers`}
+                    </Title>
+                  </CardTitle>
+                  <CardBody>
+                    <DataList
+                      aria-label={t`Image layers`}
+                      onSelectDataListItem={(id) =>
+                        this.setState({ selectedLayer: id })
+                      }
+                      selectedDataListItemId={selectedLayer}
+                    >
+                      {layers.map(({ text, size }, index) => (
+                        <DataListItem key={index} id={`layer-${index}`}>
+                          <DataListItemRow>
+                            <DataListItemCells
+                              dataListCells={[
+                                <DataListCell
+                                  key='primary content'
+                                  className='single-line-ellipsis'
+                                >
+                                  <code>{text}</code>
+                                </DataListCell>,
+                                size && (
+                                  <DataListCell key='secondary content'>
+                                    {size}
+                                  </DataListCell>
+                                ),
+                              ]}
+                            />
+                          </DataListItemRow>
+                        </DataListItem>
+                      ))}
+                    </DataList>
+                  </CardBody>
                 </Card>
               </FlexItem>
 
@@ -209,35 +205,31 @@ class ExecutionEnvironmentManifest extends React.Component<
               >
                 <FlexItem>
                   <Card>
-                    <section className='body'>
-                      <CardTitle>
-                        <Title headingLevel='h2' size='lg'>
-                          {t`Command`}
-                        </Title>
-                      </CardTitle>
-                      <CardBody>
-                        <code>{command}</code>
-                      </CardBody>
-                    </section>
+                    <CardTitle>
+                      <Title headingLevel='h2' size='lg'>
+                        {t`Command`}
+                      </Title>
+                    </CardTitle>
+                    <CardBody>
+                      <code>{command}</code>
+                    </CardBody>
                   </Card>
                 </FlexItem>
                 <FlexItem>
                   <Card>
-                    <section className='body'>
-                      <CardTitle>
-                        <Title headingLevel='h2' size='lg'>
-                          {t`Environment`}
-                        </Title>
-                      </CardTitle>
-                      <CardBody>
-                        {environment.map((line, index) => (
-                          <React.Fragment key={index}>
-                            <code>{line}</code>
-                            <br />
-                          </React.Fragment>
-                        ))}
-                      </CardBody>
-                    </section>
+                    <CardTitle>
+                      <Title headingLevel='h2' size='lg'>
+                        {t`Environment`}
+                      </Title>
+                    </CardTitle>
+                    <CardBody>
+                      {environment.map((line, index) => (
+                        <React.Fragment key={index}>
+                          <code>{line}</code>
+                          <br />
+                        </React.Fragment>
+                      ))}
+                    </CardBody>
                   </Card>
                 </FlexItem>
               </Flex>

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -21,6 +21,9 @@ import {
   LabelGroup,
   Title,
   ClipboardCopyButton,
+  Card,
+  CardBody,
+  CardTitle,
 } from '@patternfly/react-core';
 import { sum } from 'lodash';
 import { Paths, formatPath } from '../../paths';
@@ -158,41 +161,46 @@ class ExecutionEnvironmentManifest extends React.Component<
           ) : (
             <Flex>
               <FlexItem className='layers-max-width'>
-                <section className='body'>
-                  <Title headingLevel='h2' size='lg'>
-                    {t`Image layers`}
-                  </Title>
-
-                  <DataList
-                    aria-label={t`Image layers`}
-                    onSelectDataListItem={(id) =>
-                      this.setState({ selectedLayer: id })
-                    }
-                    selectedDataListItemId={selectedLayer}
-                  >
-                    {layers.map(({ text, size }, index) => (
-                      <DataListItem key={index} id={`layer-${index}`}>
-                        <DataListItemRow>
-                          <DataListItemCells
-                            dataListCells={[
-                              <DataListCell
-                                key='primary content'
-                                className='single-line-ellipsis'
-                              >
-                                <code>{text}</code>
-                              </DataListCell>,
-                              size && (
-                                <DataListCell key='secondary content'>
-                                  {size}
-                                </DataListCell>
-                              ),
-                            ]}
-                          />
-                        </DataListItemRow>
-                      </DataListItem>
-                    ))}
-                  </DataList>
-                </section>
+                <Card>
+                  <section className='body'>
+                    <CardTitle>
+                      <Title headingLevel='h2' size='lg'>
+                        {t`Image layers`}
+                      </Title>
+                    </CardTitle>
+                    <CardBody>
+                      <DataList
+                        aria-label={t`Image layers`}
+                        onSelectDataListItem={(id) =>
+                          this.setState({ selectedLayer: id })
+                        }
+                        selectedDataListItemId={selectedLayer}
+                      >
+                        {layers.map(({ text, size }, index) => (
+                          <DataListItem key={index} id={`layer-${index}`}>
+                            <DataListItemRow>
+                              <DataListItemCells
+                                dataListCells={[
+                                  <DataListCell
+                                    key='primary content'
+                                    className='single-line-ellipsis'
+                                  >
+                                    <code>{text}</code>
+                                  </DataListCell>,
+                                  size && (
+                                    <DataListCell key='secondary content'>
+                                      {size}
+                                    </DataListCell>
+                                  ),
+                                ]}
+                              />
+                            </DataListItemRow>
+                          </DataListItem>
+                        ))}
+                      </DataList>
+                    </CardBody>
+                  </section>
+                </Card>
               </FlexItem>
 
               <Flex
@@ -200,28 +208,37 @@ class ExecutionEnvironmentManifest extends React.Component<
                 className='layers-max-width'
               >
                 <FlexItem>
-                  <section className='body'>
-                    <Title headingLevel='h2' size='lg'>
-                      {t`Command`}
-                    </Title>
-
-                    <code>{command}</code>
-                  </section>
+                  <Card>
+                    <section className='body'>
+                      <CardTitle>
+                        <Title headingLevel='h2' size='lg'>
+                          {t`Command`}
+                        </Title>
+                      </CardTitle>
+                      <CardBody>
+                        <code>{command}</code>
+                      </CardBody>
+                    </section>
+                  </Card>
                 </FlexItem>
-
                 <FlexItem>
-                  <section className='body'>
-                    <Title headingLevel='h2' size='lg'>
-                      {t`Environment`}
-                    </Title>
-
-                    {environment.map((line, index) => (
-                      <React.Fragment key={index}>
-                        <code>{line}</code>
-                        <br />
-                      </React.Fragment>
-                    ))}
-                  </section>
+                  <Card>
+                    <section className='body'>
+                      <CardTitle>
+                        <Title headingLevel='h2' size='lg'>
+                          {t`Environment`}
+                        </Title>
+                      </CardTitle>
+                      <CardBody>
+                        {environment.map((line, index) => (
+                          <React.Fragment key={index}>
+                            <code>{line}</code>
+                            <br />
+                          </React.Fragment>
+                        ))}
+                      </CardBody>
+                    </section>
+                  </Card>
                 </FlexItem>
               </Flex>
             </Flex>


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-1115

Problem Description: EE Detail page tab Images click at any sha of n image - fix cards to have proper spacing

QA Criteria: EE Detail page tab Images - Cards have proper spacing between headers and content. See https://www.patternfly.org/v4/components/card/ for reference.

Proposed Solution: See https://www.patternfly.org/v4/components/card/  Use CardTitle and CardBody.
