### PR TITLE
Add '?' to all delete modals. (Issue: AAH-1148)

### DIFF
--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -267,8 +267,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             isDisabled={!confirmDelete || isDeletionPending}
             title={
               collectionVersion
-                ? t`Permanently delete collection version`
-                : t`Permanently delete collection`
+                ? t`Permanently delete collection version?`
+                : t`Permanently delete collection?`
             }
             confirmButtonTitle={t`Delete`}
           >

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -206,7 +206,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
         {deleteModalVisible && (
           <DeleteModal
             spinner={isDeletionPending}
-            title={t`Permanently delete image`}
+            title={t`Permanently delete image?`}
             cancelAction={() =>
               this.setState({
                 deleteModalVisible: false,

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -180,7 +180,7 @@ class ExecutionEnvironmentList extends React.Component<
         {deleteModalVisible && (
           <DeleteModal
             spinner={isDeletionPending}
-            title={'Permanently delete container'}
+            title={'Permanently delete container?'}
             cancelAction={() =>
               this.setState({ deleteModalVisible: false, selectedItem: null })
             }


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-1148

Problem Description: some delete modal titles have a '?', while others don't.

Proposed Solution: Add '?' to the end of all delete modal titles. 

    EE list view > delete
    Collection > delete
    Namespace > delete
    Remote registry > delete

Example: 'Permanently delete container' >> 'Permanently delete container?'
