### PR TITLE
EE form: Add ? to upstream name

### DIFF
--- a/CHANGES/1111.misc
+++ b/CHANGES/1111.misc
@@ -1,0 +1,2 @@
+ 
+Added helper to upstram name field in add/edit execution enviroments modal.

--- a/CHANGES/1111.misc
+++ b/CHANGES/1111.misc
@@ -1,2 +1,1 @@
- 
-Added helper to upstram name field in add/edit execution enviroments modal.
+ Added helper to upstram name field in add/edit execution enviroments modal.

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -1,4 +1,4 @@
-import { t } from '@lingui/macro';
+import { t, Trans } from '@lingui/macro';
 import * as React from 'react';
 import {
   Alert,
@@ -19,6 +19,7 @@ import {
   AlertType,
   APISearchTypeAhead,
   ObjectPermissionField,
+  HelperText,
 } from 'src/components';
 import {
   ContainerDistributionAPI,
@@ -211,6 +212,16 @@ export class RepositoryForm extends React.Component<IProps, IState> {
                 fieldId='upstreamName'
                 label={t`Upstream name`}
                 isRequired={true}
+                labelIcon={
+                  <HelperText
+                    content={
+                      <Trans>
+                        Use the namespace/name format for namespaced containers,{' '}
+                        <b>library/</b>name otherwise.
+                      </Trans>
+                    }
+                  />
+                }
               >
                 <TextInput
                   id='upstreamName'

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -214,12 +214,7 @@ export class RepositoryForm extends React.Component<IProps, IState> {
                 isRequired={true}
                 labelIcon={
                   <HelperText
-                    content={
-                      <Trans>
-                        Use the namespace/name format for namespaced containers,{' '}
-                        <b>library/</b>name otherwise.
-                      </Trans>
-                    }
+                    content={t`Use the namespace/name format for namespaced containers. Otherwise, use the library/name format.`}
                   />
                 }
               >

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -1,4 +1,4 @@
-import { t, Trans } from '@lingui/macro';
+import { t } from '@lingui/macro';
 import * as React from 'react';
 import {
   Alert,


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-1111

Execution Environment add/edit form:

the "Upstream name" field needs a help popup, mentioning the foo/bar format, and "library/" for the rest.

Proposed Solution: Ask Docs people how to word the explanation. Add ? with explanation. See Users form and password field for reference.