### PR TITLE
AboutModal, html comment: show UI git commit hash

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -113,7 +113,8 @@ jobs:
           for file in *.js; do
             node -e 'console.log(JSON.stringify(require("./'"$file"'"), null, 2))' |
               sed -e 's/\/home\/.*\/\(base\|pr\)\//\/DIR\//g' \
-                -e 's/\(\[name\]\|automationHub\)\.[0-9]\+\.\(\[fullhash\]\)/\1.TIMESTAMP.\2/g' |
+                -e 's/\(\[name\]\|automationHub\)\.[0-9]\+\.\(\[fullhash\]\)/\1.TIMESTAMP.\2/g' \
+                -e 's/"UI_COMMIT_HASH": ".*"/"UI_COMMIT_HASH": "HASH"/' |
               grep -v '^Current branch:' |
               grep -v '^Root folder:' > ~/webpack-config/"$version"/"$file".json
           done

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -1,8 +1,9 @@
-const { resolve } = require('path');
+const { resolve } = require('path'); // node:path
 const config = require('@redhat-cloud-services/frontend-components-config');
 const webpack = require('webpack');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const { execSync } = require('child_process'); // node:child_process
 
 const isBuild = process.env.NODE_ENV === 'production';
 
@@ -10,6 +11,8 @@ const isBuild = process.env.NODE_ENV === 'production';
 // should be imported, initialized with the following settings and exported like
 // a normal webpack config. See config/insights.prod.webpack.config.js for an
 // example
+
+const gitCommit = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
 
 // Default user defined settings
 const defaultConfigs = [
@@ -22,6 +25,7 @@ const defaultConfigs = [
   { name: 'NAMESPACE_TERM', default: 'namespaces', scope: 'global' },
   { name: 'APPLICATION_NAME', default: 'Galaxy NG', scope: 'global' },
   { name: 'UI_EXTERNAL_LOGIN_URI', default: '/login', scope: 'global' },
+  { name: 'UI_COMMIT_HASH', default: gitCommit, scope: 'global' },
 
   // Webpack scope means the variable will only be available to webpack at
   // build time

--- a/src/components/about-modal/about-modal.tsx
+++ b/src/components/about-modal/about-modal.tsx
@@ -50,6 +50,18 @@ export class AboutModalWindow extends React.Component<IProps, IState> {
     const { isOpen, onClose, brandImageAlt, productName, user, userName } =
       this.props;
     const browser = detect();
+
+    const Label = ({ children }) => (
+      <TextListItem component={TextListItemVariants.dt}>
+        {children}
+      </TextListItem>
+    );
+    const Value = ({ children }) => (
+      <TextListItem component={TextListItemVariants.dd}>
+        {children}
+      </TextListItem>
+    );
+
     return (
       <AboutModal
         isOpen={isOpen}
@@ -61,42 +73,23 @@ export class AboutModalWindow extends React.Component<IProps, IState> {
       >
         <TextContent>
           <TextList component={TextListVariants.dl}>
-            <TextListItem component={TextListItemVariants.dt}>
-              {t`Server version`}
-            </TextListItem>
-            <TextListItem component={TextListItemVariants.dd}>
-              {this.state.applicationInfo.server_version}
-            </TextListItem>
-            <TextListItem component={TextListItemVariants.dt}>
-              {t`Pulp Ansible Version`}
-            </TextListItem>
-            <TextListItem component={TextListItemVariants.dd}>
-              {this.state.applicationInfo.pulp_ansible_version}
-            </TextListItem>
-            <TextListItem component={TextListItemVariants.dt}>
-              {t`Username`}
-            </TextListItem>
-            <TextListItem component={TextListItemVariants.dd}>
-              {userName}
-            </TextListItem>
-            <TextListItem component={TextListItemVariants.dt}>
-              {t`User Groups`}
-            </TextListItem>
-            <TextListItem component={TextListItemVariants.dd}>
-              {user.groups.map((group) => group.name).join()}
-            </TextListItem>
-            <TextListItem component={TextListItemVariants.dt}>
-              {t`Browser Version`}
-            </TextListItem>
-            <TextListItem component={TextListItemVariants.dd}>
-              {browser.name + ' ' + browser.version}
-            </TextListItem>
-            <TextListItem component={TextListItemVariants.dt}>
-              {t`Browser OS`}
-            </TextListItem>
-            <TextListItem component={TextListItemVariants.dd}>
-              {browser.os}
-            </TextListItem>
+            <Label>{t`Server version`}</Label>
+            <Value>{this.state.applicationInfo.server_version}</Value>
+
+            <Label>{t`Pulp Ansible Version`}</Label>
+            <Value>{this.state.applicationInfo.pulp_ansible_version}</Value>
+
+            <Label>{t`Username`}</Label>
+            <Value>{userName}</Value>
+
+            <Label>{t`User Groups`}</Label>
+            <Value>{user.groups.map((group) => group.name).join()}</Value>
+
+            <Label>{t`Browser Version`}</Label>
+            <Value>{browser.name + ' ' + browser.version}</Value>
+
+            <Label>{t`Browser OS`}</Label>
+            <Value>{browser.os}</Value>
           </TextList>
         </TextContent>
       </AboutModal>

--- a/src/components/about-modal/about-modal.tsx
+++ b/src/components/about-modal/about-modal.tsx
@@ -79,6 +79,9 @@ export class AboutModalWindow extends React.Component<IProps, IState> {
             <Label>{t`Pulp Ansible Version`}</Label>
             <Value>{this.state.applicationInfo.pulp_ansible_version}</Value>
 
+            <Label>{t`UI Version`}</Label>
+            <Value>{UI_COMMIT_HASH}</Value>
+
             <Label>{t`Username`}</Label>
             <Value>{userName}</Value>
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -70,6 +70,7 @@ export { Tabs, TabsType } from './patternfly-wrappers/tabs';
 export { Tag } from './tags/tag';
 export { TagLabel } from './tag-label/tag-label';
 export { Tooltip } from './patternfly-wrappers/tooltip';
+export { UIVersion } from './shared/ui-version';
 export { UserForm } from './user-form/user-form';
 export { UserFormPage } from './user-form/user-form-page';
 export { WriteOnlyField } from './patternfly-wrappers/write-only-field';

--- a/src/components/shared/ui-version.tsx
+++ b/src/components/shared/ui-version.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export const HTMLComment = ({ text, ...props }) => (
+  <div {...props} dangerouslySetInnerHTML={{ __html: `<!-- ${text} -->` }} />
+);
+
+export const UIVersion = () => (
+  <HTMLComment
+    className='hub-ui-version'
+    text={`ansible-hub-ui ${UI_COMMIT_HASH}`}
+  />
+);

--- a/src/components/shared/ui-version.tsx
+++ b/src/components/shared/ui-version.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export const HTMLComment = ({ text, ...props }) => (
   <div {...props} dangerouslySetInnerHTML={{ __html: `<!-- ${text} -->` }} />
 );
+
+HTMLComment.propTypes = { text: PropTypes.string };
 
 export const UIVersion = () => (
   <HTMLComment

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,6 +13,7 @@ declare var DEPLOYMENT_MODE;
 declare var NAMESPACE_TERM;
 declare var APPLICATION_NAME;
 declare var UI_EXTERNAL_LOGIN_URI;
+declare var UI_COMMIT_HASH;
 
 // when DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE only
 interface Window {

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -118,22 +118,27 @@ class App extends Component {
     // before the app can authenticate
     if (!this.state.user || !this.state.activeUser) {
       return null;
-    } else {
-      return (
-        <AppContext.Provider
-          value={{
-            user: this.state.activeUser,
-            setUser: this.setActiveUser,
-            selectedRepo: this.state.selectedRepo,
-            alerts: this.state.alerts,
-            setAlerts: this.setAlerts,
-            settings: this.state.settings,
-          }}
-        >
-          <Routes childProps={this.props} />
-        </AppContext.Provider>
-      );
     }
+
+    const HTMLComment = ({ text }) => (
+      <div dangerouslySetInnerHTML={{ __html: `<!-- ${text} -->` }} />
+    );
+
+    return (
+      <AppContext.Provider
+        value={{
+          user: this.state.activeUser,
+          setUser: this.setActiveUser,
+          selectedRepo: this.state.selectedRepo,
+          alerts: this.state.alerts,
+          setAlerts: this.setAlerts,
+          settings: this.state.settings,
+        }}
+      >
+        <Routes childProps={this.props} />
+        <HTMLComment text={`ansible-hub-ui ${UI_COMMIT_HASH}`} />
+      </AppContext.Provider>
+    );
   }
   setActiveUser = (user) => {
     this.setState({ activeUser: user });

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -7,6 +7,7 @@ import '../app.scss';
 import { AppContext } from '../app-context';
 import { ActiveUserAPI, SettingsAPI } from 'src/api';
 import { Paths } from 'src/paths';
+import { UIVersion } from 'src/components';
 
 const DEFAULT_REPO = 'published';
 
@@ -120,10 +121,6 @@ class App extends Component {
       return null;
     }
 
-    const HTMLComment = ({ text }) => (
-      <div dangerouslySetInnerHTML={{ __html: `<!-- ${text} -->` }} />
-    );
-
     return (
       <AppContext.Provider
         value={{
@@ -136,7 +133,7 @@ class App extends Component {
         }}
       >
         <Routes childProps={this.props} />
-        <HTMLComment text={`ansible-hub-ui ${UI_COMMIT_HASH}`} />
+        <UIVersion />
       </AppContext.Provider>
     );
   }

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -38,6 +38,7 @@ import {
 } from 'src/api';
 import {
   AboutModalWindow,
+  UIVersion,
   AlertType,
   LoginLink,
   SmallLogo,
@@ -460,6 +461,7 @@ class App extends React.Component<RouteComponentProps, IState> {
         }}
       >
         {component}
+        <UIVersion />
       </AppContext.Provider>
     );
   }


### PR DESCRIPTION
This runs `git rev-parse HEAD` at build time to get the current git commit hash, and provide it as a `UI_COMMIT_HASH` config.

Then, in standalone mode, the About modal now has a new "UI Version" entry, and there's a html comment as well..
![20220126003650](https://user-images.githubusercontent.com/289743/151084743-8cbec155-72a9-4ad5-a7e7-4258ad1613db.png)

![20220126010646](https://user-images.githubusercontent.com/289743/151085897-37056231-cf3b-44e6-917b-b5413d26984a.png)

And in insights mode, there is a new html comment with the version, near the end...

TODO test & screenshot
