### PR TITLE
standalone config - change pulp api path to '/api/automation-hub/pulp/api/v3/' (dev) or '/api/galaxy/pulp/api/v3/' (prod)

### DIFF
--- a/config/standalone.dev.webpack.config.js
+++ b/config/standalone.dev.webpack.config.js
@@ -12,7 +12,7 @@ module.exports = webpackBase({
 
   // Path to the API on the API host. EX: /api/automation-hub
   API_BASE_PATH: apiBasePath,
-  PULP_API_BASE_PATH: '/pulp/api/v3/',
+  PULP_API_BASE_PATH: apiBasePath + 'pulp/api/v3/',
 
   // Path on the host where the UI is found. EX: /apps/automation-hub
   UI_BASE_PATH: '/ui/',

--- a/config/standalone.prod.webpack.config.js
+++ b/config/standalone.prod.webpack.config.js
@@ -4,7 +4,7 @@ const webpackBase = require('./webpack.base.config');
 module.exports = webpackBase({
   API_HOST: '',
   API_BASE_PATH: '/api/galaxy/',
-  PULP_API_BASE_PATH: '/pulp/api/v3/',
+  PULP_API_BASE_PATH: '/api/galaxy/pulp/api/v3/',
   UI_BASE_PATH: '/ui/',
   DEPLOYMENT_MODE: 'standalone',
   NAMESPACE_TERM: 'namespaces',

--- a/test/cypress/integration/task_status.js
+++ b/test/cypress/integration/task_status.js
@@ -4,7 +4,8 @@ describe('test status filter label on list view', () => {
     cy.visit('/ui/tasks');
     cy.intercept(
       'GET',
-      '/pulp/api/v3/tasks/?ordering=-pulp_created&offset=0&limit=10',
+      Cypress.env('prefix') +
+        'pulp/api/v3/tasks/?ordering=-pulp_created&offset=0&limit=10',
     ).as('tasks');
 
     cy.wait('@tasks');


### PR DESCRIPTION
https://github.com/ansible/galaxy_ng/pull/1247 was merged, so tasks won't work in dev ui without this

Cc @awcrosby .. do you know what happens for standalone prod? Should we change the pulp apis to `/api/galaxy/pulp/api/v3/` or do they stay in the original place?