### PR TITLE
cypress.yml: install galaxykit master

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: "Install galaxykit dependency"
       run: |
-        pip install git+https://github.com/himdel/galaxykit.git@v3-plugin-ansible
+        pip install git+https://github.com/ansible/galaxykit.git
 
     - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |


### PR DESCRIPTION
Now that https://github.com/ansible/galaxykit/pull/42, is merged, we can use master again.

(Otherwise as described in https://github.com/ansible/ansible-hub-ui/pull/1969)