### PR TITLE
Fix incorrect uses of `aria-labelledby`, replace with `data-cy`

### DIFF
--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -124,7 +124,7 @@ export class CollectionListItem extends React.Component<IProps> {
     );
 
     return (
-      <DataListItem aria-labelledby='simple-item1'>
+      <DataListItem data-cy='CollectionListItem'>
         <DataListItemRow>
           <DataListItemCells dataListCells={cells} />
         </DataListItemRow>

--- a/src/components/patternfly-wrappers/sort.tsx
+++ b/src/components/patternfly-wrappers/sort.tsx
@@ -142,12 +142,11 @@ export class Sort extends React.Component<IProps, IState> {
         {options.length > 1 ? (
           <Select
             variant={SelectVariant.single}
-            aria-label={t`Select input`}
+            aria-label={t`Sort results`}
             onToggle={(e) => this.onToggle(e)}
             onSelect={(_, name) => this.onSelect(name)}
             selections={selectedOption.title}
             isOpen={isExpanded}
-            aria-labelledby='Sort results'
           >
             {options.map((option) => (
               <SelectOption key={option.id} value={option.title} />

--- a/src/components/shared/data-form.tsx
+++ b/src/components/shared/data-form.tsx
@@ -56,7 +56,7 @@ export class DataForm extends React.Component<IProps> {
           label={field.title}
           labelIcon={!isReadonly && field.formGroupLabelIcon}
           validated={isReadonly ? 'default' : validated}
-          aria-labelledby={field.id}
+          data-cy={`DataForm-field-${field.id}`}
         >
           {isReadonly ? (
             model[field.id]

--- a/src/components/sort-table/sort-table.tsx
+++ b/src/components/sort-table/sort-table.tsx
@@ -75,7 +75,7 @@ export class SortTable extends React.Component<IProps> {
   render() {
     return (
       <thead>
-        <tr aria-labelledby='headers' data-cy='table_header'>
+        <tr data-cy='SortTable-headers'>
           {this.props.options['headers'].map((element) =>
             this.getHeaderItem(element),
           )}

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -133,7 +133,6 @@ export class UserForm extends React.Component<IProps, IState> {
         fieldId='auth_provider'
         key='readonlyAuth'
         label={t`Authentication provider`}
-        aria-labelledby='readonly-auth'
       >
         {user.auth_provider.map((provider) => (
           <Label key={provider}>{provider}</Label>
@@ -146,7 +145,7 @@ export class UserForm extends React.Component<IProps, IState> {
         fieldId='groups'
         key='readonlyGroups'
         label={t`Groups`}
-        aria-labelledby='readonly-groups'
+        data-cy='UserForm-readonly-groups'
       >
         {user.groups.map((group) => (
           <Label key={group.name}>{group.name}</Label>

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -328,11 +328,7 @@ class CertificationDashboard extends React.Component<
 
   private renderRow(version: CollectionVersion, index) {
     return (
-      <tr
-        aria-labelledby={`${version.namespace}.${version.name} v${version.version}`}
-        key={index}
-        data-cy='table_row'
-      >
+      <tr key={index} data-cy='CertificationDashboard-row'>
         <td>{version.namespace}</td>
         <td>{version.name}</td>
         <td>

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -379,7 +379,7 @@ class ExecutionEnvironmentList extends React.Component<
     ].filter((truthy) => truthy);
 
     return (
-      <tr aria-labelledby={item.name} key={index}>
+      <tr data-cy={`ExecutionEnvironmentList-row-${item.name}`} key={index}>
         <td>
           <Link
             to={formatPath(Paths.executionEnvironmentDetail, {

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -312,10 +312,7 @@ class ExecutionEnvironmentList extends React.Component<
     };
 
     return (
-      <table
-        aria-label={t`User list`}
-        className='hub-c-table-content pf-c-table'
-      >
+      <table className='hub-c-table-content pf-c-table'>
         <SortTable
           options={sortTableOptions}
           params={params}

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -412,7 +412,10 @@ class ExecutionEnvironmentRegistryList extends React.Component<
       </Tooltip>,
     ].filter(Boolean);
     return (
-      <tr aria-labelledby={item.name} key={index}>
+      <tr
+        data-cy={`ExecutionEnvironmentRegistryList-row-${item.name}`}
+        key={index}
+      >
         <td>{item.name}</td>
         <td>
           <DateComponent date={item.created_at} />

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -809,7 +809,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
       isUserMgmtDisabled = featureFlags.external_authentication;
     }
     return (
-      <tr aria-labelledby={user.username} key={index}>
+      <tr data-cy={`GroupDetail-users-${user.username}`} key={index}>
         <td>
           <Link to={formatPath(Paths.userDetail, { userID: user.id })}>
             {user.username}

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -435,7 +435,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
       </React.Fragment>,
     ];
     return (
-      <tr aria-labelledby={group.name} key={index}>
+      <tr data-cy={`GroupList-row-${group.name}`} key={index}>
         <td>
           <Link
             to={formatPath(Paths.groupDetail, {

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -273,7 +273,7 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
       item;
     const taskId = parsePulpIDFromURL(pulp_href);
     return (
-      <tr aria-labelledby={name} key={index}>
+      <tr key={index}>
         <td>
           <Link to={formatPath(Paths.taskDetail, { task: taskId })}>
             <Tooltip

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -342,7 +342,7 @@ class UserList extends React.Component<RouteComponentProps, IState> {
       );
     }
     return (
-      <tr aria-labelledby={user.username} key={index}>
+      <tr data-cy={`UserList-row-${user.username}`} key={index}>
         <td>
           <Link to={formatPath(Paths.userDetail, { userID: user.id })}>
             {user.username}

--- a/test/cypress/integration/approval_dashboard_list.js
+++ b/test/cypress/integration/approval_dashboard_list.js
@@ -61,7 +61,7 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
   it('should contains all columns.', () => {
     ['Namespace', 'Collection', 'Version', 'Date created', 'Status'].forEach(
       (item) => {
-        cy.get('[data-cy="table_header"]').contains(item);
+        cy.get('[data-cy="SortTable-headers"]').contains(item);
       },
     );
   });

--- a/test/cypress/integration/approval_dashboard_list.js
+++ b/test/cypress/integration/approval_dashboard_list.js
@@ -87,13 +87,13 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
     cy.get('[data-cy="sort_collection"]').click();
     cy.get('[data-cy="body"]').contains('approval');
 
-    cy.get('[data-cy="body"] [data-cy="table_row"]:first').contains(
+    cy.get('[data-cy="CertificationDashboard-row"]:first').contains(
       items[items.length - 1].name,
     );
-    cy.get('[data-cy="body"] [data-cy="table_row"]').contains(
+    cy.get('[data-cy="CertificationDashboard-row"]').contains(
       items[items.length - 2].name,
     );
-    cy.get('[data-cy="body"] [data-cy="table_row"]').contains(
+    cy.get('[data-cy="CertificationDashboard-row"]').contains(
       items[items.length - 3].name,
     );
   });

--- a/test/cypress/integration/collections_list.js
+++ b/test/cypress/integration/collections_list.js
@@ -68,6 +68,6 @@ describe('Collections list Tests', () => {
   it('Cards/List switch is working', () => {
     cy.get('[data-cy="view_type_list"] svg').click();
 
-    cy.get('li[aria-labelledby="simple-item1"').should('have.length', 10);
+    cy.get('[data-cy="CollectionListItem"]').should('have.length', 10);
   });
 });

--- a/test/cypress/integration/execution_environments_use_in_controller.js
+++ b/test/cypress/integration/execution_environments_use_in_controller.js
@@ -42,7 +42,7 @@ describe('Execution Environments - Use in Controller', () => {
       'Last modified',
       'Container registry type',
     ].forEach((header) =>
-      cy.get('tr[aria-labelledby="headers"] th').contains(header),
+      cy.get('tr[data-cy="SortTable-headers"] th').contains(header),
     );
 
     // one row of each type available

--- a/test/cypress/integration/group_list.js
+++ b/test/cypress/integration/group_list.js
@@ -24,7 +24,7 @@ describe('Group list tests for sorting, paging and filtering', () => {
   });
 
   it('table contains all columns', () => {
-    cy.get('tr[aria-labelledby="headers"] th').contains('Group');
+    cy.get('tr[data-cy="SortTable-headers"] th').contains('Group');
   });
 
   it('items are sorted alphabetically and paging is working', () => {

--- a/test/cypress/integration/group_permissions.js
+++ b/test/cypress/integration/group_permissions.js
@@ -83,7 +83,9 @@ describe('Group Permissions Tests', () => {
     cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/groups/**').as(
       'deleteGroup',
     );
-    cy.get(`[aria-labelledby=DeleteGroup] [aria-label=Actions]`).click();
+    cy.get(
+      `[data-cy="GroupList-row-DeleteGroup"] [aria-label="Actions"]`,
+    ).click();
     cy.get('[aria-label=Delete]').click();
     cy.contains('[role=dialog] button', 'Delete').click();
     cy.wait('@deleteGroup').then(({ response }) => {

--- a/test/cypress/integration/profile.js
+++ b/test/cypress/integration/profile.js
@@ -126,10 +126,19 @@ describe('My Profile Tests', () => {
 
     cy.get('.pf-c-button').contains('Cancel').click();
 
-    cy.get('[aria-labelledby=username]').should('not.contain', 'administrator');
-    cy.get('[aria-labelledby=first_name]').should('not.contain', 'First Name');
-    cy.get('[aria-labelledby=last_name]').should('not.contain', 'Last Name');
-    cy.get('[aria-labelledby=email]').should(
+    cy.get('[data-cy="DataForm-field-username"]').should(
+      'not.contain',
+      'administrator',
+    );
+    cy.get('[data-cy="DataForm-field-first_name"]').should(
+      'not.contain',
+      'First Name',
+    );
+    cy.get('[data-cy="DataForm-field-last_name"]').should(
+      'not.contain',
+      'Last Name',
+    );
+    cy.get('[data-cy="DataForm-field-email"]').should(
       'not.contain',
       'administrator@example.com',
     );

--- a/test/cypress/integration/profile.js
+++ b/test/cypress/integration/profile.js
@@ -98,7 +98,7 @@ describe('My Profile Tests', () => {
   });
 
   it('groups input is readonly', () => {
-    cy.get('[aria-labelledby=readonly-groups]')
+    cy.get('[data-cy="UserForm-readonly-groups"]')
       .find('input')
       .should('not.exist');
   });

--- a/test/cypress/integration/remote_registry.js
+++ b/test/cypress/integration/remote_registry.js
@@ -61,7 +61,7 @@ describe('Remote Registry Tests', () => {
     cy.menuGo('Execution Environments > Remote Registries');
 
     cy.get(
-      'tr[aria-labelledby="New remote registry1"] button[aria-label="Actions"]',
+      'tr[data-cy="ExecutionEnvironmentRegistryList-row-New remote registry1"] button[aria-label="Actions"]',
     ).click();
     cy.contains('a', 'Edit').click();
 

--- a/test/cypress/integration/remote_registry.js
+++ b/test/cypress/integration/remote_registry.js
@@ -48,7 +48,7 @@ describe('Remote Registry Tests', () => {
       'Registry URL',
       'Registry sync status',
     ].forEach((element) => {
-      cy.contains('tr[aria-labelledby="headers"]', element);
+      cy.contains('tr[data-cy="SortTable-headers"]', element);
     });
 
     cy.contains('table tr', 'New remote registry1');

--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -16,23 +16,23 @@ describe('Repo Management tests', () => {
 
   it('can see table in repo tabs and it shows data correctly', () => {
     cy.visit(localRepoUrl);
-    cy.get('[aria-labelledby="headers"]').contains('Distribution name');
-    cy.get('[aria-labelledby="headers"]').contains('Repository name');
-    cy.get('[aria-labelledby="headers"]').contains('Content count');
-    cy.get('[aria-labelledby="headers"]').contains('Last updated');
-    cy.get('[aria-labelledby="headers"]').contains('Repo URL');
-    cy.get('[aria-labelledby="headers"]').contains('CLI configuration');
+    cy.get('[data-cy="SortTable-headers"]').contains('Distribution name');
+    cy.get('[data-cy="SortTable-headers"]').contains('Repository name');
+    cy.get('[data-cy="SortTable-headers"]').contains('Content count');
+    cy.get('[data-cy="SortTable-headers"]').contains('Last updated');
+    cy.get('[data-cy="SortTable-headers"]').contains('Repo URL');
+    cy.get('[data-cy="SortTable-headers"]').contains('CLI configuration');
     cy.contains('community');
     cy.contains('published');
     cy.contains('rejected');
     cy.contains('rh-certified');
     cy.contains('staging');
     cy.get('button').contains('Remote').parent().click();
-    cy.get('[aria-labelledby="headers"]').contains('Remote name');
-    cy.get('[aria-labelledby="headers"]').contains('Repositories');
-    cy.get('[aria-labelledby="headers"]').contains('Last updated');
-    cy.get('[aria-labelledby="headers"]').contains('Last sync');
-    cy.get('[aria-labelledby="headers"]').contains('Sync status');
+    cy.get('[data-cy="SortTable-headers"]').contains('Remote name');
+    cy.get('[data-cy="SortTable-headers"]').contains('Repositories');
+    cy.get('[data-cy="SortTable-headers"]').contains('Last updated');
+    cy.get('[data-cy="SortTable-headers"]').contains('Last sync');
+    cy.get('[data-cy="SortTable-headers"]').contains('Sync status');
 
     cy.contains('Configure');
     cy.contains('Sync');

--- a/test/cypress/integration/task_list.js
+++ b/test/cypress/integration/task_list.js
@@ -25,7 +25,7 @@ describe('Task table contains correct headers and filter', () => {
     cy.get('[aria-label="name__contains"]');
     ['Task name', 'Created on', 'Started at', 'Finished at', 'Status'].forEach(
       (item) => {
-        cy.get('tr[aria-labelledby="headers"] th').contains(item);
+        cy.get('tr[data-cy="SortTable-headers"] th').contains(item);
       },
     );
   });

--- a/test/cypress/integration/user_dashboard.js
+++ b/test/cypress/integration/user_dashboard.js
@@ -12,7 +12,7 @@ describe('Hub User Management Tests', () => {
     cy.cookieLogin(adminUsername, adminPassword);
 
     cy.createUser(username, password, 'Test F', 'Test L', 'test@example.com');
-    cy.contains('[aria-labelledby=test]', 'Test F');
+    cy.contains('[data-cy="UserList-row-test"]', 'Test F');
 
     cy.createGroup('delete-user');
     cy.addPermissions('delete-user', [
@@ -28,7 +28,7 @@ describe('Hub User Management Tests', () => {
     });
 
     it('User table lists users', () => {
-      cy.contains('[aria-label="User list"] [aria-labelledby=admin]', 'admin');
+      cy.contains('[data-cy="UserList-row-admin"]', 'admin');
     });
   });
 
@@ -39,9 +39,9 @@ describe('Hub User Management Tests', () => {
     });
 
     it('Can create new users', () => {
-      cy.contains('[aria-labelledby=test]', 'Test F');
-      cy.contains('[aria-labelledby=test]', 'Test L');
-      cy.contains('[aria-labelledby=test]', 'test@example.com');
+      cy.contains('[data-cy="UserList-row-test"]', 'Test F');
+      cy.contains('[data-cy="UserList-row-test"]', 'Test L');
+      cy.contains('[data-cy="UserList-row-test"]', 'test@example.com');
 
       cy.contains('.body', 'Test F').not();
     });
@@ -49,12 +49,10 @@ describe('Hub User Management Tests', () => {
 
   describe('prevents super-user and self deletion', () => {
     function attemptToDelete(toDelete) {
+      const actionsSelector = `[data-cy="UserList-row-${toDelete}"] [aria-label="Actions"]`;
       cy.menuGo('User Access > Users');
-      cy.get(`[aria-labelledby=${toDelete}] [aria-label=Actions]`).click();
-      cy.containsnear(
-        `[aria-labelledby=${toDelete}] [aria-label=Actions]`,
-        'Delete',
-      ).click();
+      cy.get(actionsSelector).click();
+      cy.containsnear(actionsSelector, 'Delete').click();
       cy.get('footer > button:contains("Delete")').should('be.disabled');
       cy.get('footer > button:contains("Cancel")').click();
     }

--- a/test/cypress/integration/user_filter.js
+++ b/test/cypress/integration/user_filter.js
@@ -28,7 +28,7 @@ describe('Search for users', () => {
 
   let checkUserEntry = () => {
     return cy
-      .get('tbody > tr[aria-labelledby="new_user"] > td > a')
+      .get('tbody > tr[data-cy="UserList-row-new_user"] > td > a')
       .contains('new_user')
       .should('be.visible');
   };

--- a/test/cypress/integration/user_list.js
+++ b/test/cypress/integration/user_list.js
@@ -34,7 +34,7 @@ describe('User list tests for sorting, paging and filtering', () => {
       'Groups',
       'Created',
     ].forEach((item) => {
-      cy.get('tr[aria-labelledby="headers"] th').contains(item);
+      cy.get('tr[data-cy="SortTable-headers"] th').contains(item);
     });
   });
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -633,9 +633,7 @@ Cypress.Commands.add('deleteRegistries', {}, () => {
     var data = result.response.body.data;
     data.forEach((element) => {
       cy.get(
-        'tr[aria-labelledby="' +
-          element.name +
-          '"] button[aria-label="Actions"]',
+        `tr[data-cy="ExecutionEnvironmentRegistryList-row-${element.name}"] button[aria-label="Actions"]`,
       ).click();
       cy.contains('a', 'Delete').click();
       cy.contains('button', 'Delete').click();

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -348,9 +348,9 @@ Cypress.Commands.add('deleteUser', {}, (username) => {
   cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/users/*').as(
     'deleteUser',
   );
-  cy.get(`[aria-labelledby=${username}] [aria-label=Actions]`).click();
+  cy.get(`[data-cy="UserList-row-${username}"] [aria-label="Actions"]`).click();
   cy.containsnear(
-    `[aria-labelledby=${username}] [aria-label=Actions]`,
+    `[data-cy="UserList-row-${username}"] [aria-label="Actions"]`,
     'Delete',
   ).click();
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -327,16 +327,18 @@ Cypress.Commands.add('addUserToGroup', {}, (groupName, userName) => {
   cy.get('input.pf-c-select__toggle-typeahead').type(userName);
   cy.contains('button', userName).click();
   cy.contains('footer > button', 'Add').click();
-  cy.get(`[aria-labelledby=${userName}]`).should('exist');
+  cy.get(`[data-cy="GroupDetail-users-${userName}"]`).should('exist');
 });
 
 Cypress.Commands.add('removeUserFromGroup', {}, (groupName, userName) => {
   cy.menuGo('User Access > Groups');
   cy.get(`[data-cy="GroupList-row-${groupName}"] a`).click();
   cy.contains('button', 'Users').click();
-  cy.get(`[aria-labelledby=${userName}] [aria-label=Actions]`).click();
+  cy.get(
+    `[data-cy="GroupDetail-users-${userName}"] [aria-label="Actions"]`,
+  ).click();
   cy.containsnear(
-    `[aria-labelledby=${userName}] [aria-label=Actions]`,
+    `[data-cy="GroupDetail-users-${userName}"] [aria-label="Actions"]`,
     'Remove',
   ).click();
   cy.contains('button.pf-m-danger', 'Delete').click();

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -656,9 +656,7 @@ Cypress.Commands.add('deleteContainers', {}, () => {
     var data = result.response.body.data;
     data.forEach((element) => {
       cy.get(
-        'tr[aria-labelledby="' +
-          element.name +
-          '"] button[aria-label="Actions"]',
+        `tr[data-cy="ExecutionEnvironmentList-row-${element.name}"] button[aria-label="Actions"]`,
       ).click();
       cy.contains('a', 'Delete').click();
       cy.get('input[id=delete_confirm]').click();

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -213,7 +213,7 @@ Cypress.Commands.add('addPermissions', {}, (groupName, permissions) => {
     Cypress.env('prefix') + '_ui/v1/groups/*/model-permissions/*',
   ).as('groups');
   cy.menuGo('User Access > Groups');
-  cy.get(`[aria-labelledby=${groupName}] a`).click();
+  cy.get(`[data-cy="GroupList-row-${groupName}"] a`).click();
   cy.wait('@groups');
   cy.contains('button', 'Edit').click();
   permissions.forEach((permissionElement) => {
@@ -235,7 +235,7 @@ Cypress.Commands.add('addPermissions', {}, (groupName, permissions) => {
 
 Cypress.Commands.add('removePermissions', {}, (groupName, permissions) => {
   cy.menuGo('User Access > Groups');
-  cy.get(`[aria-labelledby=${groupName}] a`).click();
+  cy.get(`[data-cy="GroupList-row-${groupName}"] a`).click();
   cy.contains('button', 'Edit').click();
   permissions.forEach((permissionElement) => {
     if (permissionElement.permissions.length > 3) {
@@ -321,7 +321,7 @@ Cypress.Commands.add('addAllPermissions', {}, (groupName) => {
 
 Cypress.Commands.add('addUserToGroup', {}, (groupName, userName) => {
   cy.menuGo('User Access > Groups');
-  cy.get(`[aria-labelledby=${groupName}] a`).click();
+  cy.get(`[data-cy="GroupList-row-${groupName}"] a`).click();
   cy.contains('button', 'Users').click();
   cy.contains('button', 'Add').click();
   cy.get('input.pf-c-select__toggle-typeahead').type(userName);
@@ -332,7 +332,7 @@ Cypress.Commands.add('addUserToGroup', {}, (groupName, userName) => {
 
 Cypress.Commands.add('removeUserFromGroup', {}, (groupName, userName) => {
   cy.menuGo('User Access > Groups');
-  cy.get(`[aria-labelledby=${groupName}] a`).click();
+  cy.get(`[data-cy="GroupList-row-${groupName}"] a`).click();
   cy.contains('button', 'Users').click();
   cy.get(`[aria-labelledby=${userName}] [aria-label=Actions]`).click();
   cy.containsnear(
@@ -377,7 +377,7 @@ Cypress.Commands.add('deleteGroup', {}, (name) => {
   cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/groups/?*').as(
     'listGroups',
   );
-  cy.get(`[aria-labelledby=${name}] [aria-label=Actions]`).click();
+  cy.get(`[data-cy="GroupList-row-${name}"] [aria-label="Actions"]`).click();
   cy.get('[aria-label=Delete]').click();
   cy.contains('[role=dialog] button', 'Delete').click();
   cy.wait('@deleteGroup').then(({ response }) => {


### PR DESCRIPTION
For providing an ARIA title inline, use `aria-label`,
`aria-labelledby` should point to an `id` of a DOM element providing an actual title.
    
... but we only use it that way for `markdown-title` in `MarkdownEditor`.
    
The rest of uses should really be `data-cy`, or are unused now.
We also want to make sure those `data-cy` attributes are unique enough to be searchable - adding the component name where appropriate.

(since Friday was an accessibility themed learning day :))