### PR TITLE
Collections card view - fix author field overflow for long author names

### DIFF
--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -30,6 +30,11 @@
     width: 100%;
   }
 
+  .author .pf-c-content small {
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+
   .type-label {
     font-size: var(--pf-global--FontSize--xs);
     color: var(--pf-global--color--200);


### PR DESCRIPTION
The title is already using ellipsis for long names, but the author field doesn't, relying on wrapping for now.

This breaks on names like `approval_dashboard_namespace_test_additional_data`...

![20220221031757-allbad](https://user-images.githubusercontent.com/289743/154885199-2e7a1cc0-1361-4553-80c2-40f2be8befd3.png)

Fixing...

![20220221033626](https://user-images.githubusercontent.com/289743/154885219-347b08a2-21f5-4b0d-b42d-a2ad1b12c9bc.png)

