### PR TITLE
Uncontrolled components warning in EE Remote Registry fix

### DIFF
--- a/CHANGES/1432.misc
+++ b/CHANGES/1432.misc
@@ -1,0 +1,1 @@
+Fixed uncontrolled component warning on editing in EE remote registry

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -666,7 +666,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
               <TextInput
                 id='download_concurrency'
                 type='number'
-                value={remote.download_concurrency}
+                value={remote.download_concurrency || ''}
                 validated={
                   !this.isNumericSet(remote.download_concurrency) ||
                   remote.download_concurrency > 0
@@ -698,7 +698,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
               <TextInput
                 id='rate_limit'
                 type='number'
-                value={remote.rate_limit}
+                value={remote.rate_limit || ''}
                 onChange={(value) => this.updateRemote(value, 'rate_limit')}
               />
             </FormGroup>


### PR DESCRIPTION
EDIT: created a jira issue for this and adding `1432.misc`


Issue: [AAH-1432](https://issues.redhat.com/browse/AAH-1432)

Just a small fix of null values in `download_concurrency` and `rate_limit` in `TextInput` that was causing this warning message to show
![Screenshot from 2022-03-01 23-31-05](https://user-images.githubusercontent.com/19647757/156259873-996178eb-86d8-4c89-ad86-89563c8a5ef0.png)

