### PR TITLE
GroupAPI.removePermission - add trailing slash to prevent an extra 301 redirect

### DIFF
--- a/src/api/group.ts
+++ b/src/api/group.ts
@@ -16,9 +16,10 @@ class API extends HubAPI {
   addPermission(id, data) {
     return this.http.post(this.apiPath + id + '/model-permissions/', data);
   }
+
   removePermission(id, permissionId) {
     return this.http.delete(
-      this.apiPath + id + '/model-permissions/' + permissionId,
+      this.apiPath + id + '/model-permissions/' + permissionId + '/',
     );
   }
 }


### PR DESCRIPTION
edit a group, remove N permissions, save

before:
N requests resulting in a 301 response,
N requests resulting in a 204 response

after:
N requests resulting in a 204 response