### PR TITLE
NamespaceList: Clear filter text when clearing all filters

### DIFF
--- a/CHANGES/1382.bug
+++ b/CHANGES/1382.bug
@@ -1,0 +1,1 @@
+NamespaceList: Clear filter text when clearing all filters

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -212,7 +212,10 @@ export class NamespaceList extends React.Component<IProps, IState> {
                       />
                       <AppliedFilters
                         style={{ marginTop: '16px' }}
-                        updateParams={updateParams}
+                        updateParams={(p) => {
+                          updateParams(p);
+                          this.setState({ inputText: '' });
+                        }}
                         params={params}
                         ignoredParams={['page_size', 'page', 'sort']}
                       />


### PR DESCRIPTION
Issue: AAH-1382

Go to Namespaces list, search, clear all filters.

Before:

The filter text stays set.

| | | :point_down: |
|-|-|-|
| ![20220330005752](https://user-images.githubusercontent.com/289743/160730153-8c3131ed-dc87-4e7c-a438-3e53e381261c.png) | ![20220330005808](https://user-images.githubusercontent.com/289743/160730156-52e52467-6d97-401a-96c9-096daa4ca6ec.png) | ![20220330005917](https://user-images.githubusercontent.com/289743/160730157-b3bc40d2-544f-4013-9e02-f9e830e38cfb.png) |


After:

The filter text is reset.

| | | :point_down: |
|-|-|-|
| ![20220330005752](https://user-images.githubusercontent.com/289743/160730153-8c3131ed-dc87-4e7c-a438-3e53e381261c.png) | ![20220330005808](https://user-images.githubusercontent.com/289743/160730156-52e52467-6d97-401a-96c9-096daa4ca6ec.png) | ![20220330005752](https://user-images.githubusercontent.com/289743/160730153-8c3131ed-dc87-4e7c-a438-3e53e381261c.png) |
