### PR TITLE
Fix typescript errors related to `never` and `axios`

### DIFF
--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,11 +1,12 @@
-import axios, { AxiosInstance } from 'axios';
+import axios from 'axios';
 import { Constants } from 'src/constants';
 import { ParamHelper } from 'src/utilities';
 import Cookies from 'js-cookie';
 
 export class BaseAPI {
   apiPath: string;
-  http: AxiosInstance;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  http: any;
 
   constructor(apiBaseUrl) {
     this.http = axios.create({

--- a/src/api/execution-environment-registry.ts
+++ b/src/api/execution-environment-registry.ts
@@ -15,7 +15,7 @@ class API extends HubAPI {
     return super.update(pk, reducedData);
   }
 
-  update(_id, _obj): Promise<never> {
+  update(_id, _obj) {
     throw 'use smartUpdate()';
   }
 

--- a/src/api/remotes.ts
+++ b/src/api/remotes.ts
@@ -44,7 +44,7 @@ class API extends HubAPI {
     );
   }
 
-  update(_id, _obj): Promise<never> {
+  update(_id, _obj) {
     throw 'use smartUpdate()';
   }
 


### PR DESCRIPTION
Follow-up to #1493

editors can't seem to handle some of the typing bits, leading to `Property 'meta' does not exist on type 'never'.ts(2339)`,
turns out `Promise<never>` is superfluous here, removing :)

and also seeing

    Argument of type '(result: AxiosResponse<any>) => void' is not assignable to parameter of type '(value: AxiosResponse<any>) => AxiosResponse<any> | PromiseLike<AxiosResponse<any>>'.
    Type 'void' is not assignable to type 'AxiosResponse<any> | PromiseLike<AxiosResponse<any>>'.ts(2345)

=> changing `http` type back to `any`.

Cc @ShaiahWren does this help? :)