### PR TITLE
fix API_HOST apiPath - HubAPI already does that

### DIFF
--- a/src/api/application-info.ts
+++ b/src/api/application-info.ts
@@ -1,7 +1,11 @@
 import { HubAPI } from './hub';
 
 class API extends HubAPI {
-  apiPath = API_HOST;
+  apiPath = '';
+
+  get() {
+    return super.get('');
+  }
 }
 
 export const ApplicationInfoAPI = new API();

--- a/src/components/about-modal/about-modal.tsx
+++ b/src/components/about-modal/about-modal.tsx
@@ -36,7 +36,7 @@ export class AboutModalWindow extends React.Component<IProps, IState> {
   }
 
   componentDidMount() {
-    ApplicationInfoAPI.get('').then((result) => {
+    ApplicationInfoAPI.get().then((result) => {
       this.setState({
         applicationInfo: {
           server_version: result.data.server_version,


### PR DESCRIPTION
The about modal is not loading version info when using API_HOST..
apiPath gets appended to baseURL, but baseURL comes from API_HOST.

No-Issue