### PR TITLE
webpack config ci check: compare using the right isBuild value

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -112,6 +112,16 @@ jobs:
           npm install
 
           for file in *.js; do
+            # FIXME: that's what TARGET_ENVIRONMENT is for
+            NODE_ENV=
+            if grep -q prod <<< "$file"; then
+              NODE_ENV=production
+            fi
+            export NODE_ENV
+
+            # eliminate differences caused by branch name based logic in f-c-config
+            export BRANCH="${{ github.base_ref }}"
+
             node -e 'console.log(JSON.stringify(require("./'"$file"'"), null, 2))' |
               sed -e 's/\/home\/.*\/\(base\|pr\)\//\/DIR\//g' \
                 -e 's/\(\[name\]\|automationHub\)\.[0-9]\+\.\(\[fullhash\]\)/\1.TIMESTAMP.\2/g' \


### PR DESCRIPTION
The webpack config is based on NODE_ENV and ignoring TARGET_ENVIRONMENT now,
I'll fix that separately, but now it also means the webpack config change check is not actually checking the build config, just the dev one.

So, ensuring any `config/*.prod.webpack.config.js` will run with `NODE_ENV=production`.

Needed to properly test https://github.com/ansible/ansible-hub-ui/pull/1526, https://github.com/ansible/ansible-hub-ui/pull/1975 and https://github.com/ansible/ansible-hub-ui/pull/1893.