### PR TITLE
Fix indent of the groupped toolbar

### DIFF
--- a/CHANGES/822.misc
+++ b/CHANGES/822.misc
@@ -1,0 +1,1 @@
+Removed the extra spacing from the headers

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -64,7 +64,7 @@ export class CollectionFilter extends React.Component<IProps, IState> {
     return (
       <Toolbar>
         <ToolbarContent>
-          <ToolbarGroup>
+          <ToolbarGroup style={{ marginLeft: 0 }}>
             <ToolbarItem>
               <CompoundFilter
                 inputText={this.state.inputText}

--- a/src/components/patternfly-wrappers/toolbar.tsx
+++ b/src/components/patternfly-wrappers/toolbar.tsx
@@ -68,7 +68,7 @@ export class Toolbar extends React.Component<IProps, IState> {
     return (
       <ToolbarPF>
         <ToolbarContent>
-          <ToolbarGroup>
+          <ToolbarGroup style={{ marginLeft: 0 }}>
             <ToolbarItem>
               <InputGroup>
                 <TextInput

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -47,6 +47,7 @@ export class RepoSelector extends React.Component<IProps, IState> {
         <FlexItem>
           <InputGroup>
             <InputGroupText
+              style={{ paddingLeft: 0 }}
               variant='plain'
               className='hub-input-group-text-no-wrap'
             >


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/AAH-822

### Concern about the change
If we edit these pages (merge this PR), then the toolbar indent is not matching to the "Approval" and "User access" page's toolbar (Where they have this indent).

### Before
![image](https://user-images.githubusercontent.com/8531681/148767510-13372a22-889b-4a4b-98c4-c88104629aa9.png)

### Result
![Screenshot from 2022-01-10 10-43-08](https://user-images.githubusercontent.com/8531681/148745542-efde91a8-f73b-4ae2-9969-65ceb6b55867.png)
![Screenshot from 2022-01-10 10-43-00](https://user-images.githubusercontent.com/8531681/148745546-f38f93b3-bfa1-4093-a737-8132cd246a87.png)
