### PR TITLE
Add missing settings to App.Context in Insights mode

### DIFF
--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -77,9 +77,9 @@ export class CollectionInfo extends React.Component<IProps> {
                     only supported in ansible 2.9+
                   </Trans>
                 </div>
-                {!this.context.settings
-                  .GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD &&
-                this.context.user.is_anonymous ? (
+                {this.context.user.is_anonymous &&
+                !this.context.settings
+                  .GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD ? (
                   <Alert
                     className={'collection-download-alert'}
                     isInline

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { Routes } from './Routes';
 import '../app.scss';
 import { AppContext } from '../app-context';
-import { ActiveUserAPI } from 'src/api';
+import { ActiveUserAPI, SettingsAPI } from 'src/api';
 import { Paths } from 'src/paths';
 
 const DEFAULT_REPO = 'published';
@@ -19,6 +19,7 @@ class App extends Component {
       activeUser: null,
       selectedRepo: DEFAULT_REPO,
       alerts: [],
+      settings: {},
     };
   }
 
@@ -60,9 +61,15 @@ class App extends Component {
     insights.chrome.auth
       .getUser()
       .then((user) => this.setState({ user: user }));
-    ActiveUserAPI.getActiveUser().then((result) =>
-      this.setState({ activeUser: result.data }),
-    );
+    let promises = [];
+    promises.push(ActiveUserAPI.getActiveUser());
+    promises.push(SettingsAPI.get());
+    Promise.all(promises).then((results) => {
+      this.setState({
+        activeUser: results[0].data,
+        settings: results[1].data,
+      });
+    });
   }
 
   componentWillUnmount() {
@@ -120,6 +127,7 @@ class App extends Component {
             selectedRepo: this.state.selectedRepo,
             alerts: this.state.alerts,
             setAlerts: this.setAlerts,
+            settings: this.state.settings,
           }}
         >
           <Routes childProps={this.props} />


### PR DESCRIPTION
Issue: H-1170

Go to any collection detail view in Insights mode

Before:
Nothing is loaded. 
Error in console `TypeError: Cannot read properties of undefined (reading 'GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD')`

After:
<img width="1352" alt="Screenshot 2021-12-03 at 14 45 33" src="https://user-images.githubusercontent.com/9210860/144612693-dbd09f0d-4d95-4f29-ba50-1c98446ead88.png">

Error is no longer in the console.
