### PR TITLE
[stable-4.4] Cypress: install galaxykit 0.7.0, not latest

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: "Install galaxykit dependency"
       run: |
-        pip install galaxykit
+        pip install galaxykit==0.7.0
 
     - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |


### PR DESCRIPTION
the idea being latest belongs to 4.5 now, or master

4.2: no `cypress.yml`
4.3: `==0.1.0` since #520
4.4: here, `==0.7.0`
4.5: #1969, lastest pypi
master: `git+https://github.com/ansible/galaxykit.git` since #1343