### PR TITLE
[rbac] Filter roles for applicability to current namespace/EE

### DIFF
--- a/src/api/role.ts
+++ b/src/api/role.ts
@@ -7,7 +7,15 @@ export class API extends PulpAPI {
     return this.http.patch(this.apiPath + id, data);
   }
 
-  // list(params?)
+  list(params?, for_object_type?) {
+    const newParams = { ...params };
+    if (for_object_type) {
+      // ?for_object_type=/api/automation-hub/pulp/api/v3/.../
+      // list visible in http://localhost:8002/api/automation-hub/pulp/api/v3/
+      newParams.for_object_type = PULP_API_BASE_PATH + for_object_type + '/';
+    }
+    return super.list(newParams);
+  }
 
   getPermissions(id) {
     return this.http.get(

--- a/src/components/rbac/owners-tab.tsx
+++ b/src/components/rbac/owners-tab.tsx
@@ -30,6 +30,7 @@ interface IProps {
   groupId?: number;
   groups: GroupType[];
   name: string;
+  pulpObjectType: string;
   reload: () => void;
   selectRolesMessage: string;
   updateGroups: (groups: GroupType[]) => Promise<void>;
@@ -294,7 +295,7 @@ export class OwnersTab extends React.Component<IProps, IState> {
   }
 
   private renderGroupSelectWizard() {
-    const { groups, selectRolesMessage } = this.props;
+    const { groups, pulpObjectType, selectRolesMessage } = this.props;
     const {
       showGroupSelectWizard: { group, roles = [] },
     } = this.state;
@@ -332,6 +333,7 @@ export class OwnersTab extends React.Component<IProps, IState> {
               this.setState({ showGroupSelectWizard: { group, roles } })
             }
             message={selectRolesMessage}
+            pulpObjectType={pulpObjectType}
           />
         ),
         canJumpTo: hasGroup,
@@ -362,6 +364,7 @@ export class OwnersTab extends React.Component<IProps, IState> {
   }
 
   private renderRoleSelectWizard(group) {
+    const { pulpObjectType } = this.props;
     const {
       showRoleSelectWizard: { roles = [] },
     } = this.state;
@@ -382,6 +385,7 @@ export class OwnersTab extends React.Component<IProps, IState> {
             onRolesUpdate={(roles) =>
               this.setState({ showRoleSelectWizard: { roles } })
             }
+            pulpObjectType={pulpObjectType}
           />
         ),
         backButtonText: t`Cancel`,

--- a/src/components/rbac/select-roles.tsx
+++ b/src/components/rbac/select-roles.tsx
@@ -19,6 +19,7 @@ interface SelectRolesProps {
   selectedRoles: RoleType[];
   onRolesUpdate?: (roles) => void;
   message?: string;
+  pulpObjectType?: string;
 }
 
 export const SelectRoles: React.FC<SelectRolesProps> = ({
@@ -26,6 +27,7 @@ export const SelectRoles: React.FC<SelectRolesProps> = ({
   selectedRoles,
   onRolesUpdate,
   message,
+  pulpObjectType,
 }) => {
   const [inputText, setInputText] = useState<string>('');
   const [roles, setRoles] = useState<RoleType[]>([]);
@@ -43,13 +45,14 @@ export const SelectRoles: React.FC<SelectRolesProps> = ({
 
   const queryRoles = () => {
     setLoading(true);
-    RoleAPI.list({ name__startswith: 'galaxy.', ...localParams }).then(
-      ({ data }) => {
-        setRoles(data.results);
-        setRolesItemCount(data.count);
-        setLoading(false);
-      },
-    );
+    RoleAPI.list(
+      { name__startswith: 'galaxy.', ...localParams },
+      pulpObjectType,
+    ).then(({ data }) => {
+      setRoles(data.results);
+      setRolesItemCount(data.count);
+      setLoading(false);
+    });
   };
 
   if (loading) {

--- a/src/containers/execution-environment-detail/execution_environment_detail_owners.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_owners.tsx
@@ -55,6 +55,7 @@ class ExecutionEnvironmentDetailOwners extends React.Component<
         groupId={params.group}
         groups={groups}
         name={name}
+        pulpObjectType='pulp_container/namespaces'
         reload={loadAll}
         selectRolesMessage={t`The selected roles will be added to this specific Execution Environment.`}
         updateGroups={(groups) =>

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -403,6 +403,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
               groupId={params.group}
               groups={namespace.groups}
               name={namespace.name}
+              pulpObjectType='pulp_ansible/namespaces'
               reload={() => this.loadAll()}
               selectRolesMessage={t`The selected roles will be added to this specific namespace.`}
               updateGroups={(groups) =>


### PR DESCRIPTION
API https://github.com/pulp/pulpcore/pull/2748 https://github.com/ansible/galaxy_ng/pull/1279 (just needs the `feature/rbac-roles` API branch now)
Follow up to #1863

This enables filtering roles by `?for_object_type=(prefix)/pulp/api/v3/.../` in the Owners tab, using `pulp_ansible/namespaces` vs `pulp_container/namespaces` for namespaces/EEs.

The user now only gets to choose (galaxy) roles that contain permissions appliable to the current thing, instead of any (galaxy) roles.