### PR TITLE
Added signing related tests

### DIFF
--- a/CHANGES/1599.misc
+++ b/CHANGES/1599.misc
@@ -1,0 +1,1 @@
+Added signing related tests

--- a/src/components/collection-detail/download-signature-grid-item.tsx
+++ b/src/components/collection-detail/download-signature-grid-item.tsx
@@ -36,6 +36,7 @@ export const DownloadSignatureGridItem: FC<Props> = ({ version }) => {
               style={{ padding: 0 }}
               variant={ButtonVariant.link}
               icon={<DownloadIcon />}
+              data-cy='toggle-signature-button'
               onClick={() => {
                 setShow(!show);
               }}

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -251,6 +251,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       canSign && !can_upload_signatures && (
         <DropdownItem
           key='sign-all'
+          data-cy='sign-collection-button'
           onClick={() => this.setState({ isOpenSignAllModal: true })}
         >
           {t`Sign entire collection`}
@@ -269,6 +270,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
               this.setState({ isOpenSignModal: true });
             }
           }}
+          data-cy='sign-version-button'
         >
           {t`Sign version ${collection.latest_version.version}`}
         </DropdownItem>

--- a/src/components/signing/sign-all-certificates-modal.tsx
+++ b/src/components/signing/sign-all-certificates-modal.tsx
@@ -42,6 +42,7 @@ export const SignAllCertificatesModal: React.FC<Props> = ({
       actions={[
         <Button
           key='sign-all'
+          data-cy='modal-sign-button'
           variant={ButtonVariant.primary}
           onClick={onSubmit}
         >
@@ -67,14 +68,18 @@ export const SignAllCertificatesModal: React.FC<Props> = ({
               <Trans>Signed version(s)</Trans>
             </SplitItem>
             <SplitItem>
-              <Badge isRead>{numberOfAffected - affectedUnsigned}</Badge>
+              <Badge isRead data-cy='signed-number-badge'>
+                {numberOfAffected - affectedUnsigned}
+              </Badge>
             </SplitItem>
             <SplitItem></SplitItem>
             <SplitItem>
               <Trans>Unsigned version(s)</Trans>
             </SplitItem>
             <SplitItem>
-              <Badge isRead>{affectedUnsigned}</Badge>
+              <Badge isRead data-cy='unsigned-number-badge'>
+                {affectedUnsigned}
+              </Badge>
             </SplitItem>
           </Split>
         </GridItem>

--- a/src/components/signing/sign-single-certificate-modal.tsx
+++ b/src/components/signing/sign-single-certificate-modal.tsx
@@ -28,7 +28,12 @@ export const SignSingleCertificateModal: React.FC<Props> = ({
     isOpen={isOpen}
     onClose={onCancel}
     actions={[
-      <Button key='sign' variant={ButtonVariant.primary} onClick={onSubmit}>
+      <Button
+        key='sign'
+        data-cy='modal-sign-button'
+        variant={ButtonVariant.primary}
+        onClick={onSubmit}
+      >
         {t`Sign`}
       </Button>,
       <Button key='cancel' variant={ButtonVariant.link} onClick={onCancel}>

--- a/src/components/signing/signature-badge.tsx
+++ b/src/components/signing/signature-badge.tsx
@@ -35,6 +35,7 @@ export const SignatureBadge: FC<Props> = ({
 
   return (
     <Label
+      data-cy='signature-badge'
       variant='outline'
       className='hub-signature-badge'
       color={signState === 'signed' ? 'green' : 'orange'}

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -405,6 +405,7 @@ class CertificationDashboard extends React.Component<
       <Button
         key='approve'
         isDisabled={mustUploadSignature}
+        data-cy='approve-button'
         onClick={() =>
           this.updateCertification(
             version,

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -640,6 +640,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       canSign && !can_upload_signatures && (
         <DropdownItem
           key='sign-collections'
+          data-cy='sign-all-collections-button'
           onClick={() => this.setState({ isOpenSignModal: true })}
         >
           {t`Sign all collections`}

--- a/test/cypress/integration/signing.js
+++ b/test/cypress/integration/signing.js
@@ -1,0 +1,223 @@
+describe('signing versions', () => {
+  before(() => {
+    cy.deleteNamespacesAndCollections();
+  });
+
+  describe('auto sign on approval', () => {
+    before(() => {
+      cy.settings({
+        GALAXY_AUTO_SIGN_COLLECTIONS: true,
+        GALAXY_REQUIRE_CONTENT_APPROVAL: true,
+        GALAXY_COLLECTION_SIGNING_SERVICE: 'ansible-default',
+      }).then(() => {
+        cy.galaxykit('-i namespace create', 'autosign_test');
+        cy.galaxykit('-i collection upload autosign_test test_collection');
+      });
+    });
+
+    after(() => {
+      cy.settings();
+      cy.deleteNamespacesAndCollections();
+    });
+
+    beforeEach(() => {
+      cy.login();
+    });
+
+    it('has the switch to sync only certified repos', () => {
+      cy.visit('/ui/repositories?tab=remote');
+      cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+      cy.contains('Edit').click();
+      cy.contains('Show advanced options').click();
+      cy.get('#signed_only').should('exist');
+    });
+
+    it('signs when the Sign and Approve button is pressed', () => {
+      cy.visit('/ui/approval-dashboard');
+
+      // Check if the button is correctly worded
+      cy.get('[data-cy="approve-button"]').should(
+        'contain',
+        'Sign and approve',
+      );
+
+      // Sign the first collection
+      cy.get('[data-cy="approve-button"]').first().click();
+
+      // TODO: Maybe we can wait on some specific event?
+      cy.wait(10000);
+
+      // Go and check if it is signed in the collections
+      cy.visit('/ui/repo/published');
+      cy.get('[data-cy="signature-badge"]', { timeout: 20000 }).should(
+        'have.length',
+        1,
+      );
+      cy.get('[data-cy="signature-badge"]').first().should('contain', 'Signed');
+
+      // Optimization: check the signature button too here
+      cy.visit('/ui/repo/published/autosign_test/test_collection');
+      cy.get('[data-cy="signature-badge"]').first().should('contain', 'Signed');
+      cy.get('[data-cy="toggle-signature-button"]').should('be.visible');
+    });
+  });
+
+  describe('sign after approval', () => {
+    before(() => {
+      cy.settings({
+        GALAXY_AUTO_SIGN_COLLECTIONS: false,
+        GALAXY_REQUIRE_CONTENT_APPROVAL: false,
+        GALAXY_COLLECTION_SIGNING_SERVICE: 'ansible-default',
+      }).then(() => {
+        cy.galaxykit('-i namespace create', 'namespace_signing_test');
+        cy.galaxykit('-i collection upload namespace_signing_test collection1');
+        cy.galaxykit('-i collection upload namespace_signing_test collection2');
+
+        cy.galaxykit('-i namespace create', 'collection_signing_test');
+        cy.galaxykit(
+          '-i collection upload collection_signing_test collection1 1.0.0',
+        );
+        cy.galaxykit(
+          '-i collection upload collection_signing_test collection1 2.0.0',
+        );
+        cy.galaxykit(
+          '-i collection upload collection_signing_test collection2 1.0.0',
+        );
+        cy.galaxykit(
+          '-i collection upload collection_signing_test collection2 2.0.0',
+        );
+      });
+    });
+
+    after(() => {
+      cy.settings();
+      cy.deleteNamespacesAndCollections();
+    });
+
+    beforeEach(() => {
+      cy.login();
+    });
+
+    it('can sign all collections and versions from the namespace screen', () => {
+      cy.visit('/ui/repo/published/namespace_signing_test');
+
+      // Make sure it is unsigned at first
+      cy.get('[data-cy="signature-badge"]')
+        .first()
+        .should('contain', 'Unsigned');
+
+      // Sign
+      cy.get('[aria-label="Actions"]').first().click();
+      cy.get('[data-cy="sign-all-collections-button"]').click();
+
+      // Optimization: Check if the unsigned/signed numbers are correct in the modal
+      cy.get('[data-cy="signed-number-badge"').should('contain', '0');
+      cy.get('[data-cy="unsigned-number-badge"').should('contain', '2');
+
+      cy.get('[data-cy="modal-sign-button"]').click();
+
+      // Check if it is signed
+      cy.get('[data-cy="signature-badge"]:first', { timeout: 20000 }).should(
+        'contain',
+        'Signed',
+      );
+      cy.get('[data-cy="signature-badge"]').eq(1).should('contain', 'Signed');
+    });
+
+    it('can sign a single version in the collection from collection details', () => {
+      cy.visit('/ui/repo/published/collection_signing_test/collection1');
+
+      // Make sure it is unsigned at first
+      cy.get('[data-cy="signature-badge"]')
+        .first()
+        .should('contain', 'Unsigned');
+
+      // Sign
+      cy.get('[aria-label="Actions"]').click();
+      cy.get('[data-cy="sign-version-button"]').click();
+      cy.get('[data-cy="modal-sign-button"]').click();
+
+      // Check if it is signed
+      cy.get('[data-cy="signature-badge"]:first', { timeout: 20000 }).should(
+        'contain',
+        'Signed',
+      );
+      cy.get('[aria-label="Actions"]').first().click();
+      cy.get('[data-cy="sign-collection-button"]').click();
+      cy.get('[data-cy="signed-number-badge"').should('contain', '1');
+      cy.get('[data-cy="unsigned-number-badge"').should('contain', '1');
+    });
+
+    it('can sign all version in the collection from collection details', () => {
+      cy.visit('/ui/repo/published/collection_signing_test/collection2');
+
+      // Make sure it is unsigned at first
+      cy.get('[data-cy="signature-badge"]')
+        .first()
+        .should('contain', 'Unsigned');
+
+      // Sign
+      cy.get('[aria-label="Actions"]').first().click();
+      cy.get('[data-cy="sign-collection-button"]').click();
+
+      // Optimization: Check if the unsigned/signed numbers are correct in the modal
+      cy.get('[data-cy="signed-number-badge"').should('contain', '0');
+      cy.get('[data-cy="unsigned-number-badge"').should('contain', '2');
+
+      cy.get('[data-cy="modal-sign-button"]').click();
+
+      // Check if it is signed
+      cy.get('[data-cy="signature-badge"]:first', { timeout: 10000 }).should(
+        'contain',
+        'Signed',
+      );
+
+      // Check in the modal too
+      cy.get('[aria-label="Actions"]').first().click();
+      cy.get('[data-cy="sign-collection-button"]').click();
+      cy.get('[data-cy="signed-number-badge"').should('contain', '2');
+      cy.get('[data-cy="unsigned-number-badge"').should('contain', '0');
+    });
+  });
+
+  describe.skip('certificate upload', () => {
+    const defaultSettings = {
+      GALAXY_SIGNATURE_UPLOAD_ENABLED: true,
+      GALAXY_AUTO_SIGN_COLLECTIONS: false,
+      GALAXY_COLLECTION_SIGNING_SERVICE: 'ansible-default',
+    };
+
+    before(() => {
+      cy.galaxykit('-i namespace create', 'certificate_upload_test');
+    });
+
+    after(() => {
+      cy.settings();
+      cy.deleteNamespacesAndCollections();
+    });
+
+    beforeEach(() => {
+      cy.login();
+    });
+
+    it.skip('should upload certificate before approval', () => {
+      cy.settings({
+        ...defaultSettings,
+        GALAXY_REQUIRE_CONTENT_APPROVAL: true,
+      });
+      cy.galaxykit('-i collection upload certificate_upload_test col1');
+
+      return;
+    });
+
+    it.skip('should be able to upload certificate ONLY for a version after approval', () => {
+      cy.settings({
+        ...defaultSettings,
+        GALAXY_REQUIRE_CONTENT_APPROVAL: false,
+      });
+      cy.galaxykit('-i collection upload certificate_upload_test col2');
+
+      return;
+    });
+  });
+});

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -454,7 +454,7 @@ Cypress.Commands.add('settings', {}, (newSettings) => {
       : [];
 
   const newLines = pythonify(newSettings);
-  console.log(`SETTINGS ${settings} ${newLines.join('\n')}`);
+  cy.task('log', `SETTINGS ${settings} ${newLines.join('\n')}`);
 
   return cy
     .readFile(settings)
@@ -479,9 +479,13 @@ Cypress.Commands.add('settings', {}, (newSettings) => {
       cy.request({
         url: Cypress.env('prefix') + '_ui/v1/feature-flags/',
         retryOnStatusCodeFailure: true,
-      })
-        .its('status')
-        .should('eq', 200);
+      }).then((response) => {
+        cy.task(
+          'log',
+          `feture flags after settings change ${JSON.stringify(response.body)}`,
+        );
+        expect(response.status).to.eq(200);
+      });
     });
 });
 


### PR DESCRIPTION
Issue: AAH-1599

## TODO
* [x] Test badge as an extra tests to (also it will be included in the `signing` test suite):
  * [x] Collections list
  * [x] Namespace collection list
  * [x] Collection detail versions
* [x] Test Signature download on collection detail
* [x] Test Sync signed only on remote collection edit
* [x] Test (and probably update) the described configuration here: https://galaxyng.netlify.app/config/options/
  * [x] Requires first [AAH-1622](https://issues.redhat.com/browse/AAH-1622) 
* [x] Set up CI backend signing service

## On hold because:
* [x] Feature flags are changing https://github.com/ansible/ansible-hub-ui/pull/2211
* [x] Additional work on the UI for uploading signature https://github.com/ansible/ansible-hub-ui/pull/2231

---
* [x] If #2068 merged and galaxykit gets an upload multiple versions support (https://github.com/ansible/galaxykit/pull/44) then this PR could include those tests too.
* [x] Wait for https://github.com/ansible/galaxykit/pull/45 so we can make sure that the staging collections can be removed safely too.
