### PR TITLE
webpack-config PR check - ignore insights dev mode hashes in output

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -126,6 +126,7 @@ jobs:
               sed -e 's/\/home\/.*\/\(base\|pr\)\//\/DIR\//g' \
                 -e 's/\(\[name\]\|automationHub\)\.[0-9]\+\.\(\[fullhash\]\)/\1.TIMESTAMP.\2/g' \
                 -e 's/"UI_COMMIT_HASH": ".*"/"UI_COMMIT_HASH": "HASH"/' |
+              perl -ne 'print unless /^[0-9a-f]{64,64}$/d' |
               grep -v '^Current branch:' |
               grep -v '^Root folder:' > ~/webpack-config/"$version"/"$file".json
           done


### PR DESCRIPTION
https://github.com/ansible/ansible-hub-ui/runs/6281808562?check_suite_focus=true

    diff -Naur /home/runner/webpack-config/base/insights.dev.webpack.config.js.json /home/runner/webpack-config/pr/insights.dev.webpack.config.js.json
    --- /home/runner/webpack-config/base/insights.dev.webpack.config.js.json	2022-05-03 23:08:16.803709465 +0000
    +++ /home/runner/webpack-config/pr/insights.dev.webpack.config.js.json	2022-05-03 23:09:29.248609162 +0000
    @@ -11,13 +11,13 @@
     cloning ci-beta branch of https://github.com/redhatinsights/cloud-services-config
     cloning master branch of https://github.com/redhatinsights/entitlements-config
     cloning ci-beta branch of https://github.com/redhatinsights/landing-page-frontend-build
    -16a87a3f6f91ec8299c270e75d38be2a16cc184cbefa260184590b263b82ec62
    +24a89956405a35b5cd913853ef62404b584378732abb805d209f55d1d083447e
     Container rbac_redis listening
    -2e6c3f46d76b5cd2d833037ea0b5434e7381b2d63d6a3c4c1fbe1bada324fb3c
    +7997a8cfa03ad0003e286ee34556cfbf13321a82808a52358ae6e6e2006b25de
     Container rbac_postgres listening
     Waiting for rbac_redis
     Container rbac_rbac listening on 4012
    -e7d92b942752f5d9fd1567239ea92752b58f4a9c80205f69d5e3bdcaaf78e8bc
    +fd7f2d4e9fd551ecb1e496e3e82f3440d458612fdc39d466365e9da5fed222c4
     Container chrome_keycloak listening on 4001
     {
       "mode": "development",
    @@ -466,4 +466,4 @@
       ]
     }
     Waiting for rbac_postgres
    -c4c9d051925c1072fd20ccc6e638b31a6846cc179ec388f1fc115cd870c35c0e
    +49cb5b1205f30ad374bb8382c37d7beeca7c4a6d2a7613f1b871d78dd4ba7ea8

=> skip those hashes before comparison
