### PR TITLE
[stable-4.4][Hub-4.4.0dev] Modal header 'Permanently delete container', need to be marked as translatable string

### DIFF
--- a/CHANGES/1198.misc
+++ b/CHANGES/1198.misc
@@ -1,0 +1,1 @@
+Add translations for Permanently Delete Container and niceNames in user-list.

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -182,7 +182,7 @@ class ExecutionEnvironmentList extends React.Component<
         {deleteModalVisible && (
           <DeleteModal
             spinner={isDeletionPending}
-            title={'Permanently delete container?'}
+            title={t`Permanently delete container?`}
             cancelAction={() =>
               this.setState({ deleteModalVisible: false, selectedItem: null })
             }

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -207,10 +207,10 @@ class UserList extends React.Component<RouteComponentProps, IState> {
                   params={params}
                   ignoredParams={['page_size', 'page', 'sort']}
                   niceNames={{
-                    username__contains: 'Username',
-                    first_name__contains: 'First name',
-                    last_name__contains: 'Last name',
-                    email__contains: 'Email',
+                    username__contains: t`Username`,
+                    first_name__contains: t`First name`,
+                    last_name__contains: t`Last name`,
+                    email__contains: t`Email`,
                   }}
                 />
               </div>


### PR DESCRIPTION
Issue: AAH-1198

Backport of #1653 was done from scratch, because there was refactoring and it was easier to change several lines manualy. No
cherrypick was used.
