### PR TITLE
Adding links to namespaces has undesireable UX

### DIFF
--- a/CHANGES/149.misc
+++ b/CHANGES/149.misc
@@ -1,0 +1,1 @@
+Added validation for particular URLs in namespaces (better text and validation during writing)

--- a/src/components/namespace-form/namespace-form.scss
+++ b/src/components/namespace-form/namespace-form.scss
@@ -27,11 +27,13 @@
   margin-bottom: 10px;
 
   .link-name {
-    flex: 1;
+    flex-grow: 1;
+    flex-basis: 0;
   }
 
   .link-url {
-    flex: 2;
+    flex-grow: 2;
+    flex-basis: 0;
     margin-left: 20px;
   }
 

--- a/src/components/namespace-form/namespace-form.scss
+++ b/src/components/namespace-form/namespace-form.scss
@@ -27,18 +27,19 @@
   margin-bottom: 10px;
 
   .link-name {
-    flex-grow: 1;
+    flex: 1;
   }
 
   .link-url {
-    flex-grow: 2;
+    flex: 2;
     margin-left: 20px;
   }
 
   .link-button {
     display: flex;
-    align-items: center;
+    align-items: top;
     margin-left: 10px;
+    margin-top: 8px;
 
     .link-container {
       width: 20px;

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -26,39 +26,7 @@ import { RemoteType, WriteOnlyFieldType } from 'src/api';
 import { Constants } from 'src/constants';
 import { isFieldSet, isWriteOnly, ErrorMessagesType } from 'src/utilities';
 
-const validateURLHelper = (
-  outsideError: string | undefined,
-  url: string,
-): {
-  validated: 'default' | 'warning' | 'error';
-  helperTextInvalid?: string;
-  helperText?: string;
-} => {
-  if (outsideError) {
-    return { validated: 'error', helperTextInvalid: outsideError };
-  }
-
-  try {
-    const { protocol } = new URL(url);
-    if (protocol === 'http:') {
-      return {
-        validated: 'warning',
-        helperText: t`Consider using a secure URL (https://).`,
-      };
-    }
-
-    if (protocol === 'https:') {
-      return { validated: 'default' };
-    }
-  } catch (_) {
-    // fallthrough
-  }
-
-  return {
-    validated: 'error',
-    helperTextInvalid: t`The URL needs to be in 'http(s)://' format.`,
-  };
-};
+import { validateURLHelper } from 'src/utilities';
 
 interface IProps {
   allowEditName?: boolean;

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -190,6 +190,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
               <Form>
                 <ActionGroup>
                   <Button
+                    isDisabled={this.isSaveDisabled()}
                     variant='primary'
                     onClick={() => this.saveNamespace()}
                   >
@@ -211,6 +212,15 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
           </Main>
         )}
       </React.Fragment>
+    );
+  }
+
+  private isSaveDisabled() {
+    const namespace = this.state.namespace;
+    return namespace.links.some(
+      (link) =>
+        NamespaceForm.validateName(link).validated == 'error' ||
+        NamespaceForm.validateUrl(link).validated == 'error',
     );
   }
 

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -16,3 +16,4 @@ export { parsePulpIDFromURL } from './parse-pulp-id';
 export { lastSynced, lastSyncStatus } from './last-sync-task';
 export { waitForTask } from './wait-for-task';
 export { errorMessage } from './fail-alerts';
+export { validateURLHelper } from './validateURLHelper';

--- a/src/utilities/validateURLHelper.ts
+++ b/src/utilities/validateURLHelper.ts
@@ -1,0 +1,35 @@
+import { t } from '@lingui/macro';
+
+export function validateURLHelper(
+  outsideError: string | undefined,
+  url: string,
+): {
+  validated: 'default' | 'warning' | 'error';
+  helperTextInvalid?: string;
+  helperText?: string;
+} {
+  if (outsideError) {
+    return { validated: 'error', helperTextInvalid: outsideError };
+  }
+
+  try {
+    const { protocol } = new URL(url);
+    if (protocol === 'http:') {
+      return {
+        validated: 'warning',
+        helperText: t`Consider using a secure URL (https://).`,
+      };
+    }
+
+    if (protocol === 'https:') {
+      return { validated: 'default' };
+    }
+  } catch (_) {
+    // fallthrough
+  }
+
+  return {
+    validated: 'error',
+    helperTextInvalid: t`The URL needs to be in 'http(s)://' format.`,
+  };
+}

--- a/test/cypress/integration/namespace-edit.js
+++ b/test/cypress/integration/namespace-edit.js
@@ -9,7 +9,7 @@ describe('Edit a namespace', () => {
 
   let getLinkTextField = () => {
     return cy
-      .get('div.useful-links > div.link-name > input')
+      .get('div.useful-links > div.link-name input')
       .invoke('attr', 'placeholder', 'Link text')
       .click();
   };
@@ -117,34 +117,36 @@ describe('Edit a namespace', () => {
   });
 
   it('tests the Links field', () => {
-    getLinkTextField().type('Too long ^TrR>dG(F55:5(P:!sdafd#ZWCf2');
-    getUrlField().type('example.com');
+    getLinkTextField().first().type('Too long ^TrR>dG(F55:5(P:!sdafd#ZWCf2');
+    getUrlField().first().type('https://example.com');
     saveButton().click();
     linksHelper().should(
       'contain',
       'Text: Ensure this field has no more than 32 characters.',
     );
-    getLinkTextField().clear();
+    getLinkTextField().first().clear();
+    cy.contains('.useful-links', 'Name must not be empty.');
+
+    getLinkTextField().first().type('Link to example website');
+    getUrlField().first().clear();
+    cy.contains('.useful-links', 'URL must not be empty.');
+
+    getUrlField().first().type('example.com');
+    cy.contains('.useful-links', 'The URL needs to be in');
+
+    getUrlField().first().clear().type('https://example.com/');
     saveButton().click();
-    linksHelper().should('contain', 'Text: This field may not be blank.');
-    getLinkTextField().type('Link to example website');
-    getUrlField().clear();
-    saveButton().click();
-    linksHelper().should('contain', 'URL: This field may not be blank.');
-    getUrlField().type('example.com');
-    saveButton().click();
-    linksHelper().should('contain', "URL: 'example.com' is not a valid url.");
-    getUrlField().clear().type('https://example.com/');
-    saveButton().click();
-    cy.get('div.link > a')
+    cy.get('div.link a')
       .should('contain', 'Link to example website')
       .and('have.attr', 'href', 'https://example.com/');
   });
 
   it('removes a link', () => {
     cy.get(
-      'div.useful-links:first-child > div.link-button > div.link-container > svg',
-    ).click();
+      'div.useful-links:first-child > div.link-button > div.link-container svg',
+    )
+      .first()
+      .click();
     saveButton().click();
   });
 


### PR DESCRIPTION
Issue: AAH-149

https://issues.redhat.com/browse/AAH-149

This issue is to track some follow-on work from [AAH-18](https://issues.redhat.com/browse/AAH-18). Now at least adding links works mostly as expected, but there is still some undesirable behavior:

    Links without http:// are valid and users will enter them. "Enter a valid URL" does not make it clear what is missing, either. Schema can be added if missing.
    Every time the namespace is saved, the order of the links is reversed.
