### PR TITLE
Testing and searching for sporadic failures

### DIFF
--- a/CHANGES/1282.misc
+++ b/CHANGES/1282.misc
@@ -1,0 +1,1 @@
+ Add Sporadic failures repairs

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -54,6 +54,7 @@ describe('Imports filter test', () => {
   });
 
   it('Exact search for completed is working.', () => {
+    cy.wait(10);
     cy.get('.import-list button:first').click();
     cy.contains('a', 'Status').click();
 

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -51,10 +51,10 @@ describe('Imports filter test', () => {
       .contains('different_name')
       .should('not.exist');
     cy.get('[data-cy="import-list-data"]').contains('my_collection1');
+    cy.wait(10000);
   });
 
   it('Exact search for completed is working.', () => {
-    cy.wait(10000);
     cy.get('.import-list button:first').click();
     cy.contains('a', 'Status').click();
 

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -10,6 +10,10 @@ describe('Imports filter test', () => {
     cy.galaxykit('-i collection upload filter_test_namespace different_name');
   });
 
+  after(() => {
+    deleteNamespacesAndCollections();
+  });
+
   beforeEach(() => {
     cy.login();
     cy.visit('/ui/my-imports?namespace=filter_test_namespace');

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -21,22 +21,22 @@ describe('Imports filter test', () => {
 
   it('partial filter for name is working.', () => {
     cy.get('input[aria-label="keywords"').type('my_collection{enter}');
-    cy.get('[data-cy="import-list-data"]').contains('my_collection1');
-    cy.get('[data-cy="import-list-data"]').contains('my_collection2');
     cy.get('[data-cy="import-list-data"]')
       .contains('different_name')
       .should('not.exist');
+    cy.get('[data-cy="import-list-data"]').contains('my_collection1');
+    cy.get('[data-cy="import-list-data"]').contains('my_collection2');
   });
 
   it('exact filter for name is working.', () => {
     cy.get('input[aria-label="keywords"').type('my_collection1{enter}');
-    cy.get('[data-cy="import-list-data"]').contains('my_collection1');
     cy.get('[data-cy="import-list-data"]')
       .contains('my_collection2')
       .should('not.exist');
     cy.get('[data-cy="import-list-data"]')
       .contains('different_name')
       .should('not.exist');
+    cy.get('[data-cy="import-list-data"]').contains('my_collection1');
   });
 
   it('Exact search for completed is working.', () => {
@@ -82,12 +82,12 @@ describe('Imports filter test', () => {
     ).as('wait');
     cy.contains('a', 'Completed').click();
 
-    cy.get('[data-cy="import-list-data"]').contains('my_collection1');
+    cy.wait('@wait');
+
     cy.get('[data-cy="import-list-data"]')
       .contains('different_name')
       .should('not.exist');
-
-    cy.wait('@wait');
+    cy.get('[data-cy="import-list-data"]').contains('my_collection1');
   });
 
   it('Partial search for name and completed is working.', () => {
@@ -103,12 +103,11 @@ describe('Imports filter test', () => {
       Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
     ).as('wait');
     cy.contains('a', 'Completed').click();
+    cy.wait('@wait');
 
     cy.get('[data-cy="import-list-data"]').contains('my_collection2');
     cy.get('[data-cy="import-list-data"]')
       .contains('different_name')
       .should('not.exist');
-
-    cy.wait('@wait');
   });
 });

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -11,7 +11,7 @@ describe('Imports filter test', () => {
   });
 
   after(() => {
-    deleteNamespacesAndCollections();
+    cy.deleteNamespacesAndCollections();
   });
 
   beforeEach(() => {

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -54,7 +54,7 @@ describe('Imports filter test', () => {
   });
 
   it('Exact search for completed is working.', () => {
-    cy.wait(10);
+    cy.wait(10000);
     cy.get('.import-list button:first').click();
     cy.contains('a', 'Status').click();
 

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -20,7 +20,14 @@ describe('Imports filter test', () => {
   });
 
   it('partial filter for name is working.', () => {
+    cy.intercept(
+      'GET',
+      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
+    ).as('wait');
+
     cy.get('input[aria-label="keywords"').type('my_collection{enter}');
+    cy.wait('@wait');
+
     cy.get('[data-cy="import-list-data"]')
       .contains('different_name')
       .should('not.exist');
@@ -29,7 +36,14 @@ describe('Imports filter test', () => {
   });
 
   it('exact filter for name is working.', () => {
+    cy.intercept(
+      'GET',
+      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
+    ).as('wait');
+
     cy.get('input[aria-label="keywords"').type('my_collection1{enter}');
+    cy.wait('@wait');
+
     cy.get('[data-cy="import-list-data"]')
       .contains('my_collection2')
       .should('not.exist');

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -52,11 +52,11 @@ describe('Imports filter test', () => {
     ).as('wait');
     cy.contains('a', 'Completed').click();
 
+    cy.wait('@wait');
+
     cy.get('[data-cy="import-list-data"]').contains('my_collection1');
     cy.get('[data-cy="import-list-data"]').contains('my_collection2');
     cy.get('[data-cy="import-list-data"]').contains('different_name');
-
-    cy.wait('@wait');
   });
 
   it('Exact search for waiting is working.', () => {


### PR DESCRIPTION
Issue: AAH-1282

This is meant to fix sporadic failures in `imports_filter.js`:

    "before each" hook for "Exact search for completed is working." / "before each" hook for "exact filter for name is working."
    
    Request failed with status code 403

example: https://github.com/ansible/ansible-hub-ui/runs/5100841966?check_suite_focus=true#step:17:601 , https://github.com/ansible/ansible-hub-ui/runs/5087051667?check_suite_focus=true#step:17:603

(this does not address failures in `collection_upload` or `view_only`)