### PR TITLE
Change Server URL to Repo management URL

### DIFF
--- a/CHANGES/1072.misc
+++ b/CHANGES/1072.misc
@@ -1,0 +1,1 @@
+Changed Server URL and removed repository management note


### PR DESCRIPTION
Issue: [AAH-1072](https://issues.redhat.com/browse/AAH-1072)

- Change Server URL to Repo Management URL
- Remove the note under the URL

Before:
![Screenshot from 2022-02-03 00-27-42](https://user-images.githubusercontent.com/19647757/152457749-927f7fb7-d1d5-419c-a87a-da7af54ed5c1.png)

After:
![Screenshot from 2022-02-02 20-38-09](https://user-images.githubusercontent.com/19647757/152457761-e80f4d50-f9e7-49c5-8a77-b5f49671eaa9.png)


