### PR TITLE
Insights - fix window title

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
   },
   globals: {
     // overridden in test/.eslintrc
+    APPLICATION_NAME: "readonly",
     NAMESPACE_TERM: "readonly",
   },
   rules: {

--- a/CHANGES/1439.misc
+++ b/CHANGES/1439.misc
@@ -1,0 +1,1 @@
+Insights - fix window title

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -27,6 +27,7 @@ class App extends Component {
   componentDidMount() {
     window.insights.chrome.init();
     window.insights.chrome.identifyApp('automation-hub');
+    document.title = APPLICATION_NAME; // change window title from automationHub
 
     // This listens for insights navigation events, so this will fire
     // when items in the nav are clicked or the app is loaded for the first


### PR DESCRIPTION
Issue: AAH-1439

changes the window title from 'automationHub' to 'Automation Hub'