### PR TITLE
ListItemActions: don't render 0 when an array is empty

### DIFF
--- a/src/components/list-item-actions/list-item-actions.tsx
+++ b/src/components/list-item-actions/list-item-actions.tsx
@@ -10,6 +10,7 @@ export class ListItemActions extends React.Component<IProps> {
   render() {
     const buttons = this.props.buttons?.filter(Boolean);
     const kebabItems = this.props.kebabItems?.filter(Boolean);
+
     return (
       <td
         style={{
@@ -19,12 +20,16 @@ export class ListItemActions extends React.Component<IProps> {
           justifyContent: 'flex-end',
         }}
       >
-        {buttons?.length && <List>{buttons} </List>}
-        {kebabItems?.length && (
+        {buttons?.length ? (
+          <>
+            <List>{buttons}</List>{' '}
+          </>
+        ) : null}
+        {kebabItems?.length ? (
           <div data-cy='kebab-toggle'>
             <StatefulDropdown items={kebabItems} />{' '}
           </div>
-        )}
+        ) : null}
       </td>
     );
   }


### PR DESCRIPTION
(moving out of https://github.com/ansible/ansible-hub-ui/pull/1863)

When `buttons` or `kebabItems` are empty arrays, the length is 0 and a zero can end up displayed instead of the buttons.