### PR TITLE
replace non-descript grey ns icon with new classy ansible icon

### DIFF
--- a/CHANGES/1553.misc
+++ b/CHANGES/1553.misc
@@ -1,0 +1,1 @@
+Update namespace card icon from grey blob to to black ansible icon.

--- a/static/images/default-logo.svg
+++ b/static/images/default-logo.svg
@@ -1,33 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg enable-background="new 0 0 36 36" version="1.1" viewBox="0 0 36 36" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="logo" x="0px" y="0px" viewBox="0 0 300 300" style="enable-background:new 0 0 300 300;" xml:space="preserve">
 <style type="text/css">
-	/*stylelint-disable*/
-	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
-	.st1{filter:url(#b);}
-	.st2{mask:url(#a);}
-	.st3{fill-rule:evenodd;clip-rule:evenodd;fill:#BBBBBB;}
-	.st4{opacity:0.1;fill-rule:evenodd;clip-rule:evenodd;enable-background:new    ;}
-	.st5{opacity:8.000000e-02;fill-rule:evenodd;clip-rule:evenodd;fill:#231F20;enable-background:new    ;}
-	/*stylelint-enable*/
+	.st0{fill:#FFFFFF;}
 </style>
-			<circle class="st0" cx="18" cy="18.5" r="18"/>
-		<defs>
-			<filter id="b" x="5.2" y="7.2" width="25.6" height="53.6" filterUnits="userSpaceOnUse">
-				<feColorMatrix values="1 0 0 0 0  0 1 0 0 0  0 0 1 0 0  0 0 0 1 0"/>
-			</filter>
-		</defs>
-		<mask id="a" x="5.2" y="7.2" width="25.6" height="53.6" maskUnits="userSpaceOnUse">
-			<g class="st1">
-				<circle class="st0" cx="18" cy="18.5" r="18"/>
-			</g>
-		</mask>
-		<g class="st2">
-			<g transform="translate(5.04 6.88)">
-				<path class="st3" d="m22.6 18.1c-1.1-1.4-2.3-2.2-3.5-2.6s-1.8-0.6-6.3-0.6-6.1 0.7-6.1 0.7 0 0 0 0c-1.2 0.4-2.4 1.2-3.4 2.6-2.3 2.8-3.2 12.3-3.2 14.8 0 3.2 0.4 12.3 0.6 15.4 0 0-0.4 5.5 4 5.5l-0.3-6.3-0.4-3.5 0.2-0.9c0.9 0.4 3.6 1.2 8.6 1.2 5.3 0 8-0.9 8.8-1.3l0.2 1-0.2 3.6-0.3 6.3c3 0.1 3.7-3 3.8-4.4s0.6-12.6 0.6-16.5c0.1-2.6-0.8-12.1-3.1-15z"/>
-				<path class="st4" d="m22.5 26c-0.1-2.1-1.5-2.8-4.8-2.8l2.2 9.6s1.8-1.7 3-1.8c0 0-0.4-4.6-0.4-5z"/>
-				<path class="st3" d="m12.7 13.2c-3.5 0-6.4-2.9-6.4-6.4s2.9-6.4 6.4-6.4 6.4 2.9 6.4 6.4-2.8 6.4-6.4 6.4z"/>
-				<path class="st5" d="m9.4 6.8c0-3 2.1-5.5 4.9-6.3-0.5-0.1-1-0.2-1.6-0.2-3.5 0-6.4 2.9-6.4 6.4s2.9 6.4 6.4 6.4c0.6 0 1.1-0.1 1.6-0.2-2.8-0.6-4.9-3.1-4.9-6.1z"/>
-				<path class="st4" d="m8.3 22.4c-2 0.4-2.9 1.4-3.1 3.5l-0.6 18.6s1.7 0.7 3.6 0.9l0.1-23z"/>
-			</g>
-		</g>
+<title>Ansible-Mark-RGB</title>
+<path d="M259.8,152.9c0,59-47.8,106.8-106.8,106.8c-59,0-106.8-47.8-106.8-106.8S94,46.1,153,46.1c0,0,0,0,0,0  C212,46.1,259.8,93.9,259.8,152.9C259.8,152.9,259.8,152.9,259.8,152.9"/>
+<path class="st0" d="M154.8,112.9l27.6,68.2l-41.7-32.9L154.8,112.9z M203.9,196.8L161.4,94.5c-1-2.8-3.7-4.6-6.6-4.5  c-3-0.1-5.7,1.7-6.8,4.5l-46.7,112.2h16l18.5-46.3l55.1,44.5c2.2,1.8,3.8,2.6,5.9,2.6c4.2,0.1,7.7-3.2,7.8-7.4c0-0.1,0-0.1,0-0.2  C204.6,198.9,204.3,197.8,203.9,196.8"/>
 </svg>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/AAH-1553

Assignment: Replace nondescript grey ns icon with a new and classy ansible icon.

Screens affected: 
![Screen Shot 2022-04-29 at 11 43 37 AM](https://user-images.githubusercontent.com/64337863/165984041-13bc8e21-cad0-4643-b46b-bb30b4e1e241.png)
![Screen Shot 2022-04-29 at 12 13 31 PM](https://user-images.githubusercontent.com/64337863/165984043-2b76eb09-ee69-410a-bbf1-81e6d06ac893.png)


