### PR TITLE
[AAH-1060] Fix context of signing filter component in the search bar

### DIFF
--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -10,6 +10,7 @@ import {
 
 import { AppliedFilters, CompoundFilter } from 'src/components';
 import { Constants } from 'src/constants';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IProps {
   ignoredParams: string[];
@@ -28,6 +29,8 @@ interface IState {
 }
 
 export class CollectionFilter extends React.Component<IProps, IState> {
+  static contextType = AppContext;
+
   constructor(props) {
     super(props);
 
@@ -44,7 +47,6 @@ export class CollectionFilter extends React.Component<IProps, IState> {
 
   render() {
     const { ignoredParams, params, updateParams } = this.props;
-
     const filterConfig = [
       {
         id: 'keywords',


### PR DESCRIPTION
Issue: AAH-1060

Fix the filter component in the search bar by wrapping it in AppContext.Consumer to inject feature flags

The search filter for signing status was reading the feature flag to enable the feature from the component's `this.context`, which is not the correct context because other contexts are used between this component and the top-level AppContext. Fixed by wrapping with AppContext.Consumer

* [[PR relevant issue or pull_request](https://issues.redhat.com/browse/AAH-1060)](AAH-1060)

