### PR TITLE
Sync delete collections - wait for collection versions to be empty

### DIFF
--- a/CHANGES/1641.misc
+++ b/CHANGES/1641.misc
@@ -1,0 +1,1 @@
+Add synchronization - wait for empty collection version list.

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -723,7 +723,7 @@ Cypress.Commands.add('deleteAllCollections', {}, () => {
         cy.log('Collections are empty!');
       }
     });
-  }
+  };
 
   cy.galaxykit('collection list').then((res) => {
     const data = JSON.parse(res[0]).data;

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -707,10 +707,8 @@ Cypress.Commands.add('deleteContainersManual', {}, () => {
 });
 
 Cypress.Commands.add('deleteAllCollections', {}, () => {
-  function waitForEmptyCollection(maxLoops)
-  {
-    if (maxLoops == 0)
-    {
+  function waitForEmptyCollection(maxLoops) {
+    if (maxLoops == 0) {
       cy.log('Max loops reached while waiting for the empty collections.');
       return;
     }
@@ -719,15 +717,14 @@ Cypress.Commands.add('deleteAllCollections', {}, () => {
 
     cy.galaxykit('collection list').then((res) => {
       const data = JSON.parse(res[0]).data;
-      if (data.length != 0)
-      {
+      if (data.length != 0) {
         waitForEmptyCollection(maxLoops - 1);
-      }else{
+      } else {
         cy.log('Collections are empty!');
       }
     });
   }
-  
+
   cy.galaxykit('collection list').then((res) => {
     const data = JSON.parse(res[0]).data;
     cy.log(data.length + ' collections found for deletion.');

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -707,7 +707,7 @@ Cypress.Commands.add('deleteContainersManual', {}, () => {
 });
 
 Cypress.Commands.add('deleteAllCollections', {}, () => {
-  function waitForEmptyCollection(maxLoops) {
+  const waitForEmptyCollection = (maxLoops) => {
     if (maxLoops == 0) {
       cy.log('Max loops reached while waiting for the empty collections.');
       return;

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -707,8 +707,30 @@ Cypress.Commands.add('deleteContainersManual', {}, () => {
 });
 
 Cypress.Commands.add('deleteAllCollections', {}, () => {
+  function waitForEmptyCollection(maxLoops)
+  {
+    if (maxLoops == 0)
+    {
+      cy.log('Max loops reached while waiting for the empty collections.');
+      return;
+    }
+
+    cy.wait(3000);
+
+    cy.galaxykit('collection list').then((res) => {
+      const data = JSON.parse(res[0]).data;
+      if (data.length != 0)
+      {
+        waitForEmptyCollection(maxLoops - 1);
+      }else{
+        cy.log('Collections are empty!');
+      }
+    });
+  }
+  
   cy.galaxykit('collection list').then((res) => {
     const data = JSON.parse(res[0]).data;
+    cy.log(data.length + ' collections found for deletion.');
     data.forEach((record) => {
       cy.galaxykit(
         'collection delete',
@@ -719,11 +741,12 @@ Cypress.Commands.add('deleteAllCollections', {}, () => {
       );
     });
   });
+
+  waitForEmptyCollection(10);
 });
 
 Cypress.Commands.add('deleteNamespacesAndCollections', {}, () => {
   cy.deleteAllCollections();
-  cy.wait(5000);
   cy.galaxykit('namespace list').then((json) => {
     JSON.parse(json).data.forEach((namespace) => {
       cy.galaxykit('namespace delete', namespace.name);


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-1641

It is good to wait for collections to be empty while deleting them, because they are deleted in the background and galaxykit command only returns when the operation is queued. This may avoid some unexpected problems.

This PR depends on: https://github.com/ansible/galaxykit/pull/48