### PR TITLE
add waitForTask to set deprecation before loadCollections

### DIFF
--- a/CHANGES/1596.bug
+++ b/CHANGES/1596.bug
@@ -1,0 +1,1 @@
+Wait for setDeprecation task before running loadCollections and success handler.

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -377,7 +377,13 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           !collection.deprecated,
           this.context.selectedRepo,
         )
-          .then(() => this.loadCollections())
+          .then((result) => {
+            const taskId = result.data.task.split('tasks/')[1].replace('/', '');
+            console.log('result id', result.data);
+            waitForTask(taskId).then(() => {
+              this.loadCollections();
+            });
+          })
           .catch(() => {
             this.setState({
               warning: t`API Error: Failed to set deprecation.`,


### PR DESCRIPTION
Issue: AAH-1596

adding waitForTask to run after setDeprecation and before loadCollection and success handlers. 

Also see https://github.com/ansible/ansible-hub-ui/pull/2062 @MilanPospisil 