### PR TITLE
eslint - enable @typescript-eslint/no-unused-vars

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,7 @@
 
     // "curly": ["error", "all"],
     "eol-last": ["error", "always"],
-    // "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
 
 
     /// Rules to add from previous config (see #860)
@@ -44,7 +44,6 @@
     "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-inferrable-types": "off",
-    "@typescript-eslint/no-unused-vars": "off",
     "@typescript-eslint/no-var-requires": "off",
     "no-case-declarations": "off",
     "no-extra-boolean-cast": "off",

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -37,7 +37,7 @@ module.exports = (inputConfigs) => {
   const customConfigs = {};
   const globals = {};
 
-  defaultConfigs.forEach((item, i) => {
+  defaultConfigs.forEach((item) => {
     // == will match null and undefined, but not false
     if (inputConfigs[item.name] == null) {
       customConfigs[item.name] = item.default;

--- a/src/api/execution-environment-registry.ts
+++ b/src/api/execution-environment-registry.ts
@@ -15,7 +15,7 @@ class API extends HubAPI {
     return super.update(pk, reducedData);
   }
 
-  update(id, obj) {
+  update(_id, _obj) {
     throw 'use smartUpdate()';
   }
 

--- a/src/api/hub.ts
+++ b/src/api/hub.ts
@@ -1,4 +1,3 @@
-import { Constants } from 'src/constants';
 import { BaseAPI } from './base';
 
 export class HubAPI extends BaseAPI {

--- a/src/api/remotes.ts
+++ b/src/api/remotes.ts
@@ -44,7 +44,7 @@ class API extends HubAPI {
     );
   }
 
-  update(id, obj) {
+  update(_id, _obj) {
     throw 'use smartUpdate()';
   }
 

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -6,7 +6,6 @@ import './collection-content-list.scss';
 import { Link } from 'react-router-dom';
 import {
   SearchInput,
-  TextInput,
   Toolbar,
   ToolbarGroup,
   ToolbarItem,

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -90,7 +90,7 @@ export class CollectionList extends React.Component<IProps> {
         <StatefulDropdown
           items={[
             <DropdownItem
-              onClick={(e) =>
+              onClick={() =>
                 this.props.handleControlClick(collection.id, 'deprecate')
               }
               key='1'

--- a/src/components/execution-environment-header/execution-environment-header.tsx
+++ b/src/components/execution-environment-header/execution-environment-header.tsx
@@ -1,6 +1,6 @@
 import { t, Trans } from '@lingui/macro';
 import * as React from 'react';
-import { Tooltip, Button } from '@patternfly/react-core';
+import { Tooltip } from '@patternfly/react-core';
 import { Paths } from 'src/paths';
 import { BaseHeader, Breadcrumbs, Tabs } from 'src/components';
 import { ContainerRepositoryType } from 'src/api';

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -181,7 +181,7 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
 
   renderControllers() {
     const { image, isOpen } = this.props;
-    const { controllers, controllerCount, digest, tag } = this.state;
+    const { controllers, digest, tag } = this.state;
     const url = getContainersURL();
     const unsafeLinksSupported = !Object.keys(window).includes('chrome');
 

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -1,4 +1,4 @@
-import { t, Trans } from '@lingui/macro';
+import { t } from '@lingui/macro';
 import * as React from 'react';
 import {
   Alert,

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -1,4 +1,3 @@
-import { t } from '@lingui/macro';
 import * as React from 'react';
 import cx from 'classnames';
 import './header.scss';

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from '@lingui/macro';
 import * as React from 'react';
 import './header.scss';
 
-import { Redirect, Link } from 'react-router-dom';
+import { Redirect } from 'react-router-dom';
 
 import * as moment from 'moment';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -1,4 +1,3 @@
-import { cellWidth } from '@patternfly/react-table';
 import * as React from 'react';
 // had to declare *.svg in src/index.d.ts
 import DefaultLogo from 'src/../static/images/default-logo.svg';
@@ -59,7 +58,7 @@ export class Logo extends React.Component<IProps, IState> {
           alt={alt}
           onError={
             fallbackToDefault
-              ? (e) => this.setState({ failed: true })
+              ? () => this.setState({ failed: true })
               : () => null
           }
         />

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -46,7 +46,7 @@ export class NamespaceForm extends React.Component<IProps, IState> {
   }
 
   render() {
-    const { namespace, errorMessages, userId } = this.props;
+    const { namespace, errorMessages } = this.props;
 
     const { formErrors } = this.state;
 

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -63,13 +63,13 @@ export class NamespaceModal extends React.Component<IProps, IState> {
     });
   }
 
-  private handleSubmit = (event) => {
+  private handleSubmit = () => {
     const data: any = {
       name: this.state.newNamespaceName,
       groups: this.state.newGroups,
     };
     NamespaceAPI.create(data)
-      .then((results) => {
+      .then(() => {
         this.toggleModal();
         this.setState({
           newNamespaceName: '',

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -150,7 +150,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
             }
             isPlain={false}
             position='left'
-            items={selectedFilter.options.map((v, i) => (
+            items={selectedFilter.options.map((v) => (
               <DropdownItem
                 onClick={() => {
                   this.props.onChange(v.id);

--- a/src/components/permissions/obect-permission-field.tsx
+++ b/src/components/permissions/obect-permission-field.tsx
@@ -55,7 +55,7 @@ export class ObjectPermissionField extends React.Component<IProps, IState> {
         />
         <br />
         <div>
-          {groups.map((group, i) => (
+          {groups.map((group) => (
             <Flex
               style={{ marginTop: '16px' }}
               alignItems={{ default: 'alignItemsCenter' }}
@@ -123,7 +123,7 @@ export class ObjectPermissionField extends React.Component<IProps, IState> {
       .catch((e) => this.props.onError(e?.message));
   };
 
-  private onSelect = (event, selection, isPlaceholder) => {
+  private onSelect = (event, selection) => {
     const newGroups = [...this.props.groups];
 
     const addedGroup = this.state.searchGroups.find(

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -1,19 +1,9 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
 
-import { Link } from 'react-router-dom';
-
-import { DropdownItem } from '@patternfly/react-core';
-import {
-  DateComponent,
-  EmptyStateNoData,
-  SortTable,
-  StatefulDropdown,
-  ClipboardCopy,
-} from '..';
+import { DateComponent, EmptyStateNoData, SortTable, ClipboardCopy } from '..';
 import { Constants } from 'src/constants';
 import { getRepoUrl } from 'src/utilities';
-import { Paths, formatPath } from 'src/paths';
 
 interface IProps {
   repositories: {}[];

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -82,7 +82,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
   }
 
   render() {
-    const { remote, errorMessages } = this.props;
+    const { remote } = this.props;
     if (!remote) {
       return null;
     }

--- a/src/components/repositories/remote-repository-table.tsx
+++ b/src/components/repositories/remote-repository-table.tsx
@@ -101,7 +101,7 @@ export class RemoteRepositoryTable extends React.Component<IProps> {
         <SortTable
           options={sortTableOptions}
           params={params}
-          updateParams={(p) => null}
+          updateParams={() => null}
         />
         <tbody>{remotes.map((remote, i) => this.renderRow(remote, i))}</tbody>
       </table>

--- a/src/components/sort-table/sort-table.tsx
+++ b/src/components/sort-table/sort-table.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { t } from '@lingui/macro';
 
 import {
   LongArrowAltUpIcon,

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -201,7 +201,7 @@ export class UserForm extends React.Component<IProps, IState> {
             label={t`Super user`}
             labelOff={t`Not a super user`}
             isChecked={user.is_superuser}
-            onChange={(e) =>
+            onChange={() =>
               this.updateUserFieldByName(!user.is_superuser, 'is_superuser')
             }
           ></Switch>
@@ -265,7 +265,7 @@ export class UserForm extends React.Component<IProps, IState> {
     this.props.updateUser(newUser, this.props.errorMessages);
   };
 
-  private onSelectGroup = (event, selection, isPlaceholder) => {
+  private onSelectGroup = (event, selection) => {
     const { user } = this.props;
 
     const newUser = { ...user };

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -27,7 +27,7 @@ export function loadCollection(
     .then((result) => {
       this.setState({ collection: result }, callback);
     })
-    .catch((result) => {
+    .catch(() => {
       this.props.history.push(Paths.notFound);
     });
 }

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -5,7 +5,7 @@ import './collection-detail.scss';
 import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
 
-import { Alert, TextInputBase } from '@patternfly/react-core';
+import { Alert } from '@patternfly/react-core';
 
 import {
   CollectionHeader,

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -127,14 +127,14 @@ class CollectionImportLog extends React.Component<RouteComponentProps, IState> {
                   selectedImportDetail: importDetailResult.data,
                 });
               })
-              .catch((err) => {
+              .catch(() => {
                 this.setState({
                   apiError: failMsg,
                   loadingImports: false,
                 });
               });
           })
-          .catch((err) => {
+          .catch(() => {
             this.setState({
               apiError: failMsg,
               loadingImports: false,

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -223,7 +223,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
         response.data.links.push(emptyLink);
         this.setState({ loading: false, namespace: response.data });
       })
-      .catch((response) => {
+      .catch(() => {
         this.setState({ unauthorized: true, loading: false });
       });
   }

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -232,7 +232,7 @@ export function withContainerRepo(WrappedComponent) {
             setTimeout(() => this.loadRepo(), 10000);
           }
         })
-        .catch((e) => this.setState({ redirect: 'notFound' }));
+        .catch(() => this.setState({ redirect: 'notFound' }));
     }
 
     private getTab() {

--- a/src/containers/execution-environment-detail/execution_environment_detail.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail.tsx
@@ -180,7 +180,7 @@ class ExecutionEnvironmentDetail extends React.Component<
             loading: false,
           });
         })
-        .catch((error) => this.setState({ redirect: 'notFound' })),
+        .catch(() => this.setState({ redirect: 'notFound' })),
     );
   }
 

--- a/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
@@ -228,7 +228,7 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
             loading: false,
           });
         })
-        .catch((error) => this.setState({ redirect: 'notFound' }));
+        .catch(() => this.setState({ redirect: 'notFound' }));
     });
   }
 }

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -44,7 +44,6 @@ import {
   DateComponent,
   ClipboardCopy,
   DeleteModal,
-  LoadingPageWithHeader,
   LoadingPageSpinner,
 } from '../../components';
 
@@ -497,7 +496,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
             ],
           }}
           params={{}}
-          updateParams={(p) => null}
+          updateParams={() => null}
         />
         <tbody>
           {image_manifests.map(
@@ -567,7 +566,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
             loading: false,
           });
         })
-        .catch((error) => this.setState({ redirect: 'notFound' })),
+        .catch(() => this.setState({ redirect: 'notFound' })),
     );
   }
 

--- a/src/containers/execution-environment-detail/tag-manifest-modal.tsx
+++ b/src/containers/execution-environment-detail/tag-manifest-modal.tsx
@@ -51,11 +51,6 @@ interface IProps {
   containerRepository: ContainerRepositoryType;
 }
 
-interface ITagPromises {
-  tag: string;
-  promise: Promise<any>;
-}
-
 interface ITaskUrls {
   tag: string;
   task: string;
@@ -96,7 +91,7 @@ export class TagManifestModal extends React.Component<IProps, IState> {
   }
 
   render() {
-    const { children, closeModal, isOpen, containerManifest } = this.props;
+    const { closeModal, isOpen, containerManifest } = this.props;
 
     const {
       tagInForm,
@@ -384,10 +379,10 @@ export class TagManifestModal extends React.Component<IProps, IState> {
     } else {
       this.setState({ tagInFormError: undefined }, () => {
         ExecutionEnvironmentAPI.image(this.props.repositoryName, tag)
-          .then((result) => {
+          .then(() => {
             this.setState({ tagToVerify: tag, verifyingTag: false });
           })
-          .catch((err) => {
+          .catch(() => {
             this.setState({ tagInForm: '', verifyingTag: false }, () =>
               this.addTag(tag),
             );

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -7,7 +7,6 @@ import {
   LoadingPageWithHeader,
   Main,
   TagLabel,
-  ClipboardCopy,
   ShaLabel,
 } from '../../components';
 import {
@@ -254,7 +253,7 @@ class ExecutionEnvironmentManifest extends React.Component<
           size,
         };
       })
-      .catch((err) => {
+      .catch(() => {
         // FIXME: support manifest lists, and have API support it
         return {
           error: true,

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -185,7 +185,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
                   );
 
               promise
-                .then((r) => {
+                .then(() => {
                   this.setState(
                     {
                       remoteToEdit: null,

--- a/src/containers/login/login.tsx
+++ b/src/containers/login/login.tsx
@@ -2,11 +2,7 @@ import { t } from '@lingui/macro';
 import * as React from 'react';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
-import {
-  Button,
-  LoginForm,
-  LoginPage as PFLoginPage,
-} from '@patternfly/react-core';
+import { LoginForm, LoginPage as PFLoginPage } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import Logo from 'src/../static/images/logo_large.svg';

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -298,7 +298,7 @@ class MyImports extends React.Component<RouteComponentProps, IState> {
             },
           );
         })
-        .catch((result) => {
+        .catch(() => {
           this.setState({
             selectedImportDetails: undefined,
             importDetailError: t`Error fetching import from API`,

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -183,7 +183,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
         />
         <ImportModal
           isOpen={showImportModal}
-          onUploadSuccess={(result) =>
+          onUploadSuccess={() =>
             this.setState({
               redirect: formatPath(
                 Paths.myImports,
@@ -352,7 +352,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           this.context.selectedRepo,
         )
           .then(() => this.loadCollections())
-          .catch((error) => {
+          .catch(() => {
             this.setState({
               warning: t`API Error: Failed to set deprecation.`,
             });
@@ -417,7 +417,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
         this.loadAllRepos(val[0].data.meta.count);
       })
-      .catch((response) => {
+      .catch(() => {
         this.setState({ redirect: Paths.notFound });
       });
   }

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -9,7 +9,6 @@ import {
   BaseHeader,
   EmptyStateFilter,
   EmptyStateNoData,
-  EmptyStateUnauthorized,
   LinkTabs,
   LoadingPageSpinner,
   LoadingPageWithHeader,
@@ -18,7 +17,6 @@ import {
   Pagination,
   Toolbar,
   AlertList,
-  AlertType,
 } from 'src/components';
 import { Button, ToolbarItem } from '@patternfly/react-core';
 import { NamespaceAPI, NamespaceListType, MyNamespaceAPI } from 'src/api';

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -132,7 +132,7 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
                   remoteToEdit,
                   this.unModifiedRemote,
                 )
-                  .then((r) => {
+                  .then(() => {
                     this.setState(
                       {
                         errorMessages: {},
@@ -231,7 +231,7 @@ class RepositoryList extends React.Component<RouteComponentProps, IState> {
                 this.selectRemoteToEdit(remote)
               }
               syncRemote={(distro) =>
-                RemoteAPI.sync(distro).then((result) => this.loadContent())
+                RemoteAPI.sync(distro).then(() => this.loadContent())
               }
               user={user}
               refreshRemotes={this.refreshContent}

--- a/src/containers/settings/user-profile.tsx
+++ b/src/containers/settings/user-profile.tsx
@@ -1,11 +1,6 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import {
-  withRouter,
-  RouteComponentProps,
-  Link,
-  Redirect,
-} from 'react-router-dom';
+import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
 import { Button } from '@patternfly/react-core';
 
@@ -44,7 +39,6 @@ class UserProfile extends React.Component<RouteComponentProps, IState> {
   }
 
   componentDidMount() {
-    const id = this.props.match.params['userID'];
     ActiveUserAPI.getUser()
       .then((result) => {
         // The api doesn't return a value for the password, so set a blank one here

--- a/src/containers/task-management/task_detail.tsx
+++ b/src/containers/task-management/task_detail.tsx
@@ -19,7 +19,6 @@ import {
   LoadingPageSpinner,
   Main,
   StatusIndicator,
-  Tooltip,
 } from 'src/components';
 import {
   Button,

--- a/src/containers/user-management/delete-user-modal.tsx
+++ b/src/containers/user-management/delete-user-modal.tsx
@@ -83,7 +83,7 @@ export class DeleteUserModal extends React.Component<IProps, IState> {
   // modal
   private waitForDeleteConfirm(user) {
     UserAPI.get(user)
-      .then(async (result) => {
+      .then(async () => {
         // wait half a second
         await new Promise((r) => setTimeout(r, 500));
         this.waitForDeleteConfirm(user);

--- a/src/containers/user-management/user-create.tsx
+++ b/src/containers/user-management/user-create.tsx
@@ -77,7 +77,7 @@ class UserCreate extends React.Component<RouteComponentProps, IState> {
   private saveUser = () => {
     const { user } = this.state;
     UserAPI.create(user)
-      .then((result) => this.setState({ redirect: Paths.userList }))
+      .then(() => this.setState({ redirect: Paths.userList }))
       .catch((err) => {
         this.setState({ errorMessages: mapErrorMessages(err) });
       });

--- a/src/containers/user-management/user-detail.tsx
+++ b/src/containers/user-management/user-detail.tsx
@@ -16,8 +16,6 @@ import {
   closeAlertMixin,
   UserFormPage,
   EmptyStateUnauthorized,
-  BaseHeader,
-  Breadcrumbs,
 } from 'src/components';
 import { UserType, UserAPI } from 'src/api';
 import { Paths, formatPath } from 'src/paths';

--- a/src/containers/user-management/user-edit.tsx
+++ b/src/containers/user-management/user-edit.tsx
@@ -4,7 +4,6 @@ import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
 
 import {
   BaseHeader,
-  Breadcrumbs,
   EmptyStateUnauthorized,
   LoadingPageWithHeader,
   UserFormPage,

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -77,7 +77,7 @@ class App extends Component {
     this.appNav();
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate() {
     // This is sort of a dirty hack to make it so that collection details can
     // view repositories other than "published", but all other views are locked
     // to "published"

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -73,7 +73,7 @@ class App extends React.Component<RouteComponentProps, IState> {
     };
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate() {
     this.setRepoToURL();
   }
 

--- a/test/cypress/integration/collection.js
+++ b/test/cypress/integration/collection.js
@@ -34,7 +34,7 @@ describe('collection tests', () => {
     cy.wait('@deleteCollection').its('response.statusCode').should('eq', 202);
 
     waitForTaskToFinish('@taskStatus', 10);
-    cy.get('@taskStatus.last').then((res) => {
+    cy.get('@taskStatus.last').then(() => {
       cy.get('.pf-c-alert').contains('Successfully deleted collection.');
     });
   });

--- a/test/cypress/integration/collections_list.js
+++ b/test/cypress/integration/collections_list.js
@@ -1,4 +1,4 @@
-import { range, sortBy } from 'lodash';
+import { range } from 'lodash';
 
 describe('Collections list Tests', () => {
   let items = [];

--- a/test/cypress/integration/group_permissions.js
+++ b/test/cypress/integration/group_permissions.js
@@ -85,7 +85,7 @@ describe('Group Permissions Tests', () => {
     );
     cy.contains('tr', 'DeleteGroup').find('[aria-label=Delete]').click();
     cy.contains('[role=dialog] button', 'Delete').click();
-    cy.wait('@deleteGroup').then(({ request, response }) => {
+    cy.wait('@deleteGroup').then(({ response }) => {
       expect(response.statusCode).to.eq(204);
     });
   });

--- a/test/cypress/integration/profile.js
+++ b/test/cypress/integration/profile.js
@@ -29,7 +29,7 @@ describe('My Profile Tests', () => {
     cy.get('.body').within(() => {
       // restricted to text input types because there's a checkbox now for the
       // 'super user' option, but it's disabled.
-      cy.get('input[type="text"]').each(($el, index, $list) => {
+      cy.get('input[type="text"]').each(($el) => {
         expect(inputs).to.include($el.attr('id'));
       });
     });

--- a/test/cypress/plugins/console-logger.js
+++ b/test/cypress/plugins/console-logger.js
@@ -36,51 +36,6 @@ function log(msg) {
   console.log(msg);
 }
 
-function logEntry(params) {
-  if (eventFilter && !eventFilter('browser', params.entry)) {
-    return;
-  }
-
-  const { level, source, text, timestamp, url, lineNumber, stackTrace, args } =
-    params.entry;
-  const color = severityColors[level];
-  const icon = severityIcons[level];
-
-  const prefix = `[${new Date(timestamp).toISOString()}] ${icon} `;
-  const prefixSpacer = ' '.repeat(prefix.length);
-
-  let logMessage = `${prefix}${chalk.bold(level)} (${source}): ${text}`;
-  log(color(logMessage));
-  recordLogMessage(logMessage);
-
-  const logAdditional = (msg) => {
-    let additionalLogMessage = `${prefixSpacer}${msg}`;
-    log(color(additionalLogMessage));
-    recordLogMessage(additionalLogMessage);
-  };
-
-  if (url) {
-    logAdditional(`${chalk.bold('URL')}: ${url}`);
-  }
-
-  if (stackTrace && lineNumber) {
-    logAdditional(`Stack trace line number: ${lineNumber}`);
-    logAdditional(`Stack trace description: ${stackTrace.description}`);
-    logAdditional(`Stack call frames: ${stackTrace.callFrames.join(', ')}`);
-  }
-
-  if (args) {
-    logAdditional(`Arguments:`);
-    logAdditional(
-      '  ' +
-        JSON.stringify(args, null, 2)
-          .split('\n')
-          .join(`\n${prefixSpacer}  `)
-          .trimRight(),
-    );
-  }
-}
-
 function logConsole(params) {
   if (eventFilter && !eventFilter('console', params)) {
     return;
@@ -95,7 +50,6 @@ function logConsole(params) {
   const icon = severityIcons[level];
 
   const prefix = `[${new Date(timestamp).toISOString()}] ${icon} `;
-  const prefixSpacer = ' '.repeat(prefix.length);
 
   if (args) {
     args.forEach((arg) => {
@@ -168,10 +122,6 @@ function browserLaunchHandler(browser = {}, launchOptions) {
     })
       .then((cdp) => {
         debugLog('Connected to Chrome Debugging Protocol');
-
-        /** captures logs from the browser */
-        //   cdp.Log.enable()
-        //   cdp.Log.entryAdded(logEntry)
 
         /** captures logs from console.X calls */
         cdp.Runtime.enable();

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -15,7 +15,7 @@
 /**
  * @type {Cypress.PluginConfig}
  */
-module.exports = (on, config) => {
+module.exports = (on) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
   require('./console-logger').install(on);

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -25,7 +25,6 @@
 // Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
 
 import shell from 'shell-escape-tag';
-const urljoin = require('url-join');
 
 Cypress.Commands.add('findnear', { prevSubject: true }, (subject, selector) => {
   return subject.closest(`*:has(${selector})`).find(selector);
@@ -57,7 +56,7 @@ Cypress.Commands.add('menuGo', {}, (name) => {
 
 Cypress.Commands.add('apiLogin', {}, (username, password) => {
   let loginUrl = Cypress.env('prefix') + '_ui/v1/auth/login/';
-  cy.request('GET', loginUrl).then((response) => {
+  cy.request('GET', loginUrl).then(() => {
     cy.getCookie('csrftoken').then((csrftoken) => {
       cy.request({
         method: 'POST',
@@ -357,7 +356,7 @@ Cypress.Commands.add('deleteUser', {}, (username) => {
   cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/users/?*').as('userList');
 
   cy.contains('[role=dialog] button', 'Delete').click();
-  cy.wait('@deleteUser').then(({ request, response }) => {
+  cy.wait('@deleteUser').then(({ response }) => {
     expect(response.statusCode).to.eq(204);
   });
 
@@ -376,7 +375,7 @@ Cypress.Commands.add('deleteGroup', {}, (name) => {
   );
   cy.get(`[aria-labelledby=${name}] [aria-label=Delete]`).click();
   cy.contains('[role=dialog] button', 'Delete').click();
-  cy.wait('@deleteGroup').then(({ request, response }) => {
+  cy.wait('@deleteGroup').then(({ response }) => {
     expect(response.statusCode).to.eq(204);
   });
 


### PR DESCRIPTION
enable typescript [version](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-unused-vars.md) of [`no-unused-vars`](https://eslint.org/docs/rules/no-unused-vars)

configured so we can prepend a `_` to purposefully ignored function arguments

---

Aand fixing the following 81 errors:

```
/home/himdel/ansible-hub-ui/config/webpack.base.config.js
  40:33  error  'i' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/api/execution-environment-registry.ts
  18:10  error  'id' is defined but never used. Allowed unused args must match /^_/u   @typescript-eslint/no-unused-vars
  18:14  error  'obj' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/api/hub.ts
  1:10  error  'Constants' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/api/remotes.ts
  47:10  error  'id' is defined but never used. Allowed unused args must match /^_/u   @typescript-eslint/no-unused-vars
  47:14  error  'obj' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/collection-detail/collection-content-list.tsx
  9:3  error  'TextInput' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/collection-list/collection-list.tsx
  93:25  error  'e' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/execution-environment-header/execution-environment-header.tsx
  3:19  error  'Button' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/execution-environment/publish-to-controller-modal.tsx
  184:26  error  'controllerCount' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/execution-environment/repository-form.tsx
  1:13  error  'Trans' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/headers/base-header.tsx
  1:10  error  't' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/headers/collection-header.tsx
  5:20  error  'Link' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/logo/logo.tsx
   1:10  error  'cellWidth' is defined but never used                                @typescript-eslint/no-unused-vars
  62:18  error  'e' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/namespace-form/namespace-form.tsx
  33:39  error  'userId' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/namespace-modal/namespace-modal.tsx
   6:10  error  'OutlinedQuestionCircleIcon' is defined but never used                     @typescript-eslint/no-unused-vars
  61:27  error  'event' is defined but never used. Allowed unused args must match /^_/u    @typescript-eslint/no-unused-vars
  67:14  error  'results' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/patternfly-wrappers/compound-filter.tsx
  153:51  error  'i' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/permissions/obect-permission-field.tsx
   52:31  error  'i' is defined but never used. Allowed unused args must match /^_/u              @typescript-eslint/no-unused-vars
  118:41  error  'isPlaceholder' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/repositories/local-repository-table.tsx
   4:10  error  'Link' is defined but never used              @typescript-eslint/no-unused-vars
   6:10  error  'DropdownItem' is defined but never used      @typescript-eslint/no-unused-vars
  11:3   error  'StatefulDropdown' is defined but never used  @typescript-eslint/no-unused-vars
  16:10  error  'Paths' is defined but never used             @typescript-eslint/no-unused-vars
  16:17  error  'formatPath' is defined but never used        @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/repositories/remote-form.tsx
  85:21  error  'errorMessages' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/repositories/remote-repository-table.tsx
  104:26  error  'p' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/sort-table/sort-table.tsx
  2:10  error  't' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/components/user-form/user-form.tsx
  191:24  error  'e' is defined but never used. Allowed unused args must match /^_/u              @typescript-eslint/no-unused-vars
  255:46  error  'isPlaceholder' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/collection-detail/base.ts
  28:13  error  'result' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/collection-detail/collection-docs.tsx
  8:17  error  'TextInputBase' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/collection-detail/collection-import-log.tsx
  130:23  error  'err' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
  137:19  error  'err' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/edit-namespace/edit-namespace.tsx
  192:15  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/execution-environment-detail/base.tsx
  235:17  error  'e' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/execution-environment-detail/execution_environment_detail.tsx
  183:17  error  'error' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
  231:17  error  'error' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
   47:3   error  'LoadingPageWithHeader' is defined but never used                        @typescript-eslint/no-unused-vars
  501:26  error  'p' is defined but never used. Allowed unused args must match /^_/u      @typescript-eslint/no-unused-vars
  571:17  error  'error' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/execution-environment-detail/tag-manifest-modal.tsx
   54:11  error  'ITagPromises' is defined but never used                                  @typescript-eslint/no-unused-vars
   99:13  error  'children' is assigned a value but never used                             @typescript-eslint/no-unused-vars
  387:18  error  'result' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
  390:19  error  'err' is defined but never used. Allowed unused args must match /^_/u     @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
   10:3   error  'ClipboardCopy' is defined but never used                              @typescript-eslint/no-unused-vars
  257:15  error  'err' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/execution-environment/registry-list.tsx
  188:24  error  'r' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/login/login.tsx
  6:3  error  'Button' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/my-imports/my-imports.tsx
  301:17  error  'result' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/namespace-detail/namespace-detail.tsx
  182:29  error  'result' is defined but never used. Allowed unused args must match /^_/u    @typescript-eslint/no-unused-vars
  355:19  error  'error' is defined but never used. Allowed unused args must match /^_/u     @typescript-eslint/no-unused-vars
  420:15  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/namespace-list/namespace-list.tsx
   12:3   error  'EmptyStateUnauthorized' is defined but never used                   @typescript-eslint/no-unused-vars
  20:3  error  'AlertType' is defined but never used  @typescript-eslint/no-unused-vars
  302:22  error  'i' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/repositories/repository-list.tsx
  135:26  error  'r' is defined but never used. Allowed unused args must match /^_/u       @typescript-eslint/no-unused-vars
  234:46  error  'result' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/settings/user-profile.tsx
   6:3   error  'Link' is defined but never used         @typescript-eslint/no-unused-vars
  47:11  error  'id' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/task-management/task_detail.tsx
  22:3  error  'Tooltip' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/user-management/delete-user-modal.tsx
  86:20  error  'result' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/user-management/user-create.tsx
  80:14  error  'result' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/user-management/user-detail.tsx
  19:3  error  'BaseHeader' is defined but never used   @typescript-eslint/no-unused-vars
  20:3  error  'Breadcrumbs' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/containers/user-management/user-edit.tsx
  7:3  error  'Breadcrumbs' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/loaders/insights/insights-loader.js
  80:22  error  'prevProps' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/src/loaders/standalone/standalone-loader.tsx
  76:22  error  'prevProps' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/test/cypress/integration/collection.js
  40:38  error  'res' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/test/cypress/integration/collections_list.js
  1:17  error  'sortBy' is defined but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/test/cypress/integration/group_permissions.js
  88:37  error  'request' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/test/cypress/integration/profile.js
  35:47  error  'index' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
  35:54  error  '$list' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/test/cypress/plugins/console-logger.js
  39:10  error  'logEntry' is defined but never used               @typescript-eslint/no-unused-vars
  98:9   error  'prefixSpacer' is assigned a value but never used  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/test/cypress/plugins/index.js
  18:23  error  'config' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars

/home/himdel/ansible-hub-ui/test/cypress/support/commands.js
   28:7   error  'urljoin' is assigned a value but never used                                @typescript-eslint/no-unused-vars
   60:37  error  'response' is defined but never used. Allowed unused args must match /^_/u  @typescript-eslint/no-unused-vars
  354:34  error  'request' is defined but never used. Allowed unused args must match /^_/u   @typescript-eslint/no-unused-vars
  373:35  error  'request' is defined but never used. Allowed unused args must match /^_/u   @typescript-eslint/no-unused-vars

✖ 81 problems (81 errors, 0 warnings)
```