### PR TITLE
eslint: enable `@typescript-eslint/ban-types`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,7 +41,6 @@
 
     /// Rules we're disabling until they can be fixed, or disabled permanently
 
-    "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-inferrable-types": "off",
     "@typescript-eslint/no-var-requires": "off",

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -85,7 +85,7 @@ export class API extends HubAPI {
   }
 
   upload(
-    repositoryPath: String,
+    repositoryPath: string,
     data: CollectionUploadType,
     progressCallback: (e) => void,
     cancelToken?: any,

--- a/src/api/response-types/execution-environment.ts
+++ b/src/api/response-types/execution-environment.ts
@@ -16,7 +16,7 @@ export class ContainerManifestType {
   config_blob: {
     digest: string;
     media_type: string;
-    data?: Object;
+    data?: unknown;
   };
   tags: string[];
   layers: { digest: string; size: number }[];

--- a/src/api/response-types/execution-environment.ts
+++ b/src/api/response-types/execution-environment.ts
@@ -12,7 +12,7 @@ export class ContainerManifestType {
   pulp_id: string;
   pulp_created: string;
   digest: string;
-  schema_version: Number;
+  schema_version: number;
   config_blob: {
     digest: string;
     media_type: string;

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -24,7 +24,7 @@ interface IProps {
   namespaceURL?: string;
 }
 
-export class NamespaceCard extends React.Component<IProps, {}> {
+export class NamespaceCard extends React.Component<IProps> {
   MAX_DESCRIPTION_LENGTH = 26;
   render() {
     const { avatar_url, name, company, namespaceURL } = this.props;

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -13,7 +13,13 @@ import { Constants } from 'src/constants';
 
 interface IProps {
   ignoredParams: string[];
-  params: {};
+  params: {
+    keywords?: string;
+    page?: number;
+    page_size?: number;
+    tags?: string[];
+    view_type?: string;
+  };
   updateParams: (p) => void;
 }
 

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -33,7 +33,7 @@ interface IProps extends CollectionListType {
   repo?: string;
 }
 
-export class CollectionListItem extends React.Component<IProps, {}> {
+export class CollectionListItem extends React.Component<IProps> {
   render() {
     const {
       name,

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -16,7 +16,7 @@ interface IProps {
   status?: React.ReactNode;
 }
 
-export class BaseHeader extends React.Component<IProps, {}> {
+export class BaseHeader extends React.Component<IProps> {
   render() {
     const {
       title,

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -22,7 +22,7 @@ interface IProps {
   filters?: React.ReactNode;
 }
 
-export class PartnerHeader extends React.Component<IProps, {}> {
+export class PartnerHeader extends React.Component<IProps> {
   render() {
     const {
       breadcrumbs,

--- a/src/components/helper-text/helper-text.tsx
+++ b/src/components/helper-text/helper-text.tsx
@@ -10,7 +10,7 @@ interface IProps {
   header?: React.ReactNode;
 }
 
-export class HelperText extends React.Component<IProps, {}> {
+export class HelperText extends React.Component<IProps> {
   render() {
     return (
       <Popover

--- a/src/components/loading/loading-page-spinner.tsx
+++ b/src/components/loading/loading-page-spinner.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Bullseye, Spinner } from '@patternfly/react-core';
 
-export class LoadingPageSpinner extends React.Component<{}> {
+export class LoadingPageSpinner extends React.Component {
   render() {
     return (
       <Bullseye style={{ width: '100%', height: '100%' }}>

--- a/src/components/loading/loading-with-header.tsx
+++ b/src/components/loading/loading-with-header.tsx
@@ -4,7 +4,7 @@ import { Skeleton, Title } from '@patternfly/react-core';
 
 import { Main, LoadingPageSpinner } from 'src/components';
 
-export class LoadingPageWithHeader extends React.Component<{}> {
+export class LoadingPageWithHeader extends React.Component {
   render() {
     return (
       <React.Fragment>

--- a/src/components/markdown-editor/markdown-editor.tsx
+++ b/src/components/markdown-editor/markdown-editor.tsx
@@ -13,7 +13,7 @@ interface IProps {
   editing: boolean;
 }
 
-export class MarkdownEditor extends React.Component<IProps, {}> {
+export class MarkdownEditor extends React.Component<IProps> {
   render() {
     const { text, placeholder, updateText, helperText, editing } = this.props;
 

--- a/src/components/my-imports/import-console.tsx
+++ b/src/components/my-imports/import-console.tsx
@@ -30,7 +30,7 @@ interface IProps {
   collectionVersion?: CollectionVersion;
 }
 
-export class ImportConsole extends React.Component<IProps, {}> {
+export class ImportConsole extends React.Component<IProps> {
   lastImport: any;
   isLoading = false;
 

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -17,10 +17,11 @@ import {
   AlertType,
 } from 'src/components';
 import { NamespaceType } from 'src/api';
+import { ErrorMessagesType } from 'src/utilities';
 
 interface IProps {
   namespace: NamespaceType;
-  errorMessages: any;
+  errorMessages: ErrorMessagesType;
   userId: string;
 
   updateNamespace: (namespace) => void;

--- a/src/components/namespace-form/resources-form.tsx
+++ b/src/components/namespace-form/resources-form.tsx
@@ -23,7 +23,7 @@ interface IProps {
   updateNamespace: (data) => void;
 }
 
-export class ResourcesForm extends React.Component<IProps, {}> {
+export class ResourcesForm extends React.Component<IProps> {
   render() {
     const { namespace } = this.props;
 

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -1,11 +1,18 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import { Modal } from '@patternfly/react-core';
-import { Form, FormGroup } from '@patternfly/react-core';
-import { Button, InputGroup, TextInput, Alert } from '@patternfly/react-core';
-import { NamespaceAPI, GroupObjectPermissionType } from 'src/api';
+import {
+  Alert,
+  Button,
+  Form,
+  FormGroup,
+  InputGroup,
+  Modal,
+  TextInput,
+} from '@patternfly/react-core';
 
+import { NamespaceAPI, GroupObjectPermissionType } from 'src/api';
 import { AlertType, HelperText, ObjectPermissionField } from 'src/components';
+import { ErrorMessagesType } from 'src/utilities';
 
 interface IProps {
   isOpen: boolean;
@@ -17,7 +24,7 @@ interface IState {
   newNamespaceName: string;
   newNamespaceNameValid: boolean;
   newGroups: GroupObjectPermissionType[];
-  errorMessages: any;
+  errorMessages: ErrorMessagesType;
   formErrors: {
     groups: AlertType;
   };

--- a/src/components/numeric-label/numeric-label.tsx
+++ b/src/components/numeric-label/numeric-label.tsx
@@ -14,7 +14,7 @@ interface IProps {
   };
 }
 
-export class NumericLabel extends React.Component<IProps, {}> {
+export class NumericLabel extends React.Component<IProps> {
   render() {
     const { className, number, label, hideNumber, pluralLabels } = this.props;
     let convertedNum: number;

--- a/src/components/patternfly-wrappers/alert-list.tsx
+++ b/src/components/patternfly-wrappers/alert-list.tsx
@@ -19,7 +19,7 @@ export class AlertType {
   description?: string | JSX.Element;
 }
 
-export class AlertList extends React.Component<IProps, {}> {
+export class AlertList extends React.Component<IProps> {
   render() {
     const { alerts, closeAlert } = this.props;
     return (

--- a/src/components/patternfly-wrappers/applied-filters.tsx
+++ b/src/components/patternfly-wrappers/applied-filters.tsx
@@ -25,7 +25,7 @@ interface IProps {
   className?: string;
 }
 
-export class AppliedFilters extends React.Component<IProps, {}> {
+export class AppliedFilters extends React.Component<IProps> {
   static defaultProps = {
     ignoredParams: [],
     niceNames: {},

--- a/src/components/patternfly-wrappers/clipboard-copy.tsx
+++ b/src/components/patternfly-wrappers/clipboard-copy.tsx
@@ -8,7 +8,7 @@ interface IProps {
   [key: string]: any;
 }
 
-export class ClipboardCopy extends React.Component<IProps, {}> {
+export class ClipboardCopy extends React.Component<IProps> {
   render() {
     const { children, ...props } = this.props;
     return (

--- a/src/components/patternfly-wrappers/fileupload.tsx
+++ b/src/components/patternfly-wrappers/fileupload.tsx
@@ -6,7 +6,7 @@ import {
   FileUploadProps,
 } from '@patternfly/react-core';
 
-export class FileUpload extends React.Component<FileUploadProps, {}> {
+export class FileUpload extends React.Component<FileUploadProps> {
   render() {
     return (
       <PFFileUpload

--- a/src/components/patternfly-wrappers/tooltip.tsx
+++ b/src/components/patternfly-wrappers/tooltip.tsx
@@ -5,7 +5,7 @@ interface IProps {
   content: string;
 }
 
-export class Tooltip extends React.Component<IProps, {}> {
+export class Tooltip extends React.Component<IProps> {
   render() {
     const { content, children } = this.props;
     return (

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -6,7 +6,15 @@ import { Constants } from 'src/constants';
 import { getRepoUrl } from 'src/utilities';
 
 interface IProps {
-  repositories: {}[];
+  repositories: {
+    base_path: string;
+    name: string;
+    repository: {
+      content_count: number;
+      name: string;
+      pulp_last_updated: string;
+    };
+  }[];
   updateParams: (p) => void;
 }
 

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -20,12 +20,12 @@ import { DownloadIcon } from '@patternfly/react-icons';
 
 import { RemoteType, WriteOnlyFieldType } from 'src/api';
 import { Constants } from 'src/constants';
-import { isFieldSet, isWriteOnly } from 'src/utilities';
+import { isFieldSet, isWriteOnly, ErrorMessagesType } from 'src/utilities';
 
 interface IProps {
   allowEditName?: boolean;
   closeModal: () => void;
-  errorMessages: object;
+  errorMessages: ErrorMessagesType;
   remote: RemoteType;
   remoteType?: 'registry';
   saveRemote: () => void;

--- a/src/components/shared/data-form.tsx
+++ b/src/components/shared/data-form.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-
 import { Form, FormGroup, TextInput } from '@patternfly/react-core';
 
+import { ErrorMessagesType } from 'src/utilities';
+
 interface IProps {
-  errorMessages: any; // FIXME: { [key: string]: string }, but all callers use {}, object or any
+  errorMessages: ErrorMessagesType;
   formFields: {
     formGroupLabelIcon?: React.ReactNode;
     id: string;

--- a/src/components/status/status-indicator.tsx
+++ b/src/components/status/status-indicator.tsx
@@ -24,7 +24,7 @@ interface LabelPropType {
   text: string;
 }
 
-export class StatusIndicator extends React.Component<IProps, {}> {
+export class StatusIndicator extends React.Component<IProps> {
   static defaultProps = {
     type: 'primary',
   };

--- a/src/components/tags/deprecated-tag.tsx
+++ b/src/components/tags/deprecated-tag.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
 
-export class DeprecatedTag extends React.Component<{}, {}> {
+export class DeprecatedTag extends React.Component {
   render() {
     return (
       <div

--- a/src/components/tags/tag.tsx
+++ b/src/components/tags/tag.tsx
@@ -8,7 +8,7 @@ interface IProps {
   children: string;
 }
 
-export class Tag extends React.Component<IProps, {}> {
+export class Tag extends React.Component<IProps> {
   render() {
     return (
       <Label className='hub-c-label-tag' readOnly>

--- a/src/components/user-form/user-form-page.tsx
+++ b/src/components/user-form/user-form-page.tsx
@@ -2,15 +2,16 @@ import * as React from 'react';
 
 import { BaseHeader, Main, Breadcrumbs, UserForm } from 'src/components';
 import { UserType } from 'src/api';
+import { ErrorMessagesType } from 'src/utilities';
 
 interface IProps {
   title: string;
   user: UserType;
   breadcrumbs: any[];
-  errorMessages: object;
+  errorMessages: ErrorMessagesType;
   isReadonly?: boolean;
 
-  updateUser: (user: UserType, errorMessages: object) => void;
+  updateUser: (user: UserType, errorMessages: ErrorMessagesType) => void;
   saveUser?: () => void;
   extraControls?: React.ReactNode;
   onCancel?: () => void;

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -14,9 +14,9 @@ import {
 
 import { AlertType, APISearchTypeAhead, HelperText } from 'src/components';
 import { DataForm } from 'src/components/shared/data-form';
-
 import { UserType, GroupAPI } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
+import { ErrorMessagesType } from 'src/utilities';
 
 interface IProps {
   /** User to edit */
@@ -26,7 +26,7 @@ interface IProps {
   updateUser: (user: UserType, errorMesssages: object) => void;
 
   /** List of errors from the API */
-  errorMessages: object;
+  errorMessages: ErrorMessagesType;
 
   /** Disables the form */
   isReadonly?: boolean;

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
+import { Form, ActionGroup, Button, Spinner } from '@patternfly/react-core';
 
 import {
   PartnerHeader,
@@ -21,17 +21,19 @@ import {
   NamespaceLinkType,
 } from 'src/api';
 
-import { Form, ActionGroup, Button, Spinner } from '@patternfly/react-core';
-
 import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
-import { ParamHelper, mapErrorMessages } from 'src/utilities';
+import {
+  ErrorMessagesType,
+  ParamHelper,
+  mapErrorMessages,
+} from 'src/utilities';
 import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   namespace: NamespaceType;
   newLinkName: string;
   newLinkURL: string;
-  errorMessages: any;
+  errorMessages: ErrorMessagesType;
   saving: boolean;
   loading: boolean;
   redirect: string;

--- a/src/containers/execution-environment-detail/delete-execution-enviroment-modal.tsx
+++ b/src/containers/execution-environment-detail/delete-execution-enviroment-modal.tsx
@@ -12,10 +12,10 @@ interface IState {
 }
 
 interface IProps {
-  closeAction: Function;
+  closeAction: () => void;
   selectedItem: string;
   addAlert: (message, variant, description?) => void;
-  afterDelete: Function;
+  afterDelete: () => void;
 }
 
 export class DeleteExecutionEnviromentModal extends React.Component<

--- a/src/containers/execution-environment-detail/tag-manifest-modal.tsx
+++ b/src/containers/execution-environment-detail/tag-manifest-modal.tsx
@@ -37,7 +37,7 @@ interface IState {
   tagInForm: string;
   verifyingTag: boolean;
   tagToVerify: string;
-  pendingTasks: Number;
+  pendingTasks: number;
   tagInFormError: string;
 }
 

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -20,6 +20,7 @@ import {
   lastSynced,
   mapErrorMessages,
   parsePulpIDFromURL,
+  ErrorMessagesType,
 } from 'src/utilities';
 import {
   AlertList,
@@ -53,7 +54,7 @@ interface IState {
     page?: number;
     page_size?: number;
   };
-  remoteFormErrors: Object;
+  remoteFormErrors: ErrorMessagesType;
   remoteFormNew: boolean;
   remoteToEdit?: RemoteType;
   remoteUnmodified?: RemoteType;

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -10,7 +10,12 @@ import {
 } from 'react-router-dom';
 import { GroupAPI, UserAPI, UserType } from 'src/api';
 import { DeleteGroupModal } from './delete-group-modal';
-import { filterIsSet, mapErrorMessages, ParamHelper } from 'src/utilities';
+import {
+  filterIsSet,
+  mapErrorMessages,
+  ParamHelper,
+  ErrorMessagesType,
+} from 'src/utilities';
 import {
   AlertList,
   AlertType,
@@ -53,7 +58,7 @@ interface IState {
   deleteModalVisible: boolean;
   editModalVisible: boolean;
   selectedGroup: any;
-  groupError: any;
+  groupError: ErrorMessagesType;
   unauthorized: boolean;
   inputText: string;
 }

--- a/src/containers/namespace-list/my-namespaces.tsx
+++ b/src/containers/namespace-list/my-namespaces.tsx
@@ -6,7 +6,7 @@ import { Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
 import { EmptyStateUnauthorized } from 'src/components';
 
-class MyNamespaces extends React.Component<RouteComponentProps, {}> {
+class MyNamespaces extends React.Component<RouteComponentProps> {
   render() {
     if (!this.context.user || this.context.user.is_anonymous) {
       return <EmptyStateUnauthorized />;

--- a/src/containers/namespace-list/partners.tsx
+++ b/src/containers/namespace-list/partners.tsx
@@ -4,7 +4,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { NamespaceList } from './namespace-list';
 import { Paths } from 'src/paths';
 
-class Partners extends React.Component<RouteComponentProps, {}> {
+class Partners extends React.Component<RouteComponentProps> {
   render() {
     return (
       <NamespaceList

--- a/src/containers/not-found/not-found.tsx
+++ b/src/containers/not-found/not-found.tsx
@@ -9,7 +9,7 @@ import { Bullseye } from '@patternfly/react-core';
 
 import { BaseHeader, Main } from 'src/components';
 
-class NotFound extends React.Component<RouteComponentProps, {}> {
+class NotFound extends React.Component<RouteComponentProps> {
   render() {
     return (
       <React.Fragment>

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -13,7 +13,11 @@ import {
   EmptyStateNoData,
   EmptyStateUnauthorized,
 } from 'src/components';
-import { ParamHelper, mapErrorMessages } from 'src/utilities';
+import {
+  ParamHelper,
+  ErrorMessagesType,
+  mapErrorMessages,
+} from 'src/utilities';
 import { Constants } from 'src/constants';
 import {
   RemoteAPI,
@@ -44,7 +48,7 @@ interface IState {
   itemCount: number;
   loading: boolean;
   showRemoteFormModal: boolean;
-  errorMessages: Object; // RemoteForm modal messages
+  errorMessages: ErrorMessagesType; // RemoteForm modal messages
   unauthorised: boolean;
   content: RemoteType[] | DistributionType[];
   remoteToEdit: RemoteType;

--- a/src/containers/settings/user-profile.tsx
+++ b/src/containers/settings/user-profile.tsx
@@ -13,12 +13,12 @@ import {
 } from 'src/components';
 import { UserType, ActiveUserAPI } from 'src/api';
 import { Paths } from 'src/paths';
-import { mapErrorMessages } from 'src/utilities';
+import { mapErrorMessages, ErrorMessagesType } from 'src/utilities';
 import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   user: UserType;
-  errorMessages: object;
+  errorMessages: ErrorMessagesType;
   inEditMode: boolean;
   alerts: AlertType[];
   redirect?: string;

--- a/src/containers/user-management/user-create.tsx
+++ b/src/containers/user-management/user-create.tsx
@@ -8,14 +8,14 @@ import {
   EmptyStateUnauthorized,
   UserFormPage,
 } from 'src/components';
-import { mapErrorMessages } from 'src/utilities';
+import { mapErrorMessages, ErrorMessagesType } from 'src/utilities';
 import { UserType, UserAPI } from 'src/api';
 import { Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   user: UserType;
-  errorMessages: object;
+  errorMessages: ErrorMessagesType;
   redirect?: string;
 }
 

--- a/src/containers/user-management/user-detail.tsx
+++ b/src/containers/user-management/user-detail.tsx
@@ -21,10 +21,11 @@ import { UserType, UserAPI } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
 import { DeleteUserModal } from './delete-user-modal';
 import { AppContext } from 'src/loaders/app-context';
+import { ErrorMessagesType } from 'src/utilities';
 
 interface IState {
   userDetail: UserType;
-  errorMessages: object;
+  errorMessages: ErrorMessagesType;
   showDeleteModal: boolean;
   alerts: AlertType[];
   redirect?: string;

--- a/src/containers/user-management/user-edit.tsx
+++ b/src/containers/user-management/user-edit.tsx
@@ -8,14 +8,14 @@ import {
   LoadingPageWithHeader,
   UserFormPage,
 } from 'src/components';
-import { mapErrorMessages } from 'src/utilities';
+import { mapErrorMessages, ErrorMessagesType } from 'src/utilities';
 import { UserType, UserAPI } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   user: UserType;
-  errorMessages: object;
+  errorMessages: ErrorMessagesType;
   unauthorized: boolean;
   redirect?: string;
 }

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,7 +1,7 @@
 export { convertContentSummaryCounts } from './content-summary';
 export { ParamHelper } from './param-helper';
 export { sanitizeDocsUrls } from './sanitize-docs-urls';
-export { mapErrorMessages } from './map-error-messages';
+export { mapErrorMessages, ErrorMessagesType } from './map-error-messages';
 export { getRepoUrl, getContainersURL } from './get-repo-url';
 export { twoWayMapper } from './two-way-mapper';
 export {

--- a/src/utilities/map-error-messages.ts
+++ b/src/utilities/map-error-messages.ts
@@ -1,7 +1,11 @@
 // Transforms the error message format from the API into an object such that
 // {<backendFieldID>: <errorMessage>}
 
-export function mapErrorMessages(err) {
+export class ErrorMessagesType {
+  [key: string]: string;
+}
+
+export function mapErrorMessages(err): ErrorMessagesType {
   const messages: any = {};
 
   // 500 errors only have err.response.data string

--- a/src/utilities/param-helper.tsx
+++ b/src/utilities/param-helper.tsx
@@ -31,7 +31,7 @@ export class ParamHelper {
 
   // Replaces specified parameter with speficied value
   static setParam(
-    p: Object,
+    p: object,
     key: string,
     value: number | string | string[] | number[],
   ) {
@@ -42,7 +42,7 @@ export class ParamHelper {
   }
 
   // Appends parameter to existing value
-  static appendParam(p: Object, key: string, value: number | string) {
+  static appendParam(p: object, key: string, value: number | string) {
     const params = cloneDeep(p);
     if (params[key]) {
       if (Array.isArray(params[key])) {
@@ -59,7 +59,7 @@ export class ParamHelper {
 
   // Returns a reduced set of parameters. Useful when not all params should
   // be passed to the API
-  static getReduced(p: Object, keys: string[]) {
+  static getReduced(p: object, keys: string[]) {
     const params = cloneDeep(p);
     for (let k of keys) {
       delete params[k];
@@ -84,7 +84,7 @@ export class ParamHelper {
   }
 
   // Checks to see if a specific key value pair exists
-  static paramExists(params: Object, key: string, value: string | number) {
+  static paramExists(params: object, key: string, value: string | number) {
     const param = params[key];
 
     if (param) {
@@ -99,7 +99,7 @@ export class ParamHelper {
   }
 
   // Returns the query string for the set of parameters
-  static getQueryString(params: Object, ignoreParams?: string[]) {
+  static getQueryString(params: object, ignoreParams?: string[]) {
     let paramString = [];
     for (const key of Object.keys(params)) {
       // skip the param if its in the list of ignored params


### PR DESCRIPTION
This enables the [`@typescript-eslint/ban-types`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/ban-types.md) from default configuration.

We had it disabled because of the following, which should be fixed here:

```
/home/himdel/ansible-hub-ui/src/api/collection.ts
  88:21  error  Don't use `String` as a type. Use string instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/api/response-types/execution-environment.ts
  15:19  error  Don't use `Number` as a type. Use number instead                                                                                                                                                                                                                                                                  @typescript-eslint/ban-types
  19:12  error  Don't use `Object` as a type. The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/cards/namespace-card.tsx
  27:60  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/collection-list/collection-filter.tsx
  16:11  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/collection-list/collection-list-item.tsx
  36:65  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/headers/base-header.tsx
  19:57  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/headers/partner-header.tsx
  25:60  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/helper-text/helper-text.tsx
  13:57  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/loading/loading-page-spinner.tsx
  4:57  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/loading/loading-with-header.tsx
  7:60  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/markdown-editor/markdown-editor.tsx
  16:61  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/my-imports/import-console.tsx
  33:60  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/namespace-form/resources-form.tsx
  26:60  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/numeric-label/numeric-label.tsx
  17:59  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/patternfly-wrappers/alert-list.tsx
  22:56  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/patternfly-wrappers/applied-filters.tsx
  28:61  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/patternfly-wrappers/clipboard-copy.tsx
  11:60  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/patternfly-wrappers/fileupload.tsx
  9:66  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/patternfly-wrappers/tooltip.tsx
  8:54  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/repositories/local-repository-table.tsx
  9:17  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/status/status-indicator.tsx
  27:62  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/tags/deprecated-tag.tsx
  4:52  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types
  4:56  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/components/tags/tag.tsx
  11:50  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/containers/execution-environment-detail/tag-manifest-modal.tsx
  40:17  error  Don't use `Number` as a type. Use number instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/containers/execution-environment/registry-list.tsx
  56:21  error  Don't use `Object` as a type. The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/containers/namespace-list/my-namespaces.tsx
  9:65  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/containers/namespace-list/partners.tsx
  7:61  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/containers/not-found/not-found.tsx
  12:61  error  Don't use `{}` as a type. `{}` actually means "any non-nullish value".
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead.
- If you want a type meaning "empty object", you probably want `Record<string, never>` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/containers/repositories/repository-list.tsx
  47:18  error  Don't use `Object` as a type. The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/ban-types

/home/himdel/ansible-hub-ui/src/utilities/param-helper.tsx
   34:8   error  Don't use `Object` as a type. The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/ban-types
   45:25  error  Don't use `Object` as a type. The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/ban-types
   62:24  error  Don't use `Object` as a type. The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/ban-types
   87:30  error  Don't use `Object` as a type. The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/ban-types
  102:33  error  Don't use `Object` as a type. The `Object` type actually means "any non-nullish value", so it is marginally better than `unknown`.
- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.
- If you want a type meaning "any value", you probably want `unknown` instead  @typescript-eslint/ban-types

✖ 36 problems (36 errors, 0 warnings)
```