### PR TITLE
Test cypress failures

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -177,6 +177,7 @@ jobs:
     - name: "Run cypress"
       working-directory: 'ansible-hub-ui/test'
       run: |
+        galaxykit -s 'http://localhost:8002/api/galaxy/' -u admin -p admin user list ; echo $?
         npm run cypress:chrome
 
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: "Install galaxykit dependency"
       run: |
-        pip install git+https://github.com/ansible/galaxykit.git
+        pip install git+https://github.com/himdel/galaxykit.git@fix-fix
 
     - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: "Install galaxykit dependency"
       run: |
-        pip install git+https://github.com/himdel/galaxykit.git@fix-fix
+        pip install git+https://github.com/ansible/galaxykit.git
 
     - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |


### PR DESCRIPTION
Seeing a lot of test fail in galaxykit now (https://github.com/ansible/ansible-hub-ui/runs/5530725419?check_suite_focus=true)
we're still installing from master, not 0.7.0 so presumably something broke in the latest merges,
but cypress cuts stdout and stderr on 200 chars :(.

(TODO better cy.exec logging)