### PR TITLE
[AAH-1313] Added detailed info to the sign all modal

### DIFF
--- a/CHANGES/1313.feature
+++ b/CHANGES/1313.feature
@@ -1,0 +1,1 @@
+Added detailed information to the sign all modal

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -66,6 +66,9 @@ export class CollectionListType {
     avatar_url: string;
     company: string;
   };
+  total_versions: number;
+  signed_versions: number;
+  unsigned_versions: number;
 }
 
 export class PluginContentType {
@@ -112,6 +115,7 @@ export class CollectionDetailType {
     id: string;
     version: string;
     created: string;
+    sign_state: 'unsigned' | 'signed' | 'partial';
   }[];
   latest_version: CollectionVersionDetail;
 
@@ -119,6 +123,9 @@ export class CollectionDetailType {
   name: string;
   description: string;
   sign_state: 'unsigned' | 'signed' | 'partial';
+  total_versions: number;
+  signed_versions: number;
+  unsigned_versions: number;
   // download_count: number;
 
   namespace: {

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -150,6 +150,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         id: collection.latest_version.id,
         version: collection.latest_version.version,
         created: collection.latest_version.created_at,
+        sign_state: collection.latest_version.sign_state,
       });
     }
 
@@ -246,7 +247,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           <>
             <SignAllCertificatesModal
               name={collectionName}
-              numberOfAffected={collection.all_versions.length}
+              numberOfAffected={collection.total_versions}
+              affectedUnsigned={collection.unsigned_versions}
               isOpen={this.state.isOpenSignAllModal}
               onSubmit={this.signCollection}
               onCancel={() => {

--- a/src/components/signing/sign-all-certificates-modal.tsx
+++ b/src/components/signing/sign-all-certificates-modal.tsx
@@ -1,15 +1,25 @@
 import { t, Trans } from '@lingui/macro';
 import {
+  Badge,
   Button,
   ButtonVariant,
+  Form,
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+  Grid,
+  GridItem,
   Modal,
   ModalVariant,
+  Split,
+  SplitItem,
 } from '@patternfly/react-core';
 import React from 'react';
 
 interface Props {
   name: string;
   numberOfAffected: number;
+  affectedUnsigned: number;
   isOpen: boolean;
   onSubmit: () => void;
   onCancel: () => void;
@@ -18,35 +28,72 @@ interface Props {
 export const SignAllCertificatesModal: React.FC<Props> = ({
   name,
   numberOfAffected,
+  affectedUnsigned,
   isOpen,
   onSubmit,
   onCancel,
-}) => (
-  <Modal
-    variant={ModalVariant.medium}
-    title={t`Sign all collections`}
-    isOpen={isOpen}
-    onClose={onCancel}
-    actions={[
-      <Button key='sign-all' variant={ButtonVariant.primary} onClick={onSubmit}>
-        {t`Sign all`}
-      </Button>,
-      <Button key='cancel' variant={ButtonVariant.link} onClick={onCancel}>
-        {t`Cancel`}
-      </Button>,
-    ]}
-  >
-    <p>
-      <Trans>
-        You are about to sign <strong>all</strong> versions under{' '}
-        <strong>{name}</strong>.
-      </Trans>
-    </p>
-    <br />
-    <p>
-      <Trans>
-        This action will affect <strong>{numberOfAffected}</strong> version(s).
-      </Trans>
-    </p>
-  </Modal>
-);
+}) => {
+  return (
+    <Modal
+      variant={ModalVariant.medium}
+      title={t`Sign all collections`}
+      isOpen={isOpen}
+      onClose={onCancel}
+      actions={[
+        <Button
+          key='sign-all'
+          variant={ButtonVariant.primary}
+          onClick={onSubmit}
+        >
+          {t`Sign all`}
+        </Button>,
+        <Button key='cancel' variant={ButtonVariant.link} onClick={onCancel}>
+          {t`Cancel`}
+        </Button>,
+      ]}
+    >
+      <Grid hasGutter>
+        <GridItem span={12}>
+          <p>
+            <Trans>
+              You are about to sign <strong>{numberOfAffected}</strong>{' '}
+              version(s) under <strong>{name}</strong>.
+            </Trans>
+          </p>
+        </GridItem>
+        <GridItem span={12}>
+          <Split hasGutter>
+            <SplitItem>
+              <Trans>Signed version(s)</Trans>
+            </SplitItem>
+            <SplitItem>
+              <Badge isRead>{numberOfAffected - affectedUnsigned}</Badge>
+            </SplitItem>
+            <SplitItem></SplitItem>
+            <SplitItem>
+              <Trans>Unsigned version(s)</Trans>
+            </SplitItem>
+            <SplitItem>
+              <Badge isRead>{affectedUnsigned}</Badge>
+            </SplitItem>
+          </Split>
+        </GridItem>
+        <GridItem span={12}>
+          <Form>
+            <FormGroup
+              fieldId='service-selector'
+              label={t`Signing service selector:`}
+            >
+              <FormSelect value='ansible-default' id='service-selector'>
+                <FormSelectOption
+                  value='ansible-default'
+                  label='ansible-default'
+                />
+              </FormSelect>
+            </FormGroup>
+          </Form>
+        </GridItem>
+      </Grid>
+    </Modal>
+  );
+};

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -190,6 +190,16 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       'view_type',
     ];
 
+    const total_versions = collections.reduce(
+      (acc, c) => acc + c.total_versions,
+      0,
+    );
+
+    const unsigned_versions = collections.reduce(
+      (acc, c) => acc + c.unsigned_versions,
+      0,
+    );
+
     return (
       <React.Fragment>
         <AlertList
@@ -349,7 +359,8 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
         {canSign && (
           <SignAllCertificatesModal
             name={this.state.namespace.name}
-            numberOfAffected={this.state.itemCount}
+            numberOfAffected={total_versions}
+            affectedUnsigned={unsigned_versions}
             isOpen={this.state.isOpenSignModal}
             onSubmit={() => {
               this.signAllCertificates(namespace);


### PR DESCRIPTION
Issue: AAH-1313

Additionally fixed an issue when the sign all on namespace displayed
the number of collections to be signed instead of number of
versions inside all those collections.

P.S.: The api has support for total_versions, signed_versions and unsigned_versions now, this PR utilizes on that feature.

**Before**:
![Screenshot from 2022-05-15 10-25-47](https://user-images.githubusercontent.com/8531681/168463913-0bbfef40-bff0-449b-8016-1104ad689ca4.png)
-- Note the bug here, just in foob there are two version and in fooc there is one more, but namespace signing says 2 (number of collections instead of versions) --
![Screenshot from 2022-05-15 10-26-00](https://user-images.githubusercontent.com/8531681/168463914-225a4f8e-a391-4408-8c86-3441bb21a970.png)


**After**:
![Screenshot from 2022-05-15 10-20-22](https://user-images.githubusercontent.com/8531681/168463876-bc5c6a92-b9cf-4828-aebf-d1732bb9fd6a.png)
![Screenshot from 2022-05-15 10-20-52](https://user-images.githubusercontent.com/8531681/168463879-cf23d83f-6ce0-48ed-9e79-2ba72dbb0f1c.png)
![Screenshot from 2022-05-15 10-21-01](https://user-images.githubusercontent.com/8531681/168463880-17d330de-2901-4e15-a307-e5e908c2abd8.png)

