### PR TITLE
cloud-stage-cron: fetch to ensure master-stable and master have all the commits

### DIFF
--- a/.github/workflows/cloud-stage-cron.yml
+++ b/.github/workflows/cloud-stage-cron.yml
@@ -22,4 +22,5 @@ jobs:
     - name: "Push to master-stable"
       run: |
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/ansible/ansible-hub-ui.git
+        git fetch --all
         git push origin master:master-stable


### PR DESCRIPTION
Follow-up to #1770 

initial checkout just goes to depth: 1,
we need more commits to have both master and master-stable (and all the commits in between), so fetching all of them now.

Should fix https://github.com/ansible/ansible-hub-ui/runs/5645368756?check_suite_focus=true#step:4:7 .