### PR TITLE
Fix header on ee detail page

### DIFF
--- a/src/containers/execution-environment-manifest/execution-environment-manifest.scss
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.scss
@@ -9,6 +9,10 @@
   word-wrap: break-word;
 }
 
+.copy-sha {
+  padding-bottom: 6px;
+}
+
 .eco-clipboard-copy {
   display: inline-block;
 

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.scss
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.scss
@@ -11,6 +11,8 @@
 
 .copy-sha {
   padding-bottom: 6px;
+  display: flex;
+  align-items: center;
 }
 
 .eco-clipboard-copy {

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -20,6 +20,7 @@ import {
   FlexItem,
   LabelGroup,
   Title,
+  ClipboardCopyButton,
 } from '@patternfly/react-core';
 import { sum } from 'lodash';
 import { Paths, formatPath } from '../../paths';
@@ -118,10 +119,15 @@ class ExecutionEnvironmentManifest extends React.Component<
           }
         >
           <div className='copy-sha'>
-            <ShaLabel digest={digest} />
-            <ClipboardCopy className='eco-clipboard-copy' isReadOnly>
-              {digest}
-            </ClipboardCopy>
+            <ShaLabel digest={digest} long={true} />
+            <ClipboardCopyButton
+              className='eco-clipboard-copy'
+              variant={'plain'}
+              onClick={() => navigator.clipboard.writeText(digest)}
+              children={digest}
+              id={digest}
+              textId={t`Copy to clipboard`}
+            />
           </div>
 
           <LabelGroup numLabels={6}>

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -8,6 +8,7 @@ import {
   Main,
   TagLabel,
   ClipboardCopy,
+  ShaLabel,
 } from '../../components';
 import {
   DataList,
@@ -116,7 +117,8 @@ class ExecutionEnvironmentManifest extends React.Component<
             />
           }
         >
-          <div>
+          <div className='copy-sha'>
+            <ShaLabel digest={digest} />
             <ClipboardCopy className='eco-clipboard-copy' isReadOnly>
               {digest}
             </ClipboardCopy>


### PR DESCRIPTION
See issue: https://issues.redhat.com/browse/AAH-1116
Assignments:
* in the header sha should be a chip like in the table
* in the header add a clickboard button after the sha chip that copies whole sha
* add spacing in between lines in the header

Before:
![Screen Shot 2021-12-01 at 11 31 26 AM](https://user-images.githubusercontent.com/64337863/144274260-05e9e671-04e8-4da7-bc21-7d1147d3d082.png)

After: 
<img width="796" alt="Screen Shot 2021-12-01 at 12 38 42 PM" src="https://user-images.githubusercontent.com/64337863/144285180-082c7c5e-b644-49dd-86ff-2cfd82464f7b.png">
