### PR TITLE
[rbac] GroupRoleAPI, RoleAPI, PulpAPI - move logic to components

### DIFF
--- a/src/api/group-role.ts
+++ b/src/api/group-role.ts
@@ -14,6 +14,8 @@ class API extends PulpAPI {
   addRoleToGroup(groupId, role) {
     return this.http.post(`${this.apiPath}${groupId}/roles/`, {
       role: role.name,
+      // required field, can be empty
+      content_object: null,
     });
   }
 }

--- a/src/api/group-role.ts
+++ b/src/api/group-role.ts
@@ -1,47 +1,21 @@
 import { PulpAPI } from './pulp';
-import { RoleAPI } from './role';
 
 class API extends PulpAPI {
-  constructor() {
-    super('groups/');
-  }
+  apiPath = 'groups/';
 
-  getRolesWithPermissions(id, params?) {
-    const assignedRoles = this.list(params, `${id}/roles/`);
-
-    const allRoles = RoleAPI.list();
-
-    return Promise.all([assignedRoles, allRoles]).then(([assigned, all]) => {
-      // match roles with assigned roles
-      const results = assigned.data.results
-        .map(({ role, pulp_href }) => {
-          const data = all['data'].results.find(({ name }) => name === role);
-          if (data) {
-            return {
-              ...data,
-              // swap pulp_href role with assigned pulp_href role
-              // to delete the assigned role
-              pulp_href,
-            };
-          }
-        })
-        .filter(Boolean);
-
-      return {
-        data: results,
-        count: results.length,
-      };
+  listRoles(groupId, params?) {
+    return this.http.get(`${this.apiPath}${groupId}/roles/`, {
+      params: this.mapPageToOffset(params),
     });
   }
 
-  removeRole(id, pulpId) {
-    return this.http.delete(`${id}/roles/${pulpId}/`);
+  removeRole(groupId, roleId) {
+    return this.http.delete(`${this.apiPath}${groupId}/roles/${roleId}/`);
   }
 
-  addRoleToGroup(id, role, content_object = null) {
-    return this.http.post(`${id}/roles/`, {
+  addRoleToGroup(groupId, role) {
+    return this.http.post(`${this.apiPath}${groupId}/roles/`, {
       role: role.name,
-      content_object,
     });
   }
 }

--- a/src/api/group-role.ts
+++ b/src/api/group-role.ts
@@ -4,9 +4,7 @@ class API extends PulpAPI {
   apiPath = 'groups/';
 
   listRoles(groupId, params?) {
-    return this.http.get(`${this.apiPath}${groupId}/roles/`, {
-      params: this.mapPageToOffset(params),
-    });
+    return super.list(params, `${this.apiPath}${groupId}/roles/`);
   }
 
   removeRole(groupId, roleId) {

--- a/src/api/pulp.ts
+++ b/src/api/pulp.ts
@@ -1,12 +1,8 @@
 import { BaseAPI } from './base';
 
 export class PulpAPI extends BaseAPI {
-  constructor(extendPath?: string) {
-    if (extendPath) {
-      super(API_HOST + PULP_API_BASE_PATH + extendPath);
-    } else {
-      super(API_HOST + PULP_API_BASE_PATH);
-    }
+  constructor() {
+    super(API_HOST + PULP_API_BASE_PATH);
   }
 
   list(params?, apiPath?) {

--- a/src/api/role.ts
+++ b/src/api/role.ts
@@ -7,10 +7,7 @@ export class API extends PulpAPI {
     return this.http.patch(this.apiPath + id, data);
   }
 
-  list(params?, apiPath?) {
-    const changedParams = { ...params, name__startswith: 'galaxy.' };
-    return super.list(changedParams, apiPath);
-  }
+  // list(params?)
 
   getPermissions(id) {
     return this.http.get(

--- a/src/api/task-management.ts
+++ b/src/api/task-management.ts
@@ -3,14 +3,7 @@ import { PulpAPI } from './pulp';
 export class API extends PulpAPI {
   apiPath = 'tasks/';
 
-  list(params) {
-    const changedParams = { ...params };
-    if (changedParams['sort']) {
-      changedParams['ordering'] = changedParams['sort'];
-      delete changedParams['sort'];
-    }
-    return super.list(changedParams);
-  }
+  // list(params)
 }
 
 export const TaskManagementAPI = new API();

--- a/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
+++ b/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
@@ -88,7 +88,7 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
     setLoading(true);
 
     Promise.all([
-      RoleAPI.list(),
+      RoleAPI.list({ name__startswith: 'galaxy.' }),
       GroupRoleAPI.listRoles(group.id, {
         ...ParamHelper.getReduced(params, ['id', 'tab', ...nonQueryParams]),
         sort: ParamHelper.validSortParams(params['sort'], ['role'], 'role'),

--- a/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
+++ b/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
@@ -17,7 +17,12 @@ import {
   EmptyStateFilter,
   ListItemActions,
 } from 'src/components';
-import { GroupRoleAPI, GroupObjectPermissionType, RoleType } from 'src/api';
+import {
+  GroupRoleAPI,
+  GroupObjectPermissionType,
+  RoleAPI,
+  RoleType,
+} from 'src/api';
 
 import {
   errorMessage,
@@ -81,13 +86,35 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
 
   const queryRolesWithPermissions = () => {
     setLoading(true);
-    GroupRoleAPI.getRolesWithPermissions(group.id, {
-      ...ParamHelper.getReduced(params, ['id', 'tab', ...nonQueryParams]),
-      sort: ParamHelper.validSortParams(params['sort'], ['role'], 'role'),
-    })
-      .then(({ data, count }) => {
+
+    Promise.all([
+      RoleAPI.list(),
+      GroupRoleAPI.listRoles(group.id, {
+        ...ParamHelper.getReduced(params, ['id', 'tab', ...nonQueryParams]),
+        sort: ParamHelper.validSortParams(params['sort'], ['role'], 'role'),
+      }),
+    ])
+      .then(([allRoles, assignedRoles]) => {
+        // match roles with assigned roles
+        return assignedRoles.data.results
+          .map(({ role, pulp_href }) => {
+            const data = allRoles.data.results.find(
+              ({ name }) => name === role,
+            );
+            if (data) {
+              return {
+                ...data,
+                // swap pulp_href role with assigned pulp_href role
+                // to delete the assigned role
+                pulp_href,
+              };
+            }
+          })
+          .filter(Boolean);
+      })
+      .then((data) => {
         setRoles(data);
-        setRolesItemCount(count);
+        setRolesItemCount(data.length);
         setLoading(false);
       })
       .catch((e) => {

--- a/src/containers/group-management/group-detail-role-management/select-roles.tsx
+++ b/src/containers/group-management/group-detail-role-management/select-roles.tsx
@@ -47,11 +47,13 @@ const SelectRoles: React.FC<SelectRolesProps> = ({
 
   const queryRoles = () => {
     setLoading(true);
-    RoleAPI.list(localParams).then(({ data }) => {
-      setRoles(data.results);
-      setRolesItemCount(data.count);
-      setLoading(false);
-    });
+    RoleAPI.list({ name__startswith: 'galaxy.', ...localParams }).then(
+      ({ data }) => {
+        setRoles(data.results);
+        setRolesItemCount(data.count);
+        setLoading(false);
+      },
+    );
   };
 
   if (loading) {

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -486,6 +486,7 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
 
   private queryRoles = () => {
     const { params } = this.state;
+
     this.setState({ loading: true }, () => {
       RoleAPI.list(params)
         .then((result) => {


### PR DESCRIPTION
(moving out of https://github.com/ansible/ansible-hub-ui/pull/1863, follow-up to #1797)

`GroupRoleAPI` - move `getRolesWithPermissions` outside api, keep only `listRoles`
`GroupRoleAPI`, `PulpAPI` - use `apiPath` instead of custom constructor.
`RoleAPI` - don't hardcode filter, move to components using it
`TaskManagementAPI`: use PulpApi.list since the ordering logic was moved there

This should not actually change anything - except in role list, clearing the `galaxy.` filter  will actually work.