### PR TITLE
insights - disable global filter

### DIFF
--- a/src/loaders/app.scss
+++ b/src/loaders/app.scss
@@ -19,6 +19,11 @@
     var(--pf-global--palette--black-800);
 }
 
+// hide crc global filter - enabled for the whole ansible org but irrelevant outside AAP
+#global-filter {
+  display: none;
+}
+
 section.pf-c-nav__section.nav-title > h2 {
   height: 50px;
   font-size: var(--pf-c-nav__link--FontSize);

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -29,12 +29,6 @@ class App extends Component {
     window.insights.chrome.identifyApp('automation-hub');
     document.title = APPLICATION_NAME; // change window title from automationHub
 
-    // hide global filter - enabled for the whole ansible org but irrelevant outside AAP
-    const globalFilter = document.getElementById('global-filter');
-    if (el) {
-      el.style.display = 'none';
-    }
-
     // This listens for insights navigation events, so this will fire
     // when items in the nav are clicked or the app is loaded for the first
     // time

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -29,6 +29,12 @@ class App extends Component {
     window.insights.chrome.identifyApp('automation-hub');
     document.title = APPLICATION_NAME; // change window title from automationHub
 
+    // hide global filter - enabled for the whole ansible org but irrelevant outside AAP
+    const globalFilter = document.getElementById('global-filter');
+    if (el) {
+      el.style.display = 'none';
+    }
+
     // This listens for insights navigation events, so this will fire
     // when items in the nav are clicked or the app is loaded for the first
     // time


### PR DESCRIPTION
A global filter was added for the whole ansible org in insights mode, but it's only for AAP - introduced as part of https://issues.redhat.com/browse/RHCLOUD-18330 & https://github.com/RedHatInsights/insights-chrome/pull/1827

Disabling, same as https://github.com/RedHatInsights/tower-analytics-frontend/pull/777 :)

--- 

TODO screenshot, ensure this doesn't just work the first time, or move to render
TODO ensure the css thing doesn't affect other non-AAH pages

---

We may not need this after all, sounds like the change will be updated to restrict the filter to aap before it goes in prod.
Keeping for now not to forget.
Also, https://issues.redhat.com/browse/AAP-3077