### PR TITLE
eslint - enable `curly` (require curly brackets around single statement ifs)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,7 +29,7 @@
   rules: {
     /// Rules we actually want - some are disabled until a separate PR because they cause many errors
 
-    // "curly": ["error", "all"],
+    "curly": ["error", "all"],
     "eol-last": ["error", "always"],
     // "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
 

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -22,13 +22,14 @@ export class CollectionDependenciesList extends React.Component<IProps> {
 
     const { dependencies } = collection.latest_version.metadata;
 
-    if (!Object.keys(dependencies).length)
+    if (!Object.keys(dependencies).length) {
       return (
         <EmptyStateNoData
           title={t`No dependencies`}
           description={t`Collection does not have dependencies.`}
         />
       );
+    }
 
     return (
       <List variant={ListVariant.inline} className='dependencies-list'>

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -52,13 +52,14 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
       usedByDependenciesLoading,
     } = this.props;
 
-    if (!itemCount && !filterIsSet(params, ['name__icontains']))
+    if (!itemCount && !filterIsSet(params, ['name__icontains'])) {
       return (
         <EmptyStateNoData
           title={t`Not required for use by other collections`}
           description={t`Collection is not being used by any collection.`}
         />
       );
+    }
 
     return (
       <>

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -31,8 +31,9 @@ export class CollectionFilter extends React.Component<IProps, IState> {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.params.keywords !== this.props.params['keywords'])
+    if (prevProps.params.keywords !== this.props.params['keywords']) {
       this.setState({ inputText: this.props.params['keywords'] || '' });
+    }
   }
 
   render() {

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -158,7 +158,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
     const { name: collectionName } = collection;
     const company = collection.namespace.company || collection.namespace.name;
 
-    if (redirect) return <Redirect push to={redirect} />;
+    if (redirect) {
+      return <Redirect push to={redirect} />;
+    }
 
     const dropdownItems = [
       noDependencies

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -232,7 +232,9 @@ export class CompoundFilter extends React.Component<IProps, IState> {
   };
 
   private selectTitleById(inputText: string, selectedFilter: FilterOption) {
-    if (!inputText || !selectedFilter?.options) return inputText;
+    if (!inputText || !selectedFilter?.options) {
+      return inputText;
+    }
 
     return selectedFilter.options.find((opt) => opt.id === inputText).title;
   }

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -181,7 +181,9 @@ class CollectionDependencies extends React.Component<
 
   private loadUsedByDependencies() {
     this.setState({ usedByDependenciesLoading: true }, () => {
-      if (this.cancelToken) this.cancelToken.cancel('request-canceled');
+      if (this.cancelToken) {
+        this.cancelToken.cancel('request-canceled');
+      }
 
       this.cancelToken = CollectionAPI.getCancelToken();
 

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -39,8 +39,9 @@ class CollectionDetail extends React.Component<
   }
 
   componentDidUpdate(prevProps) {
-    if (!isEqual(prevProps.location, this.props.location))
+    if (!isEqual(prevProps.location, this.props.location)) {
       this.loadCollection(this.context.selectedRepo);
+    }
   }
 
   render() {

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -77,8 +77,9 @@ class Search extends React.Component<RouteComponentProps, IState> {
   componentDidMount() {
     this.queryCollections();
 
-    if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE)
+    if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
       this.getSynclist();
+    }
   }
 
   render() {

--- a/test/cypress/integration/collection.js
+++ b/test/cypress/integration/collection.js
@@ -1,5 +1,7 @@
 const waitForTaskToFinish = (task, maxRequests, level = 0) => {
-  if (level === maxRequests) throw `Maximum requests exceeded.`;
+  if (level === maxRequests) {
+    throw `Maximum requests exceeded.`;
+  }
 
   cy.wait(task).then(({ response }) => {
     if (response.body.state !== 'completed') {


### PR DESCRIPTION
Enables [curly](https://eslint.org/docs/rules/curly) in eslint,
and fixes the following:

```
/home/himdel/ansible-hub-ui/src/components/collection-dependencies-list/collection-dependencies-list.tsx
  26:7  error  Expected { after 'if' condition  curly

/home/himdel/ansible-hub-ui/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
  56:7  error  Expected { after 'if' condition  curly

/home/himdel/ansible-hub-ui/src/components/collection-list/collection-filter.tsx
  35:7  error  Expected { after 'if' condition  curly

/home/himdel/ansible-hub-ui/src/components/headers/collection-header.tsx
  161:19  error  Expected { after 'if' condition  curly

/home/himdel/ansible-hub-ui/src/components/patternfly-wrappers/compound-filter.tsx
  235:49  error  Expected { after 'if' condition  curly

/home/himdel/ansible-hub-ui/src/containers/collection-detail/collection-dependencies.tsx
  184:29  error  Expected { after 'if' condition  curly

/home/himdel/ansible-hub-ui/src/containers/collection-detail/collection-detail.tsx
  43:7  error  Expected { after 'if' condition  curly

/home/himdel/ansible-hub-ui/src/containers/search/search.tsx
  81:7  error  Expected { after 'if' condition  curly

/home/himdel/ansible-hub-ui/test/cypress/integration/collection.js
  2:30  error  Expected { after 'if' condition  curly
```