### PR TITLE
workflows: add cancel-in-progress to cypress, deploy/release, update-manifest

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron:  '30 5 * * *'
 
+concurrency:
+  group: cypress-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cypress:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [ "master", "master-stable", "prod-beta", "prod-stable" ]
 
+concurrency:
+  group: deploy-cloud-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cloud:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches: [ 'master' ]
 
+concurrency:
+  group: dev-release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dev:
     runs-on: ubuntu-latest

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -8,6 +8,10 @@ on:
     - '!dev'
     - '!**cloud**'
 
+concurrency:
+  group: stable-release-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   stable:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [ 'master', 'stable-prod' ]
 
+concurrency:
+  group: update-manifest-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   manifest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Workflows - using named concurrency groups allows us to automatically cancel a github action if the same one is running on the same branch - this should just kill double builds on double push and fast subsequent merges.

For cypress this just saves cpu time,
for deploy/release/update-manifest it should prevent ocasional failures trying to push to an updated branch.

(ref https://yonatankra.com/7-github-actions-tricks-i-wish-i-knew-before-i-started/, https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency)