### PR TITLE
Fix task_management_detail sporadic failure

### DIFF
--- a/test/cypress/integration/task_management_detail.js
+++ b/test/cypress/integration/task_management_detail.js
@@ -8,11 +8,11 @@ describe('Task detail', () => {
       Cypress.env('prefix') + '/content/rh-certified/v3/sync/',
     ).as('sync');
 
-    cy.contains('button', 'Sync').click();
-
     cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/remotes/?*').as(
       'remotes',
     );
+
+    cy.contains('button', 'Sync').click();
 
     cy.wait('@sync');
     cy.wait('@remotes');


### PR DESCRIPTION
(moving out of https://github.com/ansible/ansible-hub-ui/pull/1863)

    Task detail "before all" hook for "contains correct headers and field names.":
    CypressError: Timed out retrying after 5000ms: `cy.wait()` timed out waiting `5000ms` for the 1st request to the route: `remotes`. No request ever occurred.

I think this might fix it :)