### PR TITLE
[stable-4.4] [Hub-4.4.0dev] Under 'Groups > admins > Edit group permissions', the …

### DIFF
--- a/CHANGES/1199.misc
+++ b/CHANGES/1199.misc
@@ -1,0 +1,1 @@
+ Translations for chip permissions.

--- a/src/components/permissions/obect-permission-field.tsx
+++ b/src/components/permissions/obect-permission-field.tsx
@@ -64,6 +64,7 @@ export class ObjectPermissionField extends React.Component<IProps, IState> {
               <FlexItem style={{ minWidth: '200px' }}>{group.name}</FlexItem>
               <FlexItem grow={{ default: 'grow' }} style={{ width: '90%' }}>
                 <PermissionChipSelector
+                  multilingual={true}
                   availablePermissions={availablePermissions.map((perm) =>
                     twoWayMapper(perm, Constants.GROUP_HUMAN_PERMISSIONS),
                   )}

--- a/src/components/permissions/permission-chip-selector.tsx
+++ b/src/components/permissions/permission-chip-selector.tsx
@@ -1,4 +1,6 @@
 import { t } from '@lingui/macro';
+import { i18n } from '@lingui/core';
+
 import * as React from 'react';
 import {
   Label,
@@ -17,6 +19,7 @@ interface IProps {
   onSelect?: (event, selection) => void;
   onClear?: () => void;
   menuAppendTo?: 'parent' | 'inline';
+  multilingual?: boolean;
 }
 
 interface IState {
@@ -37,10 +40,24 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
       return (
         <LabelGroup>
           {items.map((text) => (
-            <Label key={text}>{text}</Label>
+            <Label key={text}>
+              {this.props.multilingual ? i18n._(text) : text}
+            </Label>
           ))}
         </LabelGroup>
       );
+    }
+
+    let selections = [];
+    if (this.props.multilingual) {
+      selections = this.props.selectedPermissions.map((value) => ({
+        // orginal english value
+        value,
+        // translated
+        toString: () => i18n._(value),
+      }));
+    } else {
+      selections = this.props.selectedPermissions;
     }
 
     return (
@@ -49,11 +66,11 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
         variant={SelectVariant.typeaheadMulti}
         typeAheadAriaLabel={t`Select permissions`}
         onToggle={this.onToggle}
-        onSelect={!!this.props.onSelect ? this.props.onSelect : this.onSelect}
+        onSelect={this.onSelect}
         onClear={
           !!this.props.onClear ? this.props.onClear : this.clearSelection
         }
-        selections={this.props.selectedPermissions}
+        selections={selections}
         isOpen={this.state.isOpen}
         placeholderText={this.placeholderText()}
         isDisabled={!!this.props.isDisabled}
@@ -67,7 +84,9 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
               />,
             ]
           : this.props.availablePermissions.map((option, index) => (
-              <SelectOption key={index} value={option} />
+              <SelectOption key={index} value={option}>
+                {this.props.multilingual ? i18n._(option) : option}
+              </SelectOption>
             ))}
       </Select>
     );
@@ -91,13 +110,22 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
   };
 
   private onSelect = (event, selection) => {
-    const newPerms = new Set(this.props.selectedPermissions);
-    if (newPerms.has(selection)) {
-      newPerms.delete(selection);
-    } else {
-      newPerms.add(selection);
+    // value contains orginal key in english
+    if (this.props.multilingual && selection.value) {
+      selection = selection.value;
     }
 
-    this.props.setSelected(Array.from(newPerms));
+    if (this.props.onSelect) {
+      this.props.onSelect(event, selection);
+    } else {
+      const newPerms = new Set(this.props.selectedPermissions);
+      if (newPerms.has(selection)) {
+        newPerms.delete(selection);
+      } else {
+        newPerms.add(selection);
+      }
+
+      this.props.setSelected(Array.from(newPerms));
+    }
   };
 }

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -24,7 +24,7 @@ export class Constants {
   static PERMISSIONS = [
     {
       name: 'namespaces',
-      label: t`Collection Namespaces`,
+      label: defineMessage({ message: `Collection Namespaces` }),
       object_permissions: [
         'galaxy.add_namespace', // model_permissions.add_namespace
         'galaxy.change_namespace', // (model_permissions.change_namespace)
@@ -34,7 +34,7 @@ export class Constants {
     },
     {
       name: 'collections',
-      label: t`Collections`,
+      label: defineMessage({ message: `Collections` }),
       object_permissions: [
         'ansible.modify_ansible_repo_content', // model_permissions.move_collection
         'ansible.delete_collection', // model_permissions.delete_collection
@@ -42,7 +42,7 @@ export class Constants {
     },
     {
       name: 'users',
-      label: t`Users`,
+      label: defineMessage({ message: `Users` }),
       object_permissions: [
         'galaxy.view_user', // model_permissions.view_user
         'galaxy.delete_user', // model_permissions.delete_user
@@ -52,7 +52,7 @@ export class Constants {
     },
     {
       name: 'groups',
-      label: t`Groups`,
+      label: defineMessage({ message: `Groups` }),
       object_permissions: [
         'galaxy.view_group', // model_permissions.view_group
         'galaxy.delete_group', // model_permissions.delete_group
@@ -62,7 +62,7 @@ export class Constants {
     },
     {
       name: 'remotes',
-      label: t`Collection Remotes`,
+      label: defineMessage({ message: `Collection Remotes` }),
       object_permissions: [
         'ansible.change_collectionremote', // model_permissions.change_remote
         'ansible.view_collectionremote',
@@ -72,7 +72,7 @@ export class Constants {
     },
     {
       name: 'containers',
-      label: t`Containers`,
+      label: defineMessage({ message: `Containers` }),
       object_permissions: [
         // Turning off private container permissions since they aren't supported yet
         // 'container.namespace_pull_containerdistribution',
@@ -93,7 +93,7 @@ export class Constants {
     },
     {
       name: 'registries',
-      label: t`Remote Registries`,
+      label: defineMessage({ message: `Remote Registries` }),
       object_permissions: [
         'galaxy.add_containerregistryremote', // model_permissions.add_containerregistry
         'galaxy.change_containerregistryremote', // model_permissions.change_containerregistry
@@ -102,7 +102,7 @@ export class Constants {
     },
     {
       name: 'task_management',
-      label: t`Task Management`,
+      label: defineMessage({ message: `Task Management` }),
       object_permissions: [
         'core.change_task',
         'core.delete_task',

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -1,4 +1,6 @@
 import { t, Trans } from '@lingui/macro';
+import { i18n } from '@lingui/core';
+
 import * as React from 'react';
 
 import {
@@ -345,7 +347,9 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
               key={group.name}
               className={group.name}
             >
-              <FlexItem style={{ minWidth: '200px' }}>{group.label}</FlexItem>
+              <FlexItem style={{ minWidth: '200px' }}>
+                {i18n._(group.label)}
+              </FlexItem>
               <FlexItem grow={{ default: 'grow' }}>
                 <PermissionChipSelector
                   availablePermissions={group.object_permissions
@@ -366,6 +370,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
                     .map((value) => twoWayMapper(value, filteredPermissions))}
                   setSelected={(perms) => this.setState({ permissions: perms })}
                   menuAppendTo='inline'
+                  multilingual={true}
                   isViewOnly={!editPermissions}
                   onClear={() => {
                     const clearedPerms = group.object_permissions;


### PR DESCRIPTION
…lists for the chip group category {Namespaces, Collections,Users,Groups,Remotes,Containers} , need to be marked as translatable string (#1655)

* Translation for permission chips selector
Issue: AAH-1199

* Change file.

* Linter

* Refactor using map.

* Refactor Permission Chip Selector and make namespace group chips multilingual

Backport of #1655
