### PR TITLE
Fixed insights mode redirect when deleting a namespace

### DIFF
--- a/CHANGES/1461.bug
+++ b/CHANGES/1461.bug
@@ -1,0 +1,1 @@
+Fixed insights mode redirect when deleting a namespace

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -559,7 +559,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       NamespaceAPI.delete(name)
         .then(() => {
           this.setState({
-            redirect: formatPath(Paths.namespaces, {}),
+            redirect: formatPath(namespaceBreadcrumb.url, {}),
             confirmDelete: false,
             isNamespacePending: false,
           });


### PR DESCRIPTION
Issue: AAH-1461

we never use `Paths.namespaces` because that only works in standalone,
`namespaceBreadcrumb.url` is always valid in both, using that one.

This replaces #1805 - same bug, different fix.