### PR TITLE
RoleListTable ExpandableRow - require rowIndex, expand breaks without it

### DIFF
--- a/src/components/role-list-table/role-list-table.tsx
+++ b/src/components/role-list-table/role-list-table.tsx
@@ -76,7 +76,7 @@ export const RoleListTable: React.FC<Props> = ({
 };
 
 export const ExpandableRow: React.FC<{
-  rowIndex?: number;
+  rowIndex: number;
   expandableRowContent?: React.ReactNode;
   colSpan?: number;
 }> = ({ rowIndex, children, expandableRowContent, colSpan }) => {


### PR DESCRIPTION
(moving out of https://github.com/ansible/ansible-hub-ui/pull/1863)

Marking `rowIndex` non-optional in `ExpandableRow` - without it, the exapndable rows don't render right and end up without the expand chevron.

(@ShaiahWren noticed this during #1860 , making sure we don't hit this again :).)