### PR TITLE
l10n: enable korean for extract&compile as well

### DIFF
--- a/.linguirc
+++ b/.linguirc
@@ -4,6 +4,6 @@
     "include": ["<rootDir>/src"]
   }],
   "format": "po",
-  "locales": ["en", "es", "fr", "nl", "ja", "zh"],
+  "locales": ["en", "es", "fr", "ko", "nl", "ja", "zh"],
   "sourceLocale": "en"
 }

--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -1,6 +1,7 @@
 import { i18n } from '@lingui/core';
 import * as plurals from 'make-plural/plurals';
 
+// remember to update .linguirc as well
 const availableLanguages = ['en', 'es', 'fr', 'ko', 'nl', 'ja', 'zh'];
 
 // Accept-Language


### PR DESCRIPTION
follow up to #2031 :) .. noticed https://github.com/ansible/ansible-hub-ui/pull/2030 didn't generate `ko.js` because it wouldn't without this.