### PR TITLE
collection_upload test - fix sporadic failure

### DIFF
--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -78,6 +78,7 @@ export class CollectionListItem extends React.Component<IProps> {
               namespace: namespace.name,
               repo: repo,
             })}
+            data-cy='CollectionList-name'
           >
             {name}
           </Link>

--- a/test/cypress/integration/collection_upload.js
+++ b/test/cypress/integration/collection_upload.js
@@ -69,6 +69,7 @@ describe('Collection Upload Tests', () => {
 
   it('should not upload new collection version when user does not have permissions', () => {
     cy.visit('/ui/repo/published/testspace');
+    cy.get('[data-cy="CollectionList-name"]').contains('testcollection');
     cy.contains('Upload new version').should('not.exist');
   });
 


### PR DESCRIPTION
Fixing (I hope)

    Collection Upload Tests
      ✓ user should not be able to upload new collection without permissions (12005ms)
      ✓ collection should be uploaded (13209ms)
      ✓ should not upload new collection version when user does not have permissions
      1) should deprecate let user deprecate and undeprecate collections

      3 passing (28s)
      1 failing

      1) Collection Upload Tests
        should deprecate let user deprecate and undeprecate collections:
        Error: The following error originated from your application code, not from Cypress. It was caused by an unhandled promise rejection.

      Request failed with status code 403

https://github.com/ansible/ansible-hub-ui/runs/5854034056?check_suite_focus=true

the idea being the previous test doesn't wait long enough and gets a 403 in one of the requests .. wait for the list to appear first
