### PR TITLE
[Hub-4.4.0dev] Text over 'Log In' button, could be marked as translatable string

### DIFF
--- a/CHANGES/1204.misc
+++ b/CHANGES/1204.misc
@@ -1,0 +1,1 @@
+Added translation to Log In button. 

--- a/src/containers/login/login.tsx
+++ b/src/containers/login/login.tsx
@@ -56,6 +56,7 @@ class LoginPage extends React.Component<RouteComponentProps, IState> {
         passwordValue={this.state.passwordValue}
         onChangePassword={this.handlePasswordChange}
         onLoginButtonClick={this.onLoginButtonClick}
+        loginButtonLabel={t`Log In`}
       />
     );
     return (


### PR DESCRIPTION
Issue: AAH-1204

https://issues.redhat.com/browse/AAH-1204

While in Japanese google-chrome, text over 'Log In' button, could be marked as translatable string.
