### PR TITLE
Add missing alert name in EE list 

### DIFF
--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -35,7 +35,7 @@ interface IProps {
   name: string;
   namespace: string;
   description: string;
-  onSave: (Promise) => void;
+  onSave: (Promise, state?: IState) => void;
   onCancel: () => void;
   permissions: string[];
   distributionPulpId: string;
@@ -156,7 +156,7 @@ export class RepositoryForm extends React.Component<IProps, IState> {
             key='save'
             variant='primary'
             isDisabled={!this.formIsValid()}
-            onClick={() => onSave(this.onSave())}
+            onClick={() => onSave(this.onSave(), this.state)}
           >
             {t`Save`}
           </Button>,
@@ -369,7 +369,7 @@ export class RepositoryForm extends React.Component<IProps, IState> {
           >
             <TextArea
               id='description'
-              value={description}
+              value={description || ''}
               isDisabled={
                 !this.props.permissions.includes(
                   'container.namespace_change_containerdistribution',

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -435,7 +435,7 @@ class ExecutionEnvironmentList extends React.Component<
         remotePulpId={pulp_id}
         distributionPulpId={distributionPulpId}
         formError={this.state.formError}
-        onSave={(promise) => {
+        onSave={(promise, form) => {
           promise
             .then(() => {
               this.setState(
@@ -446,12 +446,12 @@ class ExecutionEnvironmentList extends React.Component<
                     variant: 'success',
                     title: isNew ? (
                       <Trans>
-                        Execution environment &quot;{name}&quot; has been added
-                        successfully.
+                        Execution environment &quot;{form.name}&quot; has been
+                        added successfully.
                       </Trans>
                     ) : (
                       <Trans>
-                        Saved changes to execution environment &quot;{name}
+                        Saved changes to execution environment &quot;{form.name}
                         &quot;.
                       </Trans>
                     ),


### PR DESCRIPTION
Minor fixes which I noticed while writing tests. The EE name is missing in the alert title on adding execution environment.   

Before:
![Screenshot from 2022-05-13 18-09-15](https://user-images.githubusercontent.com/19647757/168324893-5990fcfa-a1ad-4fa5-90e7-560c467b6a24.png)

After:
![Screenshot from 2022-05-13 17-52-12](https://user-images.githubusercontent.com/19647757/168324909-da213918-3093-4da0-ba78-6958032ca989.png)

Plus fixing console error on undefined value in textarea
![Screenshot from 2022-05-13 18-08-46](https://user-images.githubusercontent.com/19647757/168324947-1d393d7c-e28d-45e7-a6e4-ed8a0a8f5231.png)