### PR TITLE
Release 4.4.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,8 @@
+4.4.2 (2022-03-01)
+Misc
+----
+
+- `AAH-635 <https://issues.redhat.com/browse/AAH-635>`_, `AAH-820 <https://issues.redhat.com/browse/AAH-820>`_, `AAH-968 <https://issues.redhat.com/browse/AAH-968>`_, `AAH-1069 <https://issues.redhat.com/browse/AAH-1069>`_, `AAH-1070 <https://issues.redhat.com/browse/AAH-1070>`_, `AAH-1195 <https://issues.redhat.com/browse/AAH-1195>`_, `AAH-1207 <https://issues.redhat.com/browse/AAH-1207>`_, `AAH-1253 <https://issues.redhat.com/browse/AAH-1253>`_
+
+
+----

--- a/CHANGES/1069.misc
+++ b/CHANGES/1069.misc
@@ -1,1 +1,0 @@
-Fixed the namespace localization

--- a/CHANGES/1070.misc
+++ b/CHANGES/1070.misc
@@ -1,1 +1,0 @@
-Fixed repo selector and taskName tooltip text translation

--- a/CHANGES/1195.misc
+++ b/CHANGES/1195.misc
@@ -1,1 +1,0 @@
-Added remote form URL validation for http(s) with warning

--- a/CHANGES/1207.misc
+++ b/CHANGES/1207.misc
@@ -1,1 +1,0 @@
-Added warning message screen in Documentation tab for Community repository

--- a/CHANGES/1253.misc
+++ b/CHANGES/1253.misc
@@ -1,1 +1,0 @@
-Change proxy password from text type to password type

--- a/CHANGES/635.misc
+++ b/CHANGES/635.misc
@@ -1,1 +1,0 @@
-Added RBAC permissions test

--- a/CHANGES/820.misc
+++ b/CHANGES/820.misc
@@ -1,1 +1,0 @@
-Namespaces list: use same filter as other screens, remove custom Toolbar override

--- a/CHANGES/968.misc
+++ b/CHANGES/968.misc
@@ -1,1 +1,0 @@
-add check that EE name is correct when typed in

--- a/ansible-hub-ui/__init__.py
+++ b/ansible-hub-ui/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "4.5.0dev"
+__version__ = "4.4.2"


### PR DESCRIPTION
galaxy_ng Release PR: https://github.com/ansible/galaxy_ng/pull/1149

---

This is just manually editing `__version__` in `ansible-hub-ui/__init__.py`, and running `towncrier build`.

---

[API PRs](https://github.com/ansible/galaxy_ng/pulls?q=is%3Apr+base%3Astable-4.4+is%3Amerged+-author%3Aapp%2Fdependabot+merged%3A2022-01-06..2022-02-28)
[UI PRs](https://github.com/ansible/ansible-hub-ui/pulls?q=is%3Apr+base%3Astable-4.4+is%3Amerged+-author%3Aapp%2Fdependabot+merged%3A2022-01-06..2022-02-28)