### PR TITLE
[stable-4.4] Fix empty string filter (#1195)

### DIFF
--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -17,7 +17,24 @@ interface IProps {
   updateParams: (p) => void;
 }
 
-export class CollectionFilter extends React.Component<IProps> {
+interface IState {
+  inputText: string;
+}
+
+export class CollectionFilter extends React.Component<IProps, IState> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      inputText: props.params.keywords || '',
+    };
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.params.keywords !== this.props.params['keywords'])
+      this.setState({ inputText: this.props.params['keywords'] || '' });
+  }
+
   render() {
     const { ignoredParams, params, updateParams } = this.props;
 
@@ -43,6 +60,8 @@ export class CollectionFilter extends React.Component<IProps> {
           <ToolbarGroup>
             <ToolbarItem>
               <CompoundFilter
+                inputText={this.state.inputText}
+                onChange={(text) => this.setState({ inputText: text })}
                 updateParams={updateParams}
                 params={params}
                 filterConfig={filterConfig}

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -54,6 +54,7 @@ interface IState {
   tagResults: { name: string; id: string }[];
   tagSelection: { name: string; id: string }[];
   tags: { tag: string; digest: string }[];
+  inputText: string;
 }
 
 const initialState = {
@@ -68,6 +69,7 @@ const initialState = {
   tagResults: [],
   tagSelection: [],
   tags: [],
+  inputText: '',
 };
 
 export class PublishToControllerModal extends React.Component<IProps, IState> {
@@ -363,6 +365,8 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
             <Flex>
               <FlexItem>
                 <CompoundFilter
+                  inputText={this.state.inputText}
+                  onChange={(text) => this.setState({ inputText: text })}
                   updateParams={(controllerParams) => {
                     controllerParams.page = 1;
                     this.setState({ controllerParams }, () =>

--- a/src/components/my-imports/import-list.tsx
+++ b/src/components/my-imports/import-list.tsx
@@ -35,6 +35,7 @@ interface IProps {
 
 interface IState {
   kwField: string;
+  inputText: string;
 }
 
 export class ImportList extends React.Component<IProps, IState> {
@@ -43,6 +44,7 @@ export class ImportList extends React.Component<IProps, IState> {
 
     this.state = {
       kwField: '',
+      inputText: '',
     };
   }
 
@@ -63,6 +65,8 @@ export class ImportList extends React.Component<IProps, IState> {
         {this.renderNamespacePicker(namespaces)}
         <Toolbar>
           <CompoundFilter
+            inputText={this.state.inputText}
+            onChange={(text) => this.setState({ inputText: text })}
             updateParams={(p) => {
               p['page'] = 1;
               this.props.updateParams(p);
@@ -103,6 +107,7 @@ export class ImportList extends React.Component<IProps, IState> {
           updateParams={(p) => {
             p['page'] = 1;
             this.props.updateParams(p);
+            this.setState({ inputText: '' });
           }}
           params={params}
           ignoredParams={['page_size', 'page', 'sort', 'ordering', 'namespace']}

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -179,7 +179,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
 
   private handleEnter(e) {
     // l10n: don't translate
-    if (e.key === 'Enter' && this.props.inputText.length > 0) {
+    if (e.key === 'Enter' && this.props.inputText.trim().length > 0) {
       this.submitFilter();
     }
   }

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -97,7 +97,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
         <Button
           onClick={() => this.submitFilter()}
           variant={ButtonVariant.control}
-          isDisabled={!this.props.inputText}
+          isDisabled={!this.props.inputText.trim().length}
         >
           <SearchIcon></SearchIcon>
         </Button>

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -35,11 +35,14 @@ interface IProps {
 
   /** Sets the current page params to p */
   updateParams: (params) => void;
+
+  inputText: string;
+
+  onChange: (inputText: string) => void;
 }
 
 interface IState {
   selectedFilter: FilterOption;
-  inputText: string;
   isExpanded: boolean;
   isCreatable: boolean;
   isOpen: boolean;
@@ -52,7 +55,6 @@ export class CompoundFilter extends React.Component<IProps, IState> {
 
     this.state = {
       selectedFilter: props.filterConfig[0],
-      inputText: '',
       isExpanded: false,
       isCreatable: false,
       isOpen: false,
@@ -66,7 +68,10 @@ export class CompoundFilter extends React.Component<IProps, IState> {
 
     const filterOptions = filterConfig.map((v) => (
       <DropdownItem
-        onClick={() => this.setState({ selectedFilter: v, inputText: '' })}
+        onClick={() => {
+          this.props.onChange('');
+          this.setState({ selectedFilter: v });
+        }}
         key={v.id}
       >
         {v.title}
@@ -92,7 +97,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
         <Button
           onClick={() => this.submitFilter()}
           variant={ButtonVariant.control}
-          isDisabled={!this.state.inputText}
+          isDisabled={!this.props.inputText}
         >
           <SearchIcon></SearchIcon>
         </Button>
@@ -137,7 +142,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
           <StatefulDropdown
             toggleType='dropdown'
             defaultText={
-              this.selectTitleById(this.state.inputText, selectedFilter) ||
+              this.selectTitleById(this.props.inputText, selectedFilter) ||
               selectedFilter.placeholder ||
               selectedFilter.title
             }
@@ -145,9 +150,10 @@ export class CompoundFilter extends React.Component<IProps, IState> {
             position='left'
             items={selectedFilter.options.map((v, i) => (
               <DropdownItem
-                onClick={() =>
-                  this.setState({ inputText: v.id }, () => this.submitFilter())
-                }
+                onClick={() => {
+                  this.props.onChange(v.id);
+                  this.submitFilter(v.id);
+                }}
                 key={v.id}
               >
                 {v.title}
@@ -163,8 +169,8 @@ export class CompoundFilter extends React.Component<IProps, IState> {
               selectedFilter.placeholder ||
               t`Filter by ${selectedFilter.title.toLowerCase()}`
             }
-            value={this.state.inputText}
-            onChange={(k) => this.setState({ inputText: k })}
+            value={this.props.inputText}
+            onChange={(k) => this.props.onChange(k)}
             onKeyPress={(e) => this.handleEnter(e)}
           />
         );
@@ -173,7 +179,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
 
   private handleEnter(e) {
     // l10n: don't translate
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && this.props.inputText.length > 0) {
       this.submitFilter();
     }
   }
@@ -188,12 +194,12 @@ export class CompoundFilter extends React.Component<IProps, IState> {
     );
   }
 
-  private submitFilter() {
+  private submitFilter(id = undefined) {
     this.props.updateParams(
       ParamHelper.setParam(
         this.props.params,
         this.state.selectedFilter.id,
-        this.state.inputText,
+        id ? id : this.props.inputText,
       ),
     );
   }

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -57,6 +57,7 @@ interface IState {
   loading: boolean;
   updatingVersions: CollectionVersion[];
   unauthorized: boolean;
+  inputText: string;
 }
 
 class CertificationDashboard extends React.Component<
@@ -91,6 +92,7 @@ class CertificationDashboard extends React.Component<
       updatingVersions: [],
       alerts: [],
       unauthorized: false,
+      inputText: '',
     };
   }
 
@@ -130,6 +132,10 @@ class CertificationDashboard extends React.Component<
                   <ToolbarGroup>
                     <ToolbarItem>
                       <CompoundFilter
+                        inputText={this.state.inputText}
+                        onChange={(text) => {
+                          this.setState({ inputText: text });
+                        }}
                         updateParams={(p) =>
                           this.updateParams(p, () => this.queryCollections())
                         }
@@ -179,9 +185,10 @@ class CertificationDashboard extends React.Component<
               </div>
               <div>
                 <AppliedFilters
-                  updateParams={(p) =>
-                    this.updateParams(p, () => this.queryCollections())
-                  }
+                  updateParams={(p) => {
+                    this.updateParams(p, () => this.queryCollections());
+                    this.setState({ inputText: '' });
+                  }}
                   params={params}
                   ignoredParams={['page_size', 'page', 'sort']}
                   niceValues={{

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -60,6 +60,7 @@ interface IState {
   params: { page?: number; page_size?: number };
   redirect: string;
   alerts: AlertType[];
+  inputText: string;
 
   // ID for manifest that is open in the manage tags modal.
   manageTagsManifestDigest: string;
@@ -106,6 +107,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
       confirmDelete: false,
       expandedImage: null,
       isDeletionPending: false,
+      inputText: '',
     };
   }
 
@@ -255,6 +257,8 @@ class ExecutionEnvironmentDetailImages extends React.Component<
               <ToolbarGroup>
                 <ToolbarItem>
                   <CompoundFilter
+                    inputText={this.state.inputText}
+                    onChange={(text) => this.setState({ inputText: text })}
                     updateParams={(p) =>
                       this.updateParams(p, () =>
                         this.queryImages(this.props.match.params['container']),
@@ -289,11 +293,12 @@ class ExecutionEnvironmentDetailImages extends React.Component<
         </div>
         <div>
           <AppliedFilters
-            updateParams={(p) =>
+            updateParams={(p) => {
               this.updateParams(p, () =>
                 this.queryImages(this.props.match.params['container']),
-              )
-            }
+              );
+              this.setState({ inputText: '' });
+            }}
             params={params}
             ignoredParams={['page_size', 'page', 'sort', 'id', 'tab']}
           />
@@ -407,8 +412,8 @@ class ExecutionEnvironmentDetailImages extends React.Component<
     ].filter((truthy) => truthy);
 
     return (
-      <>
-        <tr key={index}>
+      <React.Fragment key={index}>
+        <tr>
           <td className='pf-c-table__toggle'>
             {isManifestList ? (
               <Button
@@ -470,7 +475,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
             <td colSpan={cols}>{this.renderManifestList(image, ShaLink)}</td>
           </tr>
         )}
-      </>
+      </React.Fragment>
     );
   }
 

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -66,6 +66,7 @@ interface IState {
   selectedItem: ExecutionEnvironmentType;
   confirmDelete: boolean;
   isDeletionPending: boolean;
+  inputText: string;
 }
 
 class ExecutionEnvironmentList extends React.Component<
@@ -102,6 +103,7 @@ class ExecutionEnvironmentList extends React.Component<
       selectedItem: null,
       confirmDelete: false,
       isDeletionPending: false,
+      inputText: '',
     };
   }
 
@@ -221,6 +223,10 @@ class ExecutionEnvironmentList extends React.Component<
                       <ToolbarGroup>
                         <ToolbarItem>
                           <CompoundFilter
+                            inputText={this.state.inputText}
+                            onChange={(text) =>
+                              this.setState({ inputText: text })
+                            }
                             updateParams={(p) => {
                               p['page'] = 1;
                               this.updateParams(p, () =>
@@ -253,9 +259,10 @@ class ExecutionEnvironmentList extends React.Component<
                 </div>
                 <div>
                   <AppliedFilters
-                    updateParams={(p) =>
-                      this.updateParams(p, () => this.queryEnvironments())
-                    }
+                    updateParams={(p) => {
+                      this.updateParams(p, () => this.queryEnvironments());
+                      this.setState({ inputText: '' });
+                    }}
                     params={params}
                     ignoredParams={['page_size', 'page', 'sort']}
                   />

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -58,6 +58,7 @@ interface IState {
   remoteUnmodified?: RemoteType;
   showDeleteModal: boolean;
   showRemoteFormModal: boolean;
+  inputText: string;
 }
 
 class ExecutionEnvironmentRegistryList extends React.Component<
@@ -92,6 +93,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
       remoteUnmodified: null,
       showDeleteModal: false,
       showRemoteFormModal: false,
+      inputText: '',
     };
   }
 
@@ -240,6 +242,10 @@ class ExecutionEnvironmentRegistryList extends React.Component<
                       <ToolbarGroup>
                         <ToolbarItem>
                           <CompoundFilter
+                            inputText={this.state.inputText}
+                            onChange={(text) =>
+                              this.setState({ inputText: text })
+                            }
                             updateParams={(p) => {
                               p['page'] = 1;
                               this.updateParams(p, () =>
@@ -271,9 +277,10 @@ class ExecutionEnvironmentRegistryList extends React.Component<
                 </div>
                 <div>
                   <AppliedFilters
-                    updateParams={(p) =>
-                      this.updateParams(p, () => this.queryRegistries())
-                    }
+                    updateParams={(p) => {
+                      this.updateParams(p, () => this.queryRegistries());
+                      this.setState({ inputText: '' });
+                    }}
                     params={params}
                     ignoredParams={['page_size', 'page', 'sort']}
                     niceNames={{

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -74,6 +74,7 @@ interface IState {
   originalPermissions: { id: number; name: string }[];
   redirect?: string;
   unauthorised: boolean;
+  inputText: string;
 }
 
 class GroupDetail extends React.Component<RouteComponentProps, IState> {
@@ -112,6 +113,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
       permissions: [],
       originalPermissions: [],
       unauthorised: false,
+      inputText: '',
     };
   }
 
@@ -655,6 +657,8 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
               <ToolbarGroup>
                 <ToolbarItem>
                   <CompoundFilter
+                    inputText={this.state.inputText}
+                    onChange={(text) => this.setState({ inputText: text })}
                     updateParams={(p) =>
                       this.updateParams(p, () => this.queryUsers())
                     }
@@ -705,7 +709,10 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         </div>
         <div>
           <AppliedFilters
-            updateParams={(p) => this.updateParams(p, () => this.queryUsers())}
+            updateParams={(p) => {
+              this.updateParams(p, () => this.queryUsers());
+              this.setState({ inputText: '' });
+            }}
             params={params}
             ignoredParams={['page_size', 'page', 'sort', 'id', 'tab']}
           />

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -55,6 +55,7 @@ interface IState {
   selectedGroup: any;
   groupError: any;
   unauthorized: boolean;
+  inputText: string;
 }
 
 class GroupList extends React.Component<RouteComponentProps, IState> {
@@ -86,6 +87,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
       selectedGroup: null,
       groupError: null,
       unauthorized: false,
+      inputText: '',
     };
   }
 
@@ -157,6 +159,8 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
                     <ToolbarGroup>
                       <ToolbarItem>
                         <CompoundFilter
+                          inputText={this.state.inputText}
+                          onChange={(val) => this.setState({ inputText: val })}
                           updateParams={(p) =>
                             this.updateParams(p, () => this.queryGroups())
                           }
@@ -197,9 +201,10 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
               </div>
               <div>
                 <AppliedFilters
-                  updateParams={(p) =>
-                    this.updateParams(p, () => this.queryGroups())
-                  }
+                  updateParams={(p) => {
+                    this.updateParams(p, () => this.queryGroups());
+                    this.setState({ inputText: '' });
+                  }}
                   params={params}
                   ignoredParams={['page_size', 'page', 'sort']}
                 />

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -48,6 +48,7 @@ interface IState {
   cancelModalVisible: boolean;
   selectedTask: TaskType;
   unauthorised: boolean;
+  inputText: string;
 }
 
 export class TaskListView extends React.Component<RouteComponentProps, IState> {
@@ -76,6 +77,7 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
       cancelModalVisible: false,
       selectedTask: null,
       unauthorised: false,
+      inputText: '',
     };
   }
 
@@ -128,6 +130,10 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
                       <ToolbarGroup>
                         <ToolbarItem>
                           <CompoundFilter
+                            inputText={this.state.inputText}
+                            onChange={(text) =>
+                              this.setState({ inputText: text })
+                            }
                             updateParams={(p) => {
                               p['page'] = 1;
                               this.updateParams(p, () => this.queryTasks());
@@ -178,9 +184,10 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
                 </div>
                 <div>
                   <AppliedFilters
-                    updateParams={(p) =>
-                      this.updateParams(p, () => this.queryTasks())
-                    }
+                    updateParams={(p) => {
+                      this.updateParams(p, () => this.queryTasks());
+                      this.setState({ inputText: '' });
+                    }}
                     params={params}
                     ignoredParams={['page_size', 'page', 'sort', 'ordering']}
                     niceNames={{
@@ -189,7 +196,7 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
                     }}
                   />
                 </div>
-                {this.renderTable(params)}
+                {loading ? <LoadingPageSpinner /> : this.renderTable(params)}
                 <div style={{ paddingTop: '24px', paddingBottom: '8px' }}>
                   <Pagination
                     params={params}

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -59,6 +59,7 @@ interface IState {
   showDeleteModal: boolean;
   alerts: AlertType[];
   unauthorized: boolean;
+  inputText: string;
 }
 
 class UserList extends React.Component<RouteComponentProps, IState> {
@@ -87,6 +88,7 @@ class UserList extends React.Component<RouteComponentProps, IState> {
       itemCount: 0,
       alerts: [],
       unauthorized: false,
+      inputText: '',
     };
   }
 
@@ -146,6 +148,10 @@ class UserList extends React.Component<RouteComponentProps, IState> {
                     <ToolbarGroup>
                       <ToolbarItem>
                         <CompoundFilter
+                          inputText={this.state.inputText}
+                          onChange={(input) =>
+                            this.setState({ inputText: input })
+                          }
                           updateParams={(p) =>
                             this.updateParams(p, () => this.queryUsers())
                           }
@@ -194,9 +200,10 @@ class UserList extends React.Component<RouteComponentProps, IState> {
               </div>
               <div>
                 <AppliedFilters
-                  updateParams={(p) =>
-                    this.updateParams(p, () => this.queryUsers())
-                  }
+                  updateParams={(p) => {
+                    this.updateParams(p, () => this.queryUsers());
+                    this.setState({ inputText: '' });
+                  }}
                   params={params}
                   ignoredParams={['page_size', 'page', 'sort']}
                   niceNames={{

--- a/src/utilities/param-helper.tsx
+++ b/src/utilities/param-helper.tsx
@@ -12,6 +12,11 @@ export class ParamHelper {
     let v;
 
     paramObj.forEach((val, key) => {
+      // do not append empty values at all (this will disable searching by empty strings)
+      if (val.trim().length == 0) {
+        return;
+      }
+
       // Parse value as number if it's included in the list of numeric
       // types.
       // It seems like there should be a better way to do this based off


### PR DESCRIPTION
Backports #1195 - Disable CompoundFilter search for empty-looking strings, as well as just "".

Fixes AAH-820

manual backport because state vs props - changed in #832 which is not backported yet