### PR TITLE
PULP_API_BASE_PATH: add an env var to override the `/pulp/api/v3/` path

### DIFF
--- a/config/insights.dev.webpack.config.js
+++ b/config/insights.dev.webpack.config.js
@@ -6,6 +6,7 @@ module.exports = webpackBase({
 
   // Path to the API on the API host. EX: /api/automation-hub
   API_BASE_PATH: '/api/automation-hub/',
+  PULP_API_BASE_PATH: '/api/automation-hub/pulp/api/v3/',
 
   // Path on the host where the UI is found. EX: /apps/automation-hub
   UI_BASE_PATH: '',

--- a/config/insights.prod.webpack.config.js
+++ b/config/insights.prod.webpack.config.js
@@ -4,6 +4,7 @@ const webpackBase = require('./webpack.base.config');
 module.exports = webpackBase({
   API_HOST: '',
   API_BASE_PATH: '/api/automation-hub/',
+  PULP_API_BASE_PATH: '/api/automation-hub/pulp/api/v3/',
   UI_BASE_PATH: '',
   DEPLOYMENT_MODE: 'insights',
   NAMESPACE_TERM: 'partners',

--- a/config/standalone.dev.webpack.config.js
+++ b/config/standalone.dev.webpack.config.js
@@ -12,6 +12,7 @@ module.exports = webpackBase({
 
   // Path to the API on the API host. EX: /api/automation-hub
   API_BASE_PATH: apiBasePath,
+  PULP_API_BASE_PATH: '/pulp/api/v3/',
 
   // Path on the host where the UI is found. EX: /apps/automation-hub
   UI_BASE_PATH: '/ui/',

--- a/config/standalone.prod.webpack.config.js
+++ b/config/standalone.prod.webpack.config.js
@@ -4,6 +4,7 @@ const webpackBase = require('./webpack.base.config');
 module.exports = webpackBase({
   API_HOST: '',
   API_BASE_PATH: '/api/galaxy/',
+  PULP_API_BASE_PATH: '/pulp/api/v3/',
   UI_BASE_PATH: '/ui/',
   DEPLOYMENT_MODE: 'standalone',
   NAMESPACE_TERM: 'namespaces',

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -20,6 +20,7 @@ const defaultConfigs = [
   // as a constant after it is compiled
   { name: 'API_HOST', default: '', scope: 'global' },
   { name: 'API_BASE_PATH', default: '', scope: 'global' },
+  { name: 'PULP_API_BASE_PATH', default: '', scope: 'global' },
   { name: 'UI_BASE_PATH', default: '', scope: 'global' },
   { name: 'DEPLOYMENT_MODE', default: 'standalone', scope: 'global' },
   { name: 'NAMESPACE_TERM', default: 'namespaces', scope: 'global' },

--- a/src/api/pulp.ts
+++ b/src/api/pulp.ts
@@ -2,6 +2,6 @@ import { BaseAPI } from './base';
 
 export class PulpAPI extends BaseAPI {
   constructor() {
-    super('/pulp/api/v3/');
+    super(API_HOST + PULP_API_BASE_PATH);
   }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,7 @@ declare module '*.svg';
 /* eslint-disable no-var */
 declare var API_HOST;
 declare var API_BASE_PATH;
+declare var PULP_API_BASE_PATH;
 declare var UI_BASE_PATH;
 declare var DEPLOYMENT_MODE;
 declare var NAMESPACE_TERM;


### PR DESCRIPTION
and also respect API_HOST in PulpAPI, same as HubAPI

Related to AAH-1332 (#1589) and AAH-1367 - both will need to access pulp API endpoints in insights mode.