### PR TITLE
deleteCollection - don't mention version when deleting the whole

### DIFF
--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -793,7 +793,6 @@ export class CollectionHeader extends React.Component<IProps, IState> {
     const {
       deleteCollection,
       deleteCollection: { name },
-      collectionVersion,
     } = this.state;
     CollectionAPI.deleteCollection(this.context.selectedRepo, deleteCollection)
       .then((res) => {
@@ -804,12 +803,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             ...this.context.alerts,
             {
               variant: 'success',
-              title: (
-                <Trans>
-                  Collection &quot;{name} v{collectionVersion}
-                  &quot; has been successfully deleted.
-                </Trans>
-              ),
+              title: t`Collection "${name}" has been successfully deleted.`,
             },
           ]);
           this.setState({

--- a/test/cypress/integration/collection.js
+++ b/test/cypress/integration/collection.js
@@ -43,7 +43,7 @@ describe('collection tests', () => {
     cy.get('@taskStatus.last').then(() => {
       cy.get('h4[class=pf-c-alert__title]').should(
         'have.text',
-        'Success alert:Collection "test_collection v" has been successfully deleted.',
+        'Success alert:Collection "test_collection" has been successfully deleted.',
       );
     });
   });


### PR DESCRIPTION
noticed in #1738, looks like this was introduced in #1469 to replace "Successfully deleted collection."

we're now using the same success message in `deleteCollection` and `deleteCollectionVersion`, which is misleading (they didn't just delete one version), and broken since there is no version info, just the `v`
updating to remove the version info :) (from `deleteCollection` ; no change when deleting a version)

---

Before:

![Screenshot from 2022-03-09 11-48-37](https://user-images.githubusercontent.com/19647757/157432484-6977d327-a83e-4d42-8ecf-e194deba43c5.png)

After:
![20220405133943](https://user-images.githubusercontent.com/289743/161766853-e2ed361c-50cb-4a90-b551-7b430b81a823.png)

