### PR TITLE
Add loading page to all pages

### DIFF
--- a/CHANGES/518.misc
+++ b/CHANGES/518.misc
@@ -1,0 +1,1 @@
+Add proper page load spinners to all UI pages.

--- a/src/components/my-imports/import-list.tsx
+++ b/src/components/my-imports/import-list.tsx
@@ -6,10 +6,13 @@ import {
   Pagination,
   FormSelect,
   FormSelectOption,
-  Spinner,
   Toolbar,
 } from '@patternfly/react-core';
-import { AppliedFilters, CompoundFilter } from 'src/components';
+import {
+  AppliedFilters,
+  CompoundFilter,
+  LoadingPageSpinner,
+} from 'src/components';
 import { PulpStatus, NamespaceType, ImportListType } from 'src/api';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { filterIsSet } from 'src/utilities';
@@ -141,7 +144,7 @@ export class ImportList extends React.Component<IProps, IState> {
     if (loading) {
       return (
         <div className='loading'>
-          <Spinner />
+          <LoadingPageSpinner />
         </div>
       );
     }

--- a/src/containers/token/token-standalone.tsx
+++ b/src/containers/token/token-standalone.tsx
@@ -14,6 +14,7 @@ import {
   AlertList,
   AlertType,
   closeAlertMixin,
+  LoadingPageWithHeader,
 } from 'src/components';
 import { ActiveUserAPI } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
@@ -22,6 +23,7 @@ import { errorMessage } from 'src/utilities';
 interface IState {
   token: string;
   alerts: AlertType[];
+  loading: boolean;
 }
 
 class TokenPage extends React.Component<RouteComponentProps, IState> {
@@ -31,13 +33,23 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
     this.state = {
       token: undefined,
       alerts: [],
+      loading: true,
     };
   }
+
+  componentDidMount() {
+    this.setState({ loading: false });
+  }
+
   render() {
-    const { token, alerts } = this.state;
+    const { token, alerts, loading } = this.state;
     const unauthorised = !this.context.user || this.context.user.is_anonymous;
     const expiration = this.context.settings.GALAXY_TOKEN_EXPIRATION;
     const expirationDate = new Date(Date.now() + 1000 * 60 * expiration);
+
+    if (loading) {
+      return <LoadingPageWithHeader></LoadingPageWithHeader>;
+    }
 
     return (
       <React.Fragment>

--- a/src/containers/token/token-standalone.tsx
+++ b/src/containers/token/token-standalone.tsx
@@ -24,6 +24,7 @@ interface IState {
   token: string;
   alerts: AlertType[];
   loading: boolean;
+  loadingToken: boolean;
 }
 
 class TokenPage extends React.Component<RouteComponentProps, IState> {
@@ -34,6 +35,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
       token: undefined,
       alerts: [],
       loading: true,
+      loadingToken: true,
     };
   }
 
@@ -121,7 +123,9 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
 
   private loadToken() {
     ActiveUserAPI.getToken()
-      .then((result) => this.setState({ token: result.data.token }))
+      .then((result) =>
+        this.setState({ token: result.data.token, loadingToken: false }),
+      )
       .catch((e) => {
         const { status, statusText } = e.response;
         this.setState({
@@ -133,6 +137,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
               description: errorMessage(status, statusText),
             },
           ],
+          loadingToken: false,
         });
       });
   }

--- a/src/containers/token/token-standalone.tsx
+++ b/src/containers/token/token-standalone.tsx
@@ -14,7 +14,6 @@ import {
   AlertList,
   AlertType,
   closeAlertMixin,
-  LoadingPageWithHeader,
   LoadingPageSpinner,
 } from 'src/components';
 import { ActiveUserAPI } from 'src/api';
@@ -24,7 +23,6 @@ import { errorMessage } from 'src/utilities';
 interface IState {
   token: string;
   alerts: AlertType[];
-  loading: boolean;
   loadingToken: boolean;
 }
 
@@ -35,24 +33,15 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
     this.state = {
       token: undefined,
       alerts: [],
-      loading: true,
       loadingToken: false,
     };
   }
 
-  componentDidMount() {
-    this.setState({ loading: false });
-  }
-
   render() {
-    const { token, alerts, loading, loadingToken } = this.state;
+    const { token, alerts, loadingToken } = this.state;
     const unauthorised = !this.context.user || this.context.user.is_anonymous;
     const expiration = this.context.settings.GALAXY_TOKEN_EXPIRATION;
     const expirationDate = new Date(Date.now() + 1000 * 60 * expiration);
-
-    if (loading) {
-      return <LoadingPageWithHeader></LoadingPageWithHeader>;
-    }
 
     return (
       <React.Fragment>


### PR DESCRIPTION
Issue: AAH-518

This pr makes sure each UI page has proper page loaders - either `LoadingPageSpinner`  - most often used for components like tables, or `LoadingPageWithHeader` , with is good for loading whole pages. Most pages use either one or the other.

I have compiled a list of current and new additions in [here](https://docs.google.com/document/d/1cD2njsQJJ6JyZDzQLARcaPzGSHRUoJUMtrx-yvoH0a8/edit).
