### PR TITLE
cloud-stage-cron: clone manually

### DIFF
--- a/.github/workflows/cloud-stage-cron.yml
+++ b/.github/workflows/cloud-stage-cron.yml
@@ -10,20 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: "Checkout ansible-hub-ui master"
-      uses: actions/checkout@v2
-      with:
-        ref: 'master'
-
-    - name: "Fail if paused"
+    - name: "Checkout ansible-hub-ui-master, fail if paused, push to master-stable"
       run: |
+        git clone -b master https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/ansible/ansible-hub-ui.git
+        cd ansible-hub-ui
         [ -f .cloud-stage-cron.enabled ] || exit 1
-
-    - name: "Push to master-stable"
-      run: |
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/ansible/ansible-hub-ui.git
-        git fetch --all
         git log -1 origin/master
         git log -1 origin/master-stable
-        git log -1 HEAD
         git push origin master:master-stable


### PR DESCRIPTION
the previous fails to push master to master-stable because it believes they're not related

     ! [rejected]        master -> master-stable (non-fast-forward)

that's not true, works locally, so it's probably an artifact of how the checkout action checks out other branches.

This *might* work, if not, `push -f` probably will, but I'd still like to know the reason.