### PR TITLE
Cypress: allow changing galaxykit command in cypress.env.json, can be used to pass --ignore-certs

### DIFF
--- a/CHANGES/1273.misc
+++ b/CHANGES/1273.misc
@@ -1,0 +1,1 @@
+Cypress: allow changing galaxykit command in cypress.env.json, can be used to pass --ignore-certs

--- a/test/cypress.env.json.template
+++ b/test/cypress.env.json.template
@@ -1,8 +1,8 @@
 {
-    "prefix": "/api/automation-hub/",
-    "username": "admin",
-    "password": "admin",
-    "settings": "../../galaxy_ng/galaxy_ng/app/settings.py",
-    "restart": "true",
-    "containers": "localhost:5001"
+  "prefix": "/api/automation-hub/",
+  "username": "admin",
+  "password": "admin",
+  "settings": "../../galaxy_ng/galaxy_ng/app/settings.py",
+  "restart": "true",
+  "containers": "localhost:5001"
 }

--- a/test/cypress.env.json.template
+++ b/test/cypress.env.json.template
@@ -4,5 +4,6 @@
   "password": "admin",
   "settings": "../../galaxy_ng/galaxy_ng/app/settings.py",
   "restart": "true",
-  "containers": "localhost:5001"
+  "containers": "localhost:5001",
+  "galaxykit": "galaxykit --ignore-certs"
 }

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -394,13 +394,17 @@ Cypress.Commands.add('deleteGroup', {}, (name) => {
 Cypress.Commands.add('galaxykit', {}, (operation, ...args) => {
   const adminUsername = Cypress.env('username');
   const adminPassword = Cypress.env('password');
+  const galaxykitCommand = Cypress.env('galaxykit') || 'galaxykit';
   const server = Cypress.config().baseUrl + Cypress.env('prefix');
   const options =
     args.length >= 1 && typeof args[args.length - 1] == 'object'
       ? args.splice(args.length - 1, 1)[0]
       : [];
-  cy.log('galaxykit ' + operation + ' ' + args);
-  const cmd = shell`galaxykit -s ${server} -u ${adminUsername} -p ${adminPassword} ${shell.preserve(
+
+  cy.log(`${galaxykitCommand} ${operation} ${args}`);
+  const cmd = shell`${shell.preserve(
+    galaxykitCommand,
+  )} -s ${server} -u ${adminUsername} -p ${adminPassword} ${shell.preserve(
     operation,
   )} ${args}`;
 


### PR DESCRIPTION
Fixes AAH-1273

We can now add `"galaxykit": "galaxykit --ignore-certs"` to `cypress.env.json` to allow runnign galaxykit against a https server with invalid certificates.

Cc @hendersonreed Would this work for you? :) And also, is it just galaxykit failing on invalid https or are you seeing more failures like that?