### PR TITLE
CollectionContentList - fix by type counts being 0 when All not chosen

### DIFF
--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -41,15 +41,20 @@ export class CollectionContentList extends React.Component<IProps> {
     const keywords = params.keywords || '';
 
     for (const c of contents) {
-      const typeMatch = showing === 'all' ? true : c.content_type === showing;
-      if (!summary[c.content_type]) {
-        summary[c.content_type] = 0;
-      }
+      summary[c.content_type] ||= 0;
 
-      if (typeMatch && c.name.match(keywords)) {
-        toShow.push(c);
+      const keywordMatch = c.name.match(keywords);
+      const typeMatch = showing === 'all' ? true : c.content_type === showing;
+
+      // count only items matching keyword
+      if (keywordMatch) {
         summary[c.content_type]++;
         summary['all']++;
+      }
+
+      // show only items matching keyword + type
+      if (keywordMatch && typeMatch) {
+        toShow.push(c);
       }
     }
 


### PR DESCRIPTION
go to Collection detail, tab Contents

the "Showing: All(23) Role(9) Module(3) Action(1) Filter(8) Test(2)" line only shows correct counts when All is selected,
otherwise only the current type is counted, leaving other types at 0,
because filtering is done by both keyword and type, before counting and showing the list

this changes the code to first filter by keyword, then count, then filter by type, then show

Cc @jerabekjiri I noticed this while reviewing #1561 , but it's also present on master, can you review please? :)

---

before: (only the last 2 pics differ)

![20220131004131](https://user-images.githubusercontent.com/289743/151725003-7cc04d0f-ccaf-4422-9892-5c16347b1ea2.png)
![20220131004143](https://user-images.githubusercontent.com/289743/151725006-1f23119f-ff6e-4412-a9aa-ed2f18c96fe0.png)
![20220131004216](https://user-images.githubusercontent.com/289743/151725008-ae974384-ee15-4bdd-94bd-b3310283f51c.png)
![20220131004223](https://user-images.githubusercontent.com/289743/151725009-39d7dc02-071b-4790-81cc-ca0490c5aace.png)

after:

![20220131004242](https://user-images.githubusercontent.com/289743/151725014-ce6a3f64-0835-4a17-aba3-631819452cf6.png)
![20220131004250](https://user-images.githubusercontent.com/289743/151725016-276e49a5-be9d-41d8-887e-7a7de5d35690.png)
![20220131004256](https://user-images.githubusercontent.com/289743/151725017-03d4e3e2-5919-48f5-835d-3546df304b5d.png)
![20220131004302](https://user-images.githubusercontent.com/289743/151725018-aef3b557-a48e-4e30-a694-3c3e499271d1.png)

