### PR TITLE
Fix overflow content in ImportConsole on My imports Page

### DIFF
--- a/CHANGES/396.misc
+++ b/CHANGES/396.misc
@@ -1,0 +1,1 @@
+Fixed content overflow in ImportConsole component

--- a/src/components/my-imports/my-imports.scss
+++ b/src/components/my-imports/my-imports.scss
@@ -88,6 +88,10 @@
       font-weight: bold;
     }
 
+    pre {
+      white-space: pre-wrap;
+    }
+
     .stats {
       text-align: right;
       font-size: 12px;
@@ -133,6 +137,7 @@
     color: $white;
     line-height: 18px;
     margin-bottom: 50px;
+    word-break: break-word;
 
     .log-follow-button {
       position: relative;


### PR DESCRIPTION
Issue: [AAH-396](https://issues.redhat.com/browse/AAH-396)

This fixes content overflow in `ImportConsole` component when the text is too long in `message-list` element or when the error pops up in `title-bar` element.

before:
![Screenshot from 2022-03-02 11-58-56](https://user-images.githubusercontent.com/19647757/156356823-7df36a90-91c6-4363-8d42-016655e38f62.png)

after:
![Screenshot from 2022-03-02 12-29-11](https://user-images.githubusercontent.com/19647757/156356821-94f05090-c675-43eb-b9f1-498f94a6180b.png)
