### PR TITLE
Context alerts example

### DIFF
--- a/CHANGES/1383.task
+++ b/CHANGES/1383.task
@@ -1,0 +1,1 @@
+Make visible the delete alerts on ex env detail page using global context alerts.

--- a/src/components/patternfly-wrappers/alert-list.tsx
+++ b/src/components/patternfly-wrappers/alert-list.tsx
@@ -4,13 +4,14 @@ import {
   AlertActionCloseButton,
   AlertProps,
 } from '@patternfly/react-core';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IProps {
   /** List of alerts to display */
   alerts: AlertType[];
 
   /** Callback to close the alert at the given index */
-  closeAlert: (alertIndex) => void;
+  closeAlert?: (alertIndex) => void;
 }
 
 export class AlertType {
@@ -19,9 +20,17 @@ export class AlertType {
   description?: string | JSX.Element;
 }
 
+const closeAlertContext = (alertIndex: number, context) => {
+  const newList = [...context.alerts];
+  newList.splice(alertIndex, 1);
+  context.setAlerts(newList);
+};
+
 export class AlertList extends React.Component<IProps> {
+  static contextType = AppContext;
+
   render() {
-    const { alerts, closeAlert } = this.props;
+    const { alerts, closeAlert = closeAlertContext } = this.props;
     return (
       <div
         style={{
@@ -40,7 +49,9 @@ export class AlertList extends React.Component<IProps> {
             title={alert.title}
             variant={alert.variant}
             actionClose={
-              <AlertActionCloseButton onClose={() => closeAlert(i)} />
+              <AlertActionCloseButton
+                onClose={() => closeAlert(i, this.context)}
+              />
             }
           >
             {alert.description}

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -63,6 +63,11 @@ export function withContainerRepo(WrappedComponent) {
 
     componentDidMount() {
       this.loadRepo();
+      this.setState({ alerts: this.context.alerts || [] });
+    }
+
+    componentWillUnmount() {
+      this.context.setAlerts([]);
     }
 
     render() {
@@ -166,13 +171,16 @@ export function withContainerRepo(WrappedComponent) {
               selectedItem={repo.name}
               closeAction={() => this.setState({ showDeleteModal: false })}
               afterDelete={() => this.setState({ redirect: 'list' })}
-              addAlert={(text, variant, description = undefined) =>
-                this.setState({
-                  alerts: alerts.concat([
-                    { title: text, variant: variant, description: description },
-                  ]),
-                })
-              }
+              addAlert={(text, variant) => {
+                this.context.setAlerts([
+                  ...this.context.alerts,
+                  {
+                    variant: variant,
+                    title: text,
+                  },
+                ]);
+                this.setState({ alerts: this.context.alerts || [] });
+              }}
             ></DeleteExecutionEnvironmentModal>
           )}
           <ExecutionEnvironmentHeader


### PR DESCRIPTION
Minimal working example of context alerts in 2 components for execution environment delete persist.

connects to #1775 

@ShaiahWren When we worked together I thought the base is the base of the list view too. This was not the case, after I looked it with fresh eyes, I realized the `list view` is the one that should display the error and that one was still using the local state to display alerts. I modified that list too to use just the context for alerts.

This posed a problem that the mixin for closing the alerts is strangely tied to the `state` (I am not sure if that is a good practice or not). I added a default function which operates on the context. I think that could be baked into that component if we would like to use it exclusively in context (and then we could move the component up to the root). But I leave small details like this up to you.

P.S.: Opening a new PR was easier than sending a message and a diff file :D