### PR TITLE
[stable-4.4] Add missing handling API errors on UI  (#1115)

### DIFF
--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -27,6 +27,7 @@ interface IProps extends CollectionDetailType {
     version?: string;
   };
   updateParams: (params) => void;
+  addAlert?: (variant, title, description?) => void;
 }
 
 export class CollectionInfo extends React.Component<IProps> {
@@ -167,14 +168,22 @@ export class CollectionInfo extends React.Component<IProps> {
       namespace.name,
       name,
       latest_version.version,
-    ).then((downloadURL: string) => {
-      // By getting a reference to a hidden <a> tag, setting the href and
-      // programmatically clicking it, we can hold off on making the api
-      // calls to get the download URL until it's actually needed. Clicking
-      // the <a> tag also gets around all the problems using a popup with
-      // window.open() causes.
-      this.downloadLinkRef.current.href = downloadURL;
-      this.downloadLinkRef.current.click();
-    });
+    )
+      .then((downloadURL: string) => {
+        // By getting a reference to a hidden <a> tag, setting the href and
+        // programmatically clicking it, we can hold off on making the api
+        // calls to get the download URL until it's actually needed. Clicking
+        // the <a> tag also gets around all the problems using a popup with
+        // window.open() causes.
+        this.downloadLinkRef.current.href = downloadURL;
+        this.downloadLinkRef.current.click();
+      })
+      .catch((e) =>
+        this.props.addAlert(
+          'danger',
+          t`Error downloading collection.`,
+          e?.message,
+        ),
+      );
   }
 }

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -2,10 +2,20 @@ import { t } from '@lingui/macro';
 import * as React from 'react';
 import './namespace-form.scss';
 
-import { Form, FormGroup, TextInput, TextArea } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  TextArea,
+  Alert,
+} from '@patternfly/react-core';
 import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
 
-import { NamespaceCard, ObjectPermissionField } from 'src/components';
+import {
+  NamespaceCard,
+  ObjectPermissionField,
+  AlertType,
+} from 'src/components';
 import { NamespaceType } from 'src/api';
 
 interface IProps {
@@ -18,6 +28,9 @@ interface IProps {
 
 interface IState {
   newNamespaceGroup: string;
+  formErrors?: {
+    groups?: AlertType;
+  };
 }
 
 export class NamespaceForm extends React.Component<IProps, IState> {
@@ -26,11 +39,16 @@ export class NamespaceForm extends React.Component<IProps, IState> {
 
     this.state = {
       newNamespaceGroup: '',
+      formErrors: {
+        groups: null,
+      },
     };
   }
 
   render() {
     const { namespace, errorMessages, userId } = this.props;
+
+    const { formErrors } = this.state;
 
     if (!namespace) {
       return null;
@@ -83,16 +101,33 @@ export class NamespaceForm extends React.Component<IProps, IState> {
           )}
         >
           <br />
-
-          <ObjectPermissionField
-            groups={namespace.groups}
-            availablePermissions={['change_namespace', 'upload_to_namespace']}
-            setGroups={(g) => {
-              const newNS = { ...namespace };
-              newNS.groups = g;
-              this.props.updateNamespace(newNS);
-            }}
-          ></ObjectPermissionField>
+          {!!formErrors?.groups ? (
+            <Alert title={formErrors.groups.title} variant='danger' isInline>
+              {formErrors.groups.description}
+            </Alert>
+          ) : (
+            <ObjectPermissionField
+              groups={namespace.groups}
+              availablePermissions={['change_namespace', 'upload_to_namespace']}
+              setGroups={(g) => {
+                const newNS = { ...namespace };
+                newNS.groups = g;
+                this.props.updateNamespace(newNS);
+              }}
+              onError={(err) =>
+                this.setState({
+                  formErrors: {
+                    ...this.state.formErrors,
+                    groups: {
+                      title: t`Error loading groups.`,
+                      description: err,
+                      variant: 'danger',
+                    },
+                  },
+                })
+              }
+            ></ObjectPermissionField>
+          )}
         </FormGroup>
 
         <FormGroup

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -2,11 +2,10 @@ import { t } from '@lingui/macro';
 import * as React from 'react';
 import { Modal } from '@patternfly/react-core';
 import { Form, FormGroup } from '@patternfly/react-core';
-import { Button, InputGroup, TextInput } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { Button, InputGroup, TextInput, Alert } from '@patternfly/react-core';
 import { NamespaceAPI, GroupObjectPermissionType } from 'src/api';
 
-import { HelperText, ObjectPermissionField } from 'src/components';
+import { AlertType, HelperText, ObjectPermissionField } from 'src/components';
 
 interface IProps {
   isOpen: boolean;
@@ -19,6 +18,9 @@ interface IState {
   newNamespaceNameValid: boolean;
   newGroups: GroupObjectPermissionType[];
   errorMessages: any;
+  formErrors: {
+    groups: AlertType;
+  };
 }
 
 export class NamespaceModal extends React.Component<IProps, IState> {
@@ -33,6 +35,9 @@ export class NamespaceModal extends React.Component<IProps, IState> {
       newNamespaceNameValid: true,
       newGroups: [],
       errorMessages: {},
+      formErrors: {
+        groups: null,
+      },
     };
   }
 
@@ -87,7 +92,9 @@ export class NamespaceModal extends React.Component<IProps, IState> {
   };
 
   render() {
-    const { newNamespaceName, newGroups, newNamespaceNameValid } = this.state;
+    const { newNamespaceName, newGroups, newNamespaceNameValid, formErrors } =
+      this.state;
+
     return (
       <Modal
         variant='large'
@@ -143,12 +150,33 @@ export class NamespaceModal extends React.Component<IProps, IState> {
             fieldId='groups'
             helperTextInvalid={this.state.errorMessages['groups']}
           >
-            <ObjectPermissionField
-              availablePermissions={['change_namespace', 'upload_to_namespace']}
-              groups={newGroups}
-              setGroups={(g) => this.setState({ newGroups: g })}
-              menuAppendTo='parent'
-            />
+            {!!formErrors?.groups ? (
+              <Alert title={formErrors.groups.title} variant='danger' isInline>
+                {formErrors.groups.description}
+              </Alert>
+            ) : (
+              <ObjectPermissionField
+                availablePermissions={[
+                  'change_namespace',
+                  'upload_to_namespace',
+                ]}
+                groups={newGroups}
+                setGroups={(g) => this.setState({ newGroups: g })}
+                menuAppendTo='parent'
+                onError={(err) =>
+                  this.setState({
+                    formErrors: {
+                      ...this.state.formErrors,
+                      groups: {
+                        title: t`Error loading groups.`,
+                        description: err,
+                        variant: 'danger',
+                      },
+                    },
+                  })
+                }
+              />
+            )}
           </FormGroup>
         </Form>
       </Modal>

--- a/src/components/permissions/obect-permission-field.tsx
+++ b/src/components/permissions/obect-permission-field.tsx
@@ -5,7 +5,11 @@ import { Flex, FlexItem } from '@patternfly/react-core';
 import { TrashIcon } from '@patternfly/react-icons';
 
 import { GroupObjectPermissionType, GroupAPI } from 'src/api';
-import { APISearchTypeAhead, PermissionChipSelector } from 'src/components';
+import {
+  AlertType,
+  APISearchTypeAhead,
+  PermissionChipSelector,
+} from 'src/components';
 import { twoWayMapper } from 'src/utilities';
 import { Constants } from 'src/constants';
 
@@ -15,10 +19,12 @@ interface IProps {
   setGroups: (groups: GroupObjectPermissionType[]) => void;
   isDisabled?: boolean;
   menuAppendTo?: 'parent' | 'inline';
+  onError?: (error: string) => void;
 }
 
 interface IState {
   searchGroups: { name: string; id: number | string }[];
+  formAlerts?: AlertType;
 }
 
 export class ObjectPermissionField extends React.Component<IProps, IState> {
@@ -103,13 +109,15 @@ export class ObjectPermissionField extends React.Component<IProps, IState> {
   }
 
   private loadGroups = (name) => {
-    GroupAPI.list({ name__contains: name }).then((result) => {
-      const added = this.props.groups.map((group) => group.name);
-      const groups = result.data.data.filter(
-        (group) => !added.includes(group.name),
-      );
-      this.setState({ searchGroups: groups });
-    });
+    GroupAPI.list({ name__contains: name })
+      .then((result) => {
+        const added = this.props.groups.map((group) => group.name);
+        const groups = result.data.data.filter(
+          (group) => !added.includes(group.name),
+        );
+        this.setState({ searchGroups: groups });
+      })
+      .catch((e) => this.props.onError(e?.message));
   };
 
   private onSelect = (event, selection, isPlaceholder) => {

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -9,9 +9,10 @@ import {
   Label,
   Tooltip,
   Switch,
+  Alert,
 } from '@patternfly/react-core';
 
-import { APISearchTypeAhead, HelperText } from 'src/components';
+import { AlertType, APISearchTypeAhead, HelperText } from 'src/components';
 import { DataForm } from 'src/components/shared/data-form';
 
 import { UserType, GroupAPI } from 'src/api';
@@ -42,6 +43,9 @@ interface IProps {
 interface IState {
   passwordConfirm: string;
   searchGroups: any[];
+  formErrors: {
+    groups: AlertType;
+  };
 }
 
 export class UserForm extends React.Component<IProps, IState> {
@@ -56,6 +60,9 @@ export class UserForm extends React.Component<IProps, IState> {
     this.state = {
       passwordConfirm: '',
       searchGroups: [],
+      formErrors: {
+        groups: null,
+      },
     };
   }
 
@@ -73,7 +80,7 @@ export class UserForm extends React.Component<IProps, IState> {
       isNewUser,
       isMe,
     } = this.props;
-    const { passwordConfirm } = this.state;
+    const { passwordConfirm, formErrors } = this.state;
     const formFields = [
       { id: 'username', title: t`Username` },
       { id: 'first_name', title: t`First name` },
@@ -154,16 +161,22 @@ export class UserForm extends React.Component<IProps, IState> {
         label={t`Groups`}
         validated={this.toError(!('groups' in errorMessages))}
       >
-        <APISearchTypeAhead
-          results={this.state.searchGroups}
-          loadResults={this.loadGroups}
-          onSelect={this.onSelectGroup}
-          placeholderText={t`Select groups`}
-          selections={user.groups}
-          multiple={true}
-          onClear={this.clearGroups}
-          isDisabled={isReadonly}
-        />
+        {!!formErrors.groups ? (
+          <Alert title={formErrors.groups.title} variant='danger' isInline>
+            {formErrors.groups.description}
+          </Alert>
+        ) : (
+          <APISearchTypeAhead
+            results={this.state.searchGroups}
+            loadResults={this.loadGroups}
+            onSelect={this.onSelectGroup}
+            placeholderText={t`Select groups`}
+            selections={user.groups}
+            multiple={true}
+            onClear={this.clearGroups}
+            isDisabled={isReadonly}
+          />
+        )}
       </FormGroup>
     );
 
@@ -271,9 +284,20 @@ export class UserForm extends React.Component<IProps, IState> {
   };
 
   private loadGroups = (name) => {
-    GroupAPI.list({ name__contains: name, page_size: 5 }).then((result) =>
-      this.setState({ searchGroups: result.data.data }),
-    );
+    GroupAPI.list({ name__contains: name, page_size: 5 })
+      .then((result) => this.setState({ searchGroups: result.data.data }))
+      .catch((e) => {
+        this.setState({
+          formErrors: {
+            ...this.state.formErrors,
+            groups: {
+              variant: 'danger',
+              title: t`Error loading groups.`,
+              description: e?.message,
+            },
+          },
+        });
+      });
   };
 
   private toError(validated: boolean) {

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -1,4 +1,5 @@
 import { CollectionDetailType, CollectionAPI } from 'src/api';
+import { AlertType } from 'src/components';
 import { Paths } from 'src/paths';
 
 export interface IBaseCollectionState {
@@ -8,6 +9,7 @@ export interface IBaseCollectionState {
     keywords?: string;
   };
   collection: CollectionDetailType;
+  alerts?: AlertType[];
 }
 
 export function loadCollection(

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -9,6 +9,8 @@ import {
   CollectionInfo,
   LoadingPageWithHeader,
   Main,
+  AlertList,
+  closeAlertMixin,
 } from 'src/components';
 import { loadCollection, IBaseCollectionState } from './base';
 import { ParamHelper } from 'src/utilities/param-helper';
@@ -28,6 +30,7 @@ class CollectionDetail extends React.Component<
     this.state = {
       collection: undefined,
       params: params,
+      alerts: [],
     };
   }
 
@@ -41,7 +44,7 @@ class CollectionDetail extends React.Component<
   }
 
   render() {
-    const { collection, params } = this.state;
+    const { collection, params, alerts } = this.state;
 
     if (!collection) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
@@ -63,6 +66,10 @@ class CollectionDetail extends React.Component<
 
     return (
       <React.Fragment>
+        <AlertList
+          alerts={alerts}
+          closeAlert={(i) => this.closeAlert(i)}
+        ></AlertList>
         <CollectionHeader
           collection={collection}
           params={params}
@@ -81,6 +88,18 @@ class CollectionDetail extends React.Component<
               {...collection}
               updateParams={(p) => this.updateParams(p)}
               params={this.state.params}
+              addAlert={(variant, title, description) =>
+                this.setState({
+                  alerts: [
+                    ...this.state.alerts,
+                    {
+                      variant,
+                      title,
+                      description,
+                    },
+                  ],
+                })
+              }
             />
           </section>
         </Main>
@@ -94,6 +113,10 @@ class CollectionDetail extends React.Component<
 
   get updateParams() {
     return ParamHelper.updateParamsMixin();
+  }
+
+  private get closeAlert() {
+    return closeAlertMixin('alerts');
   }
 }
 

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -12,6 +12,7 @@ import {
   AlertType,
   Main,
   EmptyStateUnauthorized,
+  LoadingPageSpinner,
 } from 'src/components';
 import {
   MyNamespaceAPI,
@@ -24,6 +25,7 @@ import { Form, ActionGroup, Button, Spinner } from '@patternfly/react-core';
 
 import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { ParamHelper, mapErrorMessages } from 'src/utilities';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   namespace: NamespaceType;
@@ -31,6 +33,7 @@ interface IState {
   newLinkURL: string;
   errorMessages: any;
   saving: boolean;
+  loading: boolean;
   redirect: string;
   unsavedData: boolean;
   alerts: AlertType[];
@@ -54,6 +57,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
     }
 
     this.state = {
+      loading: false,
       alerts: [],
       namespace: null,
       userId: '',
@@ -69,10 +73,34 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
   }
 
   componentDidMount() {
-    ActiveUserAPI.getUser().then((result) => {
-      this.setState({ userId: result.account_number }, () =>
-        this.loadNamespace(),
-      );
+    this.setState({ loading: true }, () => {
+      ActiveUserAPI.getUser()
+        .then((result) => {
+          this.setState({ userId: result.account_number }, () =>
+            this.loadNamespace(),
+          );
+        })
+        .catch((e) =>
+          this.setState(
+            {
+              loading: false,
+              redirect: formatPath(Paths.namespaceByRepo, {
+                namespace: this.props.match.params['namespace'],
+                repo: this.context.selectedRepo,
+              }),
+            },
+            () => {
+              this.context.setAlerts([
+                ...this.context.alerts,
+                {
+                  variant: 'danger',
+                  title: t`Error loading active user.`,
+                  description: e?.message,
+                },
+              ]);
+            },
+          ),
+        );
     });
   }
 
@@ -85,6 +113,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
       params,
       userId,
       unauthorized,
+      loading,
     } = this.state;
 
     const tabs = [
@@ -92,13 +121,18 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
       { id: 'edit-resources', name: t`Edit resources` },
     ];
 
+    if (redirect) {
+      return <Redirect push to={redirect} />;
+    }
+
+    if (loading) {
+      return <LoadingPageSpinner />;
+    }
+
     if (!namespace) {
       return null;
     }
 
-    if (redirect) {
-      return <Redirect push to={redirect} />;
-    }
     return (
       <React.Fragment>
         <PartnerHeader
@@ -187,10 +221,10 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
         // on the link edit form for adding new links
         const emptyLink: NamespaceLinkType = { name: '', url: '' };
         response.data.links.push(emptyLink);
-        this.setState({ namespace: response.data });
+        this.setState({ loading: false, namespace: response.data });
       })
       .catch((response) => {
-        this.setState({ unauthorized: true });
+        this.setState({ unauthorized: true, loading: false });
       });
   }
 
@@ -210,15 +244,25 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
 
       MyNamespaceAPI.update(this.state.namespace.name, namespace)
         .then((result) => {
-          this.setState({
-            namespace: result.data,
-            errorMessages: {},
-            saving: false,
-            unsavedData: false,
-            redirect: formatPath(Paths.myCollections, {
-              namespace: this.state.namespace.name,
-            }),
-          });
+          this.setState(
+            {
+              namespace: result.data,
+              errorMessages: {},
+              saving: false,
+              unsavedData: false,
+              redirect: formatPath(Paths.myCollections, {
+                namespace: this.state.namespace.name,
+              }),
+            },
+            () =>
+              this.context.setAlerts([
+                ...this.context.alerts,
+                {
+                  variant: 'success',
+                  title: t`Namespace successfully edited.`,
+                },
+              ]),
+          );
         })
         .catch((error) => {
           const result = error.response;
@@ -252,5 +296,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
     });
   }
 }
+
+EditNamespace.contextType = AppContext;
 
 export default withRouter(EditNamespace);

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -469,19 +469,26 @@ class ExecutionEnvironmentList extends React.Component<
             itemToEdit: null,
           })
         }
+        addAlert={(variant, title, description) =>
+          this.addAlert(title, variant, description)
+        }
       />
     );
   }
 
   private queryEnvironments() {
     this.setState({ loading: true }, () =>
-      ExecutionEnvironmentAPI.list(this.state.params).then((result) =>
-        this.setState({
-          items: result.data.data,
-          itemCount: result.data.meta.count,
-          loading: false,
-        }),
-      ),
+      ExecutionEnvironmentAPI.list(this.state.params)
+        .then((result) =>
+          this.setState({
+            items: result.data.data,
+            itemCount: result.data.meta.count,
+            loading: false,
+          }),
+        )
+        .catch((e) =>
+          this.addAlert(t`Error loading environments.`, 'danger', e?.message),
+        ),
     );
   }
 

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -285,12 +285,27 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
       groups__name: this.state.selectedGroup.name,
       page: 0,
       page_size: 10,
-    }).then((result) =>
-      this.setState({
-        deleteModalUsers: result.data.data,
-        deleteModalCount: result.data.meta.count,
-      }),
-    );
+    })
+      .then((result) =>
+        this.setState({
+          deleteModalUsers: result.data.data,
+          deleteModalCount: result.data.meta.count,
+        }),
+      )
+      .catch((e) =>
+        this.setState({
+          deleteModalVisible: false,
+          selectedGroup: null,
+          alerts: [
+            ...this.state.alerts,
+            {
+              variant: 'danger',
+              title: t`Error loading users.`,
+              description: e?.message,
+            },
+          ],
+        }),
+      );
   }
 
   private saveGroup(value) {
@@ -441,13 +456,29 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
 
   private queryGroups() {
     this.setState({ loading: true }, () =>
-      GroupAPI.list(this.state.params).then((result) =>
-        this.setState({
-          groups: result.data.data,
-          itemCount: result.data.meta.count,
-          loading: false,
-        }),
-      ),
+      GroupAPI.list(this.state.params)
+        .then((result) =>
+          this.setState({
+            groups: result.data.data,
+            itemCount: result.data.meta.count,
+            loading: false,
+          }),
+        )
+        .catch((e) =>
+          this.setState({
+            groups: [],
+            itemCount: 0,
+            loading: false,
+            alerts: [
+              ...this.state.alerts,
+              {
+                variant: 'danger',
+                title: t`Error loading groups.`,
+                description: e?.message,
+              },
+            ],
+          }),
+        ),
     );
   }
 }

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -39,10 +39,10 @@ import {
   RepoSelector,
   StatefulDropdown,
   ClipboardCopy,
-  AlertType,
+  ConfirmModal,
   AlertList,
   closeAlertMixin,
-  ConfirmModal,
+  AlertType,
 } from 'src/components';
 
 import { ImportModal } from './import-modal/import-modal';
@@ -70,10 +70,10 @@ interface IState {
   updateCollection: CollectionListType;
   showControls: boolean;
   isOpenNamespaceModal: boolean;
-  alerts: AlertType[];
   isNamespaceEmpty: boolean;
   confirmDelete: boolean;
   isNamespacePending: boolean;
+  alerts: AlertType[];
 }
 
 interface IProps extends RouteComponentProps {
@@ -107,17 +107,17 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       updateCollection: null,
       showControls: false, // becomes true when my-namespaces doesn't 404
       isOpenNamespaceModal: false,
-      alerts: [],
       isNamespaceEmpty: false,
       confirmDelete: false,
       isNamespacePending: false,
+      alerts: [],
     };
   }
 
   componentDidMount() {
     this.loadAll();
 
-    if (this.context.alerts) this.setState({ alerts: this.context.alerts });
+    this.setState({ alerts: this.context.alerts || [] });
   }
 
   componentWillUnmount() {
@@ -176,6 +176,10 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
     return (
       <React.Fragment>
+        <AlertList
+          alerts={this.state.alerts}
+          closeAlert={(i) => this.closeAlert(i)}
+        />
         <ImportModal
           isOpen={showImportModal}
           onUploadSuccess={(result) =>
@@ -218,10 +222,6 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             </>
           </ConfirmModal>
         )}
-        <AlertList
-          alerts={this.state.alerts}
-          closeAlert={(i) => this.closeAlert(i)}
-        />
         {warning ? (
           <Alert
             className='namespace-warning-alert'
@@ -446,7 +446,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             ...this.state.alerts,
             {
               variant: 'danger',
-              title: 'Error loading collection repositories',
+              title: t`Error loading collection repositories.`,
               description: err?.message,
             },
           ],
@@ -562,19 +562,24 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           ]);
         })
         .catch((e) => {
-          this.setState({
-            alerts: [
-              ...this.state.alerts,
-              {
-                variant: 'danger',
-                title: t`Error deleting namespace.`,
-                description: e.message,
-              },
-            ],
-            isOpenNamespaceModal: false,
-            confirmDelete: false,
-            isNamespacePending: false,
-          });
+          this.setState(
+            {
+              isOpenNamespaceModal: false,
+              confirmDelete: false,
+              isNamespacePending: false,
+            },
+            () =>
+              this.setState({
+                alerts: [
+                  ...this.state.alerts,
+                  {
+                    variant: 'danger',
+                    title: t`Error deleting namespace.`,
+                    description: e?.message,
+                  },
+                ],
+              }),
+          );
         }),
     );
   };
@@ -583,7 +588,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
     this.setState({ isOpenNamespaceModal: false, confirmDelete: false });
   };
 
-  private get closeAlert() {
+  get closeAlert() {
     return closeAlertMixin('alerts');
   }
 }

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -18,6 +18,7 @@ import {
   Pagination,
   Toolbar,
   AlertList,
+  AlertType,
 } from 'src/components';
 import { Button, ToolbarItem } from '@patternfly/react-core';
 import { NamespaceAPI, NamespaceListType, MyNamespaceAPI } from 'src/api';
@@ -86,17 +87,36 @@ export class NamespaceList extends React.Component<IProps, IState> {
     if (this.props.filterOwner) {
       // Make a query with no params and see if it returns results to tell
       // if the user can edit namespaces
-      MyNamespaceAPI.list({}).then((results) => {
-        if (results.data.meta.count !== 0) {
-          this.loadNamespaces();
-        } else {
-          this.setState({
-            hasPermission: false,
-            namespaces: [],
-            loading: false,
-          });
-        }
-      });
+      MyNamespaceAPI.list({})
+        .then((results) => {
+          if (results.data.meta.count !== 0) {
+            this.loadNamespaces();
+          } else {
+            this.setState({
+              hasPermission: false,
+              namespaces: [],
+              loading: false,
+            });
+          }
+        })
+        .catch((e) =>
+          this.setState(
+            {
+              namespaces: [],
+              itemCount: 0,
+              loading: false,
+            },
+            () =>
+              this.context.setAlerts([
+                ...this.context.alerts,
+                {
+                  variant: 'danger',
+                  title: t`Error loading my namespaces.`,
+                  description: e?.message,
+                },
+              ]),
+          ),
+        );
     } else {
       this.loadNamespaces();
     }
@@ -154,7 +174,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
             })
           }
         ></NamespaceModal>
-        <AlertList alerts={alerts} closeAlert={(i) => this.closeAlert(i)} />
+        <AlertList alerts={alerts} closeAlert={() => this.closeAlert()} />
         <BaseHeader title={title}>
           {!this.context.user.is_anonymous && (
             <div className='tab-link-container'>
@@ -285,13 +305,32 @@ export class NamespaceList extends React.Component<IProps, IState> {
       apiFunc = (p) => NamespaceAPI.list(p);
     }
     this.setState({ loading: true }, () => {
-      apiFunc(this.state.params).then((results) => {
-        this.setState({
-          namespaces: results.data.data,
-          itemCount: results.data.meta.count,
-          loading: false,
-        });
-      });
+      apiFunc(this.state.params)
+        .then((results) => {
+          this.setState({
+            namespaces: results.data.data,
+            itemCount: results.data.meta.count,
+            loading: false,
+          });
+        })
+        .catch((e) =>
+          this.setState(
+            {
+              namespaces: [],
+              itemCount: 0,
+              loading: false,
+            },
+            () =>
+              this.context.setAlerts([
+                ...this.context.alerts,
+                {
+                  variant: 'danger',
+                  title: t`Error loading namespaces.`,
+                  description: e?.message,
+                },
+              ]),
+          ),
+        );
     });
   }
 
@@ -299,7 +338,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
     return ParamHelper.updateParamsMixin(this.nonURLParams);
   }
 
-  private closeAlert(i) {
+  private closeAlert() {
     this.context.setAlerts([]);
   }
 }

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -388,13 +388,29 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
 
   private queryTasks() {
     this.setState({ loading: true }, () => {
-      TaskManagementAPI.list(this.state.params).then((result) => {
-        this.setState({
-          items: result.data.results,
-          itemCount: result.data.count,
-          loading: false,
-        });
-      });
+      TaskManagementAPI.list(this.state.params)
+        .then((result) => {
+          this.setState({
+            items: result.data.results,
+            itemCount: result.data.count,
+            loading: false,
+          });
+        })
+        .catch((e) =>
+          this.setState({
+            loading: false,
+            items: [],
+            itemCount: 0,
+            alerts: [
+              ...this.state.alerts,
+              {
+                variant: 'danger',
+                title: t`Error loading tasks.`,
+                description: e?.message,
+              },
+            ],
+          }),
+        );
     });
   }
 

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -5,7 +5,14 @@ import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import { ClipboardCopyVariant, Button } from '@patternfly/react-core';
 
 import { Paths } from 'src/paths';
-import { BaseHeader, Main, ClipboardCopy } from 'src/components';
+import {
+  BaseHeader,
+  Main,
+  ClipboardCopy,
+  AlertList,
+  AlertType,
+  closeAlertMixin,
+} from 'src/components';
 import { getRepoUrl } from 'src/utilities';
 import { AppContext } from 'src/loaders/app-context';
 
@@ -20,6 +27,7 @@ interface IState {
     session_state: string;
     token_type: string;
   };
+  alerts: AlertType[];
 }
 
 class TokenPage extends React.Component<RouteComponentProps, IState> {
@@ -28,19 +36,35 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
 
     this.state = {
       tokenData: undefined,
+      alerts: [],
     };
   }
 
   componentDidMount() {
     // this function will fail if chrome.auth.doOffline() hasn't been called
-    (window as any).insights.chrome.auth.getOfflineToken().then((result) => {
-      this.setState({ tokenData: result.data });
-    });
+    (window as any).insights.chrome.auth
+      .getOfflineToken()
+      .then((result) => {
+        this.setState({ tokenData: result.data });
+      })
+      .catch((e) =>
+        this.setState({
+          tokenData: undefined,
+          alerts: [
+            ...this.state.alerts,
+            {
+              variant: 'danger',
+              title: t`Error loading token.`,
+              description: e?.message,
+            },
+          ],
+        }),
+      );
   }
 
   render() {
     const { user } = this.context;
-    const { tokenData } = this.state;
+    const { tokenData, alerts } = this.state;
     const renewTokenCmd = `curl https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token -d grant_type=refresh_token -d client_id="${
       user.username
     }" -d refresh_token=\"${
@@ -49,6 +73,10 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
 
     return (
       <React.Fragment>
+        <AlertList
+          alerts={alerts}
+          closeAlert={(i) => this.closeAlert(i)}
+        ></AlertList>
         <BaseHeader title={t`Connect to Hub`}></BaseHeader>
         <Main>
           <section className='body pf-c-content'>
@@ -168,6 +196,10 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
       // available to getOfflineToken() when the component mounts after
       // the reload
       .doOffline();
+  }
+
+  private get closeAlert() {
+    return closeAlertMixin('alerts');
   }
 }
 

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -399,13 +399,29 @@ class UserList extends React.Component<RouteComponentProps, IState> {
 
   private queryUsers() {
     this.setState({ loading: true }, () =>
-      UserAPI.list(this.state.params).then((result) =>
-        this.setState({
-          users: result.data.data,
-          itemCount: result.data.meta.count,
-          loading: false,
-        }),
-      ),
+      UserAPI.list(this.state.params)
+        .then((result) =>
+          this.setState({
+            users: result.data.data,
+            itemCount: result.data.meta.count,
+            loading: false,
+          }),
+        )
+        .catch((e) =>
+          this.setState({
+            users: [],
+            itemCount: 0,
+            loading: false,
+            alerts: [
+              ...this.state.alerts,
+              {
+                variant: 'danger',
+                title: t`Error loading users.`,
+                description: e?.message,
+              },
+            ],
+          }),
+        ),
     );
   }
 


### PR DESCRIPTION
stable-4.4 backport of #1115 

(manual backport because of conflicts in src/containers/token/token-standalone.tsx (#1224 is not in 4.4))

---

* add group and colleciton-info missing erros

* add EE catch alerts

* add more catch alerts

* fix double alert popup

move alerts from local state to context state

* catch errors for (my)namespace

* catch alerts in editing namespace

catch alerts if something goes wrong while editing namespace

+ add success alert on edit namespace to global context alerts

* show alert on load group error

* add more context catch alerts

* add catch alert on loading token err

* remove global alert

* drop about modal alerts

* add inline form errors to repository modal

* add namespace form errors and rename to onError

* add namespace form errors

* move alerts to collection detail

* rollback context alerts to local

* add insights alerts

* remove disabling button on error

* add l10n to alerts

* remove dead code

* remove useless alert code

* remove isDisabled attr

Issue: AAH-517
(cherry picked from commit 446c3843b82ac22c8bdcd58423004f62903d7573)