### PR TITLE
show sync button only with user permissions for changing registry

### DIFF
--- a/CHANGES/1695.misc
+++ b/CHANGES/1695.misc
@@ -1,0 +1,1 @@
+Show sync button only with user permissions for changing a registry.

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -367,13 +367,15 @@ class ExecutionEnvironmentRegistryList extends React.Component<
 
   private renderTableRow(item, index: number) {
     const buttons = [
-      <Button
-        key='sync'
-        variant='secondary'
-        onClick={() => this.syncRegistry(item)}
-      >
-        <Trans>Sync from registry</Trans>
-      </Button>,
+      this.context.user.model_permissions.change_containerregistry && (
+        <Button
+          key='sync'
+          variant='secondary'
+          onClick={() => this.syncRegistry(item)}
+        >
+          <Trans>Sync from registry</Trans>
+        </Button>
+      ),
     ];
 
     const dropdownItems = [
@@ -439,14 +441,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
           {lastSyncStatus(item) || '---'}
           {lastSynced(item)}
         </td>
-        <ListItemActions
-          kebabItems={dropdownItems}
-          buttons={
-            this.context.user.model_permissions.change_containerregistry
-              ? buttons
-              : []
-          }
-        />
+        <ListItemActions kebabItems={dropdownItems} buttons={buttons} />
       </tr>
     );
   }

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -439,7 +439,14 @@ class ExecutionEnvironmentRegistryList extends React.Component<
           {lastSyncStatus(item) || '---'}
           {lastSynced(item)}
         </td>
-        <ListItemActions kebabItems={dropdownItems} buttons={buttons} />
+        <ListItemActions
+          kebabItems={dropdownItems}
+          buttons={
+            this.context.user.model_permissions.change_containerregistry
+              ? buttons
+              : []
+          }
+        />
       </tr>
     );
   }


### PR DESCRIPTION
AAH-1695

Relevant screen: Remote Registries list view

This pr makes sure the 'Sync' button only appears when user permissions to change registry `user.model_permissions.change_containerregistry` are there.