### PR TITLE
Enable hub prefix css rule, dedup toolbar css, wrap globals

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,7 +3,7 @@
   "rules": {
     "declaration-colon-newline-after": null,
     "scss/at-import-partial-extension": null,
-    "selector-class-pattern": null,
+    "selector-class-pattern": "hub-",
     "string-quotes": "single"
   }
 }

--- a/src/components/card-list-switcher/card-list-switcher.tsx
+++ b/src/components/card-list-switcher/card-list-switcher.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 import cx from 'classnames';
-import './switcher.scss';
-
 import { ListIcon, ThLargeIcon } from '@patternfly/react-icons';
 
 import { ParamHelper } from 'src/utilities/param-helper';
+import './switcher.scss';
 
 interface IProps {
   params: {
@@ -12,7 +11,6 @@ interface IProps {
   };
   updateParams: (params) => void;
   size?: 'sm' | 'md' | 'lg' | 'xl';
-  className?: string;
 }
 
 export class CardListSwitcher extends React.Component<IProps> {
@@ -21,21 +19,16 @@ export class CardListSwitcher extends React.Component<IProps> {
   };
 
   render() {
-    let disp = this.props.params.view_type;
-    const { updateParams, params, size, className } = this.props;
-
-    if (!disp) {
-      disp = 'card';
-    }
-
-    const iconClasses = ['icon', 'clickable'];
+    const disp = this.props.params.view_type || 'card';
+    const { params, size, updateParams } = this.props;
+    const iconClasses = ['hub-icon', 'hub-m-clickable'];
 
     return (
-      <div className={className}>
+      <div className='hub-c-card-list-switcher'>
         <span data-cy='view_type_card'>
           <ThLargeIcon
             size={size}
-            className={cx(iconClasses, { selected: disp === 'card' })}
+            className={cx(iconClasses, { 'hub-selected': disp === 'card' })}
             onClick={() =>
               updateParams(ParamHelper.setParam(params, 'view_type', 'card'))
             }
@@ -44,7 +37,7 @@ export class CardListSwitcher extends React.Component<IProps> {
         <span data-cy='view_type_list'>
           <ListIcon
             size={size}
-            className={cx(iconClasses, { selected: disp === 'list' })}
+            className={cx(iconClasses, { 'hub-selected': disp === 'list' })}
             onClick={() =>
               updateParams(ParamHelper.setParam(params, 'view_type', 'list'))
             }

--- a/src/components/card-list-switcher/switcher.scss
+++ b/src/components/card-list-switcher/switcher.scss
@@ -1,3 +1,4 @@
+// FIXME: global
 .icon {
   margin-left: 8px;
   color: var(--pf-global--icon--Color--light);
@@ -7,6 +8,7 @@
   }
 }
 
+// FIXME: global
 .selected {
   color: var(--pf-global--link--Color--dark);
 }

--- a/src/components/card-list-switcher/switcher.scss
+++ b/src/components/card-list-switcher/switcher.scss
@@ -1,14 +1,14 @@
-// FIXME: global
-.icon {
-  margin-left: 8px;
-  color: var(--pf-global--icon--Color--light);
+.hub-c-card-list-switcher {
+  .hub-icon {
+    margin-left: 8px;
+    color: var(--pf-global--icon--Color--light);
 
-  &:hover {
+    &:hover {
+      color: var(--pf-global--link--Color--dark);
+    }
+  }
+
+  .hub-selected {
     color: var(--pf-global--link--Color--dark);
   }
-}
-
-// FIXME: global
-.selected {
-  color: var(--pf-global--link--Color--dark);
 }

--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -45,6 +45,7 @@
     display: flex;
     justify-content: space-between;
 
+    // FIXME do i need stuff from hub-c-card-list-switcher hub-icon ?... margin left 8px, hover color dark .. if so, maybe -m-icon ;; and does Color--light and info-color--100 match?
     .icon {
       color: var(--pf-global--info-color--100);
       margin-right: 3px;

--- a/src/components/collection-detail/collection-content-list.scss
+++ b/src/components/collection-detail/collection-content-list.scss
@@ -6,11 +6,13 @@
   }
 }
 
+// FIXME: dead since #1557?
 .hub-c-toolbar__item-type-selector {
   margin-left: 16px;
   text-transform: capitalize;
 }
 
+// FIXME: dead since #1557?
 .hub-c-toolbar__item-selected-item,
 .hub-c-toolbar__item-type-selector:hover {
   border-bottom: 2px solid var(--pf-global--link--Color);

--- a/src/components/collection-detail/collection-info.scss
+++ b/src/components/collection-detail/collection-info.scss
@@ -1,3 +1,4 @@
+// FIXME global
 .install-title {
   min-width: 100px;
   vertical-align: middle;
@@ -11,6 +12,7 @@
   overflow: hidden;
 }
 
+// FIXME global-ish (and maybe readme-container is c-collection-info__readme-container ?
 .hub-fade-out {
   position: absolute;
   z-index: 1;
@@ -26,10 +28,12 @@
   height: 50px;
 }
 
+// FIXME global
 .download-button {
   padding-left: 0;
 }
 
+// FIXME global
 .info-panel {
   padding: 8px;
 }

--- a/src/components/collection-list/collection-filter.scss
+++ b/src/components/collection-list/collection-filter.scss
@@ -1,3 +1,4 @@
+// FIXME collision namespace-detail search
 .hub-toolbar-wrapper {
   .toolbar {
     display: flex;

--- a/src/components/collection-list/list-item.scss
+++ b/src/components/collection-list/list-item.scss
@@ -1,11 +1,14 @@
+// FIXME global-ish
 .hub-entry {
   margin-top: 5px;
 }
 
+// FIXME global-ish
 .hub-right-col {
   width: 200px;
 }
 
+// FIXME global
 .content {
   text-transform: capitalize;
 }

--- a/src/components/collection-list/list.scss
+++ b/src/components/collection-list/list.scss
@@ -1,3 +1,4 @@
+// FIXME dead or missed in hub-namespace-page-controls rename?
 .controls {
   display: flex;
   justify-content: space-between;
@@ -5,11 +6,13 @@
   padding-right: 24px;
 }
 
+// FIXME global
 .top {
   padding-top: 0;
   padding-bottom: 16px;
 }
 
+// FIXME global
 .bottom {
   padding-top: 16px;
   padding-bottom: 0;

--- a/src/components/headers/header.scss
+++ b/src/components/headers/header.scss
@@ -1,5 +1,7 @@
 @import '../../global-variables.scss';
 
+// FIXME: all of them?
+
 .image {
   padding-right: 16px;
 }

--- a/src/components/helper-text/helper-text.scss
+++ b/src/components/helper-text/helper-text.scss
@@ -1,3 +1,4 @@
+// FIXME
 .helper {
   padding: 0;
 }

--- a/src/components/import-modal/import-modal.scss
+++ b/src/components/import-modal/import-modal.scss
@@ -1,5 +1,6 @@
 @import '../../global-variables.scss';
 
+// FIXME good, just add prefix to top
 .upload-collection {
   .file-error-messages {
     color: #c00;

--- a/src/components/markdown-editor/markdown-editor.scss
+++ b/src/components/markdown-editor/markdown-editor.scss
@@ -1,5 +1,6 @@
 @import '../../global-variables.scss';
 
+// FIXME good, just add prefix to top
 .markdown-editor {
   display: flex;
 
@@ -28,6 +29,7 @@
   }
 }
 
+// FIXME id?
 #resources {
   height: 500px;
   resize: none;

--- a/src/components/my-imports/my-imports.scss
+++ b/src/components/my-imports/my-imports.scss
@@ -147,6 +147,7 @@
   }
 }
 
+// FIXME likely global for alerts?
 .error,
 .failed {
   color: $red;

--- a/src/components/namespace-form/namespace-form.scss
+++ b/src/components/namespace-form/namespace-form.scss
@@ -1,4 +1,5 @@
 @import '../../global-variables.scss';
+//FIXME
 
 .hub-card-row {
   @media (max-width: $breakpoint-md) {

--- a/src/components/patternfly-wrappers/sort.scss
+++ b/src/components/patternfly-wrappers/sort.scss
@@ -4,6 +4,7 @@
   padding: 6px 0;
 }
 
+//FIXME
 .asc-button {
   margin-left: 5px;
 }

--- a/src/components/sort-table/sort-table.scss
+++ b/src/components/sort-table/sort-table.scss
@@ -1,5 +1,6 @@
 @import '../../global-variables.scss';
 
+//FIXME
 .active {
   color: $blue;
 }

--- a/src/containers/certification-dashboard/certification-dashboard.scss
+++ b/src/containers/certification-dashboard/certification-dashboard.scss
@@ -1,3 +1,4 @@
+// FIXME dup with 8 other toolbars
 .hub-certification-dashboard-toolbar {
   display: flex;
   justify-content: space-between;

--- a/src/containers/collection-detail/collection-detail.scss
+++ b/src/containers/collection-detail/collection-detail.scss
@@ -1,5 +1,6 @@
 @import '../../global-variables.scss';
 
+//FIXME
 .main {
   margin: 0;
   padding: 0;

--- a/src/containers/execution-environment-detail/execution-environment-detail_images.scss
+++ b/src/containers/execution-environment-detail/execution-environment-detail_images.scss
@@ -2,6 +2,7 @@
   max-width: 250px;
 }
 
+//FIXME
 .detail-images-toolbar {
   display: flex;
   justify-content: space-between;

--- a/src/containers/execution-environment-list/execution-environment.scss
+++ b/src/containers/execution-environment-list/execution-environment.scss
@@ -1,3 +1,4 @@
+//FIXME
 .hub-container-list-toolbar {
   display: flex;
   justify-content: space-between;

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.scss
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.scss
@@ -1,3 +1,4 @@
+//FIXME
 .single-line-ellipsis {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/containers/execution-environment/registry-list.scss
+++ b/src/containers/execution-environment/registry-list.scss
@@ -1,3 +1,4 @@
+//FIXME
 .hub-container-list-toolbar {
   display: flex;
   justify-content: space-between;

--- a/src/containers/group-management/group-management.scss
+++ b/src/containers/group-management/group-management.scss
@@ -1,3 +1,4 @@
+//FIXME
 .hub-group-list-toolbar {
   display: flex;
   justify-content: space-between;

--- a/src/containers/namespace-detail/namespace-detail.scss
+++ b/src/containers/namespace-detail/namespace-detail.scss
@@ -1,3 +1,4 @@
+//FIXME
 .namespace-detail {
   .pf-c-toolbar__content {
     padding-left: 0;

--- a/src/containers/namespace-list/namespace-list.scss
+++ b/src/containers/namespace-list/namespace-list.scss
@@ -20,6 +20,7 @@
     }
   }
 
+  //FIXME
   .toolbar {
     display: flex;
     justify-content: space-between;

--- a/src/containers/search/search.scss
+++ b/src/containers/search/search.scss
@@ -1,5 +1,6 @@
 @import '../../global-variables.scss';
 
+// FIXME
 .search-page {
   height: 100%;
   display: flex;

--- a/src/containers/search/search.scss
+++ b/src/containers/search/search.scss
@@ -6,7 +6,8 @@
   display: flex;
   flex-direction: column;
 
-  .hub-toolbar-wrapper .toolbar .hub-pagination-container .card-list-switcher {
+  // FIXME: ok but decreased specificity, check still applies
+  .hub-c-card-list-switcher {
     margin-right: 24px;
   }
 

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -112,25 +112,23 @@ class Search extends React.Component<RouteComponentProps, IState> {
                 />
 
                 <div className='hub-pagination-container'>
-                  <div className='card-list-switcher'>
-                    <CardListSwitcher
-                      size='sm'
-                      params={params}
-                      updateParams={(p) =>
-                        this.updateParams(p, () =>
-                          // Note, we have to use this.state.params instead
-                          // of params in the callback because the callback
-                          // executes before the page can re-run render
-                          // which means params doesn't contain the most
-                          // up to date state
-                          localStorage.setItem(
-                            Constants.SEARCH_VIEW_TYPE_LOCAL_KEY,
-                            this.state.params.view_type,
-                          ),
-                        )
-                      }
-                    />
-                  </div>
+                  <CardListSwitcher
+                    size='sm'
+                    params={params}
+                    updateParams={(p) =>
+                      this.updateParams(p, () =>
+                        // Note, we have to use this.state.params instead
+                        // of params in the callback because the callback
+                        // executes before the page can re-run render
+                        // which means params doesn't contain the most
+                        // up to date state
+                        localStorage.setItem(
+                          Constants.SEARCH_VIEW_TYPE_LOCAL_KEY,
+                          this.state.params.view_type,
+                        ),
+                      )
+                    }
+                  />
 
                   <Pagination
                     params={params}

--- a/src/containers/token/token.scss
+++ b/src/containers/token/token.scss
@@ -1,3 +1,4 @@
+//FIXME
 .load-token {
   padding-top: 0.75rem;
 }

--- a/src/containers/user-management/user-management.scss
+++ b/src/containers/user-management/user-management.scss
@@ -1,3 +1,4 @@
+//FIXME
 .hub-user-list-toolbar {
   display: flex;
   justify-content: space-between;

--- a/src/loaders/app.scss
+++ b/src/loaders/app.scss
@@ -1,6 +1,14 @@
 // Importing Global Variables
 @import '~@redhat-cloud-services/frontend-components-utilities/styles/all';
 
+// FIXME some or all of these should not apply to insights mode:
+// body - bad global, probably already set
+// clickable - should still be hub-m-clickable probably
+// page-sidebar - standalone menu, unless insights also uses it, would be bad anyway
+// nav-title - only set in standalone-loader, unless insights sets it somewhere
+// pre,code - pre > code unlikely, put under hub-root or something
+// body,#root - also handled by insights likely?
+
 .body {
   background-color: white;
   padding: 16px;

--- a/src/loaders/app.scss
+++ b/src/loaders/app.scss
@@ -14,6 +14,7 @@
   padding: 16px;
 }
 
+.hub-m-clickable,
 .clickable {
   cursor: pointer;
 }


### PR DESCRIPTION
Follow-up to #1620

The goal of this PR is to:

* ensure any css in `src/components/` and `src/containers/` is tied to a specific hub component by wrapping all of it in a `.hub-c-COMPONENT-NAME {` rule
* ensure all classnames use a `hub-` prefix (unless overriding a `pf-` style, and that never outside a specific component/container selector) (as per #1382)
* shared (=currently duplicated) css is pulled to a shared place - definitely all the identical toolbar classes
* ensure insights mode doesn't load possibly conflicting css - styles for standalone menu, body, or root
* remove any dead css