### PR TITLE
Fix EE detail Edit when include_tags not an array

### DIFF
--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -251,10 +251,10 @@ export function withContainerRepo(WrappedComponent) {
                 }
                 registry={this.state.repo.pulp.repository.remote?.registry}
                 excludeTags={
-                  this.state.repo.pulp.repository.remote?.exclude_tags
+                  this.state.repo.pulp.repository.remote?.exclude_tags || []
                 }
                 includeTags={
-                  this.state.repo.pulp.repository.remote?.include_tags
+                  this.state.repo.pulp.repository.remote?.include_tags || []
                 }
                 remotePulpId={this.state.repo.pulp.repository.remote?.pulp_id}
               />


### PR DESCRIPTION
Creating a remote execution environmnent and then editing it already works (as the UI will always send `include_tags: [], exclude_tags: []` when not set).

But creating one through the API, you can skip include_tags or exclude_tags without getting a validation error.
After that, editing that EE only works from the list screen, but yields a blank screen when editing from the detail screen.

Fixing by adding a `|| []` to the detail screen as well.

No-Issue

(corresponding code in list screen edit: https://github.com/ansible/ansible-hub-ui/blob/master/src/containers/execution-environment-list/execution_environment_list.tsx#L433-L434 )