### PR TITLE
Fix redirection to not existing group

### DIFF
--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -738,7 +738,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         } else {
           const { status, statusText } = e.response;
           this.addAlert(
-            t`Group "${this.state.group.name}" could not be displayed.`,
+            t`Group could not be displayed.`,
             'danger',
             errorMessage(status, statusText),
           );

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -733,12 +733,16 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         this.setState({ group: result.data });
       })
       .catch((e) => {
-        const { status, statusText } = e.response;
-        this.addAlert(
-          t`Group "${this.state.group.name}" could not be displayed.`,
-          'danger',
-          errorMessage(status, statusText),
-        );
+        if (e.response.status === 404) {
+          this.setState({ redirect: Paths.notFound });
+        } else {
+          const { status, statusText } = e.response;
+          this.addAlert(
+            t`Group "${this.state.group.name}" could not be displayed.`,
+            'danger',
+            errorMessage(status, statusText),
+          );
+        }
       });
 
     this.setState({


### PR DESCRIPTION
Issue: [AAH-1668](https://issues.redhat.com/browse/AAH-1668)

Quick fix with missing redirection on entering not existing group id. This happens only on the new `feature/rbac` branch.

![Screenshot from 2022-05-26 00-02-24](https://user-images.githubusercontent.com/19647757/170457113-fb65ff7e-effb-4db2-8305-db58dafdc2d2.png)

