### PR TITLE
[stable-4.4] Collection counts - l10n (#2137)

### DIFF
--- a/CHANGES/1684.task
+++ b/CHANGES/1684.task
@@ -1,0 +1,1 @@
+Localize collection modules/roles/... counter

--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -31,12 +31,6 @@
     width: 100%;
   }
 
-  .type-label {
-    font-size: var(--pf-global--FontSize--xs);
-    color: var(--pf-global--color--200);
-    text-transform: capitalize;
-  }
-
   .type-container {
     display: flex;
     justify-content: space-between;

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -15,7 +15,7 @@ import {
 
 import { Link } from 'react-router-dom';
 
-import { NumericLabel, Logo } from 'src/components';
+import { CollectionNumericLabel, Logo } from 'src/components';
 import { CollectionListType } from 'src/api';
 import { formatPath, Paths } from 'src/paths';
 import { convertContentSummaryCounts } from 'src/utilities';
@@ -112,17 +112,7 @@ export class CollectionCard extends React.Component<IProps> {
   private renderTypeCount(type, count) {
     return (
       <div key={type}>
-        <div>
-          <NumericLabel number={count} />
-        </div>
-        <div className='type-label'>
-          <NumericLabel
-            number={count}
-            hideNumber={true}
-            label={type}
-            pluralLabels={Constants.COLLECTION_PLURAL_LABELS[type]}
-          />
-        </div>
+        <CollectionNumericLabel count={count} newline type={type} />
       </div>
     );
   }

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -17,7 +17,7 @@ import { Link } from 'react-router-dom';
 
 import { Paths, formatPath } from 'src/paths';
 import {
-  NumericLabel,
+  CollectionNumericLabel,
   Tag,
   Logo,
   DeprecatedTag,
@@ -25,7 +25,6 @@ import {
 } from 'src/components';
 import { CollectionListType } from 'src/api';
 import { convertContentSummaryCounts } from 'src/utilities';
-import { Constants } from 'src/constants';
 
 interface IProps extends CollectionListType {
   showNamespace?: boolean;
@@ -89,14 +88,12 @@ export class CollectionListItem extends React.Component<IProps, {}> {
           ) : null}
         </div>
         <div className='entry'>{latest_version.metadata.description}</div>
-        <div className='entry pf-l-flex pf-m-wrap content'>
-          {Object.keys(contentSummary.contents).map((k) => (
-            <div key={k}>
-              <NumericLabel
-                className='numeric-label-capitalize-text'
-                label={k}
-                number={contentSummary.contents[k]}
-                pluralLabels={Constants.COLLECTION_PLURAL_LABELS[k]}
+        <div className='entry pf-l-flex pf-m-wrap'>
+          {Object.keys(contentSummary.contents).map((type) => (
+            <div key={type}>
+              <CollectionNumericLabel
+                count={contentSummary.contents[type]}
+                type={type}
               />
             </div>
           ))}

--- a/src/components/collection-list/list-item.scss
+++ b/src/components/collection-list/list-item.scss
@@ -6,12 +6,7 @@
   width: 200px;
 }
 
-.content {
-  text-transform: capitalize;
-}
-
-.numeric-label-capitalize-text {
+.hub-numeric-label-label {
   font-size: var(--pf-global--FontSize--xs);
   color: var(--pf-global--color--200);
-  text-transform: capitalize;
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -42,7 +42,10 @@ export { MarkdownEditor } from './markdown-editor/markdown-editor';
 export { NamespaceCard } from './cards/namespace-card';
 export { NamespaceForm } from './namespace-form/namespace-form';
 export { NamespaceModal } from './namespace-modal/namespace-modal';
-export { NumericLabel } from './numeric-label/numeric-label';
+export {
+  NumericLabel,
+  CollectionNumericLabel,
+} from './numeric-label/numeric-label';
 export { ObjectPermissionField } from './permissions/obect-permission-field';
 export { Pagination } from './patternfly-wrappers/pagination';
 export { PartnerHeader } from './headers/partner-header';

--- a/src/components/numeric-label/numeric-label.tsx
+++ b/src/components/numeric-label/numeric-label.tsx
@@ -1,44 +1,34 @@
 import * as React from 'react';
+import { plural } from '@lingui/macro';
 
 interface IProps {
-  className?: string;
-  number: number | string;
-  label?: string;
-  hideNumber?: boolean;
-  pluralLabels?: {
-    [key: string]: {
-      '0': string;
-      '1': string;
-      other: string;
-    }[];
-  };
+  number: number;
+  newline?: boolean;
+  label: string;
 }
 
 export class NumericLabel extends React.Component<IProps, {}> {
   render() {
-    const { className, number, label, hideNumber, pluralLabels } = this.props;
-    let convertedNum: number;
+    const { number, newline, label } = this.props;
 
-    if (typeof number === 'string') {
-      convertedNum = Number(number);
-    } else {
-      convertedNum = number;
+    let numberElem = (
+      <span key='number'>{NumericLabel.roundNumber(number)} </span>
+    );
+    let labelElem = (
+      <span key='label' className='hub-numeric-label-label'>
+        {label}
+      </span>
+    );
+
+    if (newline) {
+      numberElem = <div>{numberElem}</div>;
+      labelElem = <div>{labelElem}</div>;
     }
-
-    const plural = number === 1 ? '' : 's';
 
     return (
       <div>
-        <span>
-          {hideNumber ? null : NumericLabel.roundNumber(convertedNum)}{' '}
-        </span>
-        <span className={className}>
-          {pluralLabels ? (
-            <>{this.setPluralLabel(pluralLabels, number)}</>
-          ) : (
-            <> {label ? label + plural : null} </>
-          )}
-        </span>
+        {numberElem}
+        {labelElem}
       </div>
     );
   }
@@ -65,8 +55,38 @@ export class NumericLabel extends React.Component<IProps, {}> {
     // If larger than a billion, don't even bother.
     return '1B+';
   }
+}
 
-  private setPluralLabel(plurals, number) {
-    return number === 0 || number === 1 ? plurals[number] : plurals['other'];
+interface ICNLProps {
+  count: number;
+  newline?: boolean;
+  type: string;
+}
+
+export class CollectionNumericLabel extends React.Component<ICNLProps> {
+  render() {
+    const { count, newline, type } = this.props;
+
+    const label =
+      {
+        module: plural(count, {
+          one: 'Module',
+          other: 'Modules',
+        }),
+        role: plural(count, {
+          one: 'Role',
+          other: 'Roles',
+        }),
+        plugin: plural(count, {
+          one: 'Plugin',
+          other: 'Plugins',
+        }),
+        dependency: plural(count, {
+          one: 'Dependency',
+          other: 'Dependencies',
+        }),
+      }[type] || type;
+
+    return <NumericLabel number={count} newline={newline} label={label} />;
   }
 }

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -268,14 +268,6 @@ export class Constants {
     'windows',
   ];
 
-  static COLLECTION_PLURAL_LABELS = {
-    dependency: {
-      '0': 'dependencies',
-      '1': 'dependency',
-      other: 'dependencies',
-    },
-  };
-
   static TASK_NAMES = {
     'galaxy_ng.app.tasks.promotion._remove_content_from_repository':
       defineMessage({ message: `Remove content from repository` }),


### PR DESCRIPTION
Manual backport of https://github.com/ansible/ansible-hub-ui/pull/2137
(there were conflicts with signatures being added in 4.5 and more unprefixed css classes in 4.4)

---

* Localize collection modules/roles/... counter

Issue: AAH-1684

* Collection NumericLabel - simplify NumericLabel, provide localized CollectionNumericLabel

* changed collection card from NumericLabel(number) + newline + NumericLabel(hideNumber, label) to NumericLabel(number, newline, label)
* removed NumericLabel pluralization and css for capitalization
* merged label-sizing css into a common hub-numeric-label-label css class
* created CollectionNumericLabel(count, newline, type) which provides the translation bits and passes it to NumericLabel

(cherry picked from commit 6bca194c165a6a1a3633a17af436e41e2d7af99c)