### PR TITLE
Execution environments - add Delete to detail screen

### DIFF
--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -42,10 +42,8 @@ export interface IDetailSharedProps extends RouteComponentProps {
 
 // A higher order component to wrap individual detail pages
 export function withContainerRepo(WrappedComponent) {
-  let wrapper_class = class extends React.Component<
-    RouteComponentProps,
-    IState
-  > {
+  return class extends React.Component<RouteComponentProps, IState> {
+    static contextType = AppContext;
     constructor(props) {
       super(props);
 
@@ -326,7 +324,4 @@ export function withContainerRepo(WrappedComponent) {
         .catch(() => this.addAlert(t`Sync failed for ${name}`, 'danger'));
     }
   };
-
-  wrapper_class.contextType = AppContext;
-  return wrapper_class;
 }

--- a/src/containers/execution-environment-detail/delete-execution-enviroment-modal.tsx
+++ b/src/containers/execution-environment-detail/delete-execution-enviroment-modal.tsx
@@ -17,7 +17,7 @@ interface IProps {
   cancelAction: Function;
   selectedItem: ExecutionEnvironmentType;
   addAlert: (message, variant, description?) => void;
-  queryEnvironments: Function;
+  afterDelete: Function;
 }
 
 export class DeleteExecutionEnviromentModal extends React.Component<
@@ -41,7 +41,7 @@ export class DeleteExecutionEnviromentModal extends React.Component<
     return (
       <DeleteModal
         spinner={isDeletionPending}
-        title={'Permanently delete container'}
+        title={'Permanently delete container?'}
         cancelAction={() => cancelAction()}
         deleteAction={() => this.deleteContainer(selectedItem)}
         isDisabled={!confirmDelete || isDeletionPending}
@@ -65,7 +65,7 @@ export class DeleteExecutionEnviromentModal extends React.Component<
   }
 
   deleteContainer(selectedItem: ExecutionEnvironmentType) {
-    const { addAlert, cancelAction, queryEnvironments } = this.props;
+    const { addAlert, cancelAction, afterDelete } = this.props;
     this.setState({ isDeletionPending: true }, () =>
       ExecutionEnvironmentAPI.deleteExecutionEnvironment(selectedItem.name)
         .then((result) => {
@@ -81,7 +81,7 @@ export class DeleteExecutionEnviromentModal extends React.Component<
               'success',
               null,
             );
-            queryEnvironments();
+            afterDelete();
           });
         })
         .catch(() => {

--- a/src/containers/execution-environment-detail/delete-execution-enviroment-modal.tsx
+++ b/src/containers/execution-environment-detail/delete-execution-enviroment-modal.tsx
@@ -4,7 +4,7 @@ import { ExecutionEnvironmentAPI } from 'src/api';
 import { waitForTask } from 'src/utilities';
 import { DeleteModal } from 'src/components/delete-modal/delete-modal';
 
-import { Checkbox } from '@patternfly/react-core';
+import { Checkbox, Text } from '@patternfly/react-core';
 
 interface IState {
   confirmDelete: boolean;
@@ -38,14 +38,16 @@ export class DeleteExecutionEnviromentModal extends React.Component<
     return (
       <DeleteModal
         spinner={isDeletionPending}
-        title={'Permanently delete container?'}
+        title={'Delete container?'}
         cancelAction={() => closeAction()}
         deleteAction={() => this.deleteContainer(selectedItem)}
         isDisabled={!confirmDelete || isDeletionPending}
       >
-        <Trans>
-          Deleting <b>{selectedItem}</b> and its data will be lost.
-        </Trans>
+        <Text className='delete-container-modal-message'>
+          <Trans>
+            Deleting <b>{selectedItem}</b> and its data will be lost.
+          </Trans>
+        </Text>
         <Checkbox
           isChecked={confirmDelete}
           onChange={(value) => this.setState({ confirmDelete: value })}

--- a/src/containers/execution-environment-detail/delete-execution-enviroment-modal.tsx
+++ b/src/containers/execution-environment-detail/delete-execution-enviroment-modal.tsx
@@ -1,0 +1,97 @@
+import { t, Trans } from '@lingui/macro';
+import * as React from 'react';
+import { ExecutionEnvironmentType, ExecutionEnvironmentAPI } from 'src/api';
+import { waitForTask } from 'src/utilities';
+import { AppContext } from 'src/loaders/app-context';
+import { DeleteModal } from 'src/components/delete-modal/delete-modal';
+
+import { Checkbox } from '@patternfly/react-core';
+
+interface IState {
+  isWaitingForResponse: boolean;
+  confirmDelete: boolean;
+  isDeletionPending: boolean;
+}
+
+interface IProps {
+  cancelAction: Function;
+  selectedItem: ExecutionEnvironmentType;
+  addAlert: (message, variant, description?) => void;
+  queryEnvironments: Function;
+}
+
+export class DeleteExecutionEnviromentModal extends React.Component<
+  IProps,
+  IState
+> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      isWaitingForResponse: false,
+      confirmDelete: false,
+      isDeletionPending: false,
+    };
+  }
+
+  render() {
+    const { selectedItem, cancelAction } = this.props;
+    const { isDeletionPending, confirmDelete } = this.state;
+
+    return (
+      <DeleteModal
+        spinner={isDeletionPending}
+        title={'Permanently delete container'}
+        cancelAction={() => cancelAction()}
+        deleteAction={() => this.deleteContainer(selectedItem)}
+        isDisabled={!confirmDelete || isDeletionPending}
+      >
+        <Trans>
+          Deleting <b>{this.getName(selectedItem)}</b> and its data will be
+          lost.
+        </Trans>
+        <Checkbox
+          isChecked={confirmDelete}
+          onChange={(value) => this.setState({ confirmDelete: value })}
+          label={t`I understand that this action cannot be undone.`}
+          id='delete_confirm'
+        />
+      </DeleteModal>
+    );
+  }
+
+  getName(selectedItem: ExecutionEnvironmentType) {
+    return !!selectedItem ? selectedItem.name : '';
+  }
+
+  deleteContainer(selectedItem: ExecutionEnvironmentType) {
+    const { addAlert, cancelAction, queryEnvironments } = this.props;
+    this.setState({ isDeletionPending: true }, () =>
+      ExecutionEnvironmentAPI.deleteExecutionEnvironment(selectedItem.name)
+        .then((result) => {
+          const taskId = result.data.task.split('tasks/')[1].replace('/', '');
+          waitForTask(taskId).then(() => {
+            this.setState({
+              confirmDelete: false,
+              isDeletionPending: false,
+            });
+            cancelAction();
+            addAlert(
+              t`Success: ${this.getName(selectedItem)} was deleted`,
+              'success',
+              null,
+            );
+            queryEnvironments();
+          });
+        })
+        .catch(() => {
+          this.setState({
+            confirmDelete: false,
+            isDeletionPending: false,
+          });
+          addAlert(t`Error: delete failed`, 'danger', null);
+          cancelAction();
+        }),
+    );
+  }
+}

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -5,7 +5,6 @@ import './execution-environment.scss';
 import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import {
   Button,
-  Checkbox,
   DropdownItem,
   Label,
   Text,

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -7,7 +7,6 @@ import {
   Button,
   DropdownItem,
   Label,
-  Text,
   Toolbar,
   ToolbarContent,
   ToolbarGroup,

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -401,16 +401,6 @@ class ExecutionEnvironmentList extends React.Component<
         <DropdownItem
           key='delete'
           onClick={() =>
-            this.setState({ selectedItem: item, deleteModalVisible: true })
-          }
-        >
-          {t`Delete`}
-        </DropdownItem>
-      ),
-      this.context.user.model_permissions.delete_containerrepository && (
-        <DropdownItem
-          key='delete2'
-          onClick={() =>
             this.setState({ selectedItem: item, showDeleteModal: true })
           }
         >

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -59,8 +59,6 @@ interface IState {
   unauthorized: boolean;
   showDeleteModal: boolean;
   selectedItem: ExecutionEnvironmentType;
-  confirmDelete: boolean;
-  isDeletionPending: boolean;
   inputText: string;
 }
 
@@ -96,8 +94,6 @@ class ExecutionEnvironmentList extends React.Component<
       unauthorized: false,
       showDeleteModal: false,
       selectedItem: null,
-      confirmDelete: false,
-      isDeletionPending: false,
       inputText: '',
     };
   }

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -50,6 +50,8 @@ import { AppContext } from 'src/loaders/app-context';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { DeleteModal } from 'src/components/delete-modal/delete-modal';
 
+import { DeleteExecutionEnviromentModal } from 'src/containers/execution-environment-detail/delete-execution-enviroment-modal';
+
 interface IState {
   alerts: AlertType[];
   itemCount: number;
@@ -64,6 +66,7 @@ interface IState {
   showRemoteModal: boolean;
   unauthorized: boolean;
   deleteModalVisible: boolean;
+  showDeleteModal: boolean;
   selectedItem: ExecutionEnvironmentType;
   confirmDelete: boolean;
   isDeletionPending: boolean;
@@ -101,6 +104,7 @@ class ExecutionEnvironmentList extends React.Component<
       showRemoteModal: false,
       unauthorized: false,
       deleteModalVisible: false,
+      showDeleteModal: false,
       selectedItem: null,
       confirmDelete: false,
       isDeletionPending: false,
@@ -128,6 +132,7 @@ class ExecutionEnvironmentList extends React.Component<
       showRemoteModal,
       unauthorized,
       deleteModalVisible,
+      showDeleteModal,
       selectedItem,
       confirmDelete,
       isDeletionPending,
@@ -178,6 +183,24 @@ class ExecutionEnvironmentList extends React.Component<
         />
         {showRemoteModal && this.renderRemoteModal(itemToEdit)}
         <BaseHeader title={t`Execution Environments`}></BaseHeader>
+
+        {showDeleteModal && (
+          <DeleteExecutionEnviromentModal
+            selectedItem={selectedItem}
+            cancelAction={() =>
+              this.setState({ showDeleteModal: false, selectedItem: null })
+            }
+            queryEnvironments={() => this.queryEnvironments()}
+            addAlert={(text, variant, description = undefined) =>
+              this.setState({
+                alerts: alerts.concat([
+                  { title: text, variant: variant, description: description },
+                ]),
+              })
+            }
+          ></DeleteExecutionEnviromentModal>
+        )}
+
         {deleteModalVisible && (
           <DeleteModal
             spinner={isDeletionPending}
@@ -379,6 +402,16 @@ class ExecutionEnvironmentList extends React.Component<
           key='delete'
           onClick={() =>
             this.setState({ selectedItem: item, deleteModalVisible: true })
+          }
+        >
+          {t`Delete`}
+        </DropdownItem>
+      ),
+      this.context.user.model_permissions.delete_containerrepository && (
+        <DropdownItem
+          key='delete2'
+          onClick={() =>
+            this.setState({ selectedItem: item, showDeleteModal: true })
           }
         >
           {t`Delete`}

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -173,8 +173,8 @@ class ExecutionEnvironmentList extends React.Component<
 
         {showDeleteModal && (
           <DeleteExecutionEnviromentModal
-            selectedItem={selectedItem}
-            cancelAction={() =>
+            selectedItem={!!selectedItem ? selectedItem.name : ''}
+            closeAction={() =>
               this.setState({ showDeleteModal: false, selectedItem: null })
             }
             afterDelete={() => this.queryEnvironments()}


### PR DESCRIPTION
AAH-1089

From Issue:
problem statement: Execution environments options do not match between list and detail screens:

    ee list has Edit, Sync, Use, Delete
    ee detail has Edit, Sync, Use (no Delete)

acceptance criteria:

    EE list and detail have the same actions

PR Description:
There is need to implement delete in both list and detail. But delete is in list only. First step was to refactor the list and create standalone DeleteExecutionEviromentComponent that will replace delete functionality in list container. Now the delete component can be use also in the detail container. 
  