### PR TITLE
RemoteForm - change displayed and downloaded filenames

### DIFF
--- a/CHANGES/1235.misc
+++ b/CHANGES/1235.misc
@@ -1,0 +1,1 @@
+RemoteForm - change displayed and downloaded filenames

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -34,9 +34,18 @@ interface IProps {
   updateRemote: (remote) => void;
 }
 
+type FormFilename = {
+  name: string;
+  original: boolean;
+};
+
 interface IState {
-  filenames: { [key: string]: string };
-  original: { [key: string]: boolean };
+  filenames: {
+    requirements_file: FormFilename;
+    client_key: FormFilename;
+    client_cert: FormFilename;
+    ca_cert: FormFilename;
+  };
 }
 
 export class RemoteForm extends React.Component<IProps, IState> {
@@ -48,16 +57,22 @@ export class RemoteForm extends React.Component<IProps, IState> {
 
     this.state = {
       filenames: {
-        requirements_file: requirements_file ? 'requirements.yml' : '',
-        client_key: client_key ? 'client_key' : '',
-        client_cert: client_cert ? 'client_cert' : '',
-        ca_cert: ca_cert ? 'ca_cert' : '',
-      },
-      original: {
-        requirements_file: !!requirements_file,
-        client_key: !!client_key,
-        client_cert: !!client_cert,
-        ca_cert: !!ca_cert,
+        requirements_file: {
+          name: requirements_file ? 'requirements.yml' : '',
+          original: !!requirements_file,
+        },
+        client_key: {
+          name: client_key ? 'client_key' : '',
+          original: !!client_key,
+        },
+        client_cert: {
+          name: client_cert ? 'client_cert' : '',
+          original: !!client_cert,
+        },
+        ca_cert: {
+          name: ca_cert ? 'ca_cert' : '',
+          original: !!ca_cert,
+        },
       },
     };
 
@@ -130,7 +145,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
 
   private renderForm(requiredFields, disabledFields) {
     const { remote, errorMessages } = this.props;
-    const { original, filenames } = this.state;
+    const { filenames } = this.state;
 
     const docsAnsibleLink = (
       <a
@@ -143,17 +158,16 @@ export class RemoteForm extends React.Component<IProps, IState> {
     );
 
     const filename = (field) =>
-      original[field] ? t`(uploaded)` : filenames[field];
+      filenames[field].original ? t`(uploaded)` : filenames[field].name;
     const fileOnChange = (field) => (value, name) => {
       this.setState(
         {
           filenames: {
             ...filenames,
-            [field]: name,
-          },
-          original: {
-            ...original,
-            [field]: false,
+            [field]: {
+              name,
+              original: false,
+            },
           },
         },
         () => this.updateRemote(value, field),
@@ -292,7 +306,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
                       new Blob([this.props.remote.requirements_file], {
                         type: 'text/plain;charset=utf-8',
                       }),
-                      filenames.requirements_file,
+                      filenames.requirements_file.name,
                     );
                   }}
                   variant='plain'
@@ -534,7 +548,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
                         new Blob([this.props.remote.client_cert], {
                           type: 'text/plain;charset=utf-8',
                         }),
-                        filenames.client_cert,
+                        filenames.client_cert.name,
                       );
                     }}
                     variant='plain'
@@ -580,7 +594,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
                         new Blob([this.props.remote.ca_cert], {
                           type: 'text/plain;charset=utf-8',
                         }),
-                        filenames.ca_cert,
+                        filenames.ca_cert.name,
                       );
                     }}
                     variant='plain'


### PR DESCRIPTION
Fixes AAH-1235

the FileUpload field can be empty, displaying a value for an uploaded file, or holding an actual file for upload

this does not deal with empty field, nor with actual files, only already uploaded files

previously we've defaulted to potentially misleading filenames, making people thing they've uploaded yaml certificates
changing to be clearer, using `(uploaded)` in the field, and defaulting to extension-less filenames when downloading certificates
(the client key can not be downloaded, as it's essentially a password)

before:

|field|displayed filename|downloaded filename|
|-|-|-|
|requirements|requirements.yml|requirements.yml|
|client_key|client_key.yml|-|
|client_cert|client_cert.yml|client_cert.yml|
|ca_cert|ca_cert.yml|ca_cert.yml|

after:

|field|displayed filename|downloaded filename|
|-|-|-|
|requirements|(uploaded)|requirements.yml|
|client_key|(uploaded)|-|
|client_cert|(uploaded)|client_cert|
|ca_cert|(uploaded)|ca_cert|

empty (unchanged):
![20220110054718](https://user-images.githubusercontent.com/289743/148723139-5f04f6ef-562e-46a3-8bac-7a1fe945bbca.png)

new file upload (unchanged):
![20220110054749](https://user-images.githubusercontent.com/289743/148723141-3dba567b-e670-4c58-87b1-5659f5615b39.png)

previously uploaded (before):
![20220110055259](https://user-images.githubusercontent.com/289743/148723392-6168f794-1b8b-47a2-a2e8-a07c4b6b0273.png)

previously uploaded (after):
![20220110055230](https://user-images.githubusercontent.com/289743/148723395-e6df7893-f92d-491e-8a3d-ceef45f6263c.png)