### PR TITLE
[rbac] Add permission checks to group

### DIFF
--- a/src/components/group-management/delete-group-modal.tsx
+++ b/src/components/group-management/delete-group-modal.tsx
@@ -1,6 +1,6 @@
 import { t, Trans } from '@lingui/macro';
 import * as React from 'react';
-import { List, ListItem, Spinner } from '@patternfly/react-core';
+import { List, ListItem, Spinner, Alert } from '@patternfly/react-core';
 import { DeleteModal } from 'src/components/delete-modal/delete-modal';
 import { UserType } from 'src/api';
 
@@ -10,11 +10,13 @@ interface IProps {
   deleteAction: () => void;
   name: string;
   users?: UserType[];
+  canViewUsers?: boolean;
 }
 
 export class DeleteGroupModal extends React.Component<IProps> {
   render() {
-    const { cancelAction, count, deleteAction, name, users } = this.props;
+    const { cancelAction, count, deleteAction, name, users, canViewUsers } =
+      this.props;
 
     return (
       <DeleteModal
@@ -48,13 +50,26 @@ export class DeleteGroupModal extends React.Component<IProps> {
               </List>
             </>
           )}
-          {users && !count && <p>{t`No users will be affected.`}</p>}
-          {!users && (
-            <p>
-              <Trans>
-                Checking for affected users... <Spinner size='sm' />
-              </Trans>
-            </p>
+
+          {canViewUsers ? (
+            <>
+              {users && !count && <p>{t`No users will be affected.`}</p>}
+              {!users && (
+                <p>
+                  <Trans>
+                    Checking for affected users... <Spinner size='sm' />
+                  </Trans>
+                </p>
+              )}
+            </>
+          ) : (
+            <Alert
+              title={t`This group can include users`}
+              variant='warning'
+              isInline
+            >
+              <Trans>You don&apos;t have permission to display users.</Trans>
+            </Alert>
           )}
         </div>
       </DeleteModal>

--- a/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
+++ b/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
@@ -104,16 +104,6 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
       });
   };
 
-  const addRoles = (
-    <Button
-      onClick={() => setShowAddRolesModal(true)}
-      variant='primary'
-      data-cy='add-roles'
-    >
-      <Trans>Add roles</Trans>
-    </Button>
-  );
-
   const deleteRole = () => {
     const pulpId = parsePulpIDFromURL(selectedDeleteRole.pulp_href);
 
@@ -176,6 +166,16 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
       }
     });
   }
+
+  const addRoles = user.is_superuser && (
+    <Button
+      onClick={() => setShowAddRolesModal(true)}
+      variant='primary'
+      data-cy='add-roles'
+    >
+      <Trans>Add roles</Trans>
+    </Button>
+  );
 
   if (loading) {
     return (
@@ -312,9 +312,7 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
                       ]}
                     />
                   </ToolbarItem>
-                  {user.model_permissions.change_group && (
-                    <ToolbarItem>{addRoles}</ToolbarItem>
-                  )}
+                  <ToolbarItem>{addRoles}</ToolbarItem>
                 </ToolbarGroup>
               </ToolbarContent>
             </Toolbar>
@@ -366,12 +364,14 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
                     <td>{role.role}</td>
                     <ListItemActions
                       kebabItems={[
-                        <DropdownItem
-                          key='remove-role'
-                          onClick={() => setSelectedDeleteRole(role)}
-                        >
-                          {t`Remove Role`}
-                        </DropdownItem>,
+                        user.is_superuser && (
+                          <DropdownItem
+                            key='remove-role'
+                            onClick={() => setSelectedDeleteRole(role)}
+                          >
+                            {t`Remove Role`}
+                          </DropdownItem>
+                        ),
                       ]}
                     />
                   </ExpandableRow>

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -383,7 +383,9 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         });
     };
 
-    if (!users) {
+    const { view_user } = this.context.user.model_permissions;
+
+    if (!users && view_user) {
       this.queryUsers();
     }
 
@@ -394,6 +396,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         deleteAction={deleteAction}
         name={group.name}
         users={users}
+        canViewUsers={view_user}
       />
     );
   }

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -268,8 +268,9 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
   private renderDeleteModal() {
     const name = this.state.selectedGroup && this.state.selectedGroup.name;
     const { deleteModalUsers: users, deleteModalCount: count } = this.state;
+    const { view_user } = this.context.user.model_permissions;
 
-    if (!users) {
+    if (!users && view_user) {
       this.queryUsers();
     }
 
@@ -280,6 +281,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
         deleteAction={() => this.selectedGroup(this.state.selectedGroup)}
         name={name}
         users={users}
+        canViewUsers={view_user}
       />
     );
   }
@@ -402,20 +404,6 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
     const { user } = this.context;
     const dropdownItems = [
       <React.Fragment key='dropdown'>
-        <DropdownItem
-          key='edit'
-          onClick={() => {
-            this.setState({
-              selectedGroup: { ...group },
-              redirect: formatPath(Paths.groupDetail, {
-                group: group.id,
-              }),
-            });
-          }}
-        >
-          <Trans>Edit</Trans>
-        </DropdownItem>
-
         {!!user && user.model_permissions.delete_group && (
           <DropdownItem
             aria-label='Delete'


### PR DESCRIPTION
Issue: [AAH-1699](https://issues.redhat.com/browse/AAH-1699)

Depends on [#1316](https://github.com/ansible/galaxy_ng/pull/1316)

This PR is fixing: 
- removed the Edit button from the group list table (nothing to edit)
- only `is_superuser` can add roles
-  don't fetch users without `view_user` permission
- When deleting a group without `view_user` permission, add a warning with group potentionaly can include users.
![Screenshot from 2022-06-13 16-00-25](https://user-images.githubusercontent.com/19647757/173409922-8a556999-23e3-4cb9-ab56-a70bcaec8756.png)
