### PR TITLE
Fix proxy password in remote repositories

### DIFF
--- a/CHANGES/1253.misc
+++ b/CHANGES/1253.misc
@@ -1,0 +1,1 @@
+Change proxy password from text type to password type

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -497,7 +497,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
                   isRequired={requiredFields.includes('proxy_password')}
                   isDisabled={disabledFields.includes('proxy_password')}
                   id='proxy_password'
-                  type='text'
+                  type='password'
                   value={remote.proxy_password || ''}
                   onChange={(value) =>
                     this.updateRemote(value, 'proxy_password')


### PR DESCRIPTION
Issue: [AAH-1253](https://issues.redhat.com/browse/AAH-1253)

- Change proxy password from text type to password type to make it more secure 

before:
![Screenshot from 2022-01-27 19-36-10](https://user-images.githubusercontent.com/19647757/151868941-197b965a-e8b5-4d99-b6aa-32113cdb9863.png)

after:
![Screenshot from 2022-01-27 19-36-28](https://user-images.githubusercontent.com/19647757/151868920-68cedda8-b6cf-4225-bdfa-cc72538defca.png)

