### PR TITLE
[Signing] Updated the endpoint for signing to match the API

### DIFF
--- a/src/api/response-types/user.ts
+++ b/src/api/response-types/user.ts
@@ -25,7 +25,6 @@ export class Permissions {
   change_namespace: boolean;
   change_remote: boolean;
   move_collection: boolean;
-  sign_collections_on_namespace: boolean;
   sign_collections_on_repository: boolean;
   view_distribution: boolean;
   view_group: boolean;

--- a/src/api/sign-collections.ts
+++ b/src/api/sign-collections.ts
@@ -17,10 +17,14 @@ interface SignVersion extends SignCollection {
 type SignProps = SignNamespace | SignCollection | SignVersion;
 
 class API extends HubAPI {
-  apiPath = 'v3/sign/collections/';
+  apiPath = '_ui/v1/collection_signing/';
 
   sign(data: SignProps) {
-    return this.http.post(this.apiPath, data);
+    const { repository: distro_base_path, ...rest } = data;
+    return this.http.post(this.apiPath, {
+      ...rest,
+      distro_base_path,
+    });
   }
 }
 

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -359,7 +359,8 @@ class CertificationDashboard extends React.Component<
     const canSign =
       this.context?.featureFlags?.collection_signing === true &&
       this.context?.featureFlags?.collection_auto_sign === true &&
-      this.context?.user?.model_permissions?.sign_collections_on_namespace;
+      true;
+    // this.context?.user?.model_permissions?.sign_collections_on_namespace;
 
     if (this.state.updatingVersions.includes(version)) {
       return <ListItemActions />; // empty td;

--- a/src/utilities/can-sign.tsx
+++ b/src/utilities/can-sign.tsx
@@ -1,5 +1,5 @@
 import { IAppContextType } from '../loaders/app-context';
 
 export const canSign = (context: IAppContextType) =>
-  context.featureFlags.collection_signing &&
-  context.user.model_permissions.sign_collections_on_namespace;
+  context.featureFlags.collection_signing && true;
+// context.user.model_permissions.sign_collections_on_namespace;


### PR DESCRIPTION
No-Issue

Addressing the changes in the API, current and upcoming

https://github.com/ansible/galaxy_ng/pull/1145

### TODO:
* [ ] https://github.com/ansible/galaxy_ng/pull/1182 - as per need to update for checking the permissions for individual namespaces for signing (change_namespace) (temporalily disabled, talks with David to make it avaiable in the collection endpoint)
* [ ] Was not working on demo: https://github.com/ansible/ansible-hub-ui/blob/master/src/components/collection-list/collection-filter.tsx#L62 -- look if the feature flag is still correct