### PR TITLE
Bump stylelint to 14.3.0, switch to stylelint-config-standard-scss, fix

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,6 +2,7 @@
   "extends": "stylelint-config-standard-scss",
   "rules": {
     "declaration-colon-newline-after": null,
-    "scss/at-import-partial-extension": null
+    "scss/at-import-partial-extension": null,
+    "selector-class-pattern": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "stylelint-config-standard-scss",
   "rules": {
-    "declaration-colon-newline-after": null
+    "declaration-colon-newline-after": null,
+    "scss/at-import-partial-extension": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "stylelint-config-recommended-scss"
+  "extends": "stylelint-config-standard-scss"
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "stylelint-config-standard-scss"
+  "extends": "stylelint-config-standard-scss",
+  "rules": {
+    "declaration-colon-newline-after": null
+  }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,6 +3,7 @@
   "rules": {
     "declaration-colon-newline-after": null,
     "scss/at-import-partial-extension": null,
-    "selector-class-pattern": null
+    "selector-class-pattern": null,
+    "string-quotes": "single"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4721,25 +4721,6 @@
                 "tslib": "^1.9.3"
             }
         },
-        "@stylelint/postcss-css-in-js": {
-            "version": "0.37.2",
-            "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz",
-            "integrity": "sha512-nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==",
-            "dev": true,
-            "requires": {
-                "@babel/core": ">=7.9.0"
-            }
-        },
-        "@stylelint/postcss-markdown": {
-            "version": "0.36.2",
-            "resolved": "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.2.tgz",
-            "integrity": "sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==",
-            "dev": true,
-            "requires": {
-                "remark": "^13.0.0",
-                "unist-util-find-all-after": "^3.0.2"
-            }
-        },
         "@types/debounce-promise": {
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.4.tgz",
@@ -5856,49 +5837,6 @@
                 "core-js": "^2.5.0"
             }
         },
-        "autoprefixer": {
-            "version": "9.8.6",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
-            "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
-            "dev": true,
-            "requires": {
-                "browserslist": "^4.12.0",
-                "caniuse-lite": "^1.0.30001109",
-                "colorette": "^1.2.1",
-                "normalize-range": "^0.1.2",
-                "num2fraction": "^1.2.2",
-                "postcss": "^7.0.32",
-                "postcss-value-parser": "^4.1.0"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "7.0.36",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.2",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^6.1.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
         "available-typed-arrays": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
@@ -6035,12 +5973,6 @@
             "requires": {
                 "@babel/helper-define-polyfill-provider": "^0.3.0"
             }
-        },
-        "bail": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-            "integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-            "dev": true
         },
         "balanced-match": {
             "version": "1.0.2",
@@ -6321,24 +6253,6 @@
                 "supports-color": "^5.3.0"
             }
         },
-        "character-entities": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-            "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-            "dev": true
-        },
-        "character-entities-legacy": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-            "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-            "dev": true
-        },
-        "character-reference-invalid": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-            "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-            "dev": true
-        },
         "chardet": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
@@ -6491,6 +6405,12 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "colord": {
+            "version": "2.9.2",
+            "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+            "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
             "dev": true
         },
         "colorette": {
@@ -7761,9 +7681,9 @@
             "dev": true
         },
         "fast-glob": {
-            "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-            "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+            "version": "3.2.11",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -8285,15 +8205,6 @@
             "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
             "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
             "dev": true
-        },
-        "gonzales-pe": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
-            "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
-            "dev": true,
-            "requires": {
-                "minimist": "^1.2.5"
-            }
         },
         "graceful-fs": {
             "version": "4.2.8",
@@ -9117,12 +9028,6 @@
                 "is-extglob": "^2.1.1"
             }
         },
-        "is-hexadecimal": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-            "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-            "dev": true
-        },
         "is-interactive": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
@@ -9194,9 +9099,9 @@
             }
         },
         "is-plain-obj": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-            "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
             "dev": true
         },
         "is-plain-object": {
@@ -9536,9 +9441,9 @@
             "dev": true
         },
         "known-css-properties": {
-            "version": "0.21.0",
-            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.21.0.tgz",
-            "integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==",
+            "version": "0.24.0",
+            "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.24.0.tgz",
+            "integrity": "sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==",
             "dev": true
         },
         "leven": {
@@ -9635,12 +9540,6 @@
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
-        "lodash.clonedeep": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-            "dev": true
-        },
         "lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -9726,12 +9625,6 @@
                 }
             }
         },
-        "longest-streak": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
-            "integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
-            "dev": true
-        },
         "loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -9787,9 +9680,9 @@
             "integrity": "sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA=="
         },
         "map-obj": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.1.tgz",
-            "integrity": "sha512-+WA2/1sPmDj1dlvvJmB5G6JKfY9dpn7EVBUL06+y6PoljPkh+6V1QihwxNkbcGxCRjt2b0F9K0taiCuo7MbdFQ==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+            "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
             "dev": true
         },
         "mathml-tag-names": {
@@ -9825,19 +9718,6 @@
                 }
             }
         },
-        "mdast-util-from-markdown": {
-            "version": "0.8.5",
-            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
-            "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
-            "dev": true,
-            "requires": {
-                "@types/mdast": "^3.0.0",
-                "mdast-util-to-string": "^2.0.0",
-                "micromark": "~2.11.0",
-                "parse-entities": "^2.0.0",
-                "unist-util-stringify-position": "^2.0.0"
-            }
-        },
         "mdast-util-to-hast": {
             "version": "12.1.1",
             "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.1.1.tgz",
@@ -9854,26 +9734,6 @@
                 "unist-util-position": "^4.0.0",
                 "unist-util-visit": "^4.0.0"
             }
-        },
-        "mdast-util-to-markdown": {
-            "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
-            "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
-            "dev": true,
-            "requires": {
-                "@types/unist": "^2.0.0",
-                "longest-streak": "^2.0.0",
-                "mdast-util-to-string": "^2.0.0",
-                "parse-entities": "^2.0.0",
-                "repeat-string": "^1.0.0",
-                "zwitch": "^1.0.0"
-            }
-        },
-        "mdast-util-to-string": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-            "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-            "dev": true
         },
         "mdurl": {
             "version": "1.0.1",
@@ -9964,22 +9824,22 @@
             },
             "dependencies": {
                 "hosted-git-info": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-                    "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+                    "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
                 },
                 "normalize-package-data": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-                    "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+                    "version": "3.0.3",
+                    "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+                    "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
                     "dev": true,
                     "requires": {
                         "hosted-git-info": "^4.0.1",
-                        "resolve": "^1.20.0",
+                        "is-core-module": "^2.5.0",
                         "semver": "^7.3.4",
                         "validate-npm-package-license": "^3.0.1"
                     }
@@ -9997,12 +9857,6 @@
                     "version": "0.18.1",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
                     "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-                    "dev": true
-                },
-                "yargs-parser": {
-                    "version": "20.2.9",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-                    "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
                     "dev": true
                 }
             }
@@ -10035,16 +9889,6 @@
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
             "dev": true
-        },
-        "micromark": {
-            "version": "2.11.4",
-            "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
-            "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
-            "dev": true,
-            "requires": {
-                "debug": "^4.0.0",
-                "parse-entities": "^2.0.0"
-            }
         },
         "micromark-core-commonmark": {
             "version": "1.0.6",
@@ -10351,14 +10195,6 @@
                 "arrify": "^1.0.1",
                 "is-plain-obj": "^1.1.0",
                 "kind-of": "^6.0.3"
-            },
-            "dependencies": {
-                "is-plain-obj": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-                    "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-                    "dev": true
-                }
             }
         },
         "mkdirp": {
@@ -10498,12 +10334,6 @@
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
         },
-        "normalize-range": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-            "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
-            "dev": true
-        },
         "normalize-selector": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
@@ -10595,12 +10425,6 @@
             "requires": {
                 "boolbase": "^1.0.0"
             }
-        },
-        "num2fraction": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-            "dev": true
         },
         "object-assign": {
             "version": "4.1.1",
@@ -11057,20 +10881,6 @@
                 "callsites": "^3.0.0"
             }
         },
-        "parse-entities": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-            "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-            "dev": true,
-            "requires": {
-                "character-entities": "^1.0.0",
-                "character-entities-legacy": "^1.0.0",
-                "character-reference-invalid": "^1.0.0",
-                "is-alphanumerical": "^1.0.0",
-                "is-decimal": "^1.0.0",
-                "is-hexadecimal": "^1.0.0"
-            }
-        },
         "parse-json": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -11326,123 +11136,6 @@
                 }
             }
         },
-        "postcss-html": {
-            "version": "0.36.0",
-            "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
-            "integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
-            "dev": true,
-            "requires": {
-                "htmlparser2": "^3.10.0"
-            },
-            "dependencies": {
-                "dom-serializer": {
-                    "version": "0.2.2",
-                    "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-                    "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-                    "dev": true,
-                    "requires": {
-                        "domelementtype": "^2.0.1",
-                        "entities": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "domelementtype": {
-                            "version": "2.2.0",
-                            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-                            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-                            "dev": true
-                        },
-                        "entities": {
-                            "version": "2.2.0",
-                            "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-                            "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-                            "dev": true
-                        }
-                    }
-                },
-                "domelementtype": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-                    "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
-                    "dev": true
-                },
-                "domhandler": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-                    "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-                    "dev": true,
-                    "requires": {
-                        "domelementtype": "1"
-                    }
-                },
-                "domutils": {
-                    "version": "1.7.0",
-                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-                    "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-                    "dev": true,
-                    "requires": {
-                        "dom-serializer": "0",
-                        "domelementtype": "1"
-                    }
-                },
-                "entities": {
-                    "version": "1.1.2",
-                    "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-                    "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-                    "dev": true
-                },
-                "htmlparser2": {
-                    "version": "3.10.1",
-                    "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-                    "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-                    "dev": true,
-                    "requires": {
-                        "domelementtype": "^1.3.1",
-                        "domhandler": "^2.3.0",
-                        "domutils": "^1.5.1",
-                        "entities": "^1.1.1",
-                        "inherits": "^2.0.1",
-                        "readable-stream": "^3.1.1"
-                    }
-                }
-            }
-        },
-        "postcss-less": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
-            "integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
-            "dev": true,
-            "requires": {
-                "postcss": "^7.0.14"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "7.0.36",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.2",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^6.1.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
         "postcss-media-query-parser": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
@@ -11491,116 +11184,16 @@
             "dev": true
         },
         "postcss-safe-parser": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz",
-            "integrity": "sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==",
-            "dev": true,
-            "requires": {
-                "postcss": "^7.0.26"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "7.0.36",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.2",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^6.1.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
-        "postcss-sass": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.4.tgz",
-            "integrity": "sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==",
-            "dev": true,
-            "requires": {
-                "gonzales-pe": "^4.3.0",
-                "postcss": "^7.0.21"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "7.0.36",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.2",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^6.1.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+            "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+            "dev": true
         },
         "postcss-scss": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
-            "integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
-            "dev": true,
-            "requires": {
-                "postcss": "^7.0.6"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "7.0.36",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.2",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^6.1.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.3.tgz",
+            "integrity": "sha512-j4KxzWovfdHsyxwl1BxkUal/O4uirvHgdzMKS1aWJBAV0qh2qj5qAZqpeBfVUYGWv+4iK9Az7SPyZ4fyNju1uA==",
+            "dev": true
         },
         "postcss-selector-parser": {
             "version": "6.0.6",
@@ -11611,12 +11204,6 @@
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
             }
-        },
-        "postcss-syntax": {
-            "version": "0.36.2",
-            "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
-            "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-            "dev": true
         },
         "postcss-value-parser": {
             "version": "4.1.0",
@@ -12284,26 +11871,6 @@
             "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
             "dev": true
         },
-        "remark": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
-            "integrity": "sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==",
-            "dev": true,
-            "requires": {
-                "remark-parse": "^9.0.0",
-                "remark-stringify": "^9.0.0",
-                "unified": "^9.1.0"
-            }
-        },
-        "remark-parse": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-            "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-            "dev": true,
-            "requires": {
-                "mdast-util-from-markdown": "^0.8.0"
-            }
-        },
         "remark-rehype": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-10.1.0.tgz",
@@ -12374,15 +11941,6 @@
                 }
             }
         },
-        "remark-stringify": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
-            "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
-            "dev": true,
-            "requires": {
-                "mdast-util-to-markdown": "^0.6.0"
-            }
-        },
         "renderkid": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz",
@@ -12395,12 +11953,6 @@
                 "lodash": "^4.17.21",
                 "strip-ansi": "^6.0.1"
             }
-        },
-        "repeat-string": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
         },
         "require-directory": {
             "version": "2.1.1",
@@ -12827,12 +12379,6 @@
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
                     "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-                    "dev": true
                 }
             }
         },
@@ -13148,70 +12694,53 @@
             }
         },
         "stylelint": {
-            "version": "13.13.1",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.13.1.tgz",
-            "integrity": "sha512-Mv+BQr5XTUrKqAXmpqm6Ddli6Ief+AiPZkRsIrAoUKFuq/ElkUh9ZMYxXD0iQNZ5ADghZKLOWz1h7hTClB7zgQ==",
+            "version": "14.3.0",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.3.0.tgz",
+            "integrity": "sha512-PZXSwtJe4f4qBPWBwAbHL0M0Qjrv8iHN+cLpUNsffaVMS3YzpDDRI73+2lsqLAYfQEzxRwpll6BDKImREbpHWA==",
             "dev": true,
             "requires": {
-                "@stylelint/postcss-css-in-js": "^0.37.2",
-                "@stylelint/postcss-markdown": "^0.36.2",
-                "autoprefixer": "^9.8.6",
                 "balanced-match": "^2.0.0",
-                "chalk": "^4.1.1",
-                "cosmiconfig": "^7.0.0",
-                "debug": "^4.3.1",
+                "colord": "^2.9.2",
+                "cosmiconfig": "^7.0.1",
+                "debug": "^4.3.3",
                 "execall": "^2.0.0",
-                "fast-glob": "^3.2.5",
+                "fast-glob": "^3.2.11",
                 "fastest-levenshtein": "^1.0.12",
                 "file-entry-cache": "^6.0.1",
                 "get-stdin": "^8.0.0",
                 "global-modules": "^2.0.0",
-                "globby": "^11.0.3",
+                "globby": "^11.1.0",
                 "globjoin": "^0.1.4",
                 "html-tags": "^3.1.0",
-                "ignore": "^5.1.8",
+                "ignore": "^5.2.0",
                 "import-lazy": "^4.0.0",
                 "imurmurhash": "^0.1.4",
-                "known-css-properties": "^0.21.0",
-                "lodash": "^4.17.21",
-                "log-symbols": "^4.1.0",
+                "is-plain-object": "^5.0.0",
+                "known-css-properties": "^0.24.0",
                 "mathml-tag-names": "^2.1.3",
                 "meow": "^9.0.0",
                 "micromatch": "^4.0.4",
+                "normalize-path": "^3.0.0",
                 "normalize-selector": "^0.2.0",
-                "postcss": "^7.0.35",
-                "postcss-html": "^0.36.0",
-                "postcss-less": "^3.1.4",
+                "picocolors": "^1.0.0",
+                "postcss": "^8.4.5",
                 "postcss-media-query-parser": "^0.2.3",
                 "postcss-resolve-nested-selector": "^0.1.1",
-                "postcss-safe-parser": "^4.0.2",
-                "postcss-sass": "^0.4.4",
-                "postcss-scss": "^2.1.1",
-                "postcss-selector-parser": "^6.0.5",
-                "postcss-syntax": "^0.36.2",
-                "postcss-value-parser": "^4.1.0",
+                "postcss-safe-parser": "^6.0.0",
+                "postcss-selector-parser": "^6.0.9",
+                "postcss-value-parser": "^4.2.0",
                 "resolve-from": "^5.0.0",
-                "slash": "^3.0.0",
                 "specificity": "^0.4.1",
-                "string-width": "^4.2.2",
-                "strip-ansi": "^6.0.0",
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1",
                 "style-search": "^0.1.0",
-                "sugarss": "^2.0.0",
+                "supports-hyperlinks": "^2.2.0",
                 "svg-tags": "^1.0.0",
-                "table": "^6.6.0",
+                "table": "^6.8.0",
                 "v8-compile-cache": "^2.3.0",
-                "write-file-atomic": "^3.0.3"
+                "write-file-atomic": "^4.0.0"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "4.3.0",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^2.0.1"
-                    }
-                },
                 "array-union": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -13224,255 +12753,131 @@
                     "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
                     "dev": true
                 },
-                "chalk": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-                    "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+                "cosmiconfig": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+                    "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^4.1.0",
-                        "supports-color": "^7.1.0"
+                        "@types/parse-json": "^4.0.0",
+                        "import-fresh": "^3.2.1",
+                        "parse-json": "^5.0.0",
+                        "path-type": "^4.0.0",
+                        "yaml": "^1.10.0"
                     }
                 },
-                "color-convert": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                "debug": {
+                    "version": "4.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+                    "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
                     "dev": true,
                     "requires": {
-                        "color-name": "~1.1.4"
+                        "ms": "2.1.2"
                     }
-                },
-                "color-name": {
-                    "version": "1.1.4",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true
-                },
-                "emoji-regex": {
-                    "version": "8.0.0",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-                    "dev": true
                 },
                 "globby": {
-                    "version": "11.0.4",
-                    "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-                    "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+                    "version": "11.1.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+                    "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
                     "dev": true,
                     "requires": {
                         "array-union": "^2.1.0",
                         "dir-glob": "^3.0.1",
-                        "fast-glob": "^3.1.1",
-                        "ignore": "^5.1.4",
-                        "merge2": "^1.3.0",
+                        "fast-glob": "^3.2.9",
+                        "ignore": "^5.2.0",
+                        "merge2": "^1.4.1",
                         "slash": "^3.0.0"
                     }
                 },
-                "has-flag": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true
-                },
                 "ignore": {
-                    "version": "5.1.8",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+                    "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
                     "dev": true
                 },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                "is-plain-object": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+                    "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
                     "dev": true
                 },
-                "postcss": {
-                    "version": "7.0.36",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
+                "postcss-selector-parser": {
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+                    "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.4.2",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^6.1.0"
-                    },
-                    "dependencies": {
-                        "ansi-styles": {
-                            "version": "3.2.1",
-                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                            "dev": true,
-                            "requires": {
-                                "color-convert": "^1.9.0"
-                            }
-                        },
-                        "chalk": {
-                            "version": "2.4.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                            "dev": true,
-                            "requires": {
-                                "ansi-styles": "^3.2.1",
-                                "escape-string-regexp": "^1.0.5",
-                                "supports-color": "^5.3.0"
-                            },
-                            "dependencies": {
-                                "supports-color": {
-                                    "version": "5.5.0",
-                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                                    "dev": true,
-                                    "requires": {
-                                        "has-flag": "^3.0.0"
-                                    }
-                                }
-                            }
-                        },
-                        "color-convert": {
-                            "version": "1.9.3",
-                            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                            "dev": true,
-                            "requires": {
-                                "color-name": "1.1.3"
-                            }
-                        },
-                        "color-name": {
-                            "version": "1.1.3",
-                            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-                            "dev": true
-                        },
-                        "has-flag": {
-                            "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                            "dev": true
-                        },
-                        "supports-color": {
-                            "version": "6.1.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                            "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                            "dev": true,
-                            "requires": {
-                                "has-flag": "^3.0.0"
-                            }
-                        }
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
                     }
                 },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
                     "dev": true
-                },
-                "string-width": {
-                    "version": "4.2.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-                    "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^8.0.0",
-                        "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^6.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "7.2.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^4.0.0"
-                    }
                 },
                 "write-file-atomic": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-                    "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.0.tgz",
+                    "integrity": "sha512-JhcWoKffJNF7ivO9yflBhc7tn3wKnokMUfWpBriM9yCXj4ePQnRPcWglBkkg1AHC8nsW/EfxwwhqsLtOy59djA==",
                     "dev": true,
                     "requires": {
                         "imurmurhash": "^0.1.4",
                         "is-typedarray": "^1.0.0",
                         "signal-exit": "^3.0.2",
-                        "typedarray-to-buffer": "^3.1.5"
+                        "typedarray-to-buffer": "^4.0.0"
                     }
                 }
             }
         },
         "stylelint-config-recommended": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz",
-            "integrity": "sha512-c8aubuARSu5A3vEHLBeOSJt1udOdS+1iue7BmJDTSXoCBmfEQmmWX+59vYIj3NQdJBY6a/QRv1ozVFpaB9jaqA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
+            "integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
             "dev": true
         },
         "stylelint-config-recommended-scss": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-4.3.0.tgz",
-            "integrity": "sha512-/noGjXlO8pJTr/Z3qGMoaRFK8n1BFfOqmAbX1RjTIcl4Yalr+LUb1zb9iQ7pRx1GsEBXOAm4g2z5/jou/pfMPg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.2.tgz",
+            "integrity": "sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==",
             "dev": true,
             "requires": {
-                "stylelint-config-recommended": "^5.0.0"
+                "postcss-scss": "^4.0.2",
+                "stylelint-config-recommended": "^6.0.0",
+                "stylelint-scss": "^4.0.0"
+            }
+        },
+        "stylelint-config-standard": {
+            "version": "24.0.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-24.0.0.tgz",
+            "integrity": "sha512-+RtU7fbNT+VlNbdXJvnjc3USNPZRiRVp/d2DxOF/vBDDTi0kH5RX2Ny6errdtZJH3boO+bmqIYEllEmok4jiuw==",
+            "dev": true,
+            "requires": {
+                "stylelint-config-recommended": "^6.0.0"
+            }
+        },
+        "stylelint-config-standard-scss": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-3.0.0.tgz",
+            "integrity": "sha512-zt3ZbzIbllN1iCmc94e4pDxqpkzeR6CJo5DDXzltshuXr+82B8ylHyMMARNnUYrZH80B7wgY7UkKTYCFM0UUyw==",
+            "dev": true,
+            "requires": {
+                "stylelint-config-recommended-scss": "^5.0.2",
+                "stylelint-config-standard": "^24.0.0"
             }
         },
         "stylelint-scss": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.21.0.tgz",
-            "integrity": "sha512-CMI2wSHL+XVlNExpauy/+DbUcB/oUZLARDtMIXkpV/5yd8nthzylYd1cdHeDMJVBXeYHldsnebUX6MoV5zPW4A==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.1.0.tgz",
+            "integrity": "sha512-BNYTo7MMamhFOlcaAWp2dMpjg6hPyM/FFqfDIYzmYVLMmQJqc8lWRIiTqP4UX5bresj9Vo0dKC6odSh43VP2NA==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.15",
+                "lodash": "^4.17.21",
                 "postcss-media-query-parser": "^0.2.3",
                 "postcss-resolve-nested-selector": "^0.1.1",
-                "postcss-selector-parser": "^6.0.2",
+                "postcss-selector-parser": "^6.0.6",
                 "postcss-value-parser": "^4.1.0"
-            }
-        },
-        "sugarss": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
-            "integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
-            "dev": true,
-            "requires": {
-                "postcss": "^7.0.2"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "7.0.36",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.2",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^6.1.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
             }
         },
         "supports-color": {
@@ -13482,6 +12887,33 @@
             "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
+            }
+        },
+        "supports-hyperlinks": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
+            "integrity": "sha512-6sXEzV5+I5j8Bmq9/vUphGRM/RJNT9SCURJLjwfOg51heRtguGWDzcaBlgAzKhQa0EVNpPEKzQuBwZ8S8WaCeQ==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^4.0.0",
+                "supports-color": "^7.0.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "svg-tags": {
@@ -13496,23 +12928,22 @@
             "integrity": "sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ=="
         },
         "table": {
-            "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
-            "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+            "version": "6.8.0",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+            "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
             "dev": true,
             "requires": {
                 "ajv": "^8.0.1",
-                "lodash.clonedeep": "^4.5.0",
                 "lodash.truncate": "^4.4.2",
                 "slice-ansi": "^4.0.0",
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0"
+                "string-width": "^4.2.3",
+                "strip-ansi": "^6.0.1"
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.6.2",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
-                    "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+                    "version": "8.10.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+                    "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -13521,43 +12952,11 @@
                         "uri-js": "^4.2.2"
                     }
                 },
-                "emoji-regex": {
-                    "version": "8.0.0",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-                    "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-                    "dev": true
-                },
                 "json-schema-traverse": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
                     "dev": true
-                },
-                "string-width": {
-                    "version": "4.2.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-                    "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^8.0.0",
-                        "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^6.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-                    "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.0"
-                    }
                 }
             }
         },
@@ -13720,12 +13119,6 @@
             "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
             "dev": true
         },
-        "trough": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-            "integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-            "dev": true
-        },
         "ts-loader": {
             "version": "8.3.0",
             "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.3.0.tgz",
@@ -13864,13 +13257,10 @@
             }
         },
         "typedarray-to-buffer": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-            "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-            "dev": true,
-            "requires": {
-                "is-typedarray": "^1.0.0"
-            }
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
+            "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+            "dev": true
         },
         "typescript": {
             "version": "4.5.4",
@@ -13918,20 +13308,6 @@
             "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
             "dev": true
         },
-        "unified": {
-            "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
-            "integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
-            "dev": true,
-            "requires": {
-                "bail": "^1.0.0",
-                "extend": "^3.0.0",
-                "is-buffer": "^2.0.0",
-                "is-plain-obj": "^2.0.0",
-                "trough": "^1.0.0",
-                "vfile": "^4.0.0"
-            }
-        },
         "union": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
@@ -13949,39 +13325,15 @@
                 "@types/unist": "^2.0.0"
             }
         },
-        "unist-util-find-all-after": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.2.tgz",
-            "integrity": "sha512-xaTC/AGZ0rIM2gM28YVRAFPIZpzbpDtU3dRmp7EXlNVA8ziQc4hY3H7BHXM1J49nEmiqc3svnqMReW+PGqbZKQ==",
-            "dev": true,
-            "requires": {
-                "unist-util-is": "^4.0.0"
-            }
-        },
         "unist-util-generated": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/unist-util-generated/-/unist-util-generated-2.0.0.tgz",
             "integrity": "sha512-TiWE6DVtVe7Ye2QxOVW9kqybs6cZexNwTwSMVgkfjEReqy/xwGpAXb99OxktoWwmL+Z+Epb0Dn8/GNDYP1wnUw=="
         },
-        "unist-util-is": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-            "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-            "dev": true
-        },
         "unist-util-position": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-4.0.1.tgz",
             "integrity": "sha512-mgy/zI9fQ2HlbOtTdr2w9lhVaiFUHWQnZrFF2EUoVOqtAUdzqMtNiD99qA5a1IcjWVR8O6aVYE9u7Z2z1v0SQA=="
-        },
-        "unist-util-stringify-position": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-            "integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-            "dev": true,
-            "requires": {
-                "@types/unist": "^2.0.2"
-            }
         },
         "unist-util-visit": {
             "version": "4.1.0",
@@ -14152,28 +13504,6 @@
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
             "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
             "dev": true
-        },
-        "vfile": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-            "integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-            "dev": true,
-            "requires": {
-                "@types/unist": "^2.0.0",
-                "is-buffer": "^2.0.0",
-                "unist-util-stringify-position": "^2.0.0",
-                "vfile-message": "^2.0.0"
-            }
-        },
-        "vfile-message": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-            "integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-            "dev": true,
-            "requires": {
-                "@types/unist": "^2.0.0",
-                "unist-util-stringify-position": "^2.0.0"
-            }
         },
         "warning": {
             "version": "4.0.3",
@@ -14784,12 +14114,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-            "dev": true
-        },
-        "zwitch": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
-            "integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
             "dev": true
         }
     }

--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
         "sass-loader": "^12.4.0",
         "source-map-loader": "^3.0.1",
         "style-loader": "^3.3.1",
-        "stylelint": "^13.13.1",
-        "stylelint-config-recommended-scss": "^4.3.0",
-        "stylelint-scss": "^3.21.0",
+        "stylelint": "^14.3.0",
+        "stylelint-config-standard-scss": "^3.0.0",
+        "stylelint-scss": "^4.1.0",
         "typescript": "^4.5.4",
         "webpack": "^5.66.0",
         "webpack-cli": "^4.9.2"

--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -15,7 +15,6 @@
 
 .hub-c-card-collection-container {
   width: 280px;
-  // height: 340px;
 
   // For some reason the PF Card components overrides all the defaults for
   // divs

--- a/src/components/collection-detail/collection-content-list.scss
+++ b/src/components/collection-detail/collection-content-list.scss
@@ -1,5 +1,6 @@
 .hub-c-table-content {
   width: 100%;
+
   th {
     font-weight: bold;
   }

--- a/src/components/collection-detail/collection-info.scss
+++ b/src/components/collection-detail/collection-info.scss
@@ -19,8 +19,8 @@
   pointer-events: none;
   background-image: linear-gradient(
     to bottom,
-    rgba(255, 255, 255, 0),
-    rgba(255, 255, 255, 1) 90%
+    rgba(255, 255, 255, 0%),
+    rgba(255, 255, 255, 100%) 90%
   );
   width: 100%;
   height: 50px;

--- a/src/components/collection-detail/collection-info.scss
+++ b/src/components/collection-detail/collection-info.scss
@@ -27,12 +27,12 @@
 }
 
 .download-button {
-  padding-left: 0px;
+  padding-left: 0;
 }
 
 .info-panel {
   padding: 8px;
 }
 .hub-collection-download-alert > h4 {
-  margin-top: 0px;
+  margin-top: 0;
 }

--- a/src/components/collection-detail/collection-info.scss
+++ b/src/components/collection-detail/collection-info.scss
@@ -19,8 +19,8 @@
   pointer-events: none;
   background-image: linear-gradient(
     to bottom,
-    rgba(255 255 255 0%),
-    rgba(255 255 255 100%) 90%
+    rgba(255 255 255 / 0%),
+    rgba(255 255 255 / 100%) 90%
   );
   width: 100%;
   height: 50px;

--- a/src/components/collection-detail/collection-info.scss
+++ b/src/components/collection-detail/collection-info.scss
@@ -33,6 +33,7 @@
 .info-panel {
   padding: 8px;
 }
+
 .hub-collection-download-alert > h4 {
   margin-top: 0;
 }

--- a/src/components/collection-detail/collection-info.scss
+++ b/src/components/collection-detail/collection-info.scss
@@ -19,8 +19,8 @@
   pointer-events: none;
   background-image: linear-gradient(
     to bottom,
-    rgba(255, 255, 255, 0%),
-    rgba(255, 255, 255, 100%) 90%
+    rgba(255 255 255 0%),
+    rgba(255 255 255 100%) 90%
   );
   width: 100%;
   height: 50px;

--- a/src/components/collection-list/list.scss
+++ b/src/components/collection-list/list.scss
@@ -1,7 +1,6 @@
 .controls {
   display: flex;
   justify-content: space-between;
-
   padding-left: 24px;
   padding-right: 24px;
 }

--- a/src/components/collection-list/list.scss
+++ b/src/components/collection-list/list.scss
@@ -5,11 +5,11 @@
   padding-right: 24px;
 }
 .top {
-  padding-top: 0px;
+  padding-top: 0;
   padding-bottom: 16px;
 }
 
 .bottom {
   padding-top: 16px;
-  padding-bottom: 0px;
+  padding-bottom: 0;
 }

--- a/src/components/collection-list/list.scss
+++ b/src/components/collection-list/list.scss
@@ -4,6 +4,7 @@
   padding-left: 24px;
   padding-right: 24px;
 }
+
 .top {
   padding-top: 0;
   padding-bottom: 16px;

--- a/src/components/headers/header.scss
+++ b/src/components/headers/header.scss
@@ -88,7 +88,6 @@
     }
 
     flex-grow: 1;
-
     display: flex;
     align-items: center;
     flex-wrap: wrap;

--- a/src/components/headers/header.scss
+++ b/src/components/headers/header.scss
@@ -64,6 +64,7 @@
 .hub-tab-link-container {
   display: flex;
   margin-top: 10px;
+
   @media (max-width: $breakpoint-md) {
     flex-direction: column-reverse;
   }
@@ -81,6 +82,7 @@
     @media (min-width: $breakpoint-md) {
       justify-content: flex-end;
     }
+
     @media (max-width: $breakpoint-md) {
       margin-bottom: 10px;
     }

--- a/src/components/headers/header.scss
+++ b/src/components/headers/header.scss
@@ -34,7 +34,7 @@
 
 .background {
   background-color: white;
-  padding: 0 24px 0 24px;
+  padding: 0 24px;
 }
 
 .placeholder {

--- a/src/components/headers/header.scss
+++ b/src/components/headers/header.scss
@@ -34,7 +34,7 @@
 
 .background {
   background-color: white;
-  padding: 0px 24px 0px 24px;
+  padding: 0 24px 0 24px;
 }
 
 .placeholder {

--- a/src/components/helper-text/helper-text.scss
+++ b/src/components/helper-text/helper-text.scss
@@ -1,3 +1,3 @@
 .helper {
-  padding: 0px;
+  padding: 0;
 }

--- a/src/components/import-modal/import-modal.scss
+++ b/src/components/import-modal/import-modal.scss
@@ -52,8 +52,8 @@
         position: absolute;
         height: 3px;
         background-color: $green;
-        bottom: 0px;
-        left: 0px;
+        bottom: 0;
+        left: 0;
       }
     }
   }

--- a/src/components/import-modal/import-modal.scss
+++ b/src/components/import-modal/import-modal.scss
@@ -2,7 +2,7 @@
 
 .upload-collection {
   .file-error-messages {
-    color: #cc0000;
+    color: #c00;
   }
 
   .upload-file {

--- a/src/components/markdown-editor/markdown-editor.scss
+++ b/src/components/markdown-editor/markdown-editor.scss
@@ -1,4 +1,5 @@
 @import '../../global-variables.scss';
+
 .markdown-editor {
   display: flex;
 
@@ -26,6 +27,7 @@
     max-width: 500px;
   }
 }
+
 #resources {
   height: 500px;
   resize: none;

--- a/src/components/my-imports/my-imports.scss
+++ b/src/components/my-imports/my-imports.scss
@@ -43,12 +43,15 @@
   & > div {
     margin-bottom: 16px;
   }
+
   .pf-c-toolbar {
     padding: 0;
   }
+
   .pf-c-toolbar__content-section {
     margin: 0;
   }
+
   .list-container {
     display: flex;
     align-items: center;
@@ -94,10 +97,12 @@
 
   .title-container {
     display: inline-block;
+
     .title {
       display: inline;
       font-size: 18px;
     }
+
     .refreshing-icon {
       display: inline;
       font-size: 18px;
@@ -105,6 +110,7 @@
       opacity: 0;
       transition: 2s ease;
     }
+
     .refreshing-icon.refreshing {
       opacity: 1;
     }
@@ -145,9 +151,11 @@
 .failed {
   color: $red;
 }
+
 .warning {
   color: $warning;
 }
+
 .success {
   color: $green;
 }

--- a/src/components/my-imports/my-imports.scss
+++ b/src/components/my-imports/my-imports.scss
@@ -53,9 +53,11 @@
     display: flex;
     align-items: center;
     padding: 10px;
+
     .left {
       margin-right: 10px;
     }
+
     border-bottom: 1px solid #ededed;
   }
 

--- a/src/components/namespace-form/namespace-form.scss
+++ b/src/components/namespace-form/namespace-form.scss
@@ -1,4 +1,5 @@
 @import '../../global-variables.scss';
+
 .hub-card-row {
   @media (max-width: $breakpoint-md) {
     flex-direction: column-reverse;
@@ -38,6 +39,7 @@
     display: flex;
     align-items: center;
     margin-left: 10px;
+
     .link-container {
       width: 20px;
     }

--- a/src/components/sort-table/sort-table.scss
+++ b/src/components/sort-table/sort-table.scss
@@ -3,6 +3,7 @@
 .active {
   color: $blue;
 }
+
 .inactive {
   color: $grey;
 }

--- a/src/containers/certification-dashboard/certification-dashboard.scss
+++ b/src/containers/certification-dashboard/certification-dashboard.scss
@@ -3,6 +3,7 @@
   justify-content: space-between;
   align-items: center;
 }
+
 .hub-certification-dashboard {
   .footer {
     padding-top: 16px;

--- a/src/containers/collection-detail/collection-detail.scss
+++ b/src/containers/collection-detail/collection-detail.scss
@@ -1,8 +1,8 @@
 @import '../../global-variables.scss';
 
 .main {
-  margin: 0px;
-  padding: 0px;
+  margin: 0;
+  padding: 0;
 }
 
 .header {
@@ -26,14 +26,14 @@
     min-width: 294px;
     max-width: 294px;
     border-right: 1px solid #d8d8d8;
-    padding: 0px;
-    padding-top: 0px;
+    padding: 0;
+    padding-top: 0;
   }
 
   .docs {
     flex-grow: 1;
     padding: 24px;
-    padding-top: 0px;
+    padding-top: 0;
     overflow-x: auto;
 
     // make the height close to the height ofthe page so short docs don't

--- a/src/containers/collection-detail/collection-detail.scss
+++ b/src/containers/collection-detail/collection-detail.scss
@@ -44,6 +44,7 @@
       tr:nth-child(2n) {
         background-color: #f2f2f2;
       }
+
       td,
       th {
         border: 1px solid #ccc;
@@ -52,6 +53,7 @@
     }
   }
 }
+
 .docs-container pre {
   white-space: pre-wrap;
 }

--- a/src/containers/collection-detail/collection-detail.scss
+++ b/src/containers/collection-detail/collection-detail.scss
@@ -16,6 +16,7 @@
 .docs-container {
   padding-top: 24px;
   background-color: white;
+
   @media (min-width: $breakpoint-md) {
     display: flex;
   }

--- a/src/containers/execution-environment-detail/execution-environment-detail.scss
+++ b/src/containers/execution-environment-detail/execution-environment-detail.scss
@@ -5,6 +5,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
 }
+
 .hub-c-button-edit {
   float: right;
 }

--- a/src/containers/execution-environment-list/execution-environment.scss
+++ b/src/containers/execution-environment-list/execution-environment.scss
@@ -3,7 +3,7 @@
   justify-content: space-between;
   align-items: center;
   .pf-c-toolbar__content {
-    padding-left: 0px;
+    padding-left: 0;
   }
 }
 

--- a/src/containers/execution-environment-list/execution-environment.scss
+++ b/src/containers/execution-environment-list/execution-environment.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+
   .pf-c-toolbar__content {
     padding-left: 0;
   }

--- a/src/containers/execution-environment/registry-list.scss
+++ b/src/containers/execution-environment/registry-list.scss
@@ -3,6 +3,6 @@
   justify-content: space-between;
   align-items: center;
   .pf-c-toolbar__content {
-    padding-left: 0px;
+    padding-left: 0;
   }
 }

--- a/src/containers/execution-environment/registry-list.scss
+++ b/src/containers/execution-environment/registry-list.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+
   .pf-c-toolbar__content {
     padding-left: 0;
   }

--- a/src/containers/group-management/group-management.scss
+++ b/src/containers/group-management/group-management.scss
@@ -3,6 +3,6 @@
   justify-content: space-between;
   align-items: center;
   .pf-c-toolbar__content {
-    padding-left: 0px;
+    padding-left: 0;
   }
 }

--- a/src/containers/group-management/group-management.scss
+++ b/src/containers/group-management/group-management.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+
   .pf-c-toolbar__content {
     padding-left: 0;
   }

--- a/src/containers/my-imports/my-imports.scss
+++ b/src/containers/my-imports/my-imports.scss
@@ -2,6 +2,7 @@
 
 .hub-page-container {
   display: flex;
+
   .import-list {
     width: 400px;
   }

--- a/src/containers/namespace-detail/namespace-detail.scss
+++ b/src/containers/namespace-detail/namespace-detail.scss
@@ -1,6 +1,6 @@
 .namespace-detail {
   .pf-c-toolbar__content {
-    padding-left: 0px;
+    padding-left: 0;
   }
 }
 

--- a/src/containers/namespace-list/namespace-list.scss
+++ b/src/containers/namespace-list/namespace-list.scss
@@ -25,7 +25,7 @@
   }
 
   .pf-c-toolbar__content {
-    padding-left: 0px;
+    padding-left: 0;
   }
 
   .footer {

--- a/src/containers/namespace-list/namespace-list.scss
+++ b/src/containers/namespace-list/namespace-list.scss
@@ -8,6 +8,7 @@
     margin-top: 24px;
     margin-left: 24px;
     flex-grow: 1;
+
     .card-layout {
       display: flex;
       flex-wrap: wrap;

--- a/src/containers/not-found/not-found.scss
+++ b/src/containers/not-found/not-found.scss
@@ -1,10 +1,12 @@
 .hub-c-bullseye {
   min-height: calc(100vh - 230px);
+
   &__center {
     display: flex;
     align-items: center;
     flex-direction: column;
   }
+
   &__404 {
     font-size: 30pt;
   }

--- a/src/containers/search/search.scss
+++ b/src/containers/search/search.scss
@@ -20,6 +20,7 @@
   .collection-container {
     padding-top: 24px;
     flex-grow: 1;
+
     .cards {
       display: flex;
       flex-wrap: wrap;
@@ -44,6 +45,7 @@
 
       // Hack to hide the annoying line at the top of the data list.
       overflow: hidden;
+
       .data-list {
         margin-top: -17px;
         margin-bottom: -17px;

--- a/src/containers/search/search.scss
+++ b/src/containers/search/search.scss
@@ -19,7 +19,6 @@
 
   .collection-container {
     padding-top: 24px;
-
     flex-grow: 1;
     .cards {
       display: flex;

--- a/src/containers/search/search.scss
+++ b/src/containers/search/search.scss
@@ -14,7 +14,7 @@
   }
 
   .pf-c-toolbar__content {
-    padding-left: 0px;
+    padding-left: 0;
   }
 
   .collection-container {

--- a/src/containers/task-management/task.scss
+++ b/src/containers/task-management/task.scss
@@ -2,13 +2,16 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+
   .pf-c-toolbar__content {
     padding-left: 0;
   }
 }
+
 .hub-c-task-status {
   margin-left: 10px;
 }
+
 .hub-code-block {
   white-space: pre-wrap;
 }

--- a/src/containers/task-management/task.scss
+++ b/src/containers/task-management/task.scss
@@ -3,7 +3,7 @@
   justify-content: space-between;
   align-items: center;
   .pf-c-toolbar__content {
-    padding-left: 0px;
+    padding-left: 0;
   }
 }
 .hub-c-task-status {

--- a/src/containers/user-management/user-management.scss
+++ b/src/containers/user-management/user-management.scss
@@ -3,6 +3,6 @@
   justify-content: space-between;
   align-items: center;
   .pf-c-toolbar__content {
-    padding-left: 0px;
+    padding-left: 0;
   }
 }

--- a/src/containers/user-management/user-management.scss
+++ b/src/containers/user-management/user-management.scss
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+
   .pf-c-toolbar__content {
     padding-left: 0;
   }

--- a/src/global-variables.scss
+++ b/src/global-variables.scss
@@ -3,7 +3,7 @@ $breakpoint-md: 1000px;
 $breakpoint-sm: 700px;
 
 $white: #fff;
-$warning: #ff9900;
+$warning: #f90;
 $red: #ff5850;
 $red-hover: #ae3f3a;
 $green: #5bb75b;

--- a/src/global-variables.scss
+++ b/src/global-variables.scss
@@ -1,7 +1,6 @@
 $breakpoint-lg: 1300px;
 $breakpoint-md: 1000px;
 $breakpoint-sm: 700px;
-
 $white: #fff;
 $warning: #f90;
 $red: #ff5850;

--- a/src/loaders/app.scss
+++ b/src/loaders/app.scss
@@ -11,7 +11,7 @@
 }
 
 #page-sidebar > div {
-  padding-top: 0px;
+  padding-top: 0;
 }
 #page-sidebar {
   border-top: solid var(--pf-global--BorderWidth--sm)

--- a/src/loaders/app.scss
+++ b/src/loaders/app.scss
@@ -14,9 +14,8 @@
   padding-top: 0px;
 }
 #page-sidebar {
-  border-top-style: solid;
-  border-top-width: var(--pf-global--BorderWidth--sm);
-  border-top-color: var(--pf-global--palette--black-800);
+  border-top: solid var(--pf-global--BorderWidth--sm)
+    var(--pf-global--palette--black-800);
 }
 
 section.pf-c-nav__section.nav-title > h2 {

--- a/src/loaders/app.scss
+++ b/src/loaders/app.scss
@@ -13,6 +13,7 @@
 #page-sidebar > div {
   padding-top: 0;
 }
+
 #page-sidebar {
   border-top: solid var(--pf-global--BorderWidth--sm)
     var(--pf-global--palette--black-800);


### PR DESCRIPTION
This bumps stylelint to 14.3.0,
the new version of [`stylelint-config-recommended-scss`](https://github.com/stylelint-scss/stylelint-config-recommended-scss/blob/HEAD/index.js) changes some rules, but recommends using [`stylelint-config-standard-scss`](https://github.com/stylelint-scss/stylelint-config-standard-scss/blob/HEAD/index.js) for a more complete set of rules, doing that.

And then going by rule, details in individual commits :)

fix `alpha-value-notation`
fix `at-rule-empty-line-before`
fix `color-function-notation`
fix `color-hex-length`
fix `declaration-block-no-redundant-longhand-properties`
disable `declaration-colon-newline-after` - because `prettier` disagrees
fix `declaration-empty-line-before`
fix `length-zero-no-unit`
fix `rule-empty-line-before`
disable `scss/at-import-partial-extension` - because we resolve them at the webpack level
fix `scss/dollar-variable-empty-line-before`
fix `scss/double-slash-comment-empty-line-before`
disable `selector-class-pattern` (for now)
fix `shorthand-property-no-redundant-values`
override `string-quotes` to `single` - because `prettier` disagrees
