### PR TITLE
l10n: enable korean

### DIFF
--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -1,7 +1,7 @@
 import { i18n } from '@lingui/core';
 import * as plurals from 'make-plural/plurals';
 
-const availableLanguages = ['en', 'es', 'fr', 'nl', 'ja', 'zh'];
+const availableLanguages = ['en', 'es', 'fr', 'ko', 'nl', 'ja', 'zh'];
 
 // Accept-Language
 export const userLanguage =


### PR DESCRIPTION
To go with https://github.com/ansible/ansible-hub-ui/pull/2030 & https://github.com/ansible/galaxy_ng/pull/1244,
which add the translations.. enabling in the list of available languages.

(also https://github.com/ansible/galaxy_ng/pull/1245)