### PR TITLE
[rbac] Role lists - default sort by name, show description, pretty "Galaxy only" in AppliedFilters

### DIFF
--- a/src/api/container-distribution.ts
+++ b/src/api/container-distribution.ts
@@ -2,6 +2,8 @@ import { PulpAPI } from './pulp';
 
 export class API extends PulpAPI {
   apiPath = 'distributions/container/container/';
+
+  // patch(id, data)
 }
 
 export const ContainerDistributionAPI = new API();

--- a/src/api/group-role.ts
+++ b/src/api/group-role.ts
@@ -2,6 +2,7 @@ import { PulpAPI } from './pulp';
 
 class API extends PulpAPI {
   apiPath = 'groups/';
+  useOrdering = false; // listRoles produces surprising order when using ?ordering=role, but works with ?sort=role
 
   listRoles(groupId, params?) {
     return super.list(params, `${this.apiPath}${groupId}/roles/`);

--- a/src/api/group-role.ts
+++ b/src/api/group-role.ts
@@ -2,7 +2,7 @@ import { PulpAPI } from './pulp';
 
 class API extends PulpAPI {
   apiPath = 'groups/';
-  useOrdering = false; // listRoles produces surprising order when using ?ordering=role, but works with ?sort=role
+  useOrdering = true;
 
   listRoles(groupId, params?) {
     return super.list(params, `${this.apiPath}${groupId}/roles/`);

--- a/src/api/pulp.ts
+++ b/src/api/pulp.ts
@@ -1,13 +1,15 @@
 import { BaseAPI } from './base';
 
 export class PulpAPI extends BaseAPI {
+  useOrdering = false; // translate ?sort into ?ordering in list()
+
   constructor() {
     super(API_HOST + PULP_API_BASE_PATH);
   }
 
   list(params?, apiPath?) {
     const changedParams = { ...params };
-    if (changedParams['sort']) {
+    if (this.useOrdering && changedParams['sort']) {
       changedParams['ordering'] = changedParams['sort'];
       delete changedParams['sort'];
     }

--- a/src/api/response-types/role.ts
+++ b/src/api/response-types/role.ts
@@ -11,5 +11,7 @@ export class GroupRoleType {
   pulp_href: string;
   pulp_created: string;
   role: string;
+  description: string;
+  permissions?: string[];
   content_object: string;
 }

--- a/src/api/role.ts
+++ b/src/api/role.ts
@@ -2,10 +2,14 @@ import { PulpAPI } from './pulp';
 
 export class API extends PulpAPI {
   apiPath = 'roles/';
+  useOrdering = true;
 
   updatePermissions(id, data: unknown) {
     return this.http.patch(this.apiPath + id, data);
   }
+
+  // create(data)
+  // get(params?)
 
   list(params?, for_object_type?) {
     const newParams = { ...params };

--- a/src/api/task-management.ts
+++ b/src/api/task-management.ts
@@ -2,8 +2,11 @@ import { PulpAPI } from './pulp';
 
 export class API extends PulpAPI {
   apiPath = 'tasks/';
+  useOrdering = true;
 
+  // get(id)
   // list(params)
+  // patch(id, data)
 }
 
 export const TaskManagementAPI = new API();

--- a/src/components/rbac/owners-tab.tsx
+++ b/src/components/rbac/owners-tab.tsx
@@ -1,6 +1,7 @@
 import { t, Trans } from '@lingui/macro';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
+import { sortBy } from 'lodash';
 import {
   Button,
   DropdownItem,
@@ -97,9 +98,7 @@ export class OwnersTab extends React.Component<IProps, IState> {
   }
 
   private renderGroups({ buttonAdd, groups }) {
-    const sortedGroups = [...groups].sort(({ name: a }, { name: b }) =>
-      a < b ? -1 : a > b ? 1 : 0,
-    );
+    const sortedGroups = sortBy(groups, 'name');
 
     return (
       <>
@@ -179,7 +178,7 @@ export class OwnersTab extends React.Component<IProps, IState> {
     const { showRoleRemoveModal, showRoleSelectWizard } = this.state;
     const group = this.props.groups.find(({ id }) => Number(groupId) === id);
     const roles = group?.object_roles;
-    const sortedRoles = [...roles].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    const sortedRoles = sortBy(roles);
 
     if (!group) {
       return null;

--- a/src/components/rbac/owners-tab.tsx
+++ b/src/components/rbac/owners-tab.tsx
@@ -247,7 +247,7 @@ export class OwnersTab extends React.Component<IProps, IState> {
                     key='remove-role'
                     onClick={() => this.setState({ showRoleRemoveModal: role })}
                   >
-                    {t`Remove Role`}
+                    {t`Remove role`}
                   </DropdownItem>,
                 ]}
               />

--- a/src/components/rbac/owners-tab.tsx
+++ b/src/components/rbac/owners-tab.tsx
@@ -97,6 +97,10 @@ export class OwnersTab extends React.Component<IProps, IState> {
   }
 
   private renderGroups({ buttonAdd, groups }) {
+    const sortedGroups = [...groups].sort(({ name: a }, { name: b }) =>
+      a < b ? -1 : a > b ? 1 : 0,
+    );
+
     return (
       <>
         <div>
@@ -130,7 +134,7 @@ export class OwnersTab extends React.Component<IProps, IState> {
             updateParams={() => null}
           />
           <tbody>
-            {groups.map((group, i) => this.renderGroupRow(group, i))}
+            {sortedGroups.map((group, i) => this.renderGroupRow(group, i))}
           </tbody>
         </table>
       </>
@@ -175,6 +179,7 @@ export class OwnersTab extends React.Component<IProps, IState> {
     const { showRoleRemoveModal, showRoleSelectWizard } = this.state;
     const group = this.props.groups.find(({ id }) => Number(groupId) === id);
     const roles = group?.object_roles;
+    const sortedRoles = [...roles].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
 
     if (!group) {
       return null;
@@ -228,7 +233,7 @@ export class OwnersTab extends React.Component<IProps, IState> {
             ],
           }}
         >
-          {roles.map((role, i) => (
+          {sortedRoles.map((role, i) => (
             <ExpandableRow
               key={i}
               rowIndex={i}

--- a/src/components/rbac/role-list-table.tsx
+++ b/src/components/rbac/role-list-table.tsx
@@ -51,7 +51,7 @@ export const RoleListTable: React.FC<Props> = ({
         id: 'description',
       },
       {
-        title: t`Locked`,
+        title: t`Editable`,
         type: 'none',
         id: 'locked',
       },

--- a/src/components/rbac/select-roles.tsx
+++ b/src/components/rbac/select-roles.tsx
@@ -37,6 +37,7 @@ export const SelectRoles: React.FC<SelectRolesProps> = ({
   const [localParams, setLocalParams] = useState({
     page: 1,
     page_size: 10,
+    sort: 'name',
   });
 
   useEffect(() => {

--- a/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
+++ b/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
@@ -377,7 +377,7 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
                             key='remove-role'
                             onClick={() => setSelectedDeleteRole(role)}
                           >
-                            {t`Remove Role`}
+                            {t`Remove role`}
                           </DropdownItem>
                         ),
                       ]}

--- a/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
+++ b/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
@@ -7,7 +7,7 @@ import {
   CompoundFilter,
   DeleteModal,
   EmptyStateNoData,
-  GroupRolePermissions,
+  RolePermissions,
   LoadingPageWithHeader,
   Pagination,
   RoleListTable,
@@ -232,6 +232,11 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
         id: 'role',
       },
       {
+        title: t`Description`,
+        type: 'none',
+        id: 'description',
+      },
+      {
         title: '',
         type: 'none',
         id: 'kebab',
@@ -354,14 +359,17 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
                     key={i}
                     rowIndex={i}
                     expandableRowContent={
-                      <GroupRolePermissions
-                        name={role.role}
+                      <RolePermissions
                         filteredPermissions={filteredPermissions}
+                        selectedPermissions={role.permissions}
+                        showCustom={true}
+                        showEmpty={false}
                       />
                     }
                     data-cy={`RoleListTable-ExpandableRow-row-${role.role}`}
                   >
                     <td>{role.role}</td>
+                    <td>{role.description}</td>
                     <ListItemActions
                       kebabItems={[
                         user.is_superuser && (

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -84,7 +84,7 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
     }
 
     if (!params['sort']) {
-      params['sort'] = '-pulp_created';
+      params['sort'] = 'name';
     }
 
     if (!params['name__startswith']) {

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -420,9 +420,7 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
     RoleAPI.delete(roleID)
       .then(() =>
         this.addAlert(
-          t`
-            Role "${name}" has been successfully deleted.
-          `,
+          t`Role "${name}" has been successfully deleted.`,
           'success',
         ),
       )

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -220,16 +220,16 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
 
                               {
                                 id: 'locked',
-                                title: t`Status`,
+                                title: t`Editable`,
                                 inputType: 'select',
                                 options: [
                                   {
                                     id: 'true',
-                                    title: t`Locked`,
+                                    title: t`Built-in`,
                                   },
                                   {
                                     id: 'false',
-                                    title: t`Unlocked`,
+                                    title: t`Editable`,
                                   },
                                 ],
                               },
@@ -258,11 +258,11 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
                     params={params}
                     ignoredParams={['page_size', 'page', 'sort', 'ordering']}
                     niceValues={{
-                      locked: { true: t`Locked`, false: t`Unlocked` },
+                      locked: { true: t`Built-in`, false: t`Editable` },
                       name__startswith: { 'galaxy.': t`true` },
                     }}
                     niceNames={{
-                      locked: t`Status`,
+                      locked: t`Editable`,
                       name__icontains: t`Role name`,
                       name__startswith: t`Galaxy only`,
                     }}
@@ -300,7 +300,7 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
                             id: 'pulp_created',
                           },
                           {
-                            title: t`Locked`,
+                            title: t`Editable`,
                             type: 'none',
                             id: 'locked',
                           },
@@ -373,26 +373,23 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
                             <DateComponent date={role.pulp_created} />
                           </td>
 
-                          {role.locked ? (
-                            <Tooltip
-                              content={t`Locked roles cannot be edited or deleted.`}
-                            >
-                              <td>
-                                <Trans>Locked</Trans>
-                              </td>
-                            </Tooltip>
-                          ) : (
-                            <td>{t`Unlocked`}</td>
-                          )}
-                          {!role.locked ? (
-                            <ListItemActions
-                              kebabItems={this.renderDropdownItems(role)}
-                            />
-                          ) : (
-                            <ListItemActions
-                              kebabItems={this.renderDropdownItems(role)}
-                            />
-                          )}
+                          <td>
+                            {role.locked ? (
+                              <Tooltip
+                                content={t`Built-in roles cannot be edited or deleted.`}
+                              >
+                                <span
+                                  style={{ whiteSpace: 'nowrap' }}
+                                >{t`Built-in`}</span>
+                              </Tooltip>
+                            ) : (
+                              t`Editable`
+                            )}
+                          </td>
+
+                          <ListItemActions
+                            kebabItems={this.renderDropdownItems(role)}
+                          />
                         </ExpandableRow>
                       ))}
                     </RoleListTable>
@@ -445,7 +442,7 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
     const dropdownItems = [
       // this.context.user.model_permissions.change_containerregistry && (
 
-      <Tooltip key='edit' content={t`Locked roles cannot be edited.`}>
+      <Tooltip key='edit' content={t`Built-in roles cannot be edited.`}>
         <DropdownItem
           key='edit'
           isDisabled={locked}
@@ -462,7 +459,7 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
       // ),
       // this.context.user.model_permissions.delete_containerregistry && (
 
-      <Tooltip key='delete' content={t`Locked roles cannot be deleted.`}>
+      <Tooltip key='delete' content={t`Built-in roles cannot be deleted.`}>
         <DropdownItem
           key='delete'
           isDisabled={locked}

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -259,10 +259,12 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
                     ignoredParams={['page_size', 'page', 'sort', 'ordering']}
                     niceValues={{
                       locked: { true: t`Locked`, false: t`Unlocked` },
+                      name__startswith: { 'galaxy.': t`true` },
                     }}
                     niceNames={{
-                      name__icontains: t`Role name`,
                       locked: t`Status`,
+                      name__icontains: t`Role name`,
+                      name__startswith: t`Galaxy only`,
                     }}
                   />
                 </div>

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -439,42 +439,52 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
     const { pulp_href, locked } = role;
     const roleID = parsePulpIDFromURL(pulp_href);
 
+    const editItem = (
+      <DropdownItem
+        key='edit'
+        isDisabled={locked}
+        onClick={() =>
+          this.setState({
+            redirect: formatPath(Paths.roleEdit, { role: roleID }),
+          })
+        }
+      >
+        {t`Edit`}
+      </DropdownItem>
+    );
+    const deleteItem = (
+      <DropdownItem
+        key='delete'
+        isDisabled={locked}
+        onClick={() =>
+          this.setState({
+            showDeleteModal: true,
+            roleToEdit: role,
+          })
+        }
+      >
+        {t`Delete`}
+      </DropdownItem>
+    );
     const dropdownItems = [
-      // this.context.user.model_permissions.change_containerregistry && (
-
-      <Tooltip key='edit' content={t`Built-in roles cannot be edited.`}>
-        <DropdownItem
-          key='edit'
-          isDisabled={locked}
-          onClick={() =>
-            this.setState({
-              redirect: formatPath(Paths.roleEdit, { role: roleID }),
-            })
-          }
-        >
-          {t`Edit`}
-        </DropdownItem>
-      </Tooltip>,
-
-      // ),
-      // this.context.user.model_permissions.delete_containerregistry && (
-
-      <Tooltip key='delete' content={t`Built-in roles cannot be deleted.`}>
-        <DropdownItem
-          key='delete'
-          isDisabled={locked}
-          onClick={() =>
-            this.setState({
-              showDeleteModal: true,
-              roleToEdit: role,
-            })
-          }
-        >
-          {t`Delete`}
-        </DropdownItem>
-      </Tooltip>,
-      // ),
+      // this.context.user.model_permissions.change_containerregistry &&
+      locked ? (
+        <Tooltip key='edit' content={t`Built-in roles cannot be edited.`}>
+          {editItem}
+        </Tooltip>
+      ) : (
+        editItem
+      ),
+      // this.context.user.model_permissions.delete_containerregistry &&
+      locked ? (
+        <Tooltip key='delete' content={t`Built-in roles cannot be deleted.`}>
+          {deleteItem}
+        </Tooltip>
+      ) : (
+        deleteItem
+      ),
     ];
+
     return dropdownItems;
   };
 

--- a/test/cypress/integration/rbac_create.js
+++ b/test/cypress/integration/rbac_create.js
@@ -8,7 +8,7 @@ describe('add and delete roles', () => {
   it('adds a new role', () => {
     cy.contains('Add roles').click();
 
-    //checks role name input
+    // checks role name input
 
     cy.get('input[id="role_name"]').type('a');
 
@@ -37,7 +37,7 @@ describe('add and delete roles', () => {
     cy.get('input[id="role_name"]').clear().type(`galaxy.test${num}`);
     cy.contains('Save').should('be.enabled');
 
-    //checks role description input
+    // checks role description input
 
     cy.get('input[id="role_description"]').type('a');
 
@@ -66,13 +66,15 @@ describe('add and delete roles', () => {
 
     cy.contains('Save').click();
 
-    //check list view
+    // check list view, use filter
+
+    cy.get('[data-cy=compound_filter] input').type('test{enter}');
 
     cy.get('tbody').contains(`galaxy.test${num}`);
     cy.get('[aria-label="Details"]:first').click();
     cy.contains('Add namespace');
 
-    //delete role
+    // delete role
 
     cy.get('[aria-label="Actions"]:first').click();
     cy.contains('Delete').click();

--- a/test/cypress/integration/rbac_edit.js
+++ b/test/cypress/integration/rbac_edit.js
@@ -22,16 +22,16 @@ describe('edits a role', () => {
 
     // edit role - first filter by editable and name fragment
 
-    cy.get('[data-cy=compound_filter] > div:nth(1) > button').click();
+    cy.get('[data-cy=compound_filter] > div:nth-child(1) > button').click();
     cy.get('[data-cy=compound_filter] li[role=menuitem]')
       .contains('Editable')
       .click();
-    cy.get('[data-cy=compound_filter] > div:nth(2) > button').click();
+    cy.get('[data-cy=compound_filter] > div:nth-child(2) > button').click();
     cy.get('[data-cy=compound_filter] li[role=menuitem]')
       .contains('Editable')
       .click();
 
-    cy.get('[data-cy=compound_filter] > div:nth(1) > button').click();
+    cy.get('[data-cy=compound_filter] > div:nth-child(1) > button').click();
     cy.get('[data-cy=compound_filter] li[role=menuitem]')
       .contains('Role name')
       .click();

--- a/test/cypress/integration/rbac_edit.js
+++ b/test/cypress/integration/rbac_edit.js
@@ -1,6 +1,7 @@
 describe('edits a role', () => {
-  let num = (~~(Math.random() * 1000000)).toString();
-  before(() => {
+  const num = (~~(Math.random() * 1000000)).toString();
+
+  beforeEach(() => {
     cy.login();
     cy.menuGo('User Access > Roles');
   });
@@ -19,7 +20,24 @@ describe('edits a role', () => {
     cy.get('ul[role="listbox"] > li:first').click(); // add permission 'Add namespace'
     cy.contains('Save').click();
 
-    // edit role
+    // edit role - first filter by editable and name fragment
+
+    cy.get('[data-cy=compound_filter] > div:nth(1) > button').click();
+    cy.get('[data-cy=compound_filter] li[role=menuitem]')
+      .contains('Editable')
+      .click();
+    cy.get('[data-cy=compound_filter] > div:nth(2) > button').click();
+    cy.get('[data-cy=compound_filter] li[role=menuitem]')
+      .contains('Editable')
+      .click();
+
+    cy.get('[data-cy=compound_filter] > div:nth(1) > button').click();
+    cy.get('[data-cy=compound_filter] li[role=menuitem]')
+      .contains('Role name')
+      .click();
+    cy.get(
+      '[data-cy=compound_filter] input[aria-label="name__icontains"]',
+    ).type(`test${num}{enter}`);
 
     cy.get('[aria-label="Actions"]:first').click();
     cy.contains('Edit').click();
@@ -34,6 +52,10 @@ describe('edits a role', () => {
     cy.contains('Save').click();
 
     // check list view
+
+    cy.get(
+      '[data-cy=compound_filter] input[aria-label="name__icontains"]',
+    ).type(`test${num}{enter}`);
 
     cy.get('tbody > tr > td').eq(2).contains('new description');
     cy.get('[aria-label="Details"]:first').click();

--- a/test/cypress/integration/rbac_edit.js
+++ b/test/cypress/integration/rbac_edit.js
@@ -40,7 +40,8 @@ describe('edits a role', () => {
     ).type(`test${num}{enter}`);
 
     cy.get('[aria-label="Actions"]:first').click();
-    cy.contains('Edit').click();
+    cy.get('li[role=menuitem]').contains('Edit').click();
+
     cy.get('input[id="role_name"]').should('be.disabled');
     cy.get('input[id="role_description"]').clear().type('new description');
 

--- a/test/cypress/integration/rbac_list.js
+++ b/test/cypress/integration/rbac_list.js
@@ -15,7 +15,7 @@ describe('RBAC table contains correct headers and filter', () => {
     );
 
     //ensure proper headers
-    [('Role name', 'Description', 'Created', 'Locked')].forEach((item) => {
+    [('Role name', 'Description', 'Created', 'Editable')].forEach((item) => {
       cy.get('tr[data-cy="SortTable-headers"] th').contains(item);
     });
   });

--- a/test/cypress/integration/user_detail.js
+++ b/test/cypress/integration/user_detail.js
@@ -8,9 +8,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
   };
 
   let deleteTestGroup = () => {
-    cy.intercept('GET', Cypress.env('prefix') + `ui/group-list`).as('groups');
     cy.visit('/ui/group-list');
-    cy.wait('@groups');
     cy.intercept(
       'GET',
       Cypress.env('prefix') +

--- a/test/cypress/integration/user_detail.js
+++ b/test/cypress/integration/user_detail.js
@@ -9,7 +9,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
 
     cy.galaxykit('group create', `alphaGroup${num}`);
     cy.galaxykit('user create', 'testUser', 'testUserpassword');
-    cy.galaxykit('user group add', `alphaGroup${num}`, 'testUser');
+    cy.galaxykit('user group add', 'testUser', `alphaGroup${num}`);
   });
 
   after(() => {

--- a/test/cypress/integration/user_detail.js
+++ b/test/cypress/integration/user_detail.js
@@ -1,72 +1,57 @@
 describe('user detail tests all fields, editing, and deleting', () => {
-  let adminUsername = Cypress.env('username');
-  let adminPassword = Cypress.env('password');
-  let num = (~~(Math.random() * 1000000)).toString();
+  const num = (~~(Math.random() * 1000000)).toString();
 
-  let selectInput = (id) => {
-    return cy.get(`input[id=${id}]`).click();
-  };
-
-  let deleteTestGroup = () => {
-    cy.visit('/ui/group-list');
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') +
-        '_ui/v1/groups/*/model-permissions/?limit=100000&offset=0',
-    ).as('testGroup');
-    cy.contains(`alphaGroup${num}`).click();
-    cy.wait('@testGroup');
-    cy.get('button').contains('Delete').click();
-    cy.get('[data-cy="delete-button"]').click();
-  };
-
-  let buildUserProfile = () => {
-    cy.createGroup(`alphaGroup${num}`);
-    cy.galaxykit('user create', 'testUser', 'testUserpassword');
-    cy.addPermissions(`alphaGroup${num}`, [
-      { group: 'users', permissions: ['View user'] },
-    ]);
-    cy.addUserToGroup(`alphaGroup${num}`, 'testUser');
-    cy.visit('/ui/users');
-    cy.contains('testUser').click();
-    cy.contains('Edit').click();
-    selectInput('first_name').click().clear().type('first_name');
-    selectInput('last_name').click().clear().type('last_name');
-    selectInput('email').click().clear().type('example@example.com');
-    cy.get('button[type=submit]').click();
-    cy.reload();
-  };
+  const selectInput = (id) => cy.get(`input[id=${id}]`).click().clear();
 
   before(() => {
     cy.deleteTestUsers();
+    cy.deleteTestGroups();
+
+    cy.galaxykit('group create', `alphaGroup${num}`);
+    cy.galaxykit('user create', 'testUser', 'testUserpassword');
+    cy.galaxykit('user group add', `alphaGroup${num}`, 'testUser');
+  });
+
+  after(() => {
     cy.deleteTestUsers();
-    cy.deleteTestUsers();
-    cy.deleteTestUsers();
-    cy.login(adminUsername, adminPassword);
+    cy.deleteTestGroups();
   });
 
   beforeEach(() => {
-    cy.login(adminUsername, adminPassword);
+    cy.login();
   });
 
   it('checks all fields', () => {
-    buildUserProfile();
+    // FIXME
+    //cy.addPermissions(`alphaGroup${num}`, [
+    //  { group: 'users', permissions: ['View user'] },
+    //]);
+
+    cy.visit('/ui/users');
+    cy.contains('testUser').click();
+    cy.contains('Edit').click();
+    selectInput('first_name').type('first_name');
+    selectInput('last_name').type('last_name');
+    selectInput('email').type('example@example.com');
+    cy.get('button[type=submit]').click();
+
     cy.visit('/ui/users');
     cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/users/*/').as(
       'testUser',
     );
     cy.contains('testUser').click();
     cy.wait('@testUser');
+
     cy.get('[data-cy="DataForm-field-username"]').contains('testUser');
     cy.get('[data-cy="DataForm-field-first_name"]').contains('first_name');
     cy.get('[data-cy="DataForm-field-last_name"]').contains('last_name');
     cy.get('[data-cy="DataForm-field-email"]').contains('example@example.com');
     cy.get('[data-cy="UserForm-readonly-groups"]').contains(`alphaGroup${num}`);
+    // FIXME test the right value, not both
     cy.get('.pf-c-switch > .pf-c-switch__label').should(
       'have.text',
       'Super userNot a super user',
     );
-    deleteTestGroup();
   });
 
   it('edits user', () => {
@@ -74,9 +59,9 @@ describe('user detail tests all fields, editing, and deleting', () => {
     cy.contains('testUser').click();
     //edits some fields
     cy.contains('Edit').click();
-    selectInput('first_name').click().clear().type('new_first_name');
-    selectInput('last_name').click().clear().type('new_last_name');
-    selectInput('email').click().clear().type('new_example@example.com');
+    selectInput('first_name').type('new_first_name');
+    selectInput('last_name').type('new_last_name');
+    selectInput('email').type('new_example@example.com');
     cy.get('button[type=submit]').click();
     cy.reload();
     //checks those fields

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -468,10 +468,9 @@ Cypress.Commands.add('galaxykit', {}, (operation, ...args) => {
   const adminPassword = Cypress.env('password');
   const galaxykitCommand = Cypress.env('galaxykit') || 'galaxykit';
   const server = Cypress.config().baseUrl + Cypress.env('prefix');
-  const options =
-    args.length >= 1 && typeof args[args.length - 1] == 'object'
-      ? args.splice(args.length - 1, 1)[0]
-      : [];
+  const options = (args.length >= 1 &&
+    typeof args[args.length - 1] == 'object' &&
+    args.splice(args.length - 1, 1)[0]) || { failOnNonZeroExit: false };
 
   cy.log(`${galaxykitCommand} ${operation} ${args}`);
   const cmd = shell`${shell.preserve(
@@ -483,7 +482,8 @@ Cypress.Commands.add('galaxykit', {}, (operation, ...args) => {
   return cy.exec(cmd, options).then(({ code, stderr, stdout }) => {
     console.log(`RUN ${cmd}`, options, { code, stderr, stdout });
 
-    if (stderr) {
+    if (code || stderr) {
+      cy.log('galaxykit code: ' + code);
       cy.log('galaxykit stderr: ' + stderr);
       return Promise.reject(new Error(`Galaxykit failed: ${stderr}`));
     }

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -484,6 +484,7 @@ Cypress.Commands.add('galaxykit', {}, (operation, ...args) => {
     console.log(`RUN ${cmd}`, options, { code, stderr, stdout });
 
     if (stderr) {
+      cy.log('galaxykit stderr: ' + stderr);
       return Promise.reject(new Error(`Galaxykit failed: ${stderr}`));
     }
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -246,7 +246,7 @@ Cypress.Commands.add('removeRoleFromGroup', {}, (groupName, role) => {
   cy.get(`[data-cy="RoleListTable-ExpandableRow-row-${role}"]`)
     .find('[data-cy="kebab-toggle"]')
     .click()
-    .contains('Remove Role')
+    .contains('Remove role')
     .click();
 
   cy.intercept('DELETE', Cypress.env('pulpPrefix') + 'groups/*/roles/*').as(


### PR DESCRIPTION
Depends on https://github.com/pulp/pulpcore/issues/2703 for the sort to work => https://github.com/pulp/pulpcore/pull/2766 => https://github.com/ansible/galaxy_ng/pull/1279 => just the [branch](https://github.com/ansible/galaxy_ng/commits/feature/rbac-roles) now.

Prettify the "galaxy only" filter indicator in role list:

![20220427023743](https://user-images.githubusercontent.com/289743/165443435-3dc40725-b0e6-4fba-809c-17d66ecb73c6.png)

And make sure role lists are sorting by name everywhere by default, and showing the description where possible.

Current state:

* User Access > Roles
  * has description, locked/unlocked, expandable
  * sort by name works, not default => **made `name` default**
* User Access > Groups > detail
  * tab Access
    * just name, expandable => **added `description`, use permission data already available (since pulp 3.20)**
    * sort by name broken, not default => **it is default, indicator has problems because the tabs share state (for later), api should work after https://github.com/pulp/pulpcore/issues/2703 + removed the `sort` -> `ordering` logic from `GroupRoleAPI` .. then reenabled after https://github.com/pulp/pulpcore/pull/2849**
  * tab Access, modal Add roles
    * has description, (not expandable)
    * sort by name works, default but doesn't indicate it => **fixed**
* Collections > Namespaces > detail
  * tab Namespace owners, modal Select a group (step 2)
    * has description, (not expandable)
    * sort by name works, default but doesn't indicate it => **fixed**
  * tab Namespace owners > group detail
    * just name, expandable (permissions & description lazy loaded when expanding)
    * no sort => **sorting in ui, just by name**
  * tab Namespace owners > group detail, modal Add roles
    * has description, (not expandable)
    * sort by name works, default but doesn't indicate it => **fixed**
* Execution Environments > Execution Environments > detail
  * tab Owners, modal Select a group (step 2)
    * has description, (not expandable)
    * sort by name works, default but doesn't indicate it => **fixed**
  * tab Owners > group detail
    * just name, expandable (permissions & description lazy loaded when expanding)
    * no sort => **sorting in ui, just by name**
  * tab Owners > group detail, modal Add roles
    * has description, (not expandable)
    * sort by name works, default but doesn't indicate it => **fixed**
