### PR TITLE
cy.login() - default to admin

### DIFF
--- a/test/cypress/integration/api_token.js
+++ b/test/cypress/integration/api_token.js
@@ -1,9 +1,6 @@
 describe('API Token Tests', () => {
-  var adminUsername = Cypress.env('username');
-  var adminPassword = Cypress.env('password');
-
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
   });
 
   it('token is generated', () => {

--- a/test/cypress/integration/collection.js
+++ b/test/cypress/integration/collection.js
@@ -10,11 +10,8 @@ const waitForTaskToFinish = (task, maxRequests, level = 0) => {
 };
 
 describe('collection tests', () => {
-  const adminUsername = Cypress.env('username');
-  const adminPassword = Cypress.env('password');
-
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
   });
 
   it('deletes an entire collection', () => {

--- a/test/cypress/integration/collection_detail.js
+++ b/test/cypress/integration/collection_detail.js
@@ -1,7 +1,4 @@
 describe('Collection detail', () => {
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
-
   function tabClick(name) {
     cy.contains('li a span', name).click();
     // repo link must be in all tabs
@@ -15,7 +12,7 @@ describe('Collection detail', () => {
   });
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.visit(
       '/ui/repo/published/collection_detail_test_namespace/collection_detail_test_collection',
     );

--- a/test/cypress/integration/collection_upload.js
+++ b/test/cypress/integration/collection_upload.js
@@ -1,9 +1,6 @@
 describe('Collection Upload Tests', () => {
-  var adminUsername = Cypress.env('username');
-  var adminPassword = Cypress.env('password');
-
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
   });
 
   it('collection is uploaded', () => {

--- a/test/cypress/integration/collections_list.js
+++ b/test/cypress/integration/collections_list.js
@@ -1,12 +1,10 @@
 import { range, sortBy } from 'lodash';
 
 describe('Collections list Tests', () => {
-  var adminUsername = Cypress.env('username');
-  var adminPassword = Cypress.env('password');
   let items = [];
 
   before(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
 
     // insert test data
     range(21).forEach((i) => {
@@ -31,7 +29,7 @@ describe('Collections list Tests', () => {
   });
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.visit('/ui/repo/published');
   });
 

--- a/test/cypress/integration/docs_menu.js
+++ b/test/cypress/integration/docs_menu.js
@@ -1,10 +1,7 @@
 describe('Token Management Tests', () => {
-  const adminUsername = Cypress.env('username');
-  const adminPassword = Cypress.env('password');
-
   beforeEach(() => {
     cy.visit('/');
-    cy.login(adminUsername, adminPassword);
+    cy.login();
   });
 
   it('user can open docs dropdown menu', () => {

--- a/test/cypress/integration/execution_environments.js
+++ b/test/cypress/integration/execution_environments.js
@@ -1,10 +1,8 @@
 describe('execution environments', () => {
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
   let num = (~~(Math.random() * 1000000)).toString();
 
   before(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
 
     cy.deleteRegistries();
     cy.deleteContainers();
@@ -19,7 +17,7 @@ describe('execution environments', () => {
   });
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.menuGo('Execution Environments > Execution Environments');
   });
 

--- a/test/cypress/integration/execution_environments_edit.js
+++ b/test/cypress/integration/execution_environments_edit.js
@@ -1,10 +1,8 @@
 describe('execution environments', () => {
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
   let num = (~~(Math.random() * 1000000)).toString();
 
   before(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
 
     cy.deleteRegistries();
     cy.deleteContainers();
@@ -20,7 +18,7 @@ describe('execution environments', () => {
   });
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.menuGo('Execution Environments > Execution Environments');
   });
 

--- a/test/cypress/integration/execution_environments_use_in_controller.js
+++ b/test/cypress/integration/execution_environments_use_in_controller.js
@@ -1,6 +1,4 @@
 describe('Execution Environments - Use in Controller', () => {
-  const adminUsername = Cypress.env('username');
-  const adminPassword = Cypress.env('password');
   let num = (~~(Math.random() * 1000000)).toString(); // FIXME: maybe drop everywhere once AAH-1095 is fixed
 
   before(() => {
@@ -11,7 +9,7 @@ describe('Execution Environments - Use in Controller', () => {
       ],
     });
 
-    cy.login(adminUsername, adminPassword);
+    cy.login();
 
     cy.deleteRegistries();
     cy.deleteContainers();
@@ -31,7 +29,7 @@ describe('Execution Environments - Use in Controller', () => {
   });
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.menuGo('Execution Environments > Execution Environments');
   });
 

--- a/test/cypress/integration/group_list.js
+++ b/test/cypress/integration/group_list.js
@@ -2,8 +2,6 @@ import { range, sortBy } from 'lodash';
 
 describe('Group list tests for sorting, paging and filtering', () => {
   let items = [];
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
 
   before(() => {
     cy.deleteTestGroups();
@@ -21,7 +19,7 @@ describe('Group list tests for sorting, paging and filtering', () => {
   });
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.visit('/ui/group-list');
   });
 

--- a/test/cypress/integration/group_management.js
+++ b/test/cypress/integration/group_management.js
@@ -1,7 +1,4 @@
 describe('Hub Group Management Tests', () => {
-  var adminUsername = Cypress.env('username');
-  var adminPassword = Cypress.env('password');
-
   before(() => {
     cy.deleteTestGroups();
     cy.deleteTestGroups();
@@ -14,7 +11,7 @@ describe('Hub Group Management Tests', () => {
   });
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
   });
 
   it('admin user can create/delete a group', () => {

--- a/test/cypress/integration/namespace-delete.js
+++ b/test/cypress/integration/namespace-delete.js
@@ -1,9 +1,6 @@
 describe('Delete a namespace', () => {
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
-
   before(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
   });
 
   it('deletes a namespace', () => {

--- a/test/cypress/integration/namespace-edit.js
+++ b/test/cypress/integration/namespace-edit.js
@@ -1,7 +1,4 @@
 describe('Edit a namespace', () => {
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
-
   let kebabToggle = () => {
     return cy.get('button[id^=pf-dropdown-toggle-id-] > svg').parent().click();
   };
@@ -44,7 +41,7 @@ describe('Edit a namespace', () => {
   });
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.galaxykit('-i namespace create', 'testns1');
     cy.menuGo('Collections > Namespaces');
     cy.get('a[href*="ui/repo/published/testns1"]').click();

--- a/test/cypress/integration/namespace_form.js
+++ b/test/cypress/integration/namespace_form.js
@@ -1,7 +1,4 @@
 describe('A namespace form', () => {
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
-
   let getCreateNamespace = () => {
     return cy.get('.pf-c-button.pf-m-primary');
   };
@@ -25,7 +22,7 @@ describe('A namespace form', () => {
   };
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     createNamespace();
     cy.menuGo('Collections > Namespaces');
     getCreateNamespace().click();

--- a/test/cypress/integration/profile.js
+++ b/test/cypress/integration/profile.js
@@ -1,7 +1,4 @@
 describe('My Profile Tests', () => {
-  const adminUsername = Cypress.env('username');
-  const adminPassword = Cypress.env('password');
-
   const username = 'nopermission';
   const password = 'n0permissi0n';
 
@@ -11,7 +8,7 @@ describe('My Profile Tests', () => {
   });
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     // open the dropdown labeled with the username and then...
     cy.get('[aria-label="user-dropdown"] button').click();
     // a little hacky, but basically

--- a/test/cypress/integration/remote_registry.js
+++ b/test/cypress/integration/remote_registry.js
@@ -1,16 +1,13 @@
 describe('Remote Registry Tests', () => {
-  const adminUsername = Cypress.env('username');
-  const adminPassword = Cypress.env('password');
-
   before(() => {
     cy.visit('/');
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.deleteRegistries();
   });
 
   beforeEach(() => {
     cy.visit('/');
-    cy.login(adminUsername, adminPassword);
+    cy.login();
   });
 
   it('checks for empty state', () => {

--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -1,11 +1,9 @@
 describe('Repo Management tests', () => {
   let remoteRepoUrl = '/ui/repositories?tab=remote';
   let localRepoUrl = '/ui/repositories';
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
   });
 
   it('admin user sees download_concurrency in remote config', () => {
@@ -44,7 +42,7 @@ describe('Repo Management tests', () => {
    * when you want to save the remote proxy config.
    */
   it.skip('remote proxy config can be saved and deleted.', () => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.visit(remoteRepoUrl);
     cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
     cy.contains('Edit').click();

--- a/test/cypress/integration/task_list.js
+++ b/test/cypress/integration/task_list.js
@@ -1,9 +1,6 @@
 describe('Task table contains correct headers and filter', () => {
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
-
   before(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.visit('/ui/repositories?tab=remote');
 
     cy.intercept(
@@ -22,7 +19,7 @@ describe('Task table contains correct headers and filter', () => {
   });
 
   it('table contains all columns and filter', () => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.visit('/ui/tasks');
     cy.contains('Task Management');
     cy.get('[aria-label="name__contains"]');

--- a/test/cypress/integration/task_management_detail.js
+++ b/test/cypress/integration/task_management_detail.js
@@ -1,9 +1,6 @@
 describe('Task detail', () => {
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
-
   before(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.visit('/ui/repositories?tab=remote');
 
     cy.intercept(
@@ -22,7 +19,7 @@ describe('Task detail', () => {
   });
 
   it('contains correct headers and field names.', () => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.visit('/ui/tasks');
     cy.contains('pulp_ansible.app.tasks.collections.sync').click();
 

--- a/test/cypress/integration/token_management.js
+++ b/test/cypress/integration/token_management.js
@@ -1,15 +1,11 @@
 describe('Token Management Tests', () => {
-  const adminUsername = Cypress.env('username');
-  const adminPassword = Cypress.env('password');
-
   before(() => {
     cy.deleteTestUsers();
-    cy.galaxykit('user create', adminUsername, adminPassword);
   });
 
   beforeEach(() => {
     cy.visit('/');
-    cy.login(adminUsername, adminPassword);
+    cy.login();
   });
 
   it('user can load token', () => {

--- a/test/cypress/integration/user_filter.js
+++ b/test/cypress/integration/user_filter.js
@@ -1,15 +1,12 @@
 // This tests the filter on user page. Should apply partial matchMedia.
 
 describe('Search for users', () => {
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
-
   before(() => {
     cy.deleteTestUsers();
   });
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.menuGo('User Access > Users');
   });
 

--- a/test/cypress/integration/user_list.js
+++ b/test/cypress/integration/user_list.js
@@ -2,8 +2,6 @@ import { range, sortBy } from 'lodash';
 
 describe('User list tests for sorting, paging and filtering', () => {
   let items = [];
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
 
   before(() => {
     cy.deleteTestUsers();
@@ -23,7 +21,7 @@ describe('User list tests for sorting, paging and filtering', () => {
   });
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
     cy.visit('/ui/users');
   });
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -134,6 +134,12 @@ Cypress.Commands.add('logout', {}, () => {
 });
 
 Cypress.Commands.add('login', {}, (username, password) => {
+  if (!username && !password) {
+    // defult to admin
+    username = Cypress.env('username');
+    password = Cypress.env('password');
+  }
+
   cy.apiLogin(username, password);
 });
 


### PR DESCRIPTION
we seem to read the admin username/password config in every test, only to login
defaulting cy.login() to admin, and cleaning up the tests

(kept uses of adminUsername/adminPassword for apiLogin, manualLogin, cookieLogin, contains and attemptToDelete)