### PR TITLE
eslint - enable react default rules - `prop-types`, `no-children-prop`, `jsx-no-target-blank`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -52,7 +52,6 @@
     "prefer-const": "off",
     "react/display-name": "off",
     "react/jsx-key": "off",
-    "react/no-children-prop": "off",
     "react/no-unescaped-entities": "off",
     "react/prop-types": "off",
   },

--- a/.eslintrc
+++ b/.eslintrc
@@ -53,6 +53,5 @@
     "react/display-name": "off",
     "react/jsx-key": "off",
     "react/no-unescaped-entities": "off",
-    "react/prop-types": "off",
   },
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -52,7 +52,6 @@
     "prefer-const": "off",
     "react/display-name": "off",
     "react/jsx-key": "off",
-    "react/jsx-no-target-blank": "off",
     "react/no-children-prop": "off",
     "react/no-unescaped-entities": "off",
     "react/prop-types": "off",

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -208,7 +208,7 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
 
           return (
             <ListItem style={{ paddingTop: '8px' }}>
-              <a href={href} target='_blank'>
+              <a href={href} target='_blank' rel='noreferrer'>
                 {host}
               </a>{' '}
               {unsafeLinksSupported && (
@@ -258,7 +258,7 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
         {t`If the Controller is not listed in the table, check settings.py.`}{' '}
         {docsLink && (
           <>
-            <a href={docsLink} target='_blank'>
+            <a href={docsLink} target='_blank' rel='noreferrer'>
               {t`Learn more`}
             </a>{' '}
             <ExternalLinkAltIcon />

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -219,11 +219,12 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
               {!unsafeLinksSupported && (
                 <ClipboardCopyButton
                   variant={'plain'}
-                  children={t`Copy to clipboard`}
                   id={href}
                   textId={t`Copy to clipboard`}
                   onClick={() => navigator.clipboard.writeText(href)}
-                />
+                >
+                  {t`Copy to clipboard`}
+                </ClipboardCopyButton>
               )}
             </ListItem>
           );

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -427,7 +427,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
                 return (
                   <div className='link' key={link.key}>
-                    <a href={url} target='_blank'>
+                    <a href={url} target='_blank' rel='noreferrer'>
                       {link.name}
                     </a>
                   </div>

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -145,6 +145,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
       <a
         target='_blank'
         href='https://docs.ansible.com/ansible/latest/user_guide/collections_using.html#install-multiple-collections-with-a-requirements-file'
+        rel='noreferrer'
       >
         requirements.yml
       </a>

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -201,7 +201,7 @@ class CollectionDocs extends React.Component<
   private renderDocLink(name, href, collection, params) {
     if (!!href && href.startsWith('http')) {
       return (
-        <a href={href} target='_blank'>
+        <a href={href} target='_blank' rel='noreferrer'>
           {name}
         </a>
       );

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -126,10 +126,11 @@ class ExecutionEnvironmentManifest extends React.Component<
               className='eco-clipboard-copy'
               variant={'plain'}
               onClick={() => navigator.clipboard.writeText(digest)}
-              children={digest}
               id={digest}
               textId={t`Copy to clipboard`}
-            />
+            >
+              {digest}
+            </ClipboardCopyButton>
           </div>
 
           <LabelGroup numLabels={6}>

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -221,12 +221,11 @@ class ExecutionEnvironmentRegistryList extends React.Component<
             }
             deleteAction={() => this.deleteRegistry(remoteToEdit)}
             title={t`Delete remote registry?`}
-            children={
-              <Trans>
-                <b>{remoteToEdit.name}</b> will be deleted.
-              </Trans>
-            }
-          />
+          >
+            <Trans>
+              <b>{remoteToEdit.name}</b> will be deleted.
+            </Trans>
+          </DeleteModal>
         )}
         <BaseHeader title={t`Remote Registries`}></BaseHeader>
         {noData && !loading ? (

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -315,6 +315,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                     <a
                       href='https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#configuring-the-ansible-galaxy-client'
                       target='_blank'
+                      rel='noreferrer'
                     >
                       here
                     </a>

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -338,10 +338,9 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
       <ConfirmModal
         cancelAction={() => this.setState({ cancelModalVisible: false })}
         title={t`Stop task?`}
-        children={t`${name} will be cancelled.`}
         confirmAction={() => this.selectedTask(this.state.selectedTask, name)}
         confirmButtonTitle={t`Yes, stop`}
-      />
+      >{t`${name} will be cancelled.`}</ConfirmModal>
     );
   }
 

--- a/src/containers/task-management/task_detail.tsx
+++ b/src/containers/task-management/task_detail.tsx
@@ -355,9 +355,10 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
         cancelAction={() => this.setState({ cancelModalVisible: false })}
         confirmAction={() => this.cancelTask()}
         title={t`Stop task`}
-        children={t`${name} will stop running.`}
         confirmButtonTitle={t`Yes, stop`}
-      />
+      >
+        {t`${name} will stop running.`}
+      </ConfirmModal>
     );
   }
 

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -102,6 +102,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
                 <a
                   href='https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/'
                   target='_blank'
+                  rel='noreferrer'
                 >
                   here
                 </a>
@@ -154,6 +155,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
               <a
                 href='https://sso.redhat.com/auth/realms/redhat-external/account/applications'
                 target='_blank'
+                rel='noreferrer'
               >
                 offline API token management
               </a>{' '}

--- a/src/loaders/insights/Routes.js
+++ b/src/loaders/insights/Routes.js
@@ -300,3 +300,11 @@ export const Routes = (props) => {
     </Switch>
   );
 };
+
+Routes.propTypes = {
+  childProps: PropTypes.shape({
+    location: PropTypes.shape({
+      pathname: PropTypes.string,
+    }),
+  }),
+};

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -154,6 +154,9 @@ class App extends Component {
 App.propTypes = {
   history: PropTypes.object,
   basename: PropTypes.string.isRequired,
+  location: PropTypes.shape({
+    pathname: PropTypes.string,
+  }),
 };
 
 /**

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -238,7 +238,12 @@ class App extends React.Component<RouteComponentProps, IState> {
           }}
         >
           {item.url && item.external ? (
-            <a href={item.url} data-cy={item['data-cy']} target='_blank'>
+            <a
+              href={item.url}
+              data-cy={item['data-cy']}
+              target='_blank'
+              rel='noreferrer'
+            >
               {item.name}
               <ExternalLinkAltIcon
                 style={{ position: 'absolute', right: '32px' }}


### PR DESCRIPTION
eslint: enable `react/prop-types`

    /home/himdel/ansible-hub-ui/src/loaders/insights/Routes.js
      162:22  error  'childProps' is missing in props validation                    react/prop-types
      162:33  error  'childProps.location' is missing in props validation           react/prop-types
      162:42  error  'childProps.location.pathname' is missing in props validation  react/prop-types

    /home/himdel/ansible-hub-ui/src/loaders/insights/insights-loader.js
      89:45  error  'location' is missing in props validation           react/prop-types
      89:54  error  'location.pathname' is missing in props validation  react/prop-types
      112:45  error  'location' is missing in props validation           react/prop-types
      112:54  error  'location.pathname' is missing in props validation  react/prop-types


eslint: enable `react/no-children-prop`

    /home/himdel/ansible-hub-ui/src/components/execution-environment/publish-to-controller-modal.tsx
      222:19  error  Do not pass children as props. Instead, nest children between the opening and closing tags  react/no-children-prop

    /home/himdel/ansible-hub-ui/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
      129:15  error  Do not pass children as props. Instead, nest children between the opening and closing tags  react/no-children-prop

    /home/himdel/ansible-hub-ui/src/containers/execution-environment/registry-list.tsx
      224:13  error  Do not pass children as props. Instead, nest children between the opening and closing tags  react/no-children-prop

    /home/himdel/ansible-hub-ui/src/containers/task-management/task-list-view.tsx
      341:9  error  Do not pass children as props. Instead, nest children between the opening and closing tags  react/no-children-prop

    /home/himdel/ansible-hub-ui/src/containers/task-management/task_detail.tsx
      358:9  error  Do not pass children as props. Instead, nest children between the opening and closing tags  react/no-children-prop


eslint: enable `react/jsx-no-target-blank`

    /home/himdel/ansible-hub-ui/src/components/execution-environment/publish-to-controller-modal.tsx
      211:15  error  Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank
      261:13  error  Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank

    /home/himdel/ansible-hub-ui/src/components/headers/collection-header.tsx
      430:21  error  Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank

    /home/himdel/ansible-hub-ui/src/components/repositories/remote-form.tsx
      145:7  error  Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank

    /home/himdel/ansible-hub-ui/src/containers/collection-detail/collection-docs.tsx
      204:9  error  Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank

    /home/himdel/ansible-hub-ui/src/containers/namespace-detail/namespace-detail.tsx
      315:21  error  Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank

    /home/himdel/ansible-hub-ui/src/containers/token/token-insights.tsx
      102:17  error  Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank
      154:15  error  Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank

    /home/himdel/ansible-hub-ui/src/loaders/standalone/standalone-loader.tsx
      241:13  error  Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations  react/jsx-no-target-blank