### PR TITLE
test fix - imports_filter "before each" hook for "exact filter for name is working."

### DIFF
--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -120,8 +120,7 @@ describe('Imports filter test', () => {
   it('partial filter for name is working.', () => {
     cy.intercept(
       'GET',
-      Cypress.env('prefix') +
-        '_ui/v1/collection-versions/?namespace=*&keywords=my_collection',
+      Cypress.env('prefix') + '_ui/v1/collection-versions/?*',
     ).as('wait');
 
     cy.get('input[aria-label="keywords"').type('my_collection{enter}');
@@ -137,8 +136,7 @@ describe('Imports filter test', () => {
   it('exact filter for name is working.', () => {
     cy.intercept(
       'GET',
-      Cypress.env('prefix') +
-        '_ui/v1/collection-versions/?namespace=*&keywords=my_collection1',
+      Cypress.env('prefix') + '_ui/v1/collection-versions/?*',
     ).as('wait');
 
     cy.get('input[aria-label="keywords"').type('my_collection1{enter}');

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -88,22 +88,22 @@ describe('Imports filter test', () => {
       'GET',
       Cypress.env('prefix') +
         '_ui/v1/imports/collections/?namespace=filter_test_namespace&*',
-    ).as('collectionsInNamespace');
+    ).as('collectionsInNamespace2');
     cy.intercept(
       'GET',
       Cypress.env('prefix') + '_ui/v1/imports/collections/*',
-    ).as('collectionDetail');
+    ).as('collectionDetail2');
     cy.intercept(
       'GET',
       Cypress.env('prefix') +
         '_ui/v1/collection-versions/?namespace=filter_test_namespace&name=*',
-    ).as('collectionVersions');
+    ).as('collectionVersions2');
 
     cy.get('[aria-label="Select namespace"]').select('filter_test_namespace');
 
-    cy.wait('@collectionsInNamespace');
-    cy.wait('@collectionDetail');
-    cy.wait('@collectionVersions');
+    cy.wait('@collectionsInNamespace2');
+    cy.wait('@collectionDetail2');
+    cy.wait('@collectionVersions2');
 
     cy.get('[data-cy="ImportList-row-my_collection1"]').should('be.visible');
   });

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -9,11 +9,12 @@ describe('Imports filter test', () => {
 
     // insert test data
     cy.galaxykit('namespace create test_namespace');
-    cy.galaxykit('namespace create filter_test_namespace');
+    cy.galaxykit(`collection upload test_namespace ${testCollection}`);
 
-    cy.galaxykit('-i collection upload filter_test_namespace my_collection1');
-    cy.galaxykit('-i collection upload filter_test_namespace my_collection2');
-    cy.galaxykit('-i collection upload filter_test_namespace different_name');
+    cy.galaxykit('namespace create filter_test_namespace');
+    cy.galaxykit('collection upload filter_test_namespace my_collection1');
+    cy.galaxykit('collection upload filter_test_namespace my_collection2');
+    cy.galaxykit('collection upload filter_test_namespace different_name');
   });
 
   after(() => {
@@ -26,9 +27,8 @@ describe('Imports filter test', () => {
   });
 
   it('should display success info after importing collection', () => {
-    cy.galaxykit(`-i collection upload test_namespace ${testCollection}`);
-
     cy.visit('/ui/my-imports?namespace=test_namespace');
+
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).click();
     cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]').contains(
       `test_namespace.${testCollection}`,
@@ -42,9 +42,8 @@ describe('Imports filter test', () => {
   });
 
   it('should fail on importing existing collection', () => {
-    cy.galaxykit(`-i collection upload test_namespace ${testCollection}`);
-
     cy.visit('/ui/my-imports?namespace=test_namespace');
+
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).first().click();
     cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]').contains(
       `test_namespace.${testCollection}`,
@@ -62,6 +61,7 @@ describe('Imports filter test', () => {
 
   it('should redirect to new uploaded collection', () => {
     cy.visit('/ui/my-imports?namespace=test_namespace');
+
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).first().click();
     cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]')
       .contains(`test_namespace.${testCollection}`)

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -120,7 +120,8 @@ describe('Imports filter test', () => {
   it('partial filter for name is working.', () => {
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
+      Cypress.env('prefix') +
+        '_ui/v1/collection-versions/?namespace=*&keywords=my_collection',
     ).as('wait');
 
     cy.get('input[aria-label="keywords"').type('my_collection{enter}');
@@ -136,7 +137,8 @@ describe('Imports filter test', () => {
   it('exact filter for name is working.', () => {
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
+      Cypress.env('prefix') +
+        '_ui/v1/collection-versions/?namespace=*&keywords=my_collection1',
     ).as('wait');
 
     cy.get('input[aria-label="keywords"').type('my_collection1{enter}');
@@ -149,7 +151,6 @@ describe('Imports filter test', () => {
       .contains('different_name')
       .should('not.exist');
     cy.get('[data-cy="import-list-data"]').contains('my_collection1');
-    cy.wait(10000);
   });
 
   it('Exact search for completed is working.', () => {

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -42,6 +42,7 @@ describe('Imports filter test', () => {
   });
 
   it('should fail on importing existing collection', () => {
+    cy.galaxykit(`collection upload test_namespace ${testCollection}`);
     cy.visit('/ui/my-imports?namespace=test_namespace');
 
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).first().click();
@@ -57,16 +58,6 @@ describe('Imports filter test', () => {
     cy.get(
       '[data-cy="MyImports"] [data-cy="ImportConsole"] .message-list',
     ).contains('Failed');
-  });
-
-  it('should redirect to new uploaded collection', () => {
-    cy.visit('/ui/my-imports?namespace=test_namespace');
-
-    cy.get(`[data-cy="ImportList-row-${testCollection}"]`).first().click();
-    cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]')
-      .contains(`test_namespace.${testCollection}`)
-      .click();
-    cy.contains(testCollection);
   });
 
   it('should be able to switch between namespaces', () => {

--- a/test/cypress/integration/imports_filter.js
+++ b/test/cypress/integration/imports_filter.js
@@ -8,8 +8,8 @@ describe('Imports filter test', () => {
     cy.deleteNamespacesAndCollections();
 
     // insert test data
-    cy.galaxykit('namespace create test_namespace');
-    cy.galaxykit(`collection upload test_namespace ${testCollection}`);
+    cy.galaxykit('namespace create', 'test_namespace');
+    cy.galaxykit('collection upload', 'test_namespace', testCollection);
 
     cy.galaxykit('namespace create filter_test_namespace');
     cy.galaxykit('collection upload filter_test_namespace my_collection1');
@@ -42,7 +42,7 @@ describe('Imports filter test', () => {
   });
 
   it('should fail on importing existing collection', () => {
-    cy.galaxykit(`collection upload test_namespace ${testCollection}`);
+    cy.galaxykit('-i collection upload', 'test_namespace', testCollection);
     cy.visit('/ui/my-imports?namespace=test_namespace');
 
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).first().click();


### PR DESCRIPTION
    Imports filter test
     ✓ should display success info after importing collection (21515ms)
     ✓ should fail on importing existing collection (5266ms)
     ✓ should redirect to new uploaded collection
     ✓ should be able to switch between namespaces
     ✓ partial filter for name is working.
     1) "before each" hook for "exact filter for name is working."

    5 passing (44s)
    1 failing

    1) Imports filter test
       "before each" hook for "exact filter for name is working.":
       Error: The following error originated from your application code, not from Cypress. It was caused by an unhandled promise rejection.
       > Request failed with status code 403

looks like an earlier test is not waiting for all requests to finish first ... because it's using intercept with duplicate names and thus waiting for an earlier request :)

This is a sporadic failure, but happening often enough .. will try 5 consecutive runs:
https://github.com/ansible/ansible-hub-ui/runs/7055995886?check_suite_focus=true :heavy_check_mark: 
https://github.com/ansible/ansible-hub-ui/runs/7056145293?check_suite_focus=true :heavy_check_mark: 
https://github.com/ansible/ansible-hub-ui/runs/7056369214?check_suite_focus=true :heavy_check_mark: 
https://github.com/ansible/ansible-hub-ui/runs/7056584518?check_suite_focus=true :heavy_check_mark: 
https://github.com/ansible/ansible-hub-ui/runs/7056716828?check_suite_focus=true :heavy_check_mark: (this one failed in remote registry, but not in imports)
https://github.com/ansible/ansible-hub-ui/runs/7056907661?check_suite_focus=true :heavy_check_mark: (this one failed in view_only, but not in imports)
https://github.com/ansible/ansible-hub-ui/runs/7064717705?check_suite_focus=true :heavy_check_mark: 