### PR TITLE
[Signing 2] Add only signed options to remote form

### DIFF
--- a/CHANGES/1333.misc
+++ b/CHANGES/1333.misc
@@ -1,0 +1,1 @@
+When configuring remotes user is able to set `signed_only` to True. When that field is set to True, only signed collections are synced.

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -12,9 +12,12 @@ import {
   Modal,
   Checkbox,
   ExpandableSection,
+  Switch,
 } from '@patternfly/react-core';
 
 import { WriteOnlyField, HelperText, FileUpload } from 'src/components';
+
+import { AppContext } from 'src/loaders/app-context';
 
 import {
   DownloadIcon,
@@ -87,6 +90,8 @@ interface IState {
 }
 
 export class RemoteForm extends React.Component<IProps, IState> {
+  static contextType = AppContext;
+
   constructor(props) {
     super(props);
 
@@ -169,7 +174,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
           </Button>,
           <Button
             key='cancel'
-            variant='secondary'
+            variant='link'
             onClick={() => this.props.closeModal()}
           >
             {t`Cancel`}
@@ -255,6 +260,20 @@ export class RemoteForm extends React.Component<IProps, IState> {
             onChange={(value) => this.updateRemote(value, 'url')}
           />
         </FormGroup>
+
+        {this.context?.featureFlags?.collection_signing === true && (
+          <FormGroup
+            fieldId={'signed_only'}
+            name={t`Signed only`}
+            label={t`Download only signed collections`}
+          >
+            <Switch
+              id='signed_only'
+              isChecked={remote.signed_only}
+              onChange={(value) => this.updateRemote(value, 'signed_only')}
+            />
+          </FormGroup>
+        )}
 
         {!disabledFields.includes('token') && (
           <FormGroup


### PR DESCRIPTION
* [x] There is maybe a need to add a sign that repo is syncs only signed only 
  * Waiting for more info here: https://issues.redhat.com/browse/AAH-1333
  * Api does not supports it yet, by chat conversation we will not implement this now.

![Screenshot from 2022-02-09 09-46-40](https://user-images.githubusercontent.com/8531681/153158717-ffac8481-4467-47a6-bd0f-6680cd15a468.png)
