### PR TITLE
Signing - update API endpoint, permission checking

### DIFF
--- a/src/api/my-namespace.ts
+++ b/src/api/my-namespace.ts
@@ -3,8 +3,8 @@ import { HubAPI } from './hub';
 class API extends HubAPI {
   apiPath = this.getUIPath('my-namespaces/');
 
-  constructor() {
-    super();
+  get(id: string, params = {}) {
+    return this.http.get(this.apiPath + id + '/', { params });
   }
 }
 

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -127,6 +127,7 @@ export class CollectionDetailType {
     name: string;
     avatar_url: string;
     company: string;
+    related_fields: { my_permissions?: string[] };
   };
 }
 

--- a/src/api/response-types/namespace.ts
+++ b/src/api/response-types/namespace.ts
@@ -20,4 +20,5 @@ export class NamespaceType extends NamespaceListType {
   resources: string;
   owners: string[];
   links: NamespaceLinkType[];
+  related_fields: { my_permissions?: string[] };
 }

--- a/src/api/response-types/user.ts
+++ b/src/api/response-types/user.ts
@@ -25,8 +25,6 @@ export class Permissions {
   change_namespace: boolean;
   change_remote: boolean;
   move_collection: boolean;
-  sign_collections_on_namespace: boolean;
-  sign_collections_on_repository: boolean;
   view_distribution: boolean;
   view_group: boolean;
   view_user: boolean;

--- a/src/api/sign-collections.ts
+++ b/src/api/sign-collections.ts
@@ -2,7 +2,7 @@ import { HubAPI } from './hub';
 
 interface SignNamespace {
   signing_service?: string;
-  repository?: string;
+  distro_base_path?: string;
   namespace: string;
 }
 
@@ -17,7 +17,7 @@ interface SignVersion extends SignCollection {
 type SignProps = SignNamespace | SignCollection | SignVersion;
 
 class API extends HubAPI {
-  apiPath = 'v3/sign/collections/';
+  apiPath = this.getUIPath('collection_signing/');
 
   sign(data: SignProps) {
     return this.http.post(this.apiPath, data);

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -45,7 +45,7 @@ import {
   SignCollectionAPI,
 } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
-import { waitForTask, canSign } from 'src/utilities';
+import { waitForTask } from 'src/utilities';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { DateComponent } from '../date-component/date-component';
 import { Constants } from 'src/constants';
@@ -174,12 +174,18 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       `${moment(v.created).fromNow()} ${signedString(v)}
       ${v.version === all_versions[0].version ? t`(latest)` : ''}`;
 
-    const { name: collectionName } = collection;
-    const company = collection.namespace.company || collection.namespace.name;
+    const { name: collectionName, namespace } = collection;
+    const company = namespace.company || namespace.name;
 
     if (redirect) {
       return <Redirect push to={redirect} />;
     }
+
+    const canSign =
+      this.context.featureFlags?.collection_signing &&
+      namespace?.related_fields?.my_permissions?.includes(
+        'galaxy.change_namespace',
+      );
 
     const dropdownItems = [
       noDependencies
@@ -220,7 +226,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           {t`Delete version ${collection.latest_version.version}`}
         </DropdownItem>
       ),
-      canSign(this.context) && (
+      canSign && (
         <DropdownItem
           key='sign-all'
           onClick={() => this.setState({ isOpenSignAllModal: true })}
@@ -228,7 +234,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           {t`Sign entire collection`}
         </DropdownItem>
       ),
-      canSign(this.context) && (
+      canSign && (
         <DropdownItem
           key='sign-version'
           onClick={() => this.setState({ isOpenSignModal: true })}
@@ -240,7 +246,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     return (
       <React.Fragment>
-        {canSign(this.context) && (
+        {canSign && (
           <>
             <SignAllCertificatesModal
               name={collectionName}

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -45,7 +45,7 @@ import {
   SignCollectionAPI,
 } from 'src/api';
 import { Paths, formatPath } from 'src/paths';
-import { waitForTask } from 'src/utilities';
+import { waitForTask, canSign as canSignNS } from 'src/utilities';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { DateComponent } from '../date-component/date-component';
 import { Constants } from 'src/constants';
@@ -181,11 +181,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       return <Redirect push to={redirect} />;
     }
 
-    const canSign =
-      this.context.featureFlags?.collection_signing &&
-      namespace?.related_fields?.my_permissions?.includes(
-        'galaxy.change_namespace',
-      );
+    const canSign = canSignNS(this.context, namespace);
 
     const dropdownItems = [
       noDependencies

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -592,7 +592,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
-      repository: this.context.selectedRepo,
+      distro_base_path: this.context.selectedRepo,
       namespace: this.props.collection.namespace.name,
       collection: this.props.collection.name,
     })
@@ -643,7 +643,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
-      repository: this.context.selectedRepo,
+      distro_base_path: this.context.selectedRepo,
       namespace: this.props.collection.namespace.name,
       collection: this.props.collection.name,
       version: this.props.collection.latest_version.version,

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -356,9 +356,10 @@ class CertificationDashboard extends React.Component<
   }
 
   private renderButtons(version: CollectionVersion) {
+    const { featureFlags } = this.context;
+    // not checking namespace permissions here, auto_sign happens API side, so is the permission check
     const canSign =
-      this.context?.featureFlags?.collection_signing === true &&
-      this.context?.featureFlags?.collection_auto_sign === true;
+      featureFlags?.collection_signing && featureFlags?.collection_auto_sign;
 
     if (this.state.updatingVersions.includes(version)) {
       return <ListItemActions />; // empty td;

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -358,8 +358,7 @@ class CertificationDashboard extends React.Component<
   private renderButtons(version: CollectionVersion) {
     const canSign =
       this.context?.featureFlags?.collection_signing === true &&
-      this.context?.featureFlags?.collection_auto_sign === true &&
-      this.context?.user?.model_permissions?.sign_collections_on_namespace;
+      this.context?.featureFlags?.collection_auto_sign === true;
 
     if (this.state.updatingVersions.includes(version)) {
       return <ListItemActions />; // empty td;

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -21,7 +21,7 @@ export function loadCollection(
     this.props.match.params['namespace'],
     this.props.match.params['collection'],
     repo,
-    this.state.params,
+    { ...this.state.params, include_related: 'my_permissions' },
     forceReload,
   )
     .then((result) => {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -413,7 +413,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
-      repository: this.context.selectedRepo,
+      distro_base_path: this.context.selectedRepo,
       namespace: namespace.name,
     })
       .then((result) => {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -55,6 +55,7 @@ import {
   filterIsSet,
   errorMessage,
   waitForTask,
+  canSign as canSignNS,
 } from 'src/utilities';
 import { Constants } from 'src/constants';
 import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
@@ -490,11 +491,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           itemCount: val[0].data.meta.count,
           namespace: val[1].data,
           showControls: !!val[2],
-          canSign:
-            this.context.featureFlags?.collection_signing &&
-            val[2]?.data?.related_fields?.my_permissions?.includes(
-              'galaxy.change_namespace',
-            ),
+          canSign: canSignNS(this.context, val[2]?.data),
         });
 
         this.loadAllRepos(val[0].data.meta.count);

--- a/src/utilities/can-sign.tsx
+++ b/src/utilities/can-sign.tsx
@@ -1,4 +1,0 @@
-import { IAppContextType } from '../loaders/app-context';
-
-export const canSign = (context: IAppContextType) =>
-  context.featureFlags.collection_signing;

--- a/src/utilities/can-sign.tsx
+++ b/src/utilities/can-sign.tsx
@@ -1,5 +1,4 @@
 import { IAppContextType } from '../loaders/app-context';
 
 export const canSign = (context: IAppContextType) =>
-  context.featureFlags.collection_signing &&
-  context.user.model_permissions.sign_collections_on_namespace;
+  context.featureFlags.collection_signing;

--- a/src/utilities/can-sign.tsx
+++ b/src/utilities/can-sign.tsx
@@ -1,0 +1,8 @@
+export const canSign = ({ featureFlags }, namespace) => {
+  const permissions = namespace?.related_fields?.my_permissions || [];
+  return (
+    featureFlags?.collection_signing &&
+    permissions.includes('galaxy.change_namespace') &&
+    permissions.includes('galaxy.upload_to_namespace')
+  );
+};

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -17,3 +17,4 @@ export { lastSynced, lastSyncStatus } from './last-sync-task';
 export { waitForTask } from './wait-for-task';
 export { errorMessage } from './fail-alerts';
 export { validateURLHelper } from './validateURLHelper';
+export { canSign } from './can-sign';

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -17,4 +17,3 @@ export { lastSynced, lastSyncStatus } from './last-sync-task';
 export { waitForTask } from './wait-for-task';
 export { errorMessage } from './fail-alerts';
 export { validateURLHelper } from './validateURLHelper';
-export { canSign } from './can-sign';


### PR DESCRIPTION
This depends on ~~https://github.com/ansible/galaxy_ng/pull/1197~~ https://github.com/ansible/galaxy_ng/pull/1188
(Also on merged https://github.com/ansible/galaxy_ng/pull/1145)

Replaces https://github.com/ansible/ansible-hub-ui/pull/1801, taking the work from there and finishing the `canSign` logic using the nearest `namespace.related_fields.my_permissions`.

---

testing:
no need for custom pulp-ansible here, but depends on https://github.com/ansible/galaxy_ng/pull/1188
setting env vars for signing example in https://github.com/ansible/galaxy_ng/pull/1197#issuecomment-1086720558