### PR TITLE
[stable-4.5] Cypress: install galaxykit from pypi, not github

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: "Install galaxykit dependency"
       run: |
-        pip install git+https://github.com/himdel/galaxykit.git@v3-plugin-ansible
+        pip install galaxykit==0.8.0
 
     - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -191,6 +191,12 @@ jobs:
       run: |
         curl -s -u admin:admin http://localhost:8002/api/galaxy/_ui/v1/feature-flags/ | jq
 
+    # galaxykit#53 turns out to be incompatible with 4.5, but already released in 0.8.0, patching out
+    - name: "Patch galaxykit"
+      run: |
+        sed -i -e '/def wait_for_task/,$d' ~/.local/lib/python*/site-packages/galaxykit/utils.py
+        ( echo 'def wait_for_task(client, task):' ; echo '    return task' ) >> ~/.local/lib/python*/site-packages/galaxykit/utils.py
+
     - name: "Run cypress"
       working-directory: 'ansible-hub-ui/test'
       run: |


### PR DESCRIPTION
the idea being a stable branch should use a released version of galaxykit

4.2: no `cypress.yml`
4.3: `==0.1.0` since #520
4.4: #1968, `==0.7.0`
4.5: here, `==0.8.0` (https://github.com/ansible/galaxykit/pull/60)
master: `git+https://github.com/ansible/galaxykit.git` since #1343

---

this may not work yet? not sure if we'll need to release whatever is not released in galaxykit, draft