### PR TITLE
cypress.yml - fix podman save failure

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -67,6 +67,7 @@ jobs:
         ' | tee Containerfile
 
         buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .
+        rm -f image # ensure older version is gone, podman save errors otherwise
         podman save localhost/pulp/pulp-galaxy-ng:latest -o image
 
     - name: "Load pulp-galaxy-ng from cache"


### PR DESCRIPTION
https://github.com/ansible/ansible-hub-ui/runs/5712872845?check_suite_focus=true#step:6:501

`podman save` now fails with

    Error: docker-archive doesn't support modifying existing images

when an image already exists .. adding an explicit removal
(not quite sure why it exists when `cache-hit != 'true'` but..)
