### PR TITLE
Collections deprecate & upload rbac

### DIFF
--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -529,7 +529,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           collections: val[0].data.data,
           itemCount: val[0].data.meta.count,
           namespace: val[1].data,
-          showControls: !!val[2],
+          showControls: !!val[2], // FIXME: use the actual my_permissions list
           canSign: canSignNS(this.context, val[2]?.data),
         });
 


### PR DESCRIPTION
Follow-up to https://github.com/ansible/ansible-hub-ui/pull/1766 (AAH-1025)

Namespace detail: not changed in #1766, just adding a FIXME to check the individual permissions eventually
Collection header (collection detail screens): we already have the rbac info inside `collection`, through the magic of `include_related=my_permissions`, use that
Collection list: same as above, except we first need to add the param .. and make it work API-side: https://github.com/ansible/galaxy_ng/pull/1304

(I'm not 100% sure about `change_namespace` for deprecation, but it seems the closest one, and the previous namespace detail impl only checked that my-namespaces doesn't 404 on that one ... EDIT: David confirmed it's the right one)

(draft because ~~waiting for API PR to be merged first~~, and probably rebase after https://github.com/ansible/ansible-hub-ui/pull/2159)