### PR TITLE
Improve testing of my-imports page

### DIFF
--- a/CHANGES/625.misc
+++ b/CHANGES/625.misc
@@ -1,0 +1,1 @@
+Improved my-imports page test

--- a/src/components/my-imports/import-console.tsx
+++ b/src/components/my-imports/import-console.tsx
@@ -28,6 +28,7 @@ interface IProps {
   setFollowMessages: (follow: boolean) => void;
   hideCollectionName?: boolean;
   collectionVersion?: CollectionVersion;
+  'data-cy'?: string;
 }
 
 export class ImportConsole extends React.Component<IProps> {
@@ -67,7 +68,10 @@ export class ImportConsole extends React.Component<IProps> {
       selectedImport.state === PulpStatus.waiting;
 
     return (
-      <div className='hub-import-console pf-c-content'>
+      <div
+        className='hub-import-console pf-c-content'
+        data-cy={`ImportConsole-${this.props['data-cy']}`}
+      >
         {this.renderTitle(selectedImport)}
         <div className='message-list'>
           <div

--- a/src/components/my-imports/import-console.tsx
+++ b/src/components/my-imports/import-console.tsx
@@ -28,7 +28,6 @@ interface IProps {
   setFollowMessages: (follow: boolean) => void;
   hideCollectionName?: boolean;
   collectionVersion?: CollectionVersion;
-  'data-cy'?: string;
 }
 
 export class ImportConsole extends React.Component<IProps> {
@@ -70,7 +69,7 @@ export class ImportConsole extends React.Component<IProps> {
     return (
       <div
         className='hub-import-console pf-c-content'
-        data-cy={`ImportConsole-${this.props['data-cy']}`}
+        data-cy={'ImportConsole'}
       >
         {this.renderTitle(selectedImport)}
         <div className='message-list'>

--- a/src/components/my-imports/import-list.tsx
+++ b/src/components/my-imports/import-list.tsx
@@ -28,7 +28,6 @@ interface IProps {
     keyword?: string;
     namespace?: string;
   };
-  'data-cy'?: string;
 
   selectImport: (x) => void;
   updateParams: (filters) => void;

--- a/src/components/my-imports/import-list.tsx
+++ b/src/components/my-imports/import-list.tsx
@@ -28,6 +28,7 @@ interface IProps {
     keyword?: string;
     namespace?: string;
   };
+  'data-cy'?: string;
 
   selectImport: (x) => void;
   updateParams: (filters) => void;
@@ -173,6 +174,7 @@ export class ImportList extends React.Component<IProps, IState> {
                   item.type === selectedImport.type &&
                   item.id === selectedImport.id,
               })}
+              data-cy={`ImportList-row-${item.name}`}
             >
               <div className='left'>
                 <i className={this.getStatusClass(item.state)} />

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -118,7 +118,7 @@ class MyImports extends React.Component<RouteComponentProps, IState> {
         <BaseHeader title={t`My imports`} />
         <Main>
           <section className='body'>
-            <div className='hub-page-container'>
+            <div className='hub-page-container' data-cy='MyImports'>
               <div className='import-list'>
                 <ImportList
                   importList={importList}
@@ -155,7 +155,6 @@ class MyImports extends React.Component<RouteComponentProps, IState> {
                   selectedImport={selectedImport}
                   apiError={importDetailError}
                   collectionVersion={selectedCollectionVersion}
-                  data-cy={'MyImports'}
                 />
               </div>
             </div>

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -155,6 +155,7 @@ class MyImports extends React.Component<RouteComponentProps, IState> {
                   selectedImport={selectedImport}
                   apiError={importDetailError}
                   collectionVersion={selectedCollectionVersion}
+                  data-cy={'MyImports'}
                 />
               </div>
             </div>

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -30,48 +30,76 @@ describe('Imports filter test', () => {
 
     cy.visit('/ui/my-imports?namespace=test_namespace');
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).click();
-    cy.get('[data-cy="ImportConsole-MyImports"]').contains(
+    cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]').contains(
       `test_namespace.${testCollection}`,
     );
-    cy.get('[data-cy="ImportConsole-MyImports"] .title-bar').contains(
-      'Completed',
-      { timeout: 10000 },
-    );
-    cy.get('[data-cy="ImportConsole-MyImports"] .message-list').contains(
-      'Done',
-    );
+    cy.get(
+      '[data-cy="MyImports"] [data-cy="ImportConsole"] .title-bar',
+    ).contains('Completed', { timeout: 10000 });
+    cy.get(
+      '[data-cy="MyImports"] [data-cy="ImportConsole"] .message-list',
+    ).contains('Done');
   });
 
   it('should fail on importing existing collection', () => {
     cy.galaxykit(`-i collection upload test_namespace ${testCollection}`);
+
     cy.visit('/ui/my-imports?namespace=test_namespace');
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).first().click();
-    cy.get('[data-cy="ImportConsole-MyImports"]').contains(
+    cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]').contains(
       `test_namespace.${testCollection}`,
     );
-    cy.get('[data-cy="ImportConsole-MyImports"] .title-bar').contains(
-      'Failed',
-      { timeout: 10000 },
+    cy.get(
+      '[data-cy="MyImports"] [data-cy="ImportConsole"] .title-bar',
+    ).contains('Failed', { timeout: 10000 });
+    cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]').contains(
+      'Error message',
     );
-    cy.get('[data-cy="ImportConsole-MyImports"]').contains('Error message');
-    cy.get('[data-cy="ImportConsole-MyImports"] .message-list').contains(
-      'Failed',
-    );
+    cy.get(
+      '[data-cy="MyImports"] [data-cy="ImportConsole"] .message-list',
+    ).contains('Failed');
   });
 
   it('should redirect to new uploaded collection', () => {
     cy.visit('/ui/my-imports?namespace=test_namespace');
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).first().click();
-    cy.get('[data-cy="ImportConsole-MyImports"]')
+    cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]')
       .contains(`test_namespace.${testCollection}`)
       .click();
     cy.contains(testCollection);
   });
 
   it('should be able to switch between namespaces', () => {
+    cy.intercept(
+      'GET',
+      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
+    ).as('collectionVersions');
+    cy.intercept(
+      'GET',
+      Cypress.env('prefix') + '_ui/v1/imports/collections/*',
+    ).as('importsCollections');
+
     cy.get('[aria-label="Select namespace"]').select('test_namespace');
+
+    cy.wait('@collectionVersions');
+    cy.wait('@importsCollections');
+
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).should('be.visible');
+
+    cy.intercept(
+      'GET',
+      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
+    ).as('collectionVersions');
+    cy.intercept(
+      'GET',
+      Cypress.env('prefix') + '_ui/v1/imports/collections/*',
+    ).as('importsCollections');
+
     cy.get('[aria-label="Select namespace"]').select('filter_test_namespace');
+
+    cy.wait('@collectionVersions');
+    cy.wait('@importsCollections');
+
     cy.get('[data-cy="ImportList-row-my_collection1"]').should('be.visible');
   });
 

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -72,33 +72,47 @@ describe('Imports filter test', () => {
   it('should be able to switch between namespaces', () => {
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
-    ).as('collectionVersions');
+      Cypress.env('prefix') +
+        '_ui/v1/imports/collections/?namespace=test_namespace&*',
+    ).as('collectionsInNamespace');
     cy.intercept(
       'GET',
       Cypress.env('prefix') + '_ui/v1/imports/collections/*',
-    ).as('importsCollections');
+    ).as('collectionDetail');
+    cy.intercept(
+      'GET',
+      Cypress.env('prefix') +
+        '_ui/v1/collection-versions/?namespace=test_namespace&name=*',
+    ).as('collectionVersions');
 
     cy.get('[aria-label="Select namespace"]').select('test_namespace');
 
+    cy.wait('@collectionsInNamespace');
+    cy.wait('@collectionDetail');
     cy.wait('@collectionVersions');
-    cy.wait('@importsCollections');
 
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).should('be.visible');
 
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
-    ).as('collectionVersions');
+      Cypress.env('prefix') +
+        '_ui/v1/imports/collections/?namespace=filter_test_namespace&*',
+    ).as('collectionsInNamespace');
     cy.intercept(
       'GET',
       Cypress.env('prefix') + '_ui/v1/imports/collections/*',
-    ).as('importsCollections');
+    ).as('collectionDetail');
+    cy.intercept(
+      'GET',
+      Cypress.env('prefix') +
+        '_ui/v1/collection-versions/?namespace=filter_test_namespace&name=*',
+    ).as('collectionVersions');
 
     cy.get('[aria-label="Select namespace"]').select('filter_test_namespace');
 
+    cy.wait('@collectionsInNamespace');
+    cy.wait('@collectionDetail');
     cy.wait('@collectionVersions');
-    cy.wait('@importsCollections');
 
     cy.get('[data-cy="ImportList-row-my_collection1"]').should('be.visible');
   });


### PR DESCRIPTION
Issue: [AAH-625](https://issues.redhat.com/browse/AAH-625)

Adding/improving `imports_filter.js` tests:
- verifying `completed` state in `ImportConsole` component
- fail to import existing collection test 
- collection exists (and redirection works) after clicking on the collection link 
- switching between namespaces shows correct collections  