### PR TITLE
[stable-4.4] CollectionContentList - fix by type counts being 0 when All not chosen (#1577)

### DIFF
--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -41,16 +41,21 @@ export class CollectionContentList extends React.Component<IProps> {
     const showing = params.showing || 'all';
     const keywords = params.keywords || '';
 
-    for (let c of contents) {
-      const typeMatch = showing === 'all' ? true : c.content_type === showing;
-      if (!summary[c.content_type]) {
-        summary[c.content_type] = 0;
-      }
+    for (const c of contents) {
+      summary[c.content_type] ||= 0;
 
-      if (typeMatch && c.name.match(keywords)) {
-        toShow.push(c);
+      const keywordMatch = c.name.match(keywords);
+      const typeMatch = showing === 'all' ? true : c.content_type === showing;
+
+      // count only items matching keyword
+      if (keywordMatch) {
         summary[c.content_type]++;
         summary['all']++;
+      }
+
+      // show only items matching keyword + type
+      if (keywordMatch && typeMatch) {
+        toShow.push(c);
       }
     }
 


### PR DESCRIPTION
Manual backport of #1577, const vs let difference.
Fixes AAH-1334

---

go to Collection detail, tab Contents

the "Showing: All(23) Role(9) Module(3) Action(1) Filter(8) Test(2)" line only shows correct counts when All is selected,
otherwise only the current type is counted, leaving other types at 0,
because filtering is done by both keyword and type, before counting and showing the list

this changes the code to first filter by keyword, then count, then filter by type, then show

No-Issue

(cherry picked from commit 7e48ccf70aa1be93289da237635ce1276b776f83)