### PR TITLE
Token insights - remove inevitable "Token could not be displayed" error

### DIFF
--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -71,25 +71,10 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
 
   componentDidMount() {
     // this function will fail if chrome.auth.doOffline() hasn't been called
-    window.insights.chrome.auth
-      .getOfflineToken()
-      .then((result) => {
-        this.setState({ tokenData: result.data });
-      })
-      .catch((e) => {
-        const { status, statusText } = e.response;
-        this.setState({
-          tokenData: undefined,
-          alerts: [
-            ...this.state.alerts,
-            {
-              variant: 'danger',
-              title: t`Token could not be displayed.`,
-              description: errorMessage(status, statusText),
-            },
-          ],
-        });
-      });
+    // so it never works the first time .. loadToken() causes a reload and then it works => no error handling
+    window.insights.chrome.auth.getOfflineToken().then((result) => {
+      this.setState({ tokenData: result.data });
+    });
 
     this.getMyDistributionPath();
   }


### PR DESCRIPTION
Problem: in insights mode, load the Token page, there will always be an error alert - Token could not be displayed.

The error handling was added in #1115, but in this case, this will always error the first time.

The expected flow is:
* `TokenPage` loads, `componentDidMount` runs `getOfflineToken()` and fails, `render` displays a `{{ user_token }}` placeholder
* user clicks the "Load token" button, `loadToken` calls `doOffline()` which triggers a reload
* `TokenPage` loads, `componentDidMount` runs `getOfflineToken()` and succeds, `render` displays the token

If there's a way of doing this without a full page reload, or of telling that `doOffline` just happened successfully but `getOfflineToken` still fails, we should keep the error. But I don't know of either right now. (Short of a double redirect maybe.)

=> just removing the alert, unless anyone objects :)

Cc @Hyperkid123 , @jerabekjiri 