### PR TITLE
l10n: fix misleading quoting for test_l10n with strings involving interpolation

### DIFF
--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -15,10 +15,8 @@ async function activate(locale: string) {
   if (window.localStorage.test_l10n === 'true') {
     Object.keys(messages).forEach((key) => {
       if (Array.isArray(messages[key])) {
-        // t`Foo ${param}` -> ["Foo ", ['param']] => [">>Foo <<", ['param']]
-        messages[key] = messages[key].map((item) =>
-          Array.isArray(item) ? item : '»' + item + '«',
-        );
+        // t`Foo ${param}` -> ["Foo ", ['param']] => [">>", "Foo ", ['param'], "<<"]
+        messages[key] = ['»', ...messages[key], '«'];
       } else {
         // simple string
         messages[key] = '»' + messages[key] + '«';


### PR DESCRIPTION
given a msgid "{0} was added",
enabling `localStorage.test_l10n = true` yields

"param >>was added<<"

while similar strings using Trans format the same as

">>param was added<<"

fixing to do the same here

---

Before:

![20220222003504](https://user-images.githubusercontent.com/289743/155042794-00018ef0-e5b8-43ae-8746-ebac63880c57.png)

After:

![20220222003243](https://user-images.githubusercontent.com/289743/155042810-dbfed373-862b-456d-a252-30ad0bbcb531.png)

(Noticed when testing #1679)