### PR TITLE
[Hub-4.4.0dev] Execution Environments > alpine > Activity, the (last) string 'was added' needs to be marked as translatable string

### DIFF
--- a/CHANGES/1205.misc
+++ b/CHANGES/1205.misc
@@ -1,0 +1,1 @@
+Added translation for execution eviroment -> activities '{repository} was added' 

--- a/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
@@ -216,7 +216,7 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
                 created: lastActivity.created,
                 action: (
                   <React.Fragment>
-                    {this.props.containerRepository.name} was added
+                    {t`${this.props.containerRepository.name} was added`}
                   </React.Fragment>
                 ),
               });


### PR DESCRIPTION
Issue: AAH-1205

https://issues.redhat.com/browse/AAH-1205

While in Japanese google-chrome, do following:

    Add a new Execution Evironment say name is 'alpine'
    Upstream name say 'libpod/alpine'
    Registry 'Quay'
    Tags to include 'latest'
    Hit 'Save'
    Later do 'Sync from registry'
    Visit Execution Environments > alpine > Activity
    Observe the (last) string 'was added'

'was added' need to be marked as translatable string.

