### PR TITLE
Use GALAXY_MINIMUM_PASSWORD_LENGTH in user-form help message

### DIFF
--- a/CHANGES/1573.feature
+++ b/CHANGES/1573.feature
@@ -1,0 +1,1 @@
+Show the proper MINIMUM PASSWORD LENGTH in UI

--- a/src/components/user-form/user-form.tsx
+++ b/src/components/user-form/user-form.tsx
@@ -82,6 +82,8 @@ export class UserForm extends React.Component<IProps, IState> {
       isMe,
     } = this.props;
     const { passwordConfirm, formErrors } = this.state;
+    const minLength = this.context.settings.GALAXY_MINIMUM_PASSWORD_LENGTH || 9; // actually counts codepoints, close enough
+
     const formFields = [
       { id: 'username', title: t`Username` },
       { id: 'first_name', title: t`First name` },
@@ -94,7 +96,7 @@ export class UserForm extends React.Component<IProps, IState> {
         placeholder: isNewUser ? '' : '••••••••••••••••••••••',
         formGroupLabelIcon: (
           <HelperText
-            content={t`Create a password using at least 9 characters, including special characters , ex <!@$%>. Avoid using common names or expressions.`}
+            content={t`Create a password using at least ${minLength} characters, including special characters , ex <!@$%>. Avoid using common names or expressions.`}
           />
         ),
       },


### PR DESCRIPTION
API parts come from https://github.com/ansible/galaxy_ng/pull/1253,
we have a new `GALAXY_MINIMUM_PASSWORD_LENGTH` setting coming from the API, defaults to `null` so we're still providing the 9 default.

When overidden, the prompt will show the right number now.

![20220523135200](https://user-images.githubusercontent.com/289743/169834844-484d4dd1-0d29-4ade-a78f-5b949f50fdd7.png)

(The actual on save validation still happens server side, that already provides the right message.)

Fixes https://issues.redhat.com/browse/AAH-1573

---

note that `MinimumPasswordLengthValidator` just uses python's `len()`, so the number actually means codepoints, not characters .. so this will actually still allow 5 character passwords if each character has accents done through a modifier .. but we shouldn't expect users to know about Unicode.