### PR TITLE
Un-disable Deprecate for cloud 

### DIFF
--- a/CHANGES/1428.misc
+++ b/CHANGES/1428.misc
@@ -1,0 +1,1 @@
+Un-disable Deprecate for cloud

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -5,7 +5,6 @@ import './list.scss';
 import { Button, DropdownItem, DataList } from '@patternfly/react-core';
 
 import { CollectionListType } from 'src/api';
-import { Constants } from 'src/constants';
 import {
   CollectionListItem,
   Pagination,
@@ -95,14 +94,6 @@ export class CollectionList extends React.Component<IProps> {
                 this.props.handleControlClick(collection.id, 'deprecate')
               }
               key='deprecate'
-              isDisabled={
-                DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-              }
-              description={
-                DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-                  ? t`Temporarily disabled due to sync issues. (AAH-1237)`
-                  : null
-              }
             >
               {collection.deprecated ? t`Undeprecate` : t`Deprecate`}
             </DropdownItem>,

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -253,16 +253,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           {t`Sign version ${collection.latest_version.version}`}
         </DropdownItem>
       ),
-      <DropdownItem
-        onClick={() => this.deprecate(collection)}
-        key='deprecate'
-        isDisabled={DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE}
-        description={
-          DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-            ? t`Temporarily disabled due to sync issues. (AAH-1237)`
-            : null
-        }
-      >
+      <DropdownItem onClick={() => this.deprecate(collection)} key='deprecate'>
         {collection.deprecated ? t`Undeprecate` : t`Deprecate`}
       </DropdownItem>,
       <DropdownItem

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -327,12 +327,6 @@ class Search extends React.Component<RouteComponentProps, IState> {
       <DropdownItem
         onClick={() => this.handleControlClick(collection)}
         key='deprecate'
-        isDisabled={DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE}
-        description={
-          DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-            ? t`Temporarily disabled due to sync issues. (AAH-1237)`
-            : null
-        }
       >
         {collection.deprecated ? t`Undeprecate` : t`Deprecate`}
       </DropdownItem>,


### PR DESCRIPTION
Issue: AAH-1428

This reverts #1487,
and also removes the message from the new deprecation buttons added in #1766.
(Related to AAH-1237 and AAH-1245.)