### PR TITLE
Fix isEditing appearing in Users under group detail AppliedFilters

### DIFF
--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -723,7 +723,14 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
               this.setState({ inputText: '' });
             }}
             params={params}
-            ignoredParams={['page_size', 'page', 'sort', 'id', 'tab']}
+            ignoredParams={[
+              'id',
+              'isEditing',
+              'page',
+              'page_size',
+              'sort',
+              'tab',
+            ]}
           />
         </div>
         {this.renderUsersTable(users)}


### PR DESCRIPTION
Follow-up to #1256, in the Users tab under group detail

the new isEditing state variable started appearing in applied filters, ignoring

Issue: AAH-829

Cc @ShaiahWren :)

--

Before:
![20220113012626](https://user-images.githubusercontent.com/289743/149249262-0fbc6368-2876-4c26-8529-232efd7773a1.png)


After:
![20220113012553](https://user-images.githubusercontent.com/289743/149249267-344026a8-759f-471e-8713-244be958deec.png)

