### PR TITLE
typescript-eslint/no-explicit-any: add eslint-disable-next-line comments

### DIFF
--- a/src/api/active-user.ts
+++ b/src/api/active-user.ts
@@ -8,6 +8,7 @@ class API extends HubAPI {
     super();
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getUser(): Promise<any> {
     if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
       return new Promise((resolve, reject) => {
@@ -41,6 +42,7 @@ class API extends HubAPI {
   // insights has some asinine way of loading tokens that involves forcing the
   // page to refresh before loading the token that can't be done witha single
   // API request.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getToken(): Promise<any> {
     if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
       return new Promise((resolve, reject) => {

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -5,6 +5,7 @@ import Cookies from 'js-cookie';
 
 export class BaseAPI {
   apiPath: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   http: any;
 
   constructor(apiBaseUrl) {

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -65,8 +65,11 @@ export class PluginContentType {
   readme_filename: string;
   readme_html: string;
   doc_strings: {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     doc: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     metadata: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return: any;
     examples: string;
   };

--- a/src/api/response-types/namespace.ts
+++ b/src/api/response-types/namespace.ts
@@ -18,6 +18,7 @@ export class NamespaceListType {
 export class NamespaceType extends NamespaceListType {
   groups: GroupObjectPermissionType[];
   resources: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   owners: any[];
   links: NamespaceLinkType[];
 }

--- a/src/api/response-types/task.ts
+++ b/src/api/response-types/task.ts
@@ -8,9 +8,12 @@ export class TaskType {
   finished_at: string;
   error: { traceback: string; description: string };
   pulp_href: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   progress_reports: any[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   task_group: any;
   parent_task: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   child_tasks: any[];
   reserved_resources_record: string[];
 }

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -463,6 +463,7 @@ export class RepositoryForm extends React.Component<IProps, IState> {
     this.setState({
       [key]: Array.from(current.values()),
       [key === 'includeTags' ? 'addTagsInclude' : 'addTagsExclude']: '',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
   }
 
@@ -472,6 +473,7 @@ export class RepositoryForm extends React.Component<IProps, IState> {
 
     this.setState({
       [key]: Array.from(current.values()),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
   }
 

--- a/src/components/patternfly-wrappers/clipboard-copy.tsx
+++ b/src/components/patternfly-wrappers/clipboard-copy.tsx
@@ -5,6 +5,7 @@ import { ClipboardCopy as PFClipboardCopy } from '@patternfly/react-core';
 
 interface IProps {
   children: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
 

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -31,6 +31,7 @@ interface IProps {
   filterConfig: FilterOption[];
 
   /** Current page params */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   params: any;
 
   /** Sets the current page params to p */

--- a/src/components/patternfly-wrappers/sort.tsx
+++ b/src/components/patternfly-wrappers/sort.tsx
@@ -37,6 +37,7 @@ interface IState {
 }
 
 export class Sort extends React.Component<IProps, IState> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   options: any;
   static defaultProps = {
     sortParamName: 'sort',

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -19,6 +19,7 @@ interface IProps {
   // Path of the component that's using the component. This is required so that
   // the url for the repo can be updated correctly.
   path: Paths;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   pathParams?: any;
   isDisabled?: boolean;
 }

--- a/src/components/shared/data-form.tsx
+++ b/src/components/shared/data-form.tsx
@@ -15,6 +15,7 @@ interface IProps {
   formPrefix?: React.ReactNode;
   formSuffix?: React.ReactNode;
   isReadonly: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   model: { [key: string]: any };
   requiredFields: string[];
   updateField: (value, event) => void;
@@ -48,6 +49,7 @@ export class DataForm extends React.Component<IProps> {
           isRequired={!isReadonly && requiredFields.includes(field.id)}
           key={field.id}
           label={field.title}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           labelIcon={!isReadonly && (field.formGroupLabelIcon as any)}
           validated={isReadonly ? 'default' : validated}
           aria-labelledby={field.id}
@@ -59,6 +61,7 @@ export class DataForm extends React.Component<IProps> {
               id={field.id}
               onChange={updateField}
               placeholder={field.placeholder}
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               type={(field.type as any) || 'text'}
               validated={validated}
               value={model[field.id]}

--- a/src/components/status/status-indicator.tsx
+++ b/src/components/status/status-indicator.tsx
@@ -82,7 +82,9 @@ export class StatusIndicator extends React.Component<IProps> {
 
     return (
       <Label
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         variant={this.typeToVariantMap[type] as any}
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         color={labelProps.color as any}
         icon={labelProps.icon}
         className={this.props.className}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -20,6 +20,7 @@ interface Window {
     chrome: {
       auth: {
         doOffline: () => void;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         getOfflineToken: () => Promise<{ data: any }>;
         getUser: () => Promise<{ identity: object }>;
       };

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -58,6 +58,7 @@ interface IRoutesProps {
 }
 
 interface IAuthHandlerProps extends RouteComponentProps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Component: any;
   noAuth: boolean;
   updateInitialData: (
@@ -75,6 +76,7 @@ interface IAuthHandlerState {
 }
 
 interface IRouteConfig {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   comp: any;
   path: string;
   noAuth?: boolean;

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -424,6 +424,7 @@ class App extends React.Component<RouteComponentProps, IState> {
     },
     callback?: () => void,
   ) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.setState(data as any, () => {
       if (callback) {
         callback();


### PR DESCRIPTION
Follow-up to #1463 

We have a bunch of quite valid uses of explicit any, we can either go through the effort of explicitly typing these, or disable the whole rule, or mark the remaining ones as ok, while still warning about new ones.

Going with the last option for now.