### PR TITLE
cypress workflow: ensure cypress is running with up-to-date translations

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -130,6 +130,11 @@ jobs:
       working-directory: 'ansible-hub-ui'
       run: |
         npm install
+
+        # production displays unknown translations literally, make sure it's up to date
+        npm run gettext:extract
+        npm run gettext:compile
+
         npm run build-standalone
 
         # save the App.*.js hash for later verification


### PR DESCRIPTION
Noticed in https://github.com/ansible/ansible-hub-ui/pull/1469,
if you change translations in a PR, github actions cypress will not pick up the updates until gettext extract & compile happens,
making sure this always happens before tests.