### PR TITLE
i18n workflow: run for stable-4.4 as well

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -10,9 +10,19 @@ on:
 jobs:
   i18n:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        branch:
+          - 'master'
+          - 'stable-4.4'
+
     steps:
 
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ matrix.branch }}
+
     - name: "extract strings"
       run: |
         npm install


### PR DESCRIPTION
Follow-up to #1249
Cc @ZitaNemeckova 

turns out cron-scheduled jobs only run from master, the job is ignored in stable-4.4 now.

So, updating this one to iterate through both branches :)