### PR TITLE
Fixed the redirect in insights mode when deleting namespaces

### DIFF
--- a/CHANGES/1461.bug
+++ b/CHANGES/1461.bug
@@ -1,0 +1,1 @@
+Fixed the broken redirect on insights mode when deleting a namespace

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,12 +1,25 @@
 import { t } from '@lingui/macro';
+import { Constants } from './constants';
 import { ParamHelper } from './utilities/param-helper';
 
-export function formatPath(
+const replaceNamespaceWithPartners = (path: Paths): string => {
+  if (DEPLOYMENT_MODE !== Constants.INSIGHTS_DEPLOYMENT_MODE) {
+    return path;
+  }
+
+  if (path === Paths.namespaces) {
+    return Paths.partners;
+  } else {
+    return path;
+  }
+};
+
+export const formatPath = (
   path: Paths,
   data,
   params?: Record<string, string | boolean>,
-) {
-  let url = path as string;
+) => {
+  let url = replaceNamespaceWithPartners(path);
 
   for (const k of Object.keys(data)) {
     url = url.replace(':' + k + '+', data[k]).replace(':' + k, data[k]);
@@ -17,7 +30,7 @@ export function formatPath(
   } else {
     return url;
   }
-}
+};
 
 export enum Paths {
   executionEnvironmentDetailActivities = '/containers/:container+/_content/activity',


### PR DESCRIPTION
Issue: AAH-1461

**Before on insights**
![Screenshot from 2022-03-18 09-26-39](https://user-images.githubusercontent.com/8531681/159896331-43aa3d12-5d6e-4174-a6db-1df29cec3113.png)
![Screenshot from 2022-03-18 09-27-09](https://user-images.githubusercontent.com/8531681/159896333-e71d809c-7492-452e-8de0-92290fe65bb4.png)

**After on insights**
![Screenshot from 2022-03-24 11-05-51](https://user-images.githubusercontent.com/8531681/159896274-e9782ef9-42df-4e34-9464-802162bf2d5d.png)
![Screenshot from 2022-03-24 11-06-06](https://user-images.githubusercontent.com/8531681/159896278-4a64e912-a307-4d00-be05-c2deaeef0ac9.png)
![Screenshot from 2022-03-24 11-06-13](https://user-images.githubusercontent.com/8531681/159896280-7495c152-c7a1-4c99-bb14-27de89417f4f.png)

**After on standalone**
![Screenshot from 2022-03-24 11-18-15](https://user-images.githubusercontent.com/8531681/159896219-6311b9d1-6c86-44a3-a329-80f2a23153da.png)
![Screenshot from 2022-03-24 11-18-27](https://user-images.githubusercontent.com/8531681/159896222-269c26a6-e18c-4dcd-a27f-6e2ae3d60375.png)
![Screenshot from 2022-03-24 11-18-34](https://user-images.githubusercontent.com/8531681/159896223-08abee22-a2ee-4f8d-ad22-1c59fd8036a1.png)
