### PR TITLE
Update to use v3 apis instead of legacy ; collection test fix

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: "Install galaxykit dependency"
       run: |
-        pip install git+https://github.com/ansible/galaxykit.git
+        pip install git+https://github.com/himdel/galaxykit.git@v3-plugin-ansible
 
     - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -69,7 +69,7 @@ export class API extends HubAPI {
     isDeprecated: boolean,
     repo: string,
   ) {
-    const path = `content/${repo}/v3/collections/`;
+    const path = `v3/plugin/ansible/content/${repo}/collections/index/`;
 
     return this.patch(
       `${collection.namespace.name}/${collection.name}`,
@@ -150,7 +150,7 @@ export class API extends HubAPI {
     return new Promise((resolve, reject) => {
       this.http
         .get(
-          `content/${distro_base_path}/v3/collections/${namespace}/${name}/versions/${version}/`,
+          `v3/plugin/ansible/content/${distro_base_path}/collections/index/${namespace}/${name}/versions/${version}/`,
         )
         .then((result) => {
           resolve(result.data['download_url']);
@@ -161,13 +161,13 @@ export class API extends HubAPI {
 
   deleteCollectionVersion(repo, collection) {
     return this.http.delete(
-      `content/${repo}/v3/collections/${collection.namespace.name}/${collection.name}/versions/${collection.latest_version.version}/`,
+      `v3/plugin/ansible/content/${repo}/collections/index/${collection.namespace.name}/${collection.name}/versions/${collection.latest_version.version}/`,
     );
   }
 
   deleteCollection(repo, collection) {
     return this.http.delete(
-      `content/${repo}/v3/collections/${collection.namespace.name}/${collection.name}/`,
+      `v3/plugin/ansible/content/${repo}/collections/index/${collection.namespace.name}/${collection.name}/`,
     );
   }
 

--- a/test/cypress/integration/collection.js
+++ b/test/cypress/integration/collection.js
@@ -31,7 +31,7 @@ describe('collection tests', () => {
     cy.intercept(
       'DELETE',
       Cypress.env('prefix') +
-        '/content/published/v3/collections/test_namespace/test_collection',
+        'v3/plugin/ansible/content/published/collections/index/test_namespace/test_collection',
     ).as('deleteCollection');
     cy.intercept('GET', Cypress.env('prefix') + '/v3/tasks/*').as('taskStatus');
 


### PR DESCRIPTION
This updates us to use the new v3/plugin/ansible urls for collection deletion, deprecation and download urls,
updates the test to wait for the right request/response.
(redirects from https://github.com/pulp/pulp_ansible/blob/main/pulp_ansible/app/urls.py#L43)

This should fix the `collection.js` test failure:
https://github.com/ansible/ansible-hub-ui/runs/6152044308?check_suite_focus=true#step:17:249

---

Also updating galaxykit to (PR) to fix the `collection-list.js` test failure:
https://github.com/ansible/ansible-hub-ui/runs/6152044308?check_suite_focus=true#step:17:312


