### PR TITLE
cloud-stage-cron - add debugging info

### DIFF
--- a/.github/workflows/cloud-stage-cron.yml
+++ b/.github/workflows/cloud-stage-cron.yml
@@ -23,4 +23,7 @@ jobs:
       run: |
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/ansible/ansible-hub-ui.git
         git fetch --all
+        git log -1 origin/master
+        git log -1 origin/master-stable
+        git log -1 HEAD
         git push origin master:master-stable


### PR DESCRIPTION
Follow up to #1802 and #1770 

still doesn't work..  https://github.com/ansible/ansible-hub-ui/runs/5676767046?check_suite_focus=true#step:4:66

adding debugging info