### PR TITLE
CollectionCard: add SignatureBadge

### DIFF
--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -54,6 +54,10 @@
       color: var(--pf-global--info-color--100);
       margin-right: 3px;
     }
+
+    .hub-signature-badge {
+      margin-left: 5px;
+    }
   }
 
   .description {

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -15,7 +15,7 @@ import {
 
 import { Link } from 'react-router-dom';
 
-import { NumericLabel, Logo } from 'src/components';
+import { NumericLabel, Logo, SignatureBadge } from 'src/components';
 import { CollectionListType } from 'src/api';
 import { formatPath, Paths } from 'src/paths';
 import { convertContentSummaryCounts } from 'src/utilities';
@@ -31,8 +31,15 @@ export class CollectionCard extends React.Component<IProps> {
   MAX_DESCRIPTION_LENGTH = 60;
 
   render() {
-    const { name, latest_version, namespace, className, footer, repo } =
-      this.props;
+    const {
+      name,
+      latest_version,
+      namespace,
+      className,
+      footer,
+      repo,
+      sign_state,
+    } = this.props;
 
     const company = namespace.company || namespace.name;
     const contentSummary = convertContentSummaryCounts(latest_version.metadata);
@@ -48,6 +55,7 @@ export class CollectionCard extends React.Component<IProps> {
             unlockWidth
           />
           <TextContent>{this.getCertification(repo)}</TextContent>
+          <SignatureBadge isCompact signState={sign_state} />
         </CardHeader>
         <CardHeader>
           <div className='name'>

--- a/src/components/signing/signature-badge.tsx
+++ b/src/components/signing/signature-badge.tsx
@@ -37,6 +37,7 @@ export const SignatureBadge: FC<Props> = ({
   return (
     <Label
       variant='outline'
+      className='hub-signature-badge'
       color={signState === 'signed' ? 'green' : 'orange'}
       icon={
         signState === 'signed' ? (


### PR DESCRIPTION
replaces #1628

this just adds the signature badge to collection card, without changing how CollectionCard is structured.

![20220314174741](https://user-images.githubusercontent.com/289743/158231121-9cf06b93-2d3b-4830-93b5-344f51456778.png)
![20220314174755](https://user-images.githubusercontent.com/289743/158231125-9467f30a-34e2-4335-ba24-c56423237f87.png)

