### PR TITLE
index.d.ts: fix lingui:extract blowing up on Unexpected token function

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -42,7 +42,7 @@ interface Window {
       };
       identifyApp: (s: string) => void;
       init: () => void;
-      on: (s: string, f: function) => void;
+      on: (s: string, f: () => void) => void;
     };
   };
 }


### PR DESCRIPTION
Running `npm run gettext:extract`:

    #: src/containers/namespace-detail/namespace-detail.tsx:158
    Cannot process file /home/himdel/ansible-hub-ui/src/index.d.ts: Unexpected token (45:25)

      43 |       identifyApp: (s: string) => void;
      44 |       init: () => void;
    > 45 |       on: (s: string, f: function) => void;
        |                          ^
      46 |     };
      47 |   };
      48 | }

(it doesn't fail with a non-zero exit status code either :( )

This was casued by #1463 , looks like `function` is not supported everywhere, `() => void` works.