### PR TITLE
Adding test for rejection, approval and test for view import logs.

### DIFF
--- a/CHANGES/628.misc
+++ b/CHANGES/628.misc
@@ -1,2 +1,1 @@
-Add Approval dashboard test
-Add approving process test and redirect to import log
+Add Approval dashboard test, Add approving process test and redirect to import log

--- a/CHANGES/628.misc
+++ b/CHANGES/628.misc
@@ -1,0 +1,2 @@
+Add Approval dashboard test
+Add approving process test and redirect to import log

--- a/test/cypress/integration/approval_dashboard_list.js
+++ b/test/cypress/integration/approval_dashboard_list.js
@@ -52,6 +52,10 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
     loadData();
   });
 
+  after(() => {
+    cy.deleteNamespacesAndCollections();
+  });
+
   beforeEach(() => {
     cy.login();
     cy.visit('/ui/approval-dashboard');

--- a/test/cypress/integration/approval_dashboard_list.js
+++ b/test/cypress/integration/approval_dashboard_list.js
@@ -177,4 +177,13 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
       cy.get('[data-cy="body"]').contains(items[i].name);
     });
   });
+
+  it('should redirect to import logs.', () => {
+    cy.get(
+      '[data-cy="kebab-toggle"]:first button[aria-label="Actions"]',
+    ).click();
+    cy.contains('View Import Logs').click();
+    cy.contains('My imports');
+    cy.get('.import-list');
+  });
 });

--- a/test/cypress/integration/approval_process.js
+++ b/test/cypress/integration/approval_process.js
@@ -30,10 +30,7 @@ describe('Approval Dashboard process', () => {
     cy.contains('.body', 'No results found', { timeout: 8000 });
     cy.visit('/ui/approval-dashboard');
     cy.contains('button', 'Clear all filters').click();
-    cy.contains(
-      '[data-cy="CertificationDashboard-row"]',
-      'Approved',
-    );
+    cy.contains('[data-cy="CertificationDashboard-row"]', 'Approved');
   });
 
   it('should see item in collections.', () => {

--- a/test/cypress/integration/approval_process.js
+++ b/test/cypress/integration/approval_process.js
@@ -3,6 +3,7 @@ describe('Approval Dashboard process', () => {
     cy.settings({ GALAXY_REQUIRE_CONTENT_APPROVAL: true });
     cy.login();
     cy.deleteNamespacesAndCollections();
+    cy.galaxykit('-i namespace create', 'appp_n_test');
     cy.galaxykit('-i collection upload', 'appp_n_test', 'appp_c_test1');
   });
 

--- a/test/cypress/integration/approval_process.js
+++ b/test/cypress/integration/approval_process.js
@@ -31,11 +31,11 @@ describe('Approval Dashboard process', () => {
     cy.visit('/ui/approval-dashboard');
     cy.contains('button', 'Clear all filters').click();
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Approved');
-    
+
     // should see item in collections
     cy.visit('/ui/repo/published?page_size=100');
     cy.contains('.collection-container', 'appp_c_test1');
-  
+
     // should reject
     cy.visit('/ui/approval-dashboard');
     cy.contains('button', 'Clear all filters').click();
@@ -44,7 +44,7 @@ describe('Approval Dashboard process', () => {
     );
     cy.contains('Reject').click({ force: true });
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Rejected');
-  
+
     // should not see items in collections
     cy.visit('/ui/repo/published');
     cy.contains('No collections yet');

--- a/test/cypress/integration/approval_process.js
+++ b/test/cypress/integration/approval_process.js
@@ -1,0 +1,58 @@
+describe('Approval Dashboard process', () => {
+  before(() => {
+    cy.settings({ GALAXY_REQUIRE_CONTENT_APPROVAL: true });
+    cy.login();
+    cy.deleteNamespacesAndCollections();
+    cy.galaxykit('-i collection upload', 'appp_n_test', 'appp_c_test1');
+  });
+
+  after(() => {
+    cy.deleteNamespacesAndCollections();
+    cy.settings();
+  });
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('should not see items in collections.', () => {
+    cy.visit('/ui/repo/published');
+    cy.contains('No collections yet');
+  });
+
+  it('should approve', () => {
+    cy.visit('/ui/approval-dashboard');
+    cy.contains('[data-cy="CertificationDashboard-row"]', 'Needs review');
+    cy.contains(
+      '[data-cy="CertificationDashboard-row"] button',
+      'Sign and approve',
+    ).click();
+    cy.contains('.body', 'No results found', { timeout: 8000 });
+    cy.visit('/ui/approval-dashboard');
+    cy.contains('button', 'Clear all filters').click();
+    cy.contains(
+      '[data-cy="CertificationDashboard-row"]',
+      'Signed and approved',
+    );
+  });
+
+  it('should see item in collections.', () => {
+    cy.visit('/ui/repo/published?page_size=100');
+    cy.contains('.collection-container', 'appp_c_test1');
+  });
+
+  it('should reject', () => {
+    cy.visit('/ui/approval-dashboard');
+    cy.contains('button', 'Clear all filters').click();
+    cy.get('[data-cy="kebab-toggle"]:first button[aria-label="Actions"]').click(
+      { force: true },
+    );
+    cy.contains('Reject').click({ force: true });
+    cy.contains('[data-cy="CertificationDashboard-row"]', 'Rejected');
+  });
+
+  it('should not see items in collections.', () => {
+    cy.visit('/ui/repo/published');
+    cy.contains('No collections yet');
+  });
+});

--- a/test/cypress/integration/approval_process.js
+++ b/test/cypress/integration/approval_process.js
@@ -25,14 +25,14 @@ describe('Approval Dashboard process', () => {
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Needs review');
     cy.contains(
       '[data-cy="CertificationDashboard-row"] button',
-      'Sign and approve',
+      'Approve',
     ).click();
     cy.contains('.body', 'No results found', { timeout: 8000 });
     cy.visit('/ui/approval-dashboard');
     cy.contains('button', 'Clear all filters').click();
     cy.contains(
       '[data-cy="CertificationDashboard-row"]',
-      'Signed and approved',
+      'Approved',
     );
   });
 

--- a/test/cypress/integration/approval_process.js
+++ b/test/cypress/integration/approval_process.js
@@ -16,12 +16,11 @@ describe('Approval Dashboard process', () => {
     cy.login();
   });
 
-  it('should not see items in collections.', () => {
+  it('should test the whole approval process.', () => {
     cy.visit('/ui/repo/published');
     cy.contains('No collections yet');
-  });
 
-  it('should approve', () => {
+    // should approve
     cy.visit('/ui/approval-dashboard');
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Needs review');
     cy.contains(
@@ -32,14 +31,12 @@ describe('Approval Dashboard process', () => {
     cy.visit('/ui/approval-dashboard');
     cy.contains('button', 'Clear all filters').click();
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Approved');
-  });
-
-  it('should see item in collections.', () => {
+    
+    // should see item in collections
     cy.visit('/ui/repo/published?page_size=100');
     cy.contains('.collection-container', 'appp_c_test1');
-  });
-
-  it('should reject', () => {
+  
+    // should reject
     cy.visit('/ui/approval-dashboard');
     cy.contains('button', 'Clear all filters').click();
     cy.get('[data-cy="kebab-toggle"]:first button[aria-label="Actions"]').click(
@@ -47,9 +44,8 @@ describe('Approval Dashboard process', () => {
     );
     cy.contains('Reject').click({ force: true });
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Rejected');
-  });
-
-  it('should not see items in collections.', () => {
+  
+    // should not see items in collections
     cy.visit('/ui/repo/published');
     cy.contains('No collections yet');
   });


### PR DESCRIPTION
Issue: [AAH-628](https://issues.redhat.com/browse/AAH-628)

https://issues.redhat.com/browse/AAH-628

Finish the rest of the functionality in issue.

Note - this PR is new version of old closed PR - https://github.com/ansible/ansible-hub-ui/pull/1527.
The old PR has been long waiting for the galaxykit so it started to become obsolete and it was easier to create new PR than to repair the old one (and for example broken galaxykit collection deletion makes galaxykit deleting data useless anyway).

Additional note - I had to close also the the PR - https://github.com/ansible/ansible-hub-ui/pull/1923, accidentaly, mess from another big PR has merged into this and it was way easier to create brand new PR.
