### PR TITLE
Insights token page - user.username -> cloud-services in the curl command

### DIFF
--- a/CHANGES/1376.bug
+++ b/CHANGES/1376.bug
@@ -1,0 +1,1 @@
+Insights token page - user.username -> cloud-services in the curl command

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -95,11 +95,8 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
   }
 
   render() {
-    const { user } = this.context;
     const { tokenData, alerts } = this.state;
-    const renewTokenCmd = `curl https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token -d grant_type=refresh_token -d client_id="${
-      user.username
-    }" -d refresh_token="${
+    const renewTokenCmd = `curl https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token -d grant_type=refresh_token -d client_id="cloud-services" -d refresh_token="${
       tokenData?.refresh_token ?? '{{ user_token }}'
     }" --fail --silent --show-error --output /dev/null`;
 


### PR DESCRIPTION
Fixes AAH-1376

looks like using the actual username for `client_id` in the "renew token" curl command now triggers a 400, while using `cloud-services` works

TODO: figure out why it should be so, document the actual error in the 400 response