### PR TITLE
Changed the modal title to matching in group creation

### DIFF
--- a/CHANGES/832.misc
+++ b/CHANGES/832.misc
@@ -1,0 +1,1 @@
+Changed the modal title to matching in group creation

--- a/src/components/group-management/group-modal.tsx
+++ b/src/components/group-management/group-modal.tsx
@@ -5,6 +5,7 @@ import {
   Form,
   FormGroup,
   Modal,
+  ModalVariant,
   TextInput,
 } from '@patternfly/react-core';
 import { ErrorMessagesType } from 'src/utilities';
@@ -36,13 +37,12 @@ export class GroupModal extends React.Component<IProps, IState> {
     const { onCancel, onSave, clearErrors } = this.props;
     return (
       <Modal
-        variant='small'
+        variant={ModalVariant.medium}
         onClose={() => {
           onCancel();
         }}
         isOpen={true}
-        title={''}
-        header={<h2>{t`Create a group`}</h2>}
+        title='Create a group'
         actions={[
           <Button
             isDisabled={

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -7,6 +7,7 @@ import {
   FormGroup,
   InputGroup,
   Modal,
+  ModalVariant,
   TextInput,
 } from '@patternfly/react-core';
 
@@ -104,7 +105,7 @@ export class NamespaceModal extends React.Component<IProps, IState> {
 
     return (
       <Modal
-        variant='medium'
+        variant={ModalVariant.medium}
         title={t`Create a new namespace`}
         isOpen={this.props.isOpen}
         onClose={this.toggleModal}


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/AAH-832

After change the create group modal's header is the same as the create namespace modalá's

Before:
![image](https://user-images.githubusercontent.com/8531681/148767354-88442632-d60c-4613-ae33-39242f10c5c8.png)


After:
![Screenshot from 2022-01-07 17-25-23](https://user-images.githubusercontent.com/8531681/148574815-f12d40d4-8498-4e6f-bc93-39a61c7b2ddd.png)
