### PR TITLE
RemoteForm - only show "Download only signed collections" for remotes, not registries

### DIFF
--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -122,6 +122,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
         'auth_url',
         'token',
         'requirements_file',
+        'signed_only',
       ]);
     }
 
@@ -229,7 +230,8 @@ export class RemoteForm extends React.Component<IProps, IState> {
           />
         </FormGroup>
 
-        {this.context?.featureFlags?.collection_signing === true && (
+        {!disabledFields.includes('signed_only') &&
+        this.context.featureFlags?.collection_signing ? (
           <FormGroup
             fieldId={'signed_only'}
             name={t`Signed only`}
@@ -241,7 +243,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
               onChange={(value) => this.updateRemote(value, 'signed_only')}
             />
           </FormGroup>
-        )}
+        ) : null}
 
         {!disabledFields.includes('token') && (
           <FormGroup


### PR DESCRIPTION
Follow-up to https://github.com/ansible/ansible-hub-ui/pull/1625 (AAH-1333)

the new switch was also visible for remoteType=registry, hiding in remote registry forms :)

| |changed|unchanged|
|-|-|-|
|Before:|![20220407011741](https://user-images.githubusercontent.com/289743/162101273-6b8fa999-c0c4-4e12-97f6-7448c2a573da.png)|![20220407011726](https://user-images.githubusercontent.com/289743/162101280-a1fcf636-37d5-4b3c-88f9-83280d75e64f.png)|
|After:|![20220407003349](https://user-images.githubusercontent.com/289743/162101293-e510bc58-7dce-4507-ac96-e2b5665c4057.png)|![20220407003417](https://user-images.githubusercontent.com/289743/162101296-e2a4dcef-ea1d-4843-be34-11d5b4869bf1.png)|

