### PR TITLE
src/api: remove extra constructors

### DIFF
--- a/src/api/active-user.ts
+++ b/src/api/active-user.ts
@@ -8,10 +8,6 @@ type GetUserReturn = Awaited<
 class API extends HubAPI {
   apiPath = this.getUIPath('me/');
 
-  constructor() {
-    super();
-  }
-
   getUser(): Promise<GetUserReturn['identity']> {
     if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
       return new Promise((resolve, reject) => {

--- a/src/api/activities.ts
+++ b/src/api/activities.ts
@@ -3,10 +3,6 @@ import { HubAPI } from './hub';
 class API extends HubAPI {
   apiPath = this.getUIPath('execution-environments/repositories/');
 
-  constructor() {
-    super();
-  }
-
   list(id, page) {
     return super.list({ page: page }, this.apiPath + id + '/_content/history/');
   }

--- a/src/api/application-info.ts
+++ b/src/api/application-info.ts
@@ -2,9 +2,6 @@ import { HubAPI } from './hub';
 
 class API extends HubAPI {
   apiPath = API_HOST;
-  constructor() {
-    super();
-  }
 }
 
 export const ApplicationInfoAPI = new API();

--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -3,10 +3,6 @@ import { HubAPI } from './hub';
 export class API extends HubAPI {
   apiPath = this.getUIPath('collection-versions/');
 
-  constructor() {
-    super();
-  }
-
   setRepository(
     namespace: string,
     name: string,

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -52,10 +52,6 @@ export class API extends HubAPI {
   apiPath = this.getUIPath('repo/');
   cachedCollection: CollectionDetailType;
 
-  constructor() {
-    super();
-  }
-
   list(params?, repo?: string) {
     const path = this.apiPath + repo + '/';
     return super.list(params, path).then((response) => ({

--- a/src/api/distribution.ts
+++ b/src/api/distribution.ts
@@ -2,10 +2,6 @@ import { HubAPI } from './hub';
 
 class API extends HubAPI {
   apiPath = this.getUIPath('distributions/');
-
-  constructor() {
-    super();
-  }
 }
 
 export const DistributionAPI = new API();

--- a/src/api/feature-flags.ts
+++ b/src/api/feature-flags.ts
@@ -3,10 +3,6 @@ import { HubAPI } from './hub';
 class API extends HubAPI {
   apiPath = this.getUIPath('feature-flags/');
 
-  constructor() {
-    super();
-  }
-
   get() {
     return this.http.get(this.apiPath);
   }

--- a/src/api/generic-pulp.ts
+++ b/src/api/generic-pulp.ts
@@ -2,8 +2,10 @@ import { PulpAPI } from './pulp';
 
 export class API extends PulpAPI {
   apiPath = '';
+
   get(id: string, apiPath?: string) {
     return this.http.get(this.getPath(apiPath) + id);
   }
 }
+
 export const GenericPulpAPI = new API();

--- a/src/api/group.ts
+++ b/src/api/group.ts
@@ -3,10 +3,6 @@ import { HubAPI } from './hub';
 class API extends HubAPI {
   apiPath = this.getUIPath('groups/');
 
-  constructor() {
-    super();
-  }
-
   getPermissions(id) {
     return this.http.get(
       this.apiPath + id + '/model-permissions/?limit=100000&offset=0',

--- a/src/api/my-distribution.ts
+++ b/src/api/my-distribution.ts
@@ -2,10 +2,6 @@ import { HubAPI } from './hub';
 
 class API extends HubAPI {
   apiPath = this.getUIPath('my-distributions/');
-
-  constructor() {
-    super();
-  }
 }
 
 export const MyDistributionAPI = new API();

--- a/src/api/my-synclist.ts
+++ b/src/api/my-synclist.ts
@@ -3,10 +3,6 @@ import { HubAPI } from './hub';
 class API extends HubAPI {
   apiPath = this.getUIPath('my-synclists/');
 
-  constructor() {
-    super();
-  }
-
   curate(id) {
     return this.http.post(this.apiPath + id + '/curate/', {});
   }

--- a/src/api/namespace.ts
+++ b/src/api/namespace.ts
@@ -2,10 +2,6 @@ import { HubAPI } from './hub';
 
 class API extends HubAPI {
   apiPath = this.getUIPath('namespaces/');
-
-  constructor() {
-    super();
-  }
 }
 
 export const NamespaceAPI = new API();

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -3,10 +3,6 @@ import { HubAPI } from './hub';
 class API extends HubAPI {
   apiPath = this.getUIPath('settings/');
 
-  constructor() {
-    super();
-  }
-
   get() {
     return this.http.get(this.apiPath);
   }

--- a/src/api/task.ts
+++ b/src/api/task.ts
@@ -2,10 +2,6 @@ import { HubAPI } from './hub';
 
 export class API extends HubAPI {
   apiPath = 'v3/tasks/';
-
-  constructor() {
-    super();
-  }
 }
 
 export const TaskAPI = new API();


### PR DESCRIPTION
js classes already have a default constructor calling super, no need for the construct unless we want to do something else :)