### PR TITLE
Edit remote repo

### DIFF
--- a/CHANGES/618.test
+++ b/CHANGES/618.test
@@ -1,0 +1,1 @@
+Cypress test for editing a remote repo.

--- a/test/cypress/integration/remote_repo_edit.js
+++ b/test/cypress/integration/remote_repo_edit.js
@@ -64,6 +64,17 @@ describe('edit a remote repository', () => {
     cy.get('input[id="proxy_username"]').clear();
     cy.contains('Save').click();
     cy.wait('@editCommunityRemote');
+
+    //check for clear values
+    cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+    cy.contains('Edit').click();
+    cy.contains('Show advanced options').click();
+    cy.get('input[id="username"]').should('be.empty');
+    cy.get('input[id="password"]').should('be.empty');
+    cy.get('input[id="proxy_url"]').should('be.empty');
+    cy.get('input[id="proxy_username"]').should('be.empty');
+    cy.contains('Save').click();
+    cy.wait('@editCommunityRemote');
   });
 
   it(`edits remote repo 'rh-certified'`, () => {
@@ -123,5 +134,17 @@ describe('edit a remote repository', () => {
     cy.get('input[id="proxy_url"]').clear();
     cy.get('input[id="proxy_username"]').clear();
     cy.contains('Save').click();
+    cy.wait('@editRemote');
+
+    //check for clear values
+    cy.get('[aria-label="Actions"]').eq(1).click(); // click the kebab menu on the 'rh-certified' repo
+    cy.contains('Edit').click();
+    cy.contains('Show advanced options').click();
+    cy.get('input[id="username"]').should('be.empty');
+    cy.get('input[id="password"]').should('be.empty');
+    cy.get('input[id="proxy_url"]').should('be.empty');
+    cy.get('input[id="proxy_username"]').should('be.empty');
+    cy.contains('Save').click();
+    cy.wait('@editRemote');
   });
 });

--- a/test/cypress/integration/remote_repo_edit.js
+++ b/test/cypress/integration/remote_repo_edit.js
@@ -71,6 +71,7 @@ describe('edit a remote repository', () => {
 
   it(`edits remote repo 'rh-certified'`, () => {
     cy.visit(remoteRepoUrl);
+    cy.get('[data-cy="kebab-toggle"]').should('be.visible');
     cy.get('[data-cy="kebab-toggle"]').eq(1).click(); // click the kebab menu on the 'rh-certified' repo
     cy.contains('Edit').click();
     cy.get('input[id="name"]').should('be.disabled'); //has a readonly name field
@@ -99,6 +100,7 @@ describe('edit a remote repository', () => {
     cy.wait('@editRemote');
 
     // verify values have been saved properly.
+    cy.get('[aria-label="Actions"]').should('be.visible');
     cy.get('[aria-label="Actions"]').eq(1).click(); // click the kebab menu on the 'rh-certified' repo
     cy.contains('Edit').click();
     cy.contains('Show advanced options').click();
@@ -113,6 +115,7 @@ describe('edit a remote repository', () => {
     cy.wait('@editRemote');
 
     // clear all values
+    cy.get('[aria-label="Actions"]').should('be.visible');
     cy.get('[aria-label="Actions"]').eq(1).click(); // click the kebab menu on the 'rh-certified' repo
     cy.contains('Edit').click();
     cy.contains('Show advanced options').click();

--- a/test/cypress/integration/remote_repo_edit.js
+++ b/test/cypress/integration/remote_repo_edit.js
@@ -1,0 +1,17 @@
+describe('edit a remote repository', () => {
+  it('has Save button disabled when required fields are msising', () => {
+    cy.get('button').contains('Save').should('be.disabled');
+  });
+
+  it('has a readonly name field', () => {
+    cy.get('button').contains('Save').should('be.disabled');
+  });
+
+  it('has error messages for wrongly filled fields', () => {
+    cy.get('button').contains('Save').should('be.disabled');
+  });
+
+  it('shows and hides advanced options', () => {
+    cy.get('button').contains('Save').should('be.disabled');
+  });
+});

--- a/test/cypress/integration/remote_repo_edit.js
+++ b/test/cypress/integration/remote_repo_edit.js
@@ -1,4 +1,97 @@
 describe('edit a remote repository', () => {
+  let remoteRepoUrl = '/ui/repositories?tab=remote';
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it(`edits remote repo 'community'`, () => {
+    cy.visit(remoteRepoUrl);
+    cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+    cy.contains('Edit').click();
+    cy.get('input[id="name"]').should('be.disabled'); //has a readonly name field
+    cy.contains('Show advanced options').click(); // advanced options button is working
+
+    // enter new values
+    cy.get('input[id="username"]').type('test');
+    cy.get('input[id="password"]').type('test');
+    cy.get('input[id="proxy_url"]').type('https://example.org');
+    cy.get('input[id="proxy_username"]').type('test');
+    cy.get('input[id="proxy_password"]').type('test');
+    cy.fixture('/yaml/test.yaml')
+      .then(Cypress.Blob.binaryStringToBlob)
+      .then((fileContent) => {
+        cy.get('input[type="file"]').attachFile({
+          fileContent,
+          fileName: 'test.yaml',
+        });
+      });
+    cy.intercept(
+      'PUT',
+      Cypress.env('prefix') + 'content/community/v3/sync/config/',
+    ).as('editCommunityRemote');
+    cy.contains('Save').click();
+    cy.wait('@editCommunityRemote');
+
+    // verify values have been saved properly.
+    cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+    cy.contains('Edit').click();
+
+    cy.contains('Show advanced options').click();
+    cy.get('input[id="username"]').should('have.value', 'test');
+    cy.get('input[id="proxy_url"]').should('have.value', 'https://example.org');
+    cy.get('input[id="proxy_username"]').should('have.value', 'test');
+    cy.intercept(
+      'PUT',
+      Cypress.env('prefix') + 'content/community/v3/sync/config/',
+    ).as('editRemote');
+    cy.contains('Save').click();
+    cy.wait('@editRemote');
+
+    // clear all values
+    cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+    cy.contains('Edit').click();
+    cy.contains('Show advanced options').click();
+    cy.get('input[id="username"]').clear();
+    cy.get('input[type="password"]')
+      .siblings('button')
+      .click({ multiple: true });
+    cy.get('input[id="proxy_url"]').clear();
+    cy.get('input[id="proxy_username"]').clear();
+    cy.contains('Save').click();
+  });
+
+  it(`edits remote repo 'rh-certified'`, () => {
+    cy.visit(remoteRepoUrl);
+    cy.get('[data-cy="kebab-toggle"]').eq(1).click(); // click the kebab menu on the 'rh-certified' repo
+    cy.contains('Edit').click();
+    cy.contains('Show advanced options').click();
+    // enter new values
+    cy.get('input[id="username"]').type('test');
+    cy.get('input[id="password"]').type('test');
+
+    cy.get('input[id="proxy_url"]').type('https://example.org');
+    cy.get('input[id="proxy_username"]').type('test');
+    cy.get('input[id="proxy_password"]').type('test');
+    cy.intercept(
+      'PUT',
+      Cypress.env('prefix') + 'content/rh-certified/v3/sync/config/',
+    ).as('editRemote');
+    cy.contains('Save').click();
+    cy.wait('@editRemote');
+
+    // verify values have been saved properly.
+    cy.get('[aria-label="Actions"]').eq(1).click(); // click the kebab menu on the 'community' repo
+    cy.contains('Edit').click();
+    cy.contains('Show advanced options').click();
+    cy.get('input[id="username"]').should('have.value', 'test');
+    cy.get('input[id="proxy_url"]').should('have.value', 'https://example.org');
+    cy.get('input[id="proxy_username"]').should('have.value', 'test');
+    cy.contains('Save').click();
+  });
+
+  //requirements
+
   it('has Save button disabled when required fields are msising', () => {
     cy.get('button').contains('Save').should('be.disabled');
   });

--- a/test/cypress/integration/remote_repo_edit.js
+++ b/test/cypress/integration/remote_repo_edit.js
@@ -49,12 +49,8 @@ describe('edit a remote repository', () => {
     cy.get('input[id="username"]').should('have.value', 'test');
     cy.get('input[id="proxy_url"]').should('have.value', 'https://example.org');
     cy.get('input[id="proxy_username"]').should('have.value', 'test');
-    cy.intercept(
-      'PUT',
-      Cypress.env('prefix') + 'content/community/v3/sync/config/',
-    ).as('editRemote');
     cy.contains('Save').click();
-    cy.wait('@editRemote');
+    cy.wait('@editCommunityRemote');
 
     // clear all values
     cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
@@ -67,6 +63,7 @@ describe('edit a remote repository', () => {
     cy.get('input[id="proxy_url"]').clear();
     cy.get('input[id="proxy_username"]').clear();
     cy.contains('Save').click();
+    cy.wait('@editCommunityRemote');
   });
 
   it(`edits remote repo 'rh-certified'`, () => {

--- a/test/cypress/integration/remote_repo_edit.js
+++ b/test/cypress/integration/remote_repo_edit.js
@@ -10,9 +10,17 @@ describe('edit a remote repository', () => {
     cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
     cy.contains('Edit').click();
     cy.get('input[id="name"]').should('be.disabled'); //has a readonly name field
-    cy.contains('Show advanced options').click(); // advanced options button is working
+    cy.get('input[id="url"]').clear();
+    cy.get('button').contains('Save').should('be.disabled'); // Save button disabled when required fields are missing
+    cy.get('[id="url-helper"]').should(
+      'have.text',
+      `The URL needs to be in 'http(s)://' format.`,
+    );
+
+    cy.contains('Show advanced options').click();
 
     // enter new values
+    cy.get('input[id="url"]').type('https://galaxy.ansible.com/api/');
     cy.get('input[id="username"]').type('test');
     cy.get('input[id="password"]').type('test');
     cy.get('input[id="proxy_url"]').type('https://example.org');
@@ -65,8 +73,18 @@ describe('edit a remote repository', () => {
     cy.visit(remoteRepoUrl);
     cy.get('[data-cy="kebab-toggle"]').eq(1).click(); // click the kebab menu on the 'rh-certified' repo
     cy.contains('Edit').click();
+    cy.get('input[id="name"]').should('be.disabled'); //has a readonly name field
+    cy.get('input[id="url"]').clear();
+    cy.get('button').contains('Save').should('be.disabled'); // Save button disabled when required fields are missing
+    cy.get('[id="url-helper"]').should(
+      'have.text',
+      `The URL needs to be in 'http(s)://' format.`,
+    );
     cy.contains('Show advanced options').click();
     // enter new values
+    cy.get('input[id="url"]').type(
+      'https://cloud.redhat.com/api/automation-hub/',
+    );
     cy.get('input[id="username"]').type('test');
     cy.get('input[id="password"]').type('test');
 
@@ -81,30 +99,29 @@ describe('edit a remote repository', () => {
     cy.wait('@editRemote');
 
     // verify values have been saved properly.
-    cy.get('[aria-label="Actions"]').eq(1).click(); // click the kebab menu on the 'community' repo
+    cy.get('[aria-label="Actions"]').eq(1).click(); // click the kebab menu on the 'rh-certified' repo
     cy.contains('Edit').click();
     cy.contains('Show advanced options').click();
     cy.get('input[id="username"]').should('have.value', 'test');
     cy.get('input[id="proxy_url"]').should('have.value', 'https://example.org');
     cy.get('input[id="proxy_username"]').should('have.value', 'test');
+    cy.intercept(
+      'PUT',
+      Cypress.env('prefix') + 'content/community/v3/sync/config/',
+    ).as('editRemote');
     cy.contains('Save').click();
-  });
+    cy.wait('@editRemote');
 
-  //requirements
-
-  it('has Save button disabled when required fields are msising', () => {
-    cy.get('button').contains('Save').should('be.disabled');
-  });
-
-  it('has a readonly name field', () => {
-    cy.get('button').contains('Save').should('be.disabled');
-  });
-
-  it('has error messages for wrongly filled fields', () => {
-    cy.get('button').contains('Save').should('be.disabled');
-  });
-
-  it('shows and hides advanced options', () => {
-    cy.get('button').contains('Save').should('be.disabled');
+    // clear all values
+    cy.get('[aria-label="Actions"]').eq(1).click(); // click the kebab menu on the 'rh-certified' repo
+    cy.contains('Edit').click();
+    cy.contains('Show advanced options').click();
+    cy.get('input[id="username"]').clear();
+    cy.get('input[type="password"]')
+      .siblings('button')
+      .click({ multiple: true });
+    cy.get('input[id="proxy_url"]').clear();
+    cy.get('input[id="proxy_username"]').clear();
+    cy.contains('Save').click();
   });
 });


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/AAH-618

Moving 'edit remote repo' testing from https://github.com/ansible/ansible-hub-ui/pull/1833 to a separate pr. 

Noting that there is very limited error handling with regard to input length, spaces, etc on all inputs except the URL. 