### PR TITLE
Test sync action in EE Remote Registries

### DIFF
--- a/CHANGES/1000.misc
+++ b/CHANGES/1000.misc
@@ -1,0 +1,1 @@
+Added remote registry sync test

--- a/src/components/patternfly-wrappers/alert-list.tsx
+++ b/src/components/patternfly-wrappers/alert-list.tsx
@@ -11,6 +11,8 @@ interface IProps {
 
   /** Callback to close the alert at the given index */
   closeAlert: (alertIndex) => void;
+
+  'data-cy'?: string;
 }
 
 export class AlertType {
@@ -32,6 +34,7 @@ export class AlertList extends React.Component<IProps> {
           display: 'flex',
           flexDirection: 'column',
         }}
+        data-cy={`AlertList-${this.props['data-cy']}`}
       >
         {alerts.map((alert, i) => (
           <Alert

--- a/src/components/patternfly-wrappers/alert-list.tsx
+++ b/src/components/patternfly-wrappers/alert-list.tsx
@@ -11,8 +11,6 @@ interface IProps {
 
   /** Callback to close the alert at the given index */
   closeAlert: (alertIndex) => void;
-
-  'data-cy'?: string;
 }
 
 export class AlertType {
@@ -34,7 +32,7 @@ export class AlertList extends React.Component<IProps> {
           display: 'flex',
           flexDirection: 'column',
         }}
-        data-cy={`AlertList-${this.props['data-cy']}`}
+        data-cy='AlertList'
       >
         {alerts.map((alert, i) => (
           <Alert

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -158,7 +158,6 @@ class ExecutionEnvironmentRegistryList extends React.Component<
         <AlertList
           alerts={alerts}
           closeAlert={(i) => this.closeAlert(i)}
-          data-cy='ExecutionEnvironmentRegistryList'
         ></AlertList>
         {showRemoteFormModal && (
           <RemoteForm

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -158,6 +158,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
         <AlertList
           alerts={alerts}
           closeAlert={(i) => this.closeAlert(i)}
+          data-cy='ExecutionEnvironmentRegistryList'
         ></AlertList>
         {showRemoteFormModal && (
           <RemoteForm

--- a/test/cypress/integration/remote_registry.js
+++ b/test/cypress/integration/remote_registry.js
@@ -73,7 +73,7 @@ describe('Remote Registry Tests', () => {
 
     cy.wait('@sync');
 
-    cy.get('[data-cy="AlertList-ExecutionEnvironmentRegistryList"]').contains(
+    cy.get('[data-cy="AlertList"]').contains(
       'Sync started for remote registry "New remote registry1".',
     );
 

--- a/test/cypress/integration/remote_registry.js
+++ b/test/cypress/integration/remote_registry.js
@@ -57,6 +57,31 @@ describe('Remote Registry Tests', () => {
     cy.contains('table tr', 'https://some url2');
   });
 
+  it('user can sync succesfully remote registry', () => {
+    cy.visit('/ui/registries');
+
+    cy.intercept(
+      'POST',
+      Cypress.env('prefix') + '_ui/v1/execution-environments/registries/*/sync',
+    ).as('sync');
+
+    cy.get(
+      '[data-cy="ExecutionEnvironmentRegistryList-row-New remote registry1"]',
+    )
+      .contains('Sync from registry')
+      .click();
+
+    cy.wait('@sync');
+
+    cy.get('[data-cy="AlertList-ExecutionEnvironmentRegistryList"]').contains(
+      'Sync started for remote registry "New remote registry1".',
+    );
+
+    cy.get(
+      '[data-cy="ExecutionEnvironmentRegistryList-row-New remote registry1"]',
+    ).contains('Completed', { timeout: 10000 });
+  });
+
   it('admin can edit new remote registry', () => {
     cy.menuGo('Execution Environments > Remote Registries');
 


### PR DESCRIPTION
Issue: [AAH-1000](https://issues.redhat.com/browse/AAH-1000)

Testing successful syncing of the remote registry. 

I noticed we moved to `data-cy` attributes, so added this attribute as a prop to the `AlertList` component as well.