### PR TITLE
eslintrc: enable more default rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,7 +41,6 @@
 
     /// Rules we're disabling until they can be fixed, or disabled permanently
 
-    "@typescript-eslint/no-explicit-any": "off",
     "react/jsx-key": "off",
   },
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,7 @@
     NAMESPACE_TERM: "readonly",
   },
   rules: {
-    /// Rules we actually want - some are disabled until a separate PR because they cause many errors
+    /// Rules we actually want
 
     "curly": ["error", "all"],
     "eol-last": ["error", "always"],
@@ -45,6 +45,5 @@
     "@typescript-eslint/no-var-requires": "off",
     "react/display-name": "off",
     "react/jsx-key": "off",
-    "react/no-unescaped-entities": "off",
   },
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -43,7 +43,6 @@
 
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-var-requires": "off",
-    "react/display-name": "off",
     "react/jsx-key": "off",
   },
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -42,7 +42,6 @@
     /// Rules we're disabling until they can be fixed, or disabled permanently
 
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-var-requires": "off",
     "react/jsx-key": "off",
   },
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -27,20 +27,11 @@
     NAMESPACE_TERM: "readonly",
   },
   rules: {
-    /// Rules we actually want
-
     "curly": ["error", "all"],
     "eol-last": ["error", "always"],
     "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
 
-
-    /// Rules to add from previous config (see #860)
-
+    /// FIXME: Rules to add from previous config (see #860)
     // array-bracket-spacing camelcase comma-dangle comma-spacing comma-style curly dot-notation eol-last eqeqeq func-names indent key-spacing keyword-spacing linebreak-style max-len new-cap no-bitwise no-caller no-mixed-spaces-and-tabs no-multiple-empty-lines no-trailing-spaces no-undef no-unused-vars no-use-before-define no-var no-with object-curly-spacing object-shorthand one-var padding-line-between-statements quote-props quotes react/jsx-curly-spacing semi space-before-blocks space-in-parens space-infix-ops space-unary-ops vars-on-top wrap-iife yoda
-
-
-    /// Rules we're disabling until they can be fixed, or disabled permanently
-
-    "react/jsx-key": "off",
   },
 }

--- a/config/.eslintrc
+++ b/config/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/no-var-requires": "off"
+  }
+}

--- a/src/api/active-user.ts
+++ b/src/api/active-user.ts
@@ -11,7 +11,7 @@ class API extends HubAPI {
   getUser(): Promise<any> {
     if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
       return new Promise((resolve, reject) => {
-        (window as any).insights.chrome.auth
+        window.insights.chrome.auth
           .getUser()
           // we don't care about entitlements stuff in the UI, so just
           // return the user's identity
@@ -45,10 +45,11 @@ class API extends HubAPI {
     if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
       return new Promise((resolve, reject) => {
         reject(
-          'Use window.chrome.insights.auth to get tokens for insights deployments',
+          'Use window.insights.chrome.auth to get tokens for insights deployments',
         );
       });
     }
+
     return this.http.post('v3/auth/token/', {});
   }
 

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -48,11 +48,11 @@ export class BaseAPI {
     return this.http.get(this.getPath(apiPath) + id + '/');
   }
 
-  update(id: string | number, data: any, apiPath?: string) {
+  update(id: string | number, data, apiPath?: string) {
     return this.http.put(this.getPath(apiPath) + id + '/', data);
   }
 
-  create(data: any, apiPath?: string) {
+  create(data, apiPath?: string) {
     return this.http.post(this.getPath(apiPath), data);
   }
 
@@ -60,7 +60,7 @@ export class BaseAPI {
     return this.http.delete(this.getPath(apiPath) + id + '/');
   }
 
-  patch(id: string | number, data: any, apiPath?: string) {
+  patch(id: string | number, data, apiPath?: string) {
     return this.http.patch(this.getPath(apiPath) + id + '/', data);
   }
 
@@ -73,7 +73,7 @@ export class BaseAPI {
     // authenticated before the request is executed. On most calls it appears
     // to only add ~10ms of latency.
     if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
-      await (window as any).insights.chrome.auth.getUser();
+      await window.insights.chrome.auth.getUser();
     }
     if (DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE) {
       request.headers['X-CSRFToken'] = Cookies.get('csrftoken');

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -56,7 +56,7 @@ export class API extends HubAPI {
     super();
   }
 
-  list(params?: any, repo?: string) {
+  list(params?, repo?: string) {
     const path = this.apiPath + repo + '/';
     return super.list(params, path).then((response) => ({
       ...response,
@@ -88,7 +88,7 @@ export class API extends HubAPI {
     repositoryPath: string,
     data: CollectionUploadType,
     progressCallback: (e) => void,
-    cancelToken?: any,
+    cancelToken?,
   ) {
     const formData = new FormData();
     formData.append('file', data.file);
@@ -112,10 +112,7 @@ export class API extends HubAPI {
   }
 
   getCancelToken() {
-    const CancelToken = axios.CancelToken;
-    const source = CancelToken.source();
-
-    return source;
+    return axios.CancelToken.source();
   }
 
   // Caches the last collection returned from the server. If the requested

--- a/src/api/hub.ts
+++ b/src/api/hub.ts
@@ -3,9 +3,6 @@ import { BaseAPI } from './base';
 export class HubAPI extends BaseAPI {
   UI_API_VERSION = 'v1';
 
-  apiPath: string;
-  http: any;
-
   constructor() {
     super(API_HOST + API_BASE_PATH);
   }

--- a/src/api/import.ts
+++ b/src/api/import.ts
@@ -2,11 +2,6 @@ import { HubAPI } from './hub';
 
 export class API extends HubAPI {
   apiPath = this.getUIPath('imports/collections/');
-  mock: any;
-
-  constructor() {
-    super();
-  }
 
   get(id, path?) {
     // call this to generate more task messages

--- a/src/api/pulp.ts
+++ b/src/api/pulp.ts
@@ -1,9 +1,6 @@
 import { BaseAPI } from './base';
 
 export class PulpAPI extends BaseAPI {
-  apiPath: string;
-  http: any;
-
   constructor() {
     super('/pulp/api/v3/');
   }

--- a/src/api/response-types/permissions.ts
+++ b/src/api/response-types/permissions.ts
@@ -2,4 +2,5 @@ export class GroupObjectPermissionType {
   id: number;
   name: string;
   object_permissions: string[];
+  pulp_href?: string;
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -2,11 +2,6 @@ import { HubAPI } from './hub';
 
 export class API extends HubAPI {
   apiPath = this.getUIPath('users/');
-  mock: any;
-
-  constructor() {
-    super();
-  }
 }
 
 export const UserAPI = new API();

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -31,7 +31,7 @@ interface IProps extends CollectionDetailType {
 }
 
 export class CollectionInfo extends React.Component<IProps> {
-  downloadLinkRef: any;
+  downloadLinkRef: React.RefObject<HTMLAnchorElement>;
   static contextType = AppContext;
 
   constructor(props) {

--- a/src/components/confirm-modal/confirm-modal.tsx
+++ b/src/components/confirm-modal/confirm-modal.tsx
@@ -4,7 +4,7 @@ import { t } from '@lingui/macro';
 
 interface IProps {
   cancelAction: () => void;
-  children?: any;
+  children?: React.ReactNode;
   confirmAction?: () => void;
   isDisabled?: boolean;
   title: string;

--- a/src/components/delete-modal/delete-modal.tsx
+++ b/src/components/delete-modal/delete-modal.tsx
@@ -4,7 +4,7 @@ import { Button, Modal, Spinner } from '@patternfly/react-core';
 
 export interface IProps {
   cancelAction: () => void;
-  children?: any;
+  children?: React.ReactNode;
   deleteAction: () => void;
   isDisabled?: boolean;
   title: string;

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -350,9 +350,9 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
             <Spacer />
             <Trans>
               Click on the Controller URL that you want to use the above
-              execution environment in, and it will launch that Controller's
-              console. Log in (if necessary) and follow the steps to complete
-              the configuration.
+              execution environment in, and it will launch that
+              Controller&apos;s console. Log in (if necessary) and follow the
+              steps to complete the configuration.
             </Trans>
             <br />
             {!unsafeLinksSupported && (

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -207,7 +207,7 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
           )}`;
 
           return (
-            <ListItem style={{ paddingTop: '8px' }}>
+            <ListItem style={{ paddingTop: '8px' }} key={host}>
               <a href={href} target='_blank' rel='noreferrer'>
                 {host}
               </a>{' '}

--- a/src/components/group-management/group-modal.tsx
+++ b/src/components/group-management/group-modal.tsx
@@ -7,13 +7,14 @@ import {
   Modal,
   TextInput,
 } from '@patternfly/react-core';
+import { ErrorMessagesType } from 'src/utilities';
 
 interface IProps {
   onCancel?: () => void;
   onSave?: (string) => void;
   clearErrors?: () => void;
-  group?: any;
-  errorMessage?: any;
+  group?: { name: string };
+  errorMessage?: ErrorMessagesType;
 }
 
 interface IState {

--- a/src/components/my-imports/import-console.tsx
+++ b/src/components/my-imports/import-console.tsx
@@ -31,7 +31,7 @@ interface IProps {
 }
 
 export class ImportConsole extends React.Component<IProps> {
-  lastImport: any;
+  lastImport: React.RefObject<HTMLDivElement>;
   isLoading = false;
 
   constructor(props) {
@@ -127,7 +127,11 @@ export class ImportConsole extends React.Component<IProps> {
   private renderTitle(selectedImport) {
     const { task, hideCollectionName, collectionVersion } = this.props;
 
-    let collectionHead: any = `${selectedImport.namespace}.${selectedImport.name}`;
+    let collectionHead = (
+      <>
+        {selectedImport.namespace}.{selectedImport.name}
+      </>
+    );
     let approvalStatus = t`waiting for import to finish`;
 
     if (collectionVersion) {

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -49,7 +49,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
   }
 
   private newNamespaceNameIsValid() {
-    const error: any = this.state.errorMessages;
+    const error = this.state.errorMessages;
     const name: string = this.state.newNamespaceName;
 
     if (name == '') {
@@ -71,7 +71,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
   }
 
   private handleSubmit = () => {
-    const data: any = {
+    const data = {
       name: this.state.newNamespaceName,
       groups: this.state.newGroups,
     };
@@ -87,7 +87,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
       })
       .catch((error) => {
         const result = error.response;
-        const messages: any = this.state.errorMessages;
+        const messages = this.state.errorMessages;
         for (const e of result.data.errors) {
           messages[e.source.parameter] = e.detail;
         }

--- a/src/components/patternfly-wrappers/applied-filters.tsx
+++ b/src/components/patternfly-wrappers/applied-filters.tsx
@@ -63,7 +63,7 @@ export class AppliedFilters extends React.Component<IProps> {
 
     return (
       <div style={{ display: 'inline', marginRight: '8px' }} key={key}>
-        <ChipGroup categoryName={(niceNames[key] || key) as any}>
+        <ChipGroup categoryName={niceNames[key] || key}>
           {chips.map((v, i) => (
             <Chip
               key={i}

--- a/src/components/patternfly-wrappers/main.tsx
+++ b/src/components/patternfly-wrappers/main.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import cx from 'classnames';
 
-export class Main extends React.Component<any> {
+export class Main extends React.Component<React.HTMLProps<HTMLElement>> {
   render() {
     const { children, className, ...extra } = this.props;
     return (

--- a/src/components/patternfly-wrappers/write-only-field.tsx
+++ b/src/components/patternfly-wrappers/write-only-field.tsx
@@ -10,7 +10,7 @@ interface IProps {
   onClear: () => void;
 
   /** Component to display when the user is allowed to update this field. */
-  children: any;
+  children: React.ReactNode;
 }
 
 export class WriteOnlyField extends React.Component<IProps> {

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -249,7 +249,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
                 content={
                   <Trans>
                     This uses the same {docsAnsibleLink} format as the
-                    ansible-galaxy CLI with the caveat that roles aren't
+                    ansible-galaxy CLI with the caveat that roles aren&apos;t
                     supported and the source parameter is not supported.
                   </Trans>
                 }

--- a/src/components/repositories/remote-repository-table.tsx
+++ b/src/components/repositories/remote-repository-table.tsx
@@ -19,7 +19,7 @@ interface IProps {
 }
 
 export class RemoteRepositoryTable extends React.Component<IProps> {
-  polling: any;
+  polling: ReturnType<typeof setInterval>;
   refreshOnStatuses = [PulpStatus.waiting, PulpStatus.running];
 
   constructor(props) {

--- a/src/components/shared/data-form.tsx
+++ b/src/components/shared/data-form.tsx
@@ -15,7 +15,7 @@ interface IProps {
   formPrefix?: React.ReactNode;
   formSuffix?: React.ReactNode;
   isReadonly: boolean;
-  model: any;
+  model: { [key: string]: any };
   requiredFields: string[];
   updateField: (value, event) => void;
   onSave: () => void;

--- a/src/components/status/status-indicator.tsx
+++ b/src/components/status/status-indicator.tsx
@@ -20,7 +20,7 @@ interface IProps {
 
 interface LabelPropType {
   color: string;
-  icon: any;
+  icon: React.ReactElement;
   text: string;
 }
 

--- a/src/components/user-form/user-form-page.tsx
+++ b/src/components/user-form/user-form-page.tsx
@@ -7,7 +7,7 @@ import { ErrorMessagesType } from 'src/utilities';
 interface IProps {
   title: string;
   user: UserType;
-  breadcrumbs: any[];
+  breadcrumbs: { name: string; url?: string }[];
   errorMessages: ErrorMessagesType;
   isReadonly?: boolean;
 

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -42,7 +42,7 @@ interface IProps {
 
 interface IState {
   passwordConfirm: string;
-  searchGroups: any[];
+  searchGroups: { name: string; id: number }[];
   formErrors: {
     groups: AlertType;
   };

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -45,7 +45,8 @@ class CollectionDependencies extends React.Component<
   IState
 > {
   private ignoredParams = ['page_size', 'page', 'sort', 'name__icontains'];
-  private cancelToken = undefined;
+  private cancelToken: ReturnType<typeof CollectionAPI.getCancelToken>;
+
   constructor(props) {
     super(props);
 

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -29,8 +29,9 @@ class CollectionDocs extends React.Component<
   RouteComponentProps,
   IBaseCollectionState
 > {
-  docsRef: any;
+  docsRef: React.RefObject<HTMLDivElement>;
   searchBarRef: React.RefObject<HTMLInputElement>;
+
   constructor(props) {
     super(props);
     const params = ParamHelper.parseParamString(props.location.search);

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -44,6 +44,8 @@ export interface IDetailSharedProps extends RouteComponentProps {
 export function withContainerRepo(WrappedComponent) {
   return class extends React.Component<RouteComponentProps, IState> {
     static contextType = AppContext;
+    static displayName = `withContainerRepo(${WrappedComponent.displayName})`;
+
     constructor(props) {
       super(props);
 

--- a/src/containers/execution-environment-detail/execution_environment_detail.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail.tsx
@@ -27,7 +27,6 @@ interface IState {
   distribution_id: string;
   groups: GroupObjectPermissionType[];
   description: string;
-  namespace: any;
 }
 
 class ExecutionEnvironmentDetail extends React.Component<
@@ -45,7 +44,6 @@ class ExecutionEnvironmentDetail extends React.Component<
       distribution_id: '',
       groups: [],
       description: '',
-      namespace: {},
     };
   }
 

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -517,7 +517,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
               variant,
               features,
             }) => (
-              <tr>
+              <tr key={digest}>
                 <td>
                   <ShaLink digest={digest} />
                 </td>

--- a/src/containers/execution-environment-detail/tag-manifest-modal.tsx
+++ b/src/containers/execution-environment-detail/tag-manifest-modal.tsx
@@ -219,8 +219,8 @@ export class TagManifestModal extends React.Component<IProps, IState> {
               }
             >
               <Trans>
-                It's safe to close this window. These tasks will finish in the
-                background.
+                It&apos;s safe to close this window. These tasks will finish in
+                the background.
               </Trans>
             </Alert>
           )}

--- a/src/containers/execution-environment-detail/tag-manifest-modal.tsx
+++ b/src/containers/execution-environment-detail/tag-manifest-modal.tsx
@@ -254,16 +254,11 @@ export class TagManifestModal extends React.Component<IProps, IState> {
   private saveTags() {
     const { containerManifest } = this.props;
 
-    interface ITagPromises {
-      tag: string;
-      promise: Promise<any>;
-    }
-
-    const promises: ITagPromises[] = [];
-
     this.setState({ isSaving: true }, () => {
       const repository: ContainerRepositoryType =
         this.props.containerRepository;
+
+      const promises = [];
 
       for (const tag of this.state.tagsToRemove) {
         promises.push({

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -326,7 +326,7 @@ class ExecutionEnvironmentList extends React.Component<
     );
   }
 
-  private renderTableRow(item: any, index: number) {
+  private renderTableRow(item, index: number) {
     const description = item.description;
     const dropdownItems = [
       <DropdownItem

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -364,7 +364,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
     );
   }
 
-  private renderTableRow(item: any, index: number) {
+  private renderTableRow(item, index: number) {
     const dropdownItems = [
       this.context.user.model_permissions.change_containerregistry && (
         <DropdownItem

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -396,6 +396,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
         </DropdownItem>
       ),
       <Tooltip
+        key='index'
         content={
           item.is_indexable
             ? t`Find execution environments in this registry`
@@ -403,7 +404,6 @@ class ExecutionEnvironmentRegistryList extends React.Component<
         }
       >
         <DropdownItem
-          key='index'
           onClick={() => this.indexRegistry(item)}
           isDisabled={!item.is_indexable}
         >

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -29,7 +29,12 @@ import {
   StatefulDropdown,
   Tabs,
 } from 'src/components';
-import { GroupAPI, UserAPI, UserType } from 'src/api';
+import {
+  GroupAPI,
+  UserAPI,
+  UserType,
+  GroupObjectPermissionType,
+} from 'src/api';
 import { filterIsSet, ParamHelper, twoWayMapper } from 'src/utilities';
 import { formatPath, Paths } from 'src/paths';
 import {
@@ -51,7 +56,7 @@ import { DeleteGroupModal } from './delete-group-modal';
 import { DeleteModal } from 'src/components/delete-modal/delete-modal';
 
 interface IState {
-  group: any;
+  group: GroupObjectPermissionType;
   params: {
     id: string;
     page?: number;

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -8,7 +8,12 @@ import {
   Link,
   Redirect,
 } from 'react-router-dom';
-import { GroupAPI, UserAPI, UserType } from 'src/api';
+import {
+  GroupAPI,
+  UserAPI,
+  UserType,
+  GroupObjectPermissionType,
+} from 'src/api';
 import { DeleteGroupModal } from './delete-group-modal';
 import {
   filterIsSet,
@@ -51,13 +56,13 @@ interface IState {
   loading: boolean;
   itemCount: number;
   alerts: AlertType[];
-  groups: any[];
+  groups: GroupObjectPermissionType[];
   createModalVisible: boolean;
   deleteModalCount?: number;
   deleteModalUsers?: UserType[];
   deleteModalVisible: boolean;
   editModalVisible: boolean;
-  selectedGroup: any;
+  selectedGroup: GroupObjectPermissionType;
   groupError: ErrorMessagesType;
   unauthorized: boolean;
   inputText: string;
@@ -389,7 +394,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
     );
   }
 
-  private renderTableRow(group: any, index: number) {
+  private renderTableRow(group, index: number) {
     const { user } = this.context;
     return (
       <tr aria-labelledby={group.name} key={index}>

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -40,8 +40,8 @@ interface IState {
 }
 
 class MyImports extends React.Component<RouteComponentProps, IState> {
-  polling: any;
-  topOfPage: any;
+  polling: ReturnType<typeof setInterval>;
+  topOfPage: React.RefObject<HTMLDivElement>;
 
   constructor(props) {
     super(props);

--- a/src/containers/namespace-detail/import-modal/import-modal.tsx
+++ b/src/containers/namespace-detail/import-modal/import-modal.tsx
@@ -35,7 +35,7 @@ interface IState {
 
 export class ImportModal extends React.Component<IProps, IState> {
   acceptedFileTypes = ['application/x-gzip', 'application/gzip'];
-  cancelToken: any;
+  cancelToken: ReturnType<typeof CollectionAPI.getCancelToken>;
   COLLECTION_NAME_REGEX = /[0-9a-z_]+-[0-9a-z_]+-[0-9A-Za-z.+-]+/;
 
   constructor(props) {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -489,7 +489,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
               content={
                 <Trans>
                   Cannot delete namespace until <br />
-                  collections' dependencies have <br />
+                  collections&apos; dependencies have <br />
                   been deleted
                 </Trans>
               }

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -244,7 +244,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           contextSelector={
             <RepoSelector
               selectedRepo={this.context.selectedRepo}
-              path={this.props.match.path as any} // Paths.namespaceByRepo or Paths.myCollectionsByRepo
+              path={this.props.match.path as Paths} // Paths.namespaceByRepo or Paths.myCollectionsByRepo
               pathParams={{ namespace: namespace.name }}
             />
           }

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -295,15 +295,12 @@ export class NamespaceList extends React.Component<IProps, IState> {
   }
 
   private loadNamespaces() {
-    let apiFunc: any;
+    const { filterOwner } = this.props;
+    const api = filterOwner ? MyNamespaceAPI : NamespaceAPI;
 
-    if (this.props.filterOwner) {
-      apiFunc = (p) => MyNamespaceAPI.list(p);
-    } else {
-      apiFunc = (p) => NamespaceAPI.list(p);
-    }
     this.setState({ loading: true }, () => {
-      apiFunc(this.state.params)
+      api
+        .list(this.state.params)
         .then((results) => {
           this.setState({
             namespaces: results.data.data,

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -266,7 +266,7 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
     );
   }
 
-  private renderTableRow(item: any, index: number) {
+  private renderTableRow(item, index: number) {
     const { name, state, pulp_created, started_at, finished_at, pulp_href } =
       item;
     const taskId = parsePulpIDFromURL(pulp_href);

--- a/src/containers/task-management/task_detail.tsx
+++ b/src/containers/task-management/task_detail.tsx
@@ -49,7 +49,7 @@ interface IState {
   taskName: string;
   resources: { name: string; type: string }[];
   redirect: string;
-  refresh: any;
+  polling: ReturnType<typeof setInterval>;
 }
 
 class TaskDetail extends React.Component<RouteComponentProps, IState> {
@@ -65,7 +65,7 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
       taskName: '',
       resources: [],
       redirect: null,
-      refresh: null,
+      polling: null,
     };
   }
 
@@ -74,8 +74,8 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
   }
 
   componentWillUnmount() {
-    if (this.state.refresh) {
-      clearInterval(this.state.refresh);
+    if (this.state.polling) {
+      clearInterval(this.state.polling);
     }
   }
 
@@ -403,10 +403,11 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
   }
 
   private loadContent() {
-    const taskId = this.props.match.params['task'];
-    if (!this.state.refresh && !this.state.task) {
-      this.setState({ refresh: setInterval(() => this.loadContent(), 10000) });
+    if (!this.state.polling && !this.state.task) {
+      this.setState({ polling: setInterval(() => this.loadContent(), 10000) });
     }
+
+    const taskId = this.props.match.params['task'];
     return TaskManagementAPI.get(taskId)
       .then((result) => {
         const allRelatedTasks = [];
@@ -414,8 +415,8 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
         const childTasks = [];
         const resources = [];
         if (['canceled', 'completed', 'failed'].includes(result.data.state)) {
-          clearInterval(this.state.refresh);
-          this.setState({ refresh: null });
+          clearInterval(this.state.polling);
+          this.setState({ polling: null });
         }
         if (result.data.parent_task) {
           const parentTaskId = parsePulpIDFromURL(result.data.parent_task);

--- a/src/containers/task-management/task_detail.tsx
+++ b/src/containers/task-management/task_detail.tsx
@@ -220,9 +220,8 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
                                 childTask.pulp_href,
                               );
                               return (
-                                <React.Fragment>
+                                <React.Fragment key={childTaskId}>
                                   <Link
-                                    key={childTaskId}
                                     to={formatPath(Paths.taskDetail, {
                                       task: childTaskId,
                                     })}

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -89,7 +89,8 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
                 Certified repository in your private Automation Hub. Users with
                 the correct permissions can use the sync toggles on the{' '}
                 <Link to={Paths.search}>Collections</Link> page to control which
-                collections are added to their organization's sync repository.
+                collections are added to their organization&apos;s sync
+                repository.
               </Trans>
             </p>
           </section>
@@ -174,7 +175,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
             <p>
               <Trans>
                 Note: this URL contains all collections in Hub. To connect to
-                your organization's sync repository use the URL found on{' '}
+                your organization&apos;s sync repository use the URL found on{' '}
                 <Link to={Paths.repositories}>Repository Management</Link>.
               </Trans>
             </p>

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -42,7 +42,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
 
   componentDidMount() {
     // this function will fail if chrome.auth.doOffline() hasn't been called
-    (window as any).insights.chrome.auth
+    window.insights.chrome.auth
       .getOfflineToken()
       .then((result) => {
         this.setState({ tokenData: result.data });
@@ -198,11 +198,10 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
   }
 
   private loadToken() {
-    (window as any).insights.chrome.auth
-      // doOffline causes the page to refresh and will make the data
-      // available to getOfflineToken() when the component mounts after
-      // the reload
-      .doOffline();
+    // doOffline causes the page to refresh and will make the data
+    // available to getOfflineToken() when the component mounts after
+    // the reload
+    window.insights.chrome.auth.doOffline();
   }
 
   private get closeAlert() {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,10 +1,7 @@
 // Fool TypeScript into thinking that we actually have typings for these components.
 // This will tell typescript that anything from this module is of type any.
 
-declare module 'react-markdown';
 declare module 'react-router-hash-link';
-declare module 'file-saver';
-declare module '*.gif';
 declare module '*.svg';
 
 // Declare configuration globals here so that TypeScript compiles
@@ -16,3 +13,19 @@ declare var DEPLOYMENT_MODE;
 declare var NAMESPACE_TERM;
 declare var APPLICATION_NAME;
 declare var UI_EXTERNAL_LOGIN_URI;
+
+// when DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE only
+interface Window {
+  insights: {
+    chrome: {
+      auth: {
+        doOffline: () => void;
+        getOfflineToken: () => Promise<{ data: any }>;
+        getUser: () => Promise<{ identity: object }>;
+      };
+      identifyApp: (s: string) => void;
+      init: () => void;
+      on: (s: string, f: function) => void;
+    };
+  };
+}

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -1,4 +1,3 @@
-/* global insights */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { withRouter, matchPath } from 'react-router-dom';
@@ -25,13 +24,13 @@ class App extends Component {
   }
 
   componentDidMount() {
-    insights.chrome.init();
-    insights.chrome.identifyApp('automation-hub');
+    window.insights.chrome.init();
+    window.insights.chrome.identifyApp('automation-hub');
 
     // This listens for insights navigation events, so this will fire
     // when items in the nav are clicked or the app is loaded for the first
     // time
-    this.appNav = insights.chrome.on('APP_NAVIGATION', (event) => {
+    this.appNav = window.insights.chrome.on('APP_NAVIGATION', (event) => {
       // might be undefined early in the load, or may not happen at all
       if (!event?.domEvent) {
         return;
@@ -59,7 +58,7 @@ class App extends Component {
       }
     });
 
-    insights.chrome.auth
+    window.insights.chrome.auth
       .getUser()
       .then((user) => this.setState({ user: user }));
     let promises = [];

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -319,14 +319,16 @@ class App extends React.Component<RouteComponentProps, IState> {
     );
   }
 
-  private menu(): any[] {
+  private menu() {
     const menuItem = (name, options = {}) => ({
+      active: false,
       condition: () => true,
       ...options,
       type: 'item',
       name,
     });
     const menuSection = (name, options = {}, items = []) => ({
+      active: false,
       condition: (...params) =>
         some(items, (item) => item.condition(...params)), // any visible items inside
       ...options,

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { ParamHelper } from './utilities/param-helper';
 
-export function formatPath(path: Paths, data: any, params?: object) {
+export function formatPath(path: Paths, data, params?: object) {
   let url = path as string;
 
   for (const k of Object.keys(data)) {

--- a/src/utilities/map-error-messages.ts
+++ b/src/utilities/map-error-messages.ts
@@ -6,7 +6,7 @@ export class ErrorMessagesType {
 }
 
 export function mapErrorMessages(err): ErrorMessagesType {
-  const messages: any = {};
+  const messages = {};
 
   // 500 errors only have err.response.data string
   if (typeof err.response.data === 'string') {

--- a/src/utilities/param-helper.tsx
+++ b/src/utilities/param-helper.tsx
@@ -69,7 +69,7 @@ export class ParamHelper {
   }
 
   // Removes a parameter, or a specific key value pair from a parameter object
-  static deleteParam(p: any, key: string, value?: string | number) {
+  static deleteParam(p, key: string, value?: string | number) {
     const params = cloneDeep(p);
     if (value && Array.isArray(params[key]) && params[key].length > 1) {
       const i = params[key].indexOf(value);

--- a/src/utilities/two-way-mapper.ts
+++ b/src/utilities/two-way-mapper.ts
@@ -1,5 +1,5 @@
 // returns value/key based on given value/key and a mapper
-export function twoWayMapper(value: string, mapper: any) {
+export function twoWayMapper(value: string, mapper: object) {
   if (Object.values(mapper).includes(value)) {
     return Object.keys(mapper).find((key) => mapper[key] === value);
   }

--- a/src/utilities/write-only-fields.ts
+++ b/src/utilities/write-only-fields.ts
@@ -23,7 +23,7 @@ export function isFieldSet(
 // Deletes any write only fields from the object so that they don't
 // get sent to the API
 export function clearSetFieldsFromRequest(
-  data: any,
+  data,
   writeOnlyFields: WriteOnlyFieldType[],
 ): object {
   const newObj = { ...data };

--- a/test/cypress/plugins/.eslintrc
+++ b/test/cypress/plugins/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "@typescript-eslint/no-var-requires": "off"
+  }
+}


### PR DESCRIPTION
Enabling these default rules: `@typescript-eslint/no-explicit-any`, `@typescript-eslint/no-var-requires`, `react/display-name`, `react/jsx-key`, `react/no-unescaped-entities`

`no-explicit-any` warns about 25 more uses of `any`, but those shouldn't make PRs go red (https://github.com/ansible/ansible-hub-ui/runs/4698268100?check_suite_focus=true#step:4:92), and can be fixed separately