### PR TITLE
Warning message for missing collection's documentation in Community repository

### DIFF
--- a/CHANGES/1207.misc
+++ b/CHANGES/1207.misc
@@ -1,0 +1,1 @@
+Added warning message screen in Documentation tab for Community repository

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -96,45 +96,43 @@ export class CollectionContentList extends React.Component<IProps> {
             </ToolbarGroup>
           </Toolbar>
         </div>
-        {toShow.length > 0 ? (
-          <table className='hub-c-table-content pf-c-table pf-m-compact'>
-            <thead>
-              <tr>
-                <th>{t`Name`}</th>
-                <th>{t`Type`}</th>
-                <th>{t`Description`}</th>
+        <table className='hub-c-table-content pf-c-table pf-m-compact'>
+          <thead>
+            <tr>
+              <th>{t`Name`}</th>
+              <th>{t`Type`}</th>
+              <th>{t`Description`}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {toShow.map((content, i) => (
+              <tr key={i}>
+                <td>
+                  <Link
+                    to={formatPath(
+                      Paths.collectionContentDocsByRepo,
+                      {
+                        collection: collection,
+                        namespace: namespace,
+                        type: content.content_type,
+                        name: content.name,
+                        repo: this.context.selectedRepo,
+                      },
+                      ParamHelper.getReduced(params, this.ignoredParams),
+                    )}
+                  >
+                    {content.name}
+                  </Link>
+                </td>
+                <td>{content.content_type}</td>
+                <td>{content.description}</td>
               </tr>
-            </thead>
-            <tbody>
-              {toShow.map((content, i) => (
-                <tr key={i}>
-                  <td>
-                    <Link
-                      to={formatPath(
-                        Paths.collectionContentDocsByRepo,
-                        {
-                          collection: collection,
-                          namespace: namespace,
-                          type: content.content_type,
-                          name: content.name,
-                          repo: this.context.selectedRepo,
-                        },
-                        ParamHelper.getReduced(params, this.ignoredParams),
-                      )}
-                    >
-                      {content.name}
-                    </Link>
-                  </td>
-                  <td>{content.content_type}</td>
-                  <td>{content.description}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        ) : (
+            ))}
+          </tbody>
+        </table>
+        {toShow.length <= 0 &&
           this.context.selectedRepo === 'community' &&
-          this.renderCommunityWarningMessage()
-        )}
+          this.renderCommunityWarningMessage()}
       </div>
     );
   }

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -11,6 +11,10 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+
+import { EmptyStateCustom } from 'src/components';
+
 import { ContentSummaryType } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
 import { ParamHelper } from 'src/utilities/param-helper';
@@ -92,41 +96,56 @@ export class CollectionContentList extends React.Component<IProps> {
             </ToolbarGroup>
           </Toolbar>
         </div>
-        <table className='hub-c-table-content pf-c-table pf-m-compact'>
-          <thead>
-            <tr>
-              <th>{t`Name`}</th>
-              <th>{t`Type`}</th>
-              <th>{t`Description`}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {toShow.map((content, i) => (
-              <tr key={i}>
-                <td>
-                  <Link
-                    to={formatPath(
-                      Paths.collectionContentDocsByRepo,
-                      {
-                        collection: collection,
-                        namespace: namespace,
-                        type: content.content_type,
-                        name: content.name,
-                        repo: this.context.selectedRepo,
-                      },
-                      ParamHelper.getReduced(params, this.ignoredParams),
-                    )}
-                  >
-                    {content.name}
-                  </Link>
-                </td>
-                <td>{content.content_type}</td>
-                <td>{content.description}</td>
+        {toShow.length > 0 ? (
+          <table className='hub-c-table-content pf-c-table pf-m-compact'>
+            <thead>
+              <tr>
+                <th>{t`Name`}</th>
+                <th>{t`Type`}</th>
+                <th>{t`Description`}</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {toShow.map((content, i) => (
+                <tr key={i}>
+                  <td>
+                    <Link
+                      to={formatPath(
+                        Paths.collectionContentDocsByRepo,
+                        {
+                          collection: collection,
+                          namespace: namespace,
+                          type: content.content_type,
+                          name: content.name,
+                          repo: this.context.selectedRepo,
+                        },
+                        ParamHelper.getReduced(params, this.ignoredParams),
+                      )}
+                    >
+                      {content.name}
+                    </Link>
+                  </td>
+                  <td>{content.content_type}</td>
+                  <td>{content.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          this.context.selectedRepo === 'community' &&
+          this.renderCommunityWarningMessage()
+        )}
       </div>
+    );
+  }
+
+  private renderCommunityWarningMessage() {
+    return (
+      <EmptyStateCustom
+        title={t`Warning`}
+        description={t`Community collections do not have docs nor content counts, but all content gets synchronized`}
+        icon={ExclamationTriangleIcon}
+      />
     );
   }
 }

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -130,7 +130,7 @@ export class CollectionContentList extends React.Component<IProps> {
             ))}
           </tbody>
         </table>
-        {toShow.length <= 0 &&
+        {summary.all <= 0 &&
           this.context.selectedRepo === 'community' &&
           this.renderCommunityWarningMessage()}
       </div>

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -22,7 +22,10 @@ import { ParamHelper, sanitizeDocsUrls } from 'src/utilities';
 import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
 
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import {
+  ExclamationTriangleIcon,
+  ExclamationCircleIcon,
+} from '@patternfly/react-icons';
 
 // renders markdown files in collection docs/ directory
 class CollectionDocs extends React.Component<
@@ -189,6 +192,9 @@ class CollectionDocs extends React.Component<
                     )}
                   />
                 )
+              ) : this.context.selectedRepo === 'community' &&
+                !collection.latest_version.docs_blob.contents ? (
+                this.renderCommunityWarningMessage()
               ) : (
                 this.renderNotFound(collection.name)
               )}
@@ -265,6 +271,16 @@ class CollectionDocs extends React.Component<
         title={t`Not found`}
         description={t`The file is not available for this version of ${collectionName}`}
         icon={ExclamationCircleIcon}
+      />
+    );
+  }
+
+  private renderCommunityWarningMessage() {
+    return (
+      <EmptyStateCustom
+        title={t`Warning`}
+        description={t`Community collections do not have docs nor content counts, but all content gets synchronized`}
+        icon={ExclamationTriangleIcon}
       />
     );
   }


### PR DESCRIPTION
Issue: [AAH-1207](https://issues.redhat.com/browse/AAH-1207)

- Add warning message to Documentation tab if no Documentation is present in Community collection

Before:
![Screenshot from 2022-01-26 18-10-47](https://user-images.githubusercontent.com/19647757/151213708-7ca8a78a-b557-4b86-adcf-994c033e53a3.png)

After:
![Screenshot from 2022-01-26 17-54-03](https://user-images.githubusercontent.com/19647757/151213879-48a67ef8-412f-4611-b626-701d16e988f8.png)

- Should this warning message be displayed in the `Contents` tab as well? 
