### PR TITLE
[stable-4.5] Un-disable Deprecate for cloud  (#2159)

### DIFF
--- a/CHANGES/1428.misc
+++ b/CHANGES/1428.misc
@@ -1,0 +1,1 @@
+Un-disable Deprecate for cloud

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -5,7 +5,6 @@ import './list.scss';
 import { Button, DropdownItem, DataList } from '@patternfly/react-core';
 
 import { CollectionListType } from 'src/api';
-import { Constants } from 'src/constants';
 import {
   CollectionListItem,
   Pagination,
@@ -95,14 +94,6 @@ export class CollectionList extends React.Component<IProps> {
                 this.props.handleControlClick(collection.id, 'deprecate')
               }
               key='deprecate'
-              isDisabled={
-                DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-              }
-              description={
-                DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-                  ? t`Temporarily disabled due to sync issues. (AAH-1237)`
-                  : null
-              }
             >
               {collection.deprecated ? t`Undeprecate` : t`Deprecate`}
             </DropdownItem>,


### PR DESCRIPTION
Manual backport of #2159 to stable-4.5, only 1 Deprecate button in 4.5.
The exception is insights only, so no reason to keep it in 4.5.

---

* Revert "CollectionList: disable Deprecate for cloud (#1487)"

This reverts commit 335bc89812b78bb14b6cc57e4cd6360efba60de5.

Issue: AAH-1428

* ~~collection-header, search: also undisable deprecation for cloud~~

(cherry picked from commit bda07ad77464767d86b4c48d4085d358d3b54fec)