### PR TITLE
Edit remote registry - Save button enabled when invalid data

### DIFF
--- a/CHANGES/1357.misc
+++ b/CHANGES/1357.misc
@@ -1,0 +1,1 @@
+Add Save button disable when URL is invalid.

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -733,8 +733,10 @@ export class RemoteForm extends React.Component<IProps, IState> {
       }
     }
 
-    if (validateURLHelper(this.props.errorMessages['url'], remote.url).validated == 'error')
-    {
+    if (
+      validateURLHelper(this.props.errorMessages['url'], remote.url)
+        .validated == 'error'
+    ) {
       return false;
     }
 

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -733,10 +733,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
       }
     }
 
-    if (
-      validateURLHelper(this.props.errorMessages['url'], remote.url)
-        .validated == 'error'
-    ) {
+    if (validateURLHelper(null, remote.url).validated == 'error') {
       return false;
     }
 

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -733,6 +733,11 @@ export class RemoteForm extends React.Component<IProps, IState> {
       }
     }
 
+    if (validateURLHelper(this.props.errorMessages['url'], remote.url).validated == 'error')
+    {
+      return false;
+    }
+
     return true;
   }
 

--- a/test/cypress/integration/remote_registry.js
+++ b/test/cypress/integration/remote_registry.js
@@ -24,11 +24,11 @@ describe('Remote Registry Tests', () => {
 
   it('admin can add new remote registry', () => {
     cy.menuGo('Execution Environments > Remote Registries');
-    cy.addRemoteRegistry('New remote registry1', 'some url1');
-    cy.addRemoteRegistry('New remote registry2', 'some url2', {
+    cy.addRemoteRegistry('New remote registry1', 'https://some url1');
+    cy.addRemoteRegistry('New remote registry2', 'https://some url2', {
       username: 'some username2',
       password: 'some password2',
-      proxy_url: 'some proxy_url2',
+      proxy_url: 'https://some proxy_url2',
       proxy_username: 'some proxy_username2',
       proxy_password: 'some proxy_password2',
       download_concurrency: 5,
@@ -53,8 +53,8 @@ describe('Remote Registry Tests', () => {
 
     cy.contains('table tr', 'New remote registry1');
     cy.contains('table tr', 'New remote registry2');
-    cy.contains('table tr', 'some url1');
-    cy.contains('table tr', 'some url2');
+    cy.contains('table tr', 'https://some url1');
+    cy.contains('table tr', 'https://some url2');
   });
 
   it('admin can edit new remote registry', () => {
@@ -66,7 +66,7 @@ describe('Remote Registry Tests', () => {
     cy.contains('a', 'Edit').click();
 
     cy.get('input[id = "url"]').clear();
-    cy.get('input[id = "url"]').type('some new url2');
+    cy.get('input[id = "url"]').type('https://some new url2');
 
     cy.intercept(
       'GET',
@@ -77,7 +77,7 @@ describe('Remote Registry Tests', () => {
     cy.wait('@registriesGet');
 
     cy.visit('/ui/registries');
-    cy.contains('table tr', 'some new url2');
+    cy.contains('table tr', 'https://some new url2');
   });
 
   it('admin can delete data', () => {


### PR DESCRIPTION
Issue: [AAH-1357](https://issues.redhat.com/browse/AAH-1357)

Edit remote registry - Save button enabled when invalid data
When URL is invalid, save button should be disabled.