### PR TITLE
[POC] pr-checks: add CHANGES or No Issue on check_commit failure

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -30,8 +30,9 @@ jobs:
 
     - name: "Update the dev tag"
       run: |
-        git config --local user.name "Dev release workflow"
-        git config --local user.email "ansible-hub-ui+dev@example.com"
+        git config --local user.name "GitHub Actions: Dev release workflow"
+        git config --local user.email "ansible-hub-ui+dev-release@example.com"
+
         git tag -f dev
         git push -f --tags
 

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -33,8 +33,9 @@ jobs:
 
     - name: "commit"
       run: |
-        git config --global user.name 'GH Actions'
-        git config --global user.email 'gh_actions@users.noreply.github.com'
+        git config --global user.name 'GitHub Actions: i18n workflow'
+        git config --global user.email 'ansible-hub-ui+i18n@example.com'
+
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/ansible/ansible-hub-ui.git
         git add locale/
         if git commit -m "Automated updated of i18n strings on $(date +'%Y-%m-%d')"; then

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,25 +5,24 @@ on:
     branches: [ 'master', 'stable-*' ]
 
 jobs:
-
   check_commit:
-
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
-          fetch-depth: 0  # include all history
 
-      - name: Run script to validate commits for both pull request and a push
-        env:
-          GITHUB_PR_COMMITS_URL: ${{ github.event.pull_request.commits_url }}
-          GITHUB_USER: ${{ github.event.pull_request.user.login }}
-          START_COMMIT: ${{ github.event.before }}
-          END_COMMIT: ${{ github.event.after }}
-        run: |
-          curl https://raw.githubusercontent.com/ansible/galaxy_ng/master/.ci/scripts/validate_commit_message_custom.py | python
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
+        fetch-depth: 0  # include all history
+
+    - name: Run script to validate commits for both pull request and a push
+      env:
+        GITHUB_PR_COMMITS_URL: ${{ github.event.pull_request.commits_url }}
+        GITHUB_USER: ${{ github.event.pull_request.user.login }}
+        START_COMMIT: ${{ github.event.before }}
+        END_COMMIT: ${{ github.event.after }}
+      run: |
+        curl https://raw.githubusercontent.com/ansible/galaxy_ng/master/.ci/scripts/validate_commit_message_custom.py | python
 
   pr-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,6 +33,9 @@ jobs:
     - name: "commit No-Issue | Fixes + CHANGES"
       if: ${{ failure() }}
       run: |
+        git config --global user.name 'GitHub Actions: PR checks workflow'
+        git config --global user.email 'ansible-hub-ui+pr-checks@example.com'
+
         if [ -n "$ISSUE" ]; then
           mkdir -p CHANGES
           gh pr view ${{github.event.number}} --json title --jq .title > CHANGES/"$ISSUE".misc

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,9 @@ name: "PR checks"
 
 on:
   pull_request:
-    branches: [ 'master', 'stable-*' ]
+    branches: [ 'pr-add-changes' ]
+  pull_request_target:
+    branches: [ 'pr-add-changes' ]
 
 jobs:
   check_commit:
@@ -50,55 +52,3 @@ jobs:
         git log -1 -p
 
         git push
-
-  pr-checks:
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: "Checkout ansible-hub-ui (${{ github.ref }})"
-      uses: actions/checkout@v2
-
-    - name: "Install node 14"
-      uses: actions/setup-node@v2
-      with:
-        node-version: '14'
-        cache: 'npm'
-
-    - name: "Checks"
-      run: |
-        # fail if npm install had to change package-lock.json
-        npm install
-        git diff --exit-code package-lock.json
-
-        # same in test/
-        pushd test/
-        npm install
-        git diff --exit-code package-lock.json
-        popd
-
-        # dependencies
-        pip install lint-po
-
-        # run linters
-        npm run lint
-
-  merge-commits:
-    runs-on: ubuntu-latest
-    steps:
-
-    # need to checkout out head, the merge commit won't have any merges in history
-    # also need more than 1 commit, assuming no PR will have more than 128
-    - name: "Checkout ansible-hub-ui HEAD"
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 128
-        ref: ${{ github.event.pull_request.head.sha }}
-
-    - name: "Ensure no merge commits"
-      run: |
-        # fail on merge commits in the PR
-        # since squash&merge doesn't create merge commits,
-        # and the last non-squash merges were in Jul 2019,
-        # we can just look for any merge commits since 2020
-        count=`git log --min-parents=2 --since 2020-01-01 | tee /dev/stderr | wc -l`
-        [ "$count" = 0 ]

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,15 +24,15 @@ jobs:
       run: |
         curl https://raw.githubusercontent.com/ansible/galaxy_ng/master/.ci/scripts/validate_commit_message_custom.py | python
 
-    - name: "parse issue number"
+    - name: "parse issue number, switch branch, commit, push"
       if: ${{ failure() }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        ISSUE=`gh pr view ${{github.event.number}} | grep AAH- | sed 's/^.*\<AAH-\([0-9]\+\).*$/\1/'`
-        echo "ISSUE=${ISSUE}" >> $GITHUB_ENV
+        ISSUE=`( gh pr view ${{github.event.number}} ; gh pr view ${{github.event.number}} -c ) | grep AAH- | sed 's/^.*\<AAH-\([0-9]\+\).*$/\1/'`
 
-    - name: "commit No-Issue | Fixes + CHANGES"
-      if: ${{ failure() }}
-      run: |
+        gh pr checkout ${{github.event.number}}
+
         git config --global user.name 'GitHub Actions: PR checks workflow'
         git config --global user.email 'ansible-hub-ui+pr-checks@example.com'
 
@@ -44,6 +44,8 @@ jobs:
         else
           git commit --allow-empty -m "No-Issue"
         fi
+        git log -1 -p
+
         git push
 
   pr-checks:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -24,6 +24,25 @@ jobs:
       run: |
         curl https://raw.githubusercontent.com/ansible/galaxy_ng/master/.ci/scripts/validate_commit_message_custom.py | python
 
+    - name: "parse issue number"
+      if: ${{ failure() }}
+      run: |
+        ISSUE=`gh pr view ${{github.event.number}} | grep AAH- | sed 's/^.*\<AAH-\([0-9]\+\).*$/\1/'`
+        echo "ISSUE=${ISSUE}" >> $GITHUB_ENV
+
+    - name: "commit No-Issue | Fixes + CHANGES"
+      if: ${{ failure() }}
+      run: |
+        if [ -n "$ISSUE" ]; then
+          mkdir -p CHANGES
+          gh pr view ${{github.event.number}} --json title --jq .title > CHANGES/"$ISSUE".misc
+          git add CHANGES
+          git commit -m "Fixes: AAH-$ISSUE"
+        else
+          git commit --allow-empty -m "No-Issue"
+        fi
+        git push
+
   pr-checks:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,18 +29,21 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        ISSUE=`( gh pr view ${{github.event.number}} ; gh pr view ${{github.event.number}} -c ) | grep AAH- | sed 's/^.*\<AAH-\([0-9]\+\).*$/\1/'`
+        ISSUES=`( gh pr view "${{github.event.number}}" ; gh pr view "${{github.event.number}}" -c ; echo "$GITHUB_HEAD_REF" ) | perl -nE 'say($1) while /\bAAH-?(\d+)\b/gi'`
 
-        gh pr checkout ${{github.event.number}}
+        gh pr checkout "${{github.event.number}}"
 
         git config --global user.name 'GitHub Actions: PR checks workflow'
         git config --global user.email 'ansible-hub-ui+pr-checks@example.com'
 
-        if [ -n "$ISSUE" ]; then
+        if [ -n "$ISSUES" ]; then
+          TITLE=`gh pr view "${{github.event.number}}" --json title --jq .title`
           mkdir -p CHANGES
-          gh pr view ${{github.event.number}} --json title --jq .title > CHANGES/"$ISSUE".misc
-          git add CHANGES
-          git commit -m "Fixes: AAH-$ISSUE"
+          for ISSUE in $ISSUES; do
+            [ -e CHANGES/"$ISSUE".misc ] || echo "$TITLE" > CHANGES/"$ISSUE".misc
+            git add CHANGES
+            git commit --allow-empty -m "Issue: AAH-$ISSUE"
+          done
         else
           git commit --allow-empty -m "No-Issue"
         fi


### PR DESCRIPTION
When the `check_commit` check fails, this reads the PR description and comments to find any AAH references,

when found, creates CHANGES/$number.misc, containing the PR title
when not found, commits an empty commit with the no issue comment

(testing if this works from a pull_requrest action, may need [pull_request_target](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#pull_request_target) for the push)