### PR TITLE
Fix "Publish container images" documentation link version - 2.0-ea -> 2.1

### DIFF
--- a/CHANGES/1364.bug
+++ b/CHANGES/1364.bug
@@ -1,0 +1,1 @@
+Fix "Publish container images" documentation link version - 2.0-ea -> 2.1

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -128,7 +128,7 @@ class ExecutionEnvironmentList extends React.Component<
         variant='link'
         onClick={() =>
           window.open(
-            'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.0-ea/html-single/managing_containers_in_private_automation_hub/index',
+            'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/managing_containers_in_private_automation_hub/index',
             '_blank',
           )
         }


### PR DESCRIPTION
Fixes AAH-1364

Exection Environments list:
The "Publish container images" button currently links to 4.3 documentation, updating to link to 4.4. (even for master, since 4.5 docs don't exist yet).

![20220304005531](https://user-images.githubusercontent.com/289743/156678589-d49cfe44-d859-4cf0-95c5-8a6db9a0890c.png)

2.0 = 4.3
2.1 = 4.4
(2.2 = 4.5, but no such link exists yet)