### PR TITLE
eslint: enable more default rules - `no-inferrable-types`, `no-prototype-builtins`, `no-case-declarations`, `no-useless-escape`, `no-extra-boolean-cast`, `prefer-const`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,6 @@
 
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-var-requires": "off",
-    "no-prototype-builtins": "off",
     "no-useless-escape": "off",
     "prefer-const": "off",
     "react/display-name": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,6 @@
 
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-var-requires": "off",
-    "prefer-const": "off",
     "react/display-name": "off",
     "react/jsx-key": "off",
     "react/no-unescaped-entities": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,6 @@
 
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-var-requires": "off",
-    "no-useless-escape": "off",
     "prefer-const": "off",
     "react/display-name": "off",
     "react/jsx-key": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,6 @@
 
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-var-requires": "off",
-    "no-case-declarations": "off",
     "no-extra-boolean-cast": "off",
     "no-prototype-builtins": "off",
     "no-useless-escape": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -42,7 +42,6 @@
     /// Rules we're disabling until they can be fixed, or disabled permanently
 
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-inferrable-types": "off",
     "@typescript-eslint/no-var-requires": "off",
     "no-case-declarations": "off",
     "no-extra-boolean-cast": "off",

--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,6 @@
 
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-var-requires": "off",
-    "no-extra-boolean-cast": "off",
     "no-prototype-builtins": "off",
     "no-useless-escape": "off",
     "prefer-const": "off",

--- a/src/api/task-management.ts
+++ b/src/api/task-management.ts
@@ -4,7 +4,7 @@ export class API extends PulpAPI {
   apiPath = 'tasks/';
 
   list(params) {
-    let changedParams = { ...params };
+    const changedParams = { ...params };
     if (changedParams['sort']) {
       changedParams['ordering'] = changedParams['sort'];
       delete changedParams['sort'];

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -35,12 +35,12 @@ export class CollectionContentList extends React.Component<IProps> {
     const { contents, collection, namespace, params, updateParams } =
       this.props;
 
-    let toShow: ContentSummaryType[] = [];
+    const toShow: ContentSummaryType[] = [];
     const summary = { all: 0 };
     const showing = params.showing || 'all';
     const keywords = params.keywords || '';
 
-    for (let c of contents) {
+    for (const c of contents) {
       const typeMatch = showing === 'all' ? true : c.content_type === showing;
       if (!summary[c.content_type]) {
         summary[c.content_type] = 0;

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -65,7 +65,7 @@ export class CollectionListItem extends React.Component<IProps> {
       );
     }
 
-    let contentSummary = convertContentSummaryCounts(latest_version.metadata);
+    const contentSummary = convertContentSummaryCounts(latest_version.metadata);
 
     cells.push(
       <DataListCell key='content'>

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -227,7 +227,7 @@ export class RepositoryForm extends React.Component<IProps, IState> {
                 className='hub-formgroup-registry'
                 isRequired={true}
               >
-                {!!formErrors?.registries ? (
+                {formErrors?.registries ? (
                   <Alert
                     title={formErrors.registries.title}
                     variant='danger'
@@ -380,7 +380,7 @@ export class RepositoryForm extends React.Component<IProps, IState> {
             label={t`Groups with access`}
             className='hub-formgroup-groups'
           >
-            {!!formErrors?.groups ? (
+            {formErrors?.groups ? (
               <Alert title={formErrors.groups.title} variant='danger' isInline>
                 {formErrors.groups.description}
               </Alert>

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -261,7 +261,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             cancelAction={this.closeModal}
             deleteAction={() =>
               this.setState({ isDeletionPending: true }, () => {
-                !!collectionVersion
+                collectionVersion
                   ? this.deleteCollectionVersion(collectionVersion)
                   : this.deleteCollection();
               })

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -102,7 +102,7 @@ export class NamespaceForm extends React.Component<IProps, IState> {
           )}
         >
           <br />
-          {!!formErrors?.groups ? (
+          {formErrors?.groups ? (
             <Alert title={formErrors.groups.title} variant='danger' isInline>
               {formErrors.groups.description}
             </Alert>

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -157,7 +157,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
             fieldId='groups'
             helperTextInvalid={this.state.errorMessages['groups']}
           >
-            {!!formErrors?.groups ? (
+            {formErrors?.groups ? (
               <Alert title={formErrors.groups.title} variant='danger' isInline>
                 {formErrors.groups.description}
               </Alert>

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -110,22 +110,6 @@ export class CompoundFilter extends React.Component<IProps, IState> {
   private renderInput(selectedFilter: FilterOption) {
     switch (selectedFilter.inputType) {
       case 'multiple':
-        const options = selectedFilter.options.map((option) => (
-          // patternfly does not allow for us to set a display name aside from the ID
-          // which unfortunately means that multiple select will ignore the human readable
-          // option.title
-          <SelectOption key={option.id} value={option.id} />
-        ));
-
-        const toggle = [
-          <SelectGroup
-            label={t`Filter by ${selectedFilter.id}`}
-            key={selectedFilter.id}
-          >
-            {options}
-          </SelectGroup>,
-        ];
-
         return (
           <Select
             variant={SelectVariant.checkbox}
@@ -136,7 +120,19 @@ export class CompoundFilter extends React.Component<IProps, IState> {
             selections={this.props.params[this.state.selectedFilter.id]}
             isGrouped
           >
-            {toggle}
+            {[
+              <SelectGroup
+                label={t`Filter by ${selectedFilter.id}`}
+                key={selectedFilter.id}
+              >
+                {selectedFilter.options.map((option) => (
+                  // patternfly does not allow for us to set a display name aside from the ID
+                  // which unfortunately means that multiple select will ignore the human readable
+                  // option.title
+                  <SelectOption key={option.id} value={option.id} />
+                ))}
+              </SelectGroup>,
+            ]}
           </Select>
         );
       case 'select':

--- a/src/components/patternfly-wrappers/sort.tsx
+++ b/src/components/patternfly-wrappers/sort.tsx
@@ -80,7 +80,7 @@ export class Sort extends React.Component<IProps, IState> {
   }
 
   private setDescending() {
-    let field = this.getSelected(this.props.params);
+    const field = this.getSelected(this.props.params);
     const descending = !this.getIsDescending(this.props.params);
 
     this.props.updateParams(

--- a/src/components/permissions/permission-chip-selector.tsx
+++ b/src/components/permissions/permission-chip-selector.tsx
@@ -49,10 +49,8 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
         variant={SelectVariant.typeaheadMulti}
         typeAheadAriaLabel={t`Select permissions`}
         onToggle={this.onToggle}
-        onSelect={!!this.props.onSelect ? this.props.onSelect : this.onSelect}
-        onClear={
-          !!this.props.onClear ? this.props.onClear : this.clearSelection
-        }
+        onSelect={this.props.onSelect ? this.props.onSelect : this.onSelect}
+        onClear={this.props.onClear ? this.props.onClear : this.clearSelection}
         selections={this.props.selectedPermissions}
         isOpen={this.state.isOpen}
         placeholderText={this.placeholderText()}

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -38,7 +38,7 @@ export class LocalRepositoryTable extends React.Component<IProps> {
 
   private renderTable(repositories) {
     const params = { sort: 'repository' };
-    let sortTableOptions = {
+    const sortTableOptions = {
       headers: [
         {
           title: t`Distribution name`,

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -112,7 +112,7 @@ export class LocalRepositoryTable extends React.Component<IProps> {
         <td>{distribution.repository.name}</td>
         <td>{distribution.repository.content_count}</td>
         {DEPLOYMENT_MODE ===
-        Constants.INSIGHTS_DEPLOYMENT_MODE ? null : !!distribution.repository
+        Constants.INSIGHTS_DEPLOYMENT_MODE ? null : distribution.repository
             .pulp_last_updated ? (
           <td>
             <DateComponent date={distribution.repository.pulp_last_updated} />

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -51,7 +51,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
       caCertFilename,
     ] = Array(4).fill('');
 
-    if (!!props.remote) {
+    if (props.remote) {
       requirementsFilename = this.props.remote.requirements_file
         ? 'requirements.yml'
         : '';

--- a/src/components/repositories/remote-repository-table.tsx
+++ b/src/components/repositories/remote-repository-table.tsx
@@ -58,7 +58,7 @@ export class RemoteRepositoryTable extends React.Component<IProps> {
 
   private renderTable(remotes) {
     const params = { sort: 'repository' };
-    let sortTableOptions = {
+    const sortTableOptions = {
       headers: [
         {
           title: t`Remote name`,

--- a/src/components/repositories/remote-repository-table.tsx
+++ b/src/components/repositories/remote-repository-table.tsx
@@ -114,7 +114,7 @@ export class RemoteRepositoryTable extends React.Component<IProps> {
       <tr key={i}>
         <td>{remote.name}</td>
         <td>{remote.repositories.map((r) => r.name).join(', ')}</td>
-        {!!remote.updated_at ? (
+        {remote.updated_at ? (
           <td>
             <DateComponent date={remote.updated_at} />
           </td>

--- a/src/components/sort-table/sort-table.tsx
+++ b/src/components/sort-table/sort-table.tsx
@@ -39,7 +39,7 @@ export class SortTable extends React.Component<IProps> {
       return;
     }
     let Icon;
-    let activeIcon =
+    const activeIcon =
       !!this.props.params['sort'] &&
       id == this.props.params['sort'].replace('-', '');
     let isMinus = false;

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -161,7 +161,7 @@ export class UserForm extends React.Component<IProps, IState> {
         label={t`Groups`}
         validated={this.toError(!('groups' in errorMessages))}
       >
-        {!!formErrors.groups ? (
+        {formErrors.groups ? (
           <Alert title={formErrors.groups.title} variant='danger' isInline>
             {formErrors.groups.description}
           </Alert>

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -236,7 +236,7 @@ class CertificationDashboard extends React.Component<
         />
       );
     }
-    let sortTableOptions = {
+    const sortTableOptions = {
       headers: [
         {
           title: t`Namespace`,

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -108,7 +108,7 @@ class CollectionDependencies extends React.Component<
 
     const dependenciesParams = ParamHelper.getReduced(params, ['version']);
 
-    const noDependencies: boolean = !Object.keys(
+    const noDependencies = !Object.keys(
       collection.latest_version.metadata.dependencies,
     ).length;
 

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -205,7 +205,7 @@ class CollectionDocs extends React.Component<
           {name}
         </a>
       );
-    } else if (!!href) {
+    } else if (href) {
       // TODO: right now this will break if people put
       // ../ at the front of their urls. Need to find a
       // way to document this

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -204,7 +204,7 @@ export function withContainerRepo(WrappedComponent) {
                     .then((results) => {
                       let task = results.find((x) => x.data && x.data.task);
                       this.setState({ editing: false, loading: true });
-                      if (!!task) {
+                      if (task) {
                         waitForTask(
                           task.data.task.split('tasks/')[1].replace('/', ''),
                         ).then(() => {

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -144,7 +144,6 @@ export function withContainerRepo(WrappedComponent) {
       ].filter((truthy) => truthy);
 
       const { alerts, repo, publishToController, showDeleteModal } = this.state;
-      let selectedItem = repo.name;
 
       return (
         <React.Fragment>
@@ -161,7 +160,7 @@ export function withContainerRepo(WrappedComponent) {
           />
           {showDeleteModal && (
             <DeleteExecutionEnviromentModal
-              selectedItem={selectedItem}
+              selectedItem={repo.name}
               closeAction={() => this.setState({ showDeleteModal: false })}
               afterDelete={() => this.setState({ redirect: 'list' })}
               addAlert={(text, variant, description = undefined) =>

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -202,7 +202,7 @@ export function withContainerRepo(WrappedComponent) {
                 onSave={(promise) => {
                   promise
                     .then((results) => {
-                      let task = results.find((x) => x.data && x.data.task);
+                      const task = results.find((x) => x.data && x.data.task);
                       this.setState({ editing: false, loading: true });
                       if (task) {
                         waitForTask(

--- a/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
@@ -116,13 +116,13 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
     this.setState({ loading: true }, () => {
       ActivitiesAPI.list(name, this.state.page)
         .then((result) => {
-          let activities = [];
+          const activities = [];
           result.data.data.forEach((activity) => {
             {
               activity.added.forEach((action) => {
                 let activityDescription;
                 if (action.pulp_type === 'container.tag') {
-                  let removed = activity.removed.find((item) => {
+                  const removed = activity.removed.find((item) => {
                     return item.tag_name === action.tag_name;
                   });
                   if (removed) {
@@ -210,7 +210,7 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
               ),
             });
           } else {
-            let lastActivity = activities[activities.length - 1];
+            const lastActivity = activities[activities.length - 1];
             if (lastActivity) {
               activities.push({
                 created: lastActivity.created,

--- a/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
@@ -76,7 +76,7 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
                     return (
                       <tr key={i}>
                         <td>{action.action}</td>
-                        {!!action.created ? (
+                        {action.created ? (
                           <td>
                             <DateComponent date={action.created} />
                           </td>
@@ -125,7 +125,7 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
                   let removed = activity.removed.find((item) => {
                     return item.tag_name === action.tag_name;
                   });
-                  if (!!removed) {
+                  if (removed) {
                     activityDescription = (
                       <React.Fragment>
                         <Trans>
@@ -195,7 +195,7 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
               });
             }
           });
-          if (!!result.data.links.next) {
+          if (result.data.links.next) {
             this.setState({ page: this.state.page + 1 });
             activities.push({
               created: '',
@@ -211,7 +211,7 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
             });
           } else {
             let lastActivity = activities[activities.length - 1];
-            if (!!lastActivity) {
+            if (lastActivity) {
               activities.push({
                 created: lastActivity.created,
                 action: (

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -373,7 +373,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
     );
 
     const url = getContainersURL();
-    let instruction =
+    const instruction =
       image.tags.length === 0
         ? image.digest
         : this.props.match.params['container'] + ':' + image.tags[0];
@@ -587,7 +587,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
         selectedImage.digest,
       )
         .then((result) => {
-          let taskId = result.data.task.split('tasks/')[1].replace('/', '');
+          const taskId = result.data.task.split('tasks/')[1].replace('/', '');
           this.setState({
             selectedImage: null,
           });

--- a/src/containers/execution-environment-detail/tag-manifest-modal.tsx
+++ b/src/containers/execution-environment-detail/tag-manifest-modal.tsx
@@ -140,14 +140,14 @@ export class TagManifestModal extends React.Component<IProps, IState> {
         */}
         <Form onSubmit={(e) => e.preventDefault()}>
           <FormGroup
-            validated={!!tagInFormError ? 'error' : 'default'}
+            validated={tagInFormError ? 'error' : 'default'}
             helperTextInvalid={tagInFormError}
             fieldId='add-new-tag'
             label={t`Add new tag`}
           >
             <InputGroup>
               <TextInput
-                validated={!!tagInFormError ? 'error' : 'default'}
+                validated={tagInFormError ? 'error' : 'default'}
                 type='text'
                 id='add-new-tag'
                 value={tagInForm}

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -274,7 +274,7 @@ class ExecutionEnvironmentList extends React.Component<
       return <EmptyStateFilter />;
     }
 
-    let sortTableOptions = {
+    const sortTableOptions = {
       headers: [
         {
           title: t`Container repository name`,

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -167,7 +167,7 @@ class ExecutionEnvironmentList extends React.Component<
 
         {showDeleteModal && (
           <DeleteExecutionEnviromentModal
-            selectedItem={!!selectedItem ? selectedItem.name : ''}
+            selectedItem={selectedItem ? selectedItem.name : ''}
             closeAction={() =>
               this.setState({ showDeleteModal: false, selectedItem: null })
             }

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -165,7 +165,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
             updateRemote={(r: RemoteType) => this.setState({ remoteToEdit: r })}
             saveRemote={() => {
               const { remoteFormNew, remoteToEdit } = this.state;
-              let newRemote = { ...remoteToEdit };
+              const newRemote = { ...remoteToEdit };
 
               if (remoteFormNew) {
                 // prevent "This field may not be blank." when writing in and then deleting username/password/etc
@@ -177,7 +177,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
                 });
               }
 
-              let promise = remoteFormNew
+              const promise = remoteFormNew
                 ? ExecutionEnvironmentRegistryAPI.create(newRemote)
                 : ExecutionEnvironmentRegistryAPI.smartUpdate(
                     remoteToEdit.pk,
@@ -315,7 +315,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
       return <EmptyStateFilter />;
     }
 
-    let sortTableOptions = {
+    const sortTableOptions = {
       headers: [
         {
           title: t`Name`,

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -322,7 +322,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     }
     if (isUserMgmtDisabled) {
       Constants.USER_GROUP_MGMT_PERMISSIONS.forEach((perm) => {
-        if (filteredPermissions.hasOwnProperty(perm)) {
+        if (perm in filteredPermissions) {
           delete filteredPermissions[perm];
         }
       });

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -316,7 +316,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
     } = this.state;
     const { user, featureFlags } = this.context;
     let isUserMgmtDisabled = false;
-    let filteredPermissions = { ...Constants.HUMAN_PERMISSIONS };
+    const filteredPermissions = { ...Constants.HUMAN_PERMISSIONS };
     if (featureFlags) {
       isUserMgmtDisabled = featureFlags.external_authentication;
     }
@@ -735,7 +735,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
       return <EmptyStateFilter />;
     }
 
-    let sortTableOptions = {
+    const sortTableOptions = {
       headers: [
         {
           title: t`Username`,

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -359,7 +359,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
       return <EmptyStateFilter />;
     }
 
-    let sortTableOptions = {
+    const sortTableOptions = {
       headers: [
         {
           title: t`Group`,

--- a/src/containers/namespace-detail/import-modal/import-modal.tsx
+++ b/src/containers/namespace-detail/import-modal/import-modal.tsx
@@ -36,7 +36,7 @@ interface IState {
 export class ImportModal extends React.Component<IProps, IState> {
   acceptedFileTypes = ['application/x-gzip', 'application/gzip'];
   cancelToken: any;
-  COLLECTION_NAME_REGEX = /[0-9a-z_]+\-[0-9a-z_]+\-[0-9A-Za-z.+-]+/;
+  COLLECTION_NAME_REGEX = /[0-9a-z_]+-[0-9a-z_]+-[0-9A-Za-z.+-]+/;
 
   constructor(props) {
     super(props);

--- a/src/containers/namespace-detail/import-modal/import-modal.tsx
+++ b/src/containers/namespace-detail/import-modal/import-modal.tsx
@@ -214,7 +214,7 @@ export class ImportModal extends React.Component<IProps, IState> {
           // Upload fails
           if (errors.response.data.errors) {
             const messages = [];
-            for (let err of errors.response.data.errors) {
+            for (const err of errors.response.data.errors) {
               messages.push(
                 err.detail ||
                   err.title ||

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -141,7 +141,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    let extra = [];
+    const extra = [];
 
     if (user?.model_permissions?.add_namespace) {
       extra.push(

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -218,7 +218,7 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
     if (items.length === 0) {
       return <EmptyStateFilter />;
     }
-    let sortTableOptions = {
+    const sortTableOptions = {
       headers: [
         {
           title: t`Task name`,
@@ -269,7 +269,7 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
   private renderTableRow(item: any, index: number) {
     const { name, state, pulp_created, started_at, finished_at, pulp_href } =
       item;
-    let taskId = parsePulpIDFromURL(pulp_href);
+    const taskId = parsePulpIDFromURL(pulp_href);
     return (
       <tr aria-labelledby={name} key={index}>
         <td>

--- a/src/containers/task-management/task_detail.tsx
+++ b/src/containers/task-management/task_detail.tsx
@@ -216,7 +216,7 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
                       <DescriptionListDescription>
                         {childTasks.length
                           ? childTasks.map((childTask) => {
-                              let childTaskId = parsePulpIDFromURL(
+                              const childTaskId = parsePulpIDFromURL(
                                 childTask.pulp_href,
                               );
                               return (
@@ -403,22 +403,22 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
   }
 
   private loadContent() {
-    let taskId = this.props.match.params['task'];
+    const taskId = this.props.match.params['task'];
     if (!this.state.refresh && !this.state.task) {
       this.setState({ refresh: setInterval(() => this.loadContent(), 10000) });
     }
     return TaskManagementAPI.get(taskId)
       .then((result) => {
-        let allRelatedTasks = [];
+        const allRelatedTasks = [];
         let parentTask = null;
-        let childTasks = [];
-        let resources = [];
+        const childTasks = [];
+        const resources = [];
         if (['canceled', 'completed', 'failed'].includes(result.data.state)) {
           clearInterval(this.state.refresh);
           this.setState({ refresh: null });
         }
         if (result.data.parent_task) {
-          let parentTaskId = parsePulpIDFromURL(result.data.parent_task);
+          const parentTaskId = parsePulpIDFromURL(result.data.parent_task);
           allRelatedTasks.push(
             TaskManagementAPI.get(parentTaskId)
               .then((result) => {
@@ -431,7 +431,7 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
         }
         if (result.data.child_tasks.length) {
           result.data.child_tasks.forEach((child) => {
-            let childTaskId = parsePulpIDFromURL(child);
+            const childTaskId = parsePulpIDFromURL(child);
             allRelatedTasks.push(
               TaskManagementAPI.get(childTaskId)
                 .then((result) => {
@@ -445,10 +445,10 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
         }
         if (result.data.reserved_resources_record.length) {
           result.data.reserved_resources_record.forEach((resource) => {
-            let url = resource.replace('/pulp/api/v3/', '');
-            let id = parsePulpIDFromURL(url);
-            let urlParts = resource.split('/');
-            let type = id ? urlParts[4] : urlParts[urlParts.length - 2];
+            const url = resource.replace('/pulp/api/v3/', '');
+            const id = parsePulpIDFromURL(url);
+            const urlParts = resource.split('/');
+            const type = id ? urlParts[4] : urlParts[urlParts.length - 2];
             if (id) {
               allRelatedTasks.push(
                 GenericPulpAPI.get(url)

--- a/src/containers/task-management/task_detail.tsx
+++ b/src/containers/task-management/task_detail.tsx
@@ -100,13 +100,13 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
     } = this.state;
     const breadcrumbs = [
       { url: Paths.taskList, name: t`Task management` },
-      { name: !!task ? taskName : '' },
+      { name: task ? taskName : '' },
     ];
     let parentTaskId = null;
-    if (!!parentTask) {
+    if (parentTask) {
       parentTaskId = parsePulpIDFromURL(parentTask.pulp_href);
     }
-    if (!!redirect) {
+    if (redirect) {
       return <Redirect to={redirect}></Redirect>;
     }
 
@@ -191,13 +191,13 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
                     <DescriptionListGroup>
                       <DescriptionListTerm>{t`Task group`}</DescriptionListTerm>
                       <DescriptionListDescription>
-                        {!!task.task_group ? task.task_group : t`No task group`}
+                        {task.task_group ? task.task_group : t`No task group`}
                       </DescriptionListDescription>
                     </DescriptionListGroup>
                     <DescriptionListGroup>
                       <DescriptionListTerm>{t`Parent task`}</DescriptionListTerm>
                       <DescriptionListDescription>
-                        {!!parentTask ? (
+                        {parentTask ? (
                           <Link
                             to={formatPath(Paths.taskDetail, {
                               task: parentTaskId,
@@ -214,7 +214,7 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
                     <DescriptionListGroup>
                       <DescriptionListTerm>{t`Child tasks`}</DescriptionListTerm>
                       <DescriptionListDescription>
-                        {!!childTasks.length
+                        {childTasks.length
                           ? childTasks.map((childTask) => {
                               let childTaskId = parsePulpIDFromURL(
                                 childTask.pulp_href,
@@ -246,7 +246,7 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
                     {t`Reserve resources`}
                   </Title>
                   <br />
-                  {!!resources.length ? (
+                  {resources.length ? (
                     <DescriptionList isHorizontal>
                       {resources.map((resource, index) => {
                         return (
@@ -287,7 +287,7 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
                       {t`Progress messages`}
                     </Title>
                     <br />
-                    {!!task.progress_reports.length ? (
+                    {task.progress_reports.length ? (
                       <DescriptionList isHorizontal>
                         {task.progress_reports
                           .reverse()
@@ -417,7 +417,7 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
           clearInterval(this.state.refresh);
           this.setState({ refresh: null });
         }
-        if (!!result.data.parent_task) {
+        if (result.data.parent_task) {
           let parentTaskId = parsePulpIDFromURL(result.data.parent_task);
           allRelatedTasks.push(
             TaskManagementAPI.get(parentTaskId)
@@ -429,7 +429,7 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
               }),
           );
         }
-        if (!!result.data.child_tasks.length) {
+        if (result.data.child_tasks.length) {
           result.data.child_tasks.forEach((child) => {
             let childTaskId = parsePulpIDFromURL(child);
             allRelatedTasks.push(
@@ -443,13 +443,13 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
             );
           });
         }
-        if (!!result.data.reserved_resources_record.length) {
+        if (result.data.reserved_resources_record.length) {
           result.data.reserved_resources_record.forEach((resource) => {
             let url = resource.replace('/pulp/api/v3/', '');
             let id = parsePulpIDFromURL(url);
             let urlParts = resource.split('/');
-            let type = !!id ? urlParts[4] : urlParts[urlParts.length - 2];
-            if (!!id) {
+            let type = id ? urlParts[4] : urlParts[urlParts.length - 2];
+            if (id) {
               allRelatedTasks.push(
                 GenericPulpAPI.get(url)
                   .then((result) => {

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -67,9 +67,9 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
     const { tokenData, alerts } = this.state;
     const renewTokenCmd = `curl https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token -d grant_type=refresh_token -d client_id="${
       user.username
-    }" -d refresh_token=\"${
+    }" -d refresh_token="${
       tokenData?.refresh_token ?? '{{ user_token }}'
-    }\" --fail --silent --show-error --output /dev/null`;
+    }" --fail --silent --show-error --output /dev/null`;
 
     return (
       <React.Fragment>

--- a/src/containers/token/token-standalone.tsx
+++ b/src/containers/token/token-standalone.tsx
@@ -34,7 +34,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
   }
   render() {
     const { token, alerts } = this.state;
-    let unauthorised = !this.context.user || this.context.user.is_anonymous;
+    const unauthorised = !this.context.user || this.context.user.is_anonymous;
     const expiration = this.context.settings.GALAXY_TOKEN_EXPIRATION;
     const expirationDate = new Date(Date.now() + 1000 * 60 * expiration);
 

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -253,7 +253,7 @@ class UserList extends React.Component<RouteComponentProps, IState> {
       );
     }
 
-    let sortTableOptions = {
+    const sortTableOptions = {
       headers: [
         {
           title: t`Username`,

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -96,7 +96,7 @@ class AuthHandler extends React.Component<
     // to check for an active user.
     const { user, settings } = this.context;
     if (!user || !settings) {
-      let promises = [];
+      const promises = [];
       promises.push(
         FeatureFlagsAPI.get().then(({ data }) => {
           // we need this even if ActiveUserAPI fails, otherwise isExternalAuth will always be false, breaking keycloak redirect

--- a/src/utilities/content-summary.ts
+++ b/src/utilities/content-summary.ts
@@ -25,7 +25,7 @@ export function convertContentSummaryCounts(
     },
   };
 
-  for (let c of content) {
+  for (const c of content) {
     if (c.content_type === 'role') {
       summary.contents.role++;
     } else if (c.content_type === 'module') {

--- a/src/utilities/get-repo-url.ts
+++ b/src/utilities/get-repo-url.ts
@@ -2,9 +2,9 @@
 export function getRepoUrl(distributionPath: string) {
   // If the api is hosted on another URL, use API_HOST as the host part of the URL.
   // Otherwise use the host that the UI is served from
-  const host = !!API_HOST ? API_HOST : window.location.origin;
+  const host = API_HOST ? API_HOST : window.location.origin;
 
-  return !!distributionPath
+  return distributionPath
     ? `${host}${API_BASE_PATH}content/${distributionPath}/`
     : `${host}${API_BASE_PATH}`;
 }

--- a/src/utilities/param-helper.tsx
+++ b/src/utilities/param-helper.tsx
@@ -61,7 +61,7 @@ export class ParamHelper {
   // be passed to the API
   static getReduced(p: object, keys: string[]) {
     const params = cloneDeep(p);
-    for (let k of keys) {
+    for (const k of keys) {
       delete params[k];
     }
 
@@ -100,7 +100,8 @@ export class ParamHelper {
 
   // Returns the query string for the set of parameters
   static getQueryString(params: object, ignoreParams?: string[]) {
-    let paramString = [];
+    const paramString = [];
+
     for (const key of Object.keys(params)) {
       // skip the param if its in the list of ignored params
       if (ignoreParams && ignoreParams.includes(key)) {

--- a/src/utilities/truncate_sha.ts
+++ b/src/utilities/truncate_sha.ts
@@ -1,4 +1,4 @@
 export function truncateSha(sha) {
-  let splitSha = sha.split(':');
+  const splitSha = sha.split(':');
   return splitSha[0] + ':' + splitSha[1].slice(0, 8);
 }


### PR DESCRIPTION
Reenabling more eslint default rules and fixing the code:

---

eslint: enable `@typescript-eslint/no-inferrable-types`

    /home/himdel/ansible-hub-ui/src/containers/collection-detail/collection-dependencies.tsx
      111:11  error  Type boolean trivially inferred from a boolean literal, remove type annotation  @typescript-eslint/no-inferrable-types

---

eslint: enable `no-prototype-builtins`

    /home/himdel/ansible-hub-ui/src/containers/group-management/group-detail.tsx
      325:33  error  Do not access Object.prototype method 'hasOwnProperty' from target object  no-prototype-builtins

---

eslint: enable `no-case-declarations`

    /home/himdel/ansible-hub-ui/src/components/patternfly-wrappers/compound-filter.tsx
      113:9  error  Unexpected lexical declaration in case block  no-case-declarations
      120:9  error  Unexpected lexical declaration in case block  no-case-declarations

---

eslint: enable `no-useless-escape`

    /home/himdel/ansible-hub-ui/src/containers/namespace-detail/import-modal/import-modal.tsx
      39:38  error  Unnecessary escape character: \-  no-useless-escape
      39:50  error  Unnecessary escape character: \-  no-useless-escape

    /home/himdel/ansible-hub-ui/src/containers/token/token-insights.tsx
      70:25  error  Unnecessary escape character: \"  no-useless-escape
      72:6   error  Unnecessary escape character: \"  no-useless-escape

---

eslint: enable `no-extra-boolean-cast`

    /home/himdel/ansible-hub-ui/src/components/execution-environment/repository-form.tsx
      230:18  error  Redundant double negation  no-extra-boolean-cast
      383:14  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/components/headers/collection-header.tsx
      262:17  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/components/namespace-form/namespace-form.tsx
      104:12  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/components/namespace-modal/namespace-modal.tsx
      153:14  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/components/permissions/permission-chip-selector.tsx
      52:19  error  Redundant double negation  no-extra-boolean-cast
      54:11  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/components/repositories/local-repository-table.tsx
      107:53  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/components/repositories/remote-form.tsx
      54:9  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/components/repositories/remote-repository-table.tsx
      117:10  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/components/user-form/user-form.tsx
      164:10  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/containers/collection-detail/collection-docs.tsx
      208:16  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/containers/execution-environment-detail/base.tsx
      170:27  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
      79:26  error  Redundant double negation  no-extra-boolean-cast
      128:23  error  Redundant double negation  no-extra-boolean-cast
      198:15  error  Redundant double negation  no-extra-boolean-cast
      214:17  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/containers/execution-environment-detail/tag-manifest-modal.tsx
      143:24  error  Redundant double negation  no-extra-boolean-cast
      150:28  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/containers/execution-environment-list/execution_environment_list.tsx
      163:18  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/containers/task-management/task_detail.tsx
      103:15  error  Redundant double negation  no-extra-boolean-cast
      106:9   error  Redundant double negation  no-extra-boolean-cast
      109:9   error  Redundant double negation  no-extra-boolean-cast
      191:26  error  Redundant double negation  no-extra-boolean-cast
      197:26  error  Redundant double negation  no-extra-boolean-cast
      214:26  error  Redundant double negation  no-extra-boolean-cast
      246:20  error  Redundant double negation  no-extra-boolean-cast
      287:22  error  Redundant double negation  no-extra-boolean-cast
      416:13  error  Redundant double negation  no-extra-boolean-cast
      428:13  error  Redundant double negation  no-extra-boolean-cast
      442:13  error  Redundant double negation  no-extra-boolean-cast
      447:24  error  Redundant double negation  no-extra-boolean-cast
      448:17  error  Redundant double negation  no-extra-boolean-cast

    /home/himdel/ansible-hub-ui/src/utilities/get-repo-url.ts
      5:16  error  Redundant double negation  no-extra-boolean-cast
      7:10  error  Redundant double negation  no-extra-boolean-cast

---

eslint: enable `prefer-const`

    /home/himdel/ansible-hub-ui/src/api/task-management.ts
      7:9  error  'changedParams' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/components/collection-detail/collection-content-list.tsx
      38:9   error  'toShow' is never reassigned. Use 'const' instead  prefer-const
      43:14  error  'c' is never reassigned. Use 'const' instead       prefer-const

    /home/himdel/ansible-hub-ui/src/components/collection-list/collection-list-item.tsx
      68:9  error  'contentSummary' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/components/patternfly-wrappers/sort.tsx
      83:9  error  'field' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/components/repositories/local-repository-table.tsx
      33:9  error  'sortTableOptions' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/components/repositories/remote-repository-table.tsx
      61:9  error  'sortTableOptions' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/components/sort-table/sort-table.tsx
      42:9  error  'activeIcon' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/containers/certification-dashboard/certification-dashboard.tsx
      239:9  error  'sortTableOptions' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/containers/execution-environment-detail/base.tsx
      168:27  error  'task' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
      119:15  error  'activities' is never reassigned. Use 'const' instead    prefer-const
      125:23  error  'removed' is never reassigned. Use 'const' instead       prefer-const
      213:17  error  'lastActivity' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
      368:9   error  'instruction' is never reassigned. Use 'const' instead  prefer-const
      582:15  error  'taskId' is never reassigned. Use 'const' instead       prefer-const

    /home/himdel/ansible-hub-ui/src/containers/execution-environment-list/execution_environment_list.tsx
      294:9  error  'sortTableOptions' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/containers/execution-environment/registry-list.tsx
      167:19  error  'newRemote' is never reassigned. Use 'const' instead         prefer-const
      179:19  error  'promise' is never reassigned. Use 'const' instead           prefer-const
      314:9   error  'sortTableOptions' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/containers/group-management/group-detail.tsx
      319:9  error  'filteredPermissions' is never reassigned. Use 'const' instead  prefer-const
      738:9  error  'sortTableOptions' is never reassigned. Use 'const' instead     prefer-const

    /home/himdel/ansible-hub-ui/src/containers/group-management/group-list.tsx
      357:9  error  'sortTableOptions' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/containers/namespace-detail/import-modal/import-modal.tsx
      217:22  error  'err' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/containers/namespace-list/namespace-list.tsx
      144:9  error  'extra' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/containers/task-management/task-list-view.tsx
      221:9  error  'sortTableOptions' is never reassigned. Use 'const' instead  prefer-const
      269:9  error  'taskId' is never reassigned. Use 'const' instead            prefer-const

    /home/himdel/ansible-hub-ui/src/containers/task-management/task_detail.tsx
      216:35  error  'childTaskId' is never reassigned. Use 'const' instead      prefer-const
      402:9   error  'taskId' is never reassigned. Use 'const' instead           prefer-const
      408:13  error  'allRelatedTasks' is never reassigned. Use 'const' instead  prefer-const
      410:13  error  'childTasks' is never reassigned. Use 'const' instead       prefer-const
      411:13  error  'resources' is never reassigned. Use 'const' instead        prefer-const
      417:15  error  'parentTaskId' is never reassigned. Use 'const' instead     prefer-const
      430:17  error  'childTaskId' is never reassigned. Use 'const' instead      prefer-const
      444:17  error  'url' is never reassigned. Use 'const' instead              prefer-const
      445:17  error  'id' is never reassigned. Use 'const' instead               prefer-const
      446:17  error  'urlParts' is never reassigned. Use 'const' instead         prefer-const
      447:17  error  'type' is never reassigned. Use 'const' instead             prefer-const

    /home/himdel/ansible-hub-ui/src/containers/token/token-standalone.tsx
      37:9  error  'unauthorised' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/containers/user-management/user-list.tsx
      256:9  error  'sortTableOptions' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/loaders/standalone/routes.tsx
      99:11  error  'promises' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/utilities/content-summary.ts
      28:12  error  'c' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/utilities/param-helper.tsx
      64:14  error  'k' is never reassigned. Use 'const' instead            prefer-const
      103:9   error  'paramString' is never reassigned. Use 'const' instead  prefer-const

    /home/himdel/ansible-hub-ui/src/utilities/truncate_sha.ts
      2:7  error  'splitSha' is never reassigned. Use 'const' instead  prefer-const
