### PR TITLE
read alerts from context after delete and redirect

### DIFF
--- a/CHANGES/1383.task
+++ b/CHANGES/1383.task
@@ -1,0 +1,1 @@
+Makes visible the delete alert upon deletion and redirect from ex env detail page.

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -166,12 +166,14 @@ export function withContainerRepo(WrappedComponent) {
               selectedItem={repo.name}
               closeAction={() => this.setState({ showDeleteModal: false })}
               afterDelete={() => this.setState({ redirect: 'list' })}
-              addAlert={(text, variant, description = undefined) =>
-                this.setState({
-                  alerts: alerts.concat([
-                    { title: text, variant: variant, description: description },
-                  ]),
-                })
+              addAlert={(text, variant) =>
+                this.context.setAlerts([
+                  ...this.context.alerts,
+                  {
+                    variant: variant,
+                    title: text,
+                  },
+                ])
               }
             ></DeleteExecutionEnvironmentModal>
           )}

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -165,15 +165,16 @@ export function withContainerRepo(WrappedComponent) {
             <DeleteExecutionEnvironmentModal
               selectedItem={repo.name}
               closeAction={() => this.setState({ showDeleteModal: false })}
-              afterDelete={() => this.setState({ redirect: 'list' })}
-              addAlert={(text, variant) =>
-                this.context.setAlerts([
-                  ...this.context.alerts,
-                  {
-                    variant: variant,
-                    title: text,
-                  },
-                ])
+              afterDelete={() => {
+                this.context.setAlerts(this.state.alerts);
+                this.setState({ redirect: 'list' });
+              }}
+              addAlert={(text, variant, description = undefined) =>
+                this.setState({
+                  alerts: alerts.concat([
+                    { title: text, variant: variant, description: description },
+                  ]),
+                })
               }
             ></DeleteExecutionEnvironmentModal>
           )}

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -104,7 +104,12 @@ class ExecutionEnvironmentList extends React.Component<
       this.setState({ unauthorized: true, loading: false });
     } else {
       this.queryEnvironments();
+      this.setState({ alerts: this.context.alerts });
     }
+  }
+
+  componentWillUnmount() {
+    this.context.setAlerts([]);
   }
 
   render() {


### PR DESCRIPTION
Issue: AAH-1383

Assignment: Make visible the delete alerts on ex env detail page using global context alerts.
Replaces https://github.com/ansible/ansible-hub-ui/pull/1775 and https://github.com/ansible/ansible-hub-ui/pull/1800