### PR TITLE
frontend-components-config: downgrade from 4.6.6 to 4.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4458,12 +4458,12 @@
             "integrity": "sha512-BBVg40L4gx0Gew2kDdGNxP+EtDwGeBuJwXewKrTjXlCa4uhOOj7TqJ5rxhS4GULfYiYbUGdYe7UMFVb+mKDVVg=="
         },
         "@redhat-cloud-services/frontend-components-config": {
-            "version": "4.6.6",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.6.tgz",
-            "integrity": "sha512-aOOwpFhfKxb+OEWNp92fFR/52AwgOXK+l3A3tZBQPcJL2aRS+WMOooqya0vhmSvRmQWAZYawY+aq4xdDpXMkNg==",
+            "version": "4.6.4",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.4.tgz",
+            "integrity": "sha512-fariIRhk4D3Bvpz02cvmbxhPRLWADecLeYpR6xpnIQH64JSzJDoffKgiYoBgqFmoZTpsK+TseySBjtpmpcXjKA==",
             "dev": true,
             "requires": {
-                "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.17",
+                "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.11",
                 "assert": "^2.0.0",
                 "axios": "^0.25.0",
                 "babel-loader": "^8.2.2",
@@ -4621,9 +4621,9 @@
                     }
                 },
                 "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "version": "7.3.7",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -4647,10 +4647,13 @@
             }
         },
         "@redhat-cloud-services/frontend-components-config-utilities": {
-            "version": "1.5.17",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.17.tgz",
-            "integrity": "sha512-eXDUIdzfL7CVliHIVThaNY+t5+qd5Jgx360uoURMWdEFQmPHlaAo7hpEqQBcFw77oPFmI1bqE5tOOUkVHPfHmA==",
-            "dev": true
+            "version": "1.5.20",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.20.tgz",
+            "integrity": "sha512-u9lXLL9h8e0eP+H33y8StWFUnxAwXQ/dFOUVXU3Z2ZOmMJUJX5WN1fz13OopHS1volRb5DCt6RmGoW4vd4aJCg==",
+            "dev": true,
+            "requires": {
+                "node-fetch": "2.6.7"
+            }
         },
         "@redhat-cloud-services/frontend-components-utilities": {
             "version": "3.2.10",
@@ -4961,9 +4964,9 @@
             "dev": true
         },
         "@types/uglify-js": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.1.tgz",
-            "integrity": "sha512-O3MmRAk6ZuAKa9CHgg0Pr0+lUOqoMLpc9AS4R8ano2auvsg7IE8syF3Xh/NPr26TWklxYcqoEEFdzLLs1fV9PQ==",
+            "version": "3.13.2",
+            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.2.tgz",
+            "integrity": "sha512-/xFrPIo+4zOeNGtVMbf9rUm0N+i4pDf1ynExomqtokIJmVzR3962lJ1UE+MmexMkA0cmN9oTzg5Xcbwge0Ij2Q==",
             "dev": true,
             "requires": {
                 "source-map": "^0.6.1"
@@ -5579,9 +5582,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.10.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
-                    "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+                    "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -6282,9 +6285,9 @@
             "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
         },
         "clean-css": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.2.4.tgz",
-            "integrity": "sha512-nKseG8wCzEuji/4yrgM/5cthL9oTDc5UOQyFMvW/Q53oP6gLH690o1NbuTh6Y18nujr7BxlsFuS7gXLnLzKJGg==",
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.0.tgz",
+            "integrity": "sha512-YYuuxv4H/iNb1Z/5IbMRoxgrzjWGhOEFfd+groZ5dMCVkpENiMZmwspdrzBo9286JjM1gZJPAyL7ZIdzuvu2AQ==",
             "dev": true,
             "requires": {
                 "source-map": "~0.6.0"
@@ -6762,22 +6765,22 @@
             }
         },
         "css-select": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.2.1.tgz",
-            "integrity": "sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+            "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
             "dev": true,
             "requires": {
                 "boolbase": "^1.0.0",
-                "css-what": "^5.1.0",
-                "domhandler": "^4.3.0",
+                "css-what": "^6.0.1",
+                "domhandler": "^4.3.1",
                 "domutils": "^2.8.0",
                 "nth-check": "^2.0.1"
             }
         },
         "css-what": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.1.0.tgz",
-            "integrity": "sha512-arSMRWIIFY0hV8pIxZMEfmMI47Wj3R/aWpZDDxWYCPEiOMv6tfOrnpDtgxBYPEQD4V0Y/958+1TdC3iWTFcUPw==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+            "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
             "dev": true
         },
         "cssesc": {
@@ -7008,9 +7011,9 @@
             }
         },
         "dom-serializer": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-            "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+            "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
             "dev": true,
             "requires": {
                 "domelementtype": "^2.0.1",
@@ -7019,9 +7022,9 @@
             }
         },
         "domelementtype": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-            "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
             "dev": true
         },
         "domhandler": {
@@ -10367,6 +10370,15 @@
                 }
             }
         },
+        "node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dev": true,
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
+        },
         "node-forge": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -13031,6 +13043,12 @@
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
             "dev": true
         },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+            "dev": true
+        },
         "tree-kill": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -13102,9 +13120,9 @@
                     "dev": true
                 },
                 "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "version": "7.3.7",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -13503,6 +13521,12 @@
                 "defaults": "^1.0.3"
             }
         },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+            "dev": true
+        },
         "webpack": {
             "version": "5.72.0",
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.72.0.tgz",
@@ -13745,12 +13769,6 @@
                         "slash": "^3.0.0"
                     }
                 },
-                "ignore": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-                    "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-                    "dev": true
-                },
                 "ipaddr.js": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
@@ -13847,6 +13865,16 @@
             "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
             "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
             "dev": true
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+            "dev": true,
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
         },
         "which": {
             "version": "2.0.2",
@@ -14016,9 +14044,9 @@
             "dev": true
         },
         "yargs": {
-            "version": "17.4.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.0.tgz",
-            "integrity": "sha512-WJudfrk81yWFSOkZYpAZx4Nt7V4xp7S/uJkX0CnxovMCt1wCE8LNftPpNuF9X/u9gN5nsD7ycYtRcDf2pL3UiA==",
+            "version": "17.4.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.4.1.tgz",
+            "integrity": "sha512-WSZD9jgobAg3ZKuCQZSa3g9QOJeCCqLoLAykiWgmXnDo9EPnn4RPf5qVTtzgOx66o6/oqhcA5tHtJXpG8pMt3g==",
             "dev": true,
             "requires": {
                 "cliui": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "@lingui/cli": "^3.13.2",
         "@lingui/macro": "^3.13.3",
         "@ls-lint/ls-lint": "^1.11.0",
-        "@redhat-cloud-services/frontend-components-config": "^4.6.6",
+        "@redhat-cloud-services/frontend-components-config": "4.6.4",
         "@typescript-eslint/eslint-plugin": "^5.18.0",
         "@typescript-eslint/parser": "^5.20.0",
         "babel-core": "^7.0.0-bridge.0",


### PR DESCRIPTION
(Already merged in master-stable, works on [stage](https://console.stage.redhat.com/ansible/automation-hub), this is to fix it in master and thus [stage beta](https://console.stage.redhat.com/beta/ansible/automation-hub).)

Revert #1814

frontend-components-config 4.6.6 seem to cause a "Something went wrong" screen on cloud.
Downgrading to 4.6.4 which works.

---

(don't merge yet, we're still trying to figure out what actually changed...
MM points to `window.automationHub.init()` throwing an exception,
could be related to an extra `The resource from “https://console.stage.redhat.com/beta/apps/automation-hub/css/automationHub.f5162efe821be5a64169.css” was blocked due to MIME type (“text/css”) mismatch (X-Content-Type-Options: nosniff).` error)