### PR TITLE
task_detail: use PULP_API_BASE_PATH when parsing pulp urls

### DIFF
--- a/src/containers/task-management/task_detail.tsx
+++ b/src/containers/task-management/task_detail.tsx
@@ -454,7 +454,7 @@ class TaskDetail extends React.Component<RouteComponentProps, IState> {
         }
         if (result.data.reserved_resources_record.length) {
           result.data.reserved_resources_record.forEach((resource) => {
-            const url = resource.replace('/pulp/api/v3/', '');
+            const url = resource.replace(PULP_API_BASE_PATH, '');
             const id = parsePulpIDFromURL(url);
             const urlParts = resource.split('/');
             const type = id ? urlParts[4] : urlParts[urlParts.length - 2];

--- a/test/cypress/integration/task_list.js
+++ b/test/cypress/integration/task_list.js
@@ -3,16 +3,20 @@ describe('Task table contains correct headers and filter', () => {
     cy.login();
     cy.visit('/ui/repositories?tab=remote');
 
+    cy.contains('Repo Management');
+    cy.contains('Configure');
+    cy.contains('Sync');
+
     cy.intercept(
       'POST',
       Cypress.env('prefix') + '/content/rh-certified/v3/sync/',
     ).as('sync');
 
-    cy.contains('button', 'Sync').click();
-
     cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/remotes/?*').as(
       'remotes',
     );
+
+    cy.contains('button', 'Sync').click();
 
     cy.wait('@sync');
     cy.wait('@remotes');

--- a/test/cypress/integration/task_management_detail.js
+++ b/test/cypress/integration/task_management_detail.js
@@ -3,6 +3,10 @@ describe('Task detail', () => {
     cy.login();
     cy.visit('/ui/repositories?tab=remote');
 
+    cy.contains('Repo Management');
+    cy.contains('Configure');
+    cy.contains('Sync');
+
     cy.intercept(
       'POST',
       Cypress.env('prefix') + '/content/rh-certified/v3/sync/',


### PR DESCRIPTION
PULP_API_BASE_PATH introduced in #1857,
for now it does exactly the same thing,
but #1589 will need this :).

--

and fix tests by doing the same thing as https://github.com/ansible/ansible-hub-ui/pull/1985, but also in task_list, and making the initial wait more explicit