### PR TITLE
Group list and detail view parity

### DIFF
--- a/CHANGES/1088.misc
+++ b/CHANGES/1088.misc
@@ -1,0 +1,1 @@
+Cosmetic changes to group lis and detail views, adjust wording for delete group modal.

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -609,7 +609,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         title={t`Remove user from group?`}
       >
         <Trans>
-          <b>{username}</b> will be removed from <b>{groupname}</b>.
+          User <b>{username}</b> will be removed from group<b>{groupname}</b>.
         </Trans>
       </DeleteModal>
     );
@@ -868,7 +868,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         <td>
           <DateComponent date={user.date_joined} />
         </td>
-        <td>
+        <td style={{ paddingRight: '0px', textAlign: 'right' }}>
           {' '}
           {!!currentUser &&
             currentUser.model_permissions.change_group &&

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -447,7 +447,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
             {group.name}
           </Link>
         </td>
-        <td>
+        <td style={{ paddingRight: '0px', textAlign: 'right' }}>
           {dropdownItems.length > 0 && (
             <StatefulDropdown items={dropdownItems} />
           )}


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/AAH-1088
This pr makes cosmetic changes to group detail and list views, making sure that kebab dropdown for edit and delete functions are moved to the far right of table. Also see changes to the wording on remove user from group modal to match UX models implemented elsewhere on the app (see alerts notifications).

- [x]  list view delete button (toggle dropdown) is moved to the right

- [x] detail view delete button (toggle) is moved to the right
- [x] Confirmed: group detail has edit, delete, and add/remove functions
- [x] Confirmed: group list has delete and edit buttons (toggle dropdown) 

Before:
-List
![Screen Shot 2022-03-04 at 1 51 14 PM](https://user-images.githubusercontent.com/64337863/156827100-7c34a648-b26d-4896-9955-cdf4d3035532.png)
-detail
![Screen Shot 2022-03-04 at 1 52 15 PM](https://user-images.githubusercontent.com/64337863/156827105-c3ef72df-0bfc-4850-9599-2d305cd40db9.png)


After:
-list
![Screen Shot 2022-03-04 at 1 51 35 PM](https://user-images.githubusercontent.com/64337863/156827102-1205787d-d51d-4bb7-a478-1d6cd935bacc.png)
-detail
![Screen Shot 2022-03-04 at 1 55 24 PM](https://user-images.githubusercontent.com/64337863/156827107-284fb714-aa66-4458-9b95-76beaf3224e7.png)
