### PR TITLE
Edit group permissions - correctly hide user/group-related permissions in keycloak mode

### DIFF
--- a/CHANGES/1688.bug
+++ b/CHANGES/1688.bug
@@ -1,0 +1,1 @@
+Edit group permissions - correctly hide user/group-related permissions in keycloak mode


### PR DESCRIPTION
Fixes AAH-1688

When in keycloak mode, editing group permissions should still work, but blows up...

```
core.development.js:435 Uncaught TypeError: Cannot read properties of undefined (reading 'values')
    at I18n._ (core.development.js:435:1)
    at permission-chip-selector.tsx:86:44
    at Array.map (<anonymous>)
    at PermissionChipSelector.render (permission-chip-selector.tsx:84:45)
    at finishClassComponent (react-dom.development.js:17160:1)
    at updateClassComponent (react-dom.development.js:17110:1)
    at beginWork (react-dom.development.js:18620:1)
    at HTMLUnknownElement.callCallback (react-dom.development.js:188:1)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:237:1)
    at invokeGuardedCallback (react-dom.development.js:292:1)
_ @ core.development.js:435

The above error occurred in the <PermissionChipSelector> component:
    in PermissionChipSelector (created by GroupDetail)
    in div (created by FlexItem)
    in FlexItem (created by GroupDetail)
    in div (created by Flex)
    in Flex (created by GroupDetail)
    in div (created by GroupDetail)
    in section (created by GroupDetail)
    in section (created by Main)
    in Main (created by GroupDetail)
    in GroupDetail (created by Context.Consumer)
    in withRouter(GroupDetail) (created by AuthHandler)
    in AuthHandler (created by Context.Consumer)
    in Route (created by Routes)
    in Switch (created by Routes)
    in Routes (created by App)
    in main (created by Page)
    in div (created by Page)
    in Page (created by App)
    in App (created by Context.Consumer)
    in withRouter(App)
    in I18nProvider
    in Router (created by BrowserRouter)
    in BrowserRouter
```

that's because we're correctly creating `filteredPermissions` but then using them only for mapping the values, instead of taking the original list from there.

The end result is the UI is trying to display these:

![20220620191306](https://user-images.githubusercontent.com/289743/174665848-0c09d933-5a8e-4594-b107-2847b1a8c1da.png)
![20220620191314](https://user-images.githubusercontent.com/289743/174665850-19c71a72-d69c-462b-83ac-a804546c3f8f.png)

but failing to look up human strings for `'galaxy.delete_user', 'galaxy.add_user', 'galaxy.change_user', 'galaxy.delete_group', 'galaxy.add_group'` causing them to become `undefined`, and blowing up trying to translate that.


Rewrote the `availablePermissions` and `selectedPermissions` logic, now:

![20220620191041](https://user-images.githubusercontent.com/289743/174666064-671fdf86-f118-47b8-beb6-957f98351484.png)
![20220620191050](https://user-images.githubusercontent.com/289743/174666067-87ab981c-768d-4429-b4cc-57fdb07c022e.png)

