### PR TITLE
Search for sporadic failures 2 (group_management, execution_environments_use_in_controller.)

### DIFF
--- a/CHANGES/1410.misc
+++ b/CHANGES/1410.misc
@@ -1,0 +1,1 @@
+Search for sporadic failures - focus on execution enviroments use in controller. 

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -246,7 +246,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
             </div>
           </div>
         </BaseHeader>
-        <Main>
+        <Main data-cy='main-tabs'>
           {params.tab == 'permissions' ? this.renderPermissions() : null}
           {params.tab == 'users' ? this.renderUsers(users) : null}
         </Main>

--- a/test/cypress/integration/execution_environments_use_in_controller.js
+++ b/test/cypress/integration/execution_environments_use_in_controller.js
@@ -82,6 +82,7 @@ describe('Execution Environments - Use in Controller', () => {
       it(`Use in Controller - ${type} ${opener.name}`, () => {
         opener(type);
 
+        // sporadic failure
         // shows links
         cy.contains('a', 'https://www.example.com')
           .should('have.attr', 'href')

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -625,6 +625,9 @@ Cypress.Commands.add('syncRemoteContainer', {}, (name) => {
     '.pf-c-alert__title',
     `Sync started for execution environment "${name}".`,
   );
+  // wait for finish
+  cy.contains('a', 'detail page').click();
+  cy.contains('.title-box h1', 'Completed', { timeout: 20000 });
 });
 
 Cypress.Commands.add('deleteRegistries', {}, () => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -342,7 +342,7 @@ Cypress.Commands.add('removeUserFromGroup', {}, (groupName, userName) => {
     'Remove',
   ).click();
   cy.contains('button.pf-m-danger', 'Delete').click();
-  cy.contains(userName).should('not.exist');
+  cy.contains('[data-cy=main-tabs]', userName).should('not.exist');
 });
 
 Cypress.Commands.add('deleteUser', {}, (username) => {


### PR DESCRIPTION
Issue: AAH-1410

Focus mostly on execution_enviroments_use_in_controller.js. It tries to repair it - it now waits for the delete task to be completed (delete user command).

And it repairs also group management - there is new error due to alert PR. New alerts now contains name of the user and the test had very bad selector (no selector) that searches the user name at the whole page (for not contains). It worked before, but now the alert also contains the user name and it wrongly finds it there and fail.
