### PR TITLE
Fix missing collection version number in collection deletion alert

### DIFF
--- a/CHANGES/1431.misc
+++ b/CHANGES/1431.misc
@@ -1,0 +1,1 @@
+Fixed and reworked collection deletion to fix missing collection version in alert

--- a/test/cypress/integration/collection.js
+++ b/test/cypress/integration/collection.js
@@ -43,7 +43,7 @@ describe('collection tests', () => {
     cy.get('@taskStatus.last').then(() => {
       cy.get('h4[class=pf-c-alert__title]').should(
         'have.text',
-        'Success alert:Collection "test_collection v" has been successfully deleted.',
+        'Success alert:Collection "test_collection v1.0.0" has been successfully deleted.',
       );
     });
   });


### PR DESCRIPTION
Issue: [AAH-1431](https://issues.redhat.com/browse/AAH-1431)

Fixes a small issue with the missing version number in Alert on **successful deleting collection**. I had to slightly rework the collection deletion code, because before we didn't need to show the collection version in alert and therefore it was null on deleting entire collection. 

before:
![Screenshot from 2022-03-09 11-48-37](https://user-images.githubusercontent.com/19647757/157432484-6977d327-a83e-4d42-8ecf-e194deba43c5.png)

after:
![Screenshot from 2022-03-09 11-51-11](https://user-images.githubusercontent.com/19647757/157432491-d195051b-40f7-4ceb-8ec6-b8dd25b48fa9.png)

