### PR TITLE
Disable enter on submit empty filter string, disable empty filter from params URL

### DIFF
--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -181,7 +181,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
 
   private handleEnter(e) {
     // l10n: don't translate
-    if (e.key === 'Enter' && this.props.inputText.length > 0) {
+    if (e.key === 'Enter' && this.props.inputText.trim().length > 0) {
       this.submitFilter();
     }
   }

--- a/src/utilities/param-helper.tsx
+++ b/src/utilities/param-helper.tsx
@@ -13,7 +13,9 @@ export class ParamHelper {
 
     paramObj.forEach((val, key) => {
       // do not append empty values at all (this will disable searching by empty strings)
-      if (val.trim().length == 0) return;
+      if (val.trim().length == 0) {
+        return;
+      }
 
       // Parse value as number if it's included in the list of numeric
       // types.

--- a/src/utilities/param-helper.tsx
+++ b/src/utilities/param-helper.tsx
@@ -12,6 +12,9 @@ export class ParamHelper {
     let v;
 
     paramObj.forEach((val, key) => {
+      // do not append empty values at all (this will disable searching by empty strings)
+      if (val.trim().length == 0) return;
+
       // Parse value as number if it's included in the list of numeric
       // types.
       // It seems like there should be a better way to do this based off


### PR DESCRIPTION
This PR corrects previous PR, which was incomplete:

https://github.com/ansible/ansible-hub-ui/pull/1195
AAH-820

It disables enter (submit) when user fills only empty filter text. It also does not add empty filter parameters from URL to container component state.