### PR TITLE
[rbac] Test Namespace/EE owners

### DIFF
--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -287,11 +287,17 @@ export function withContainerRepo(WrappedComponent) {
 
     private getTab() {
       const tabs = ['detail', 'images', 'activity', 'owners'];
-      const location = this.props.location.pathname.split('/').pop();
+      const location = this.props.location.pathname.split('/');
+      const index = location.findIndex((s) => s === '_content');
 
-      for (const tab of tabs) {
-        if (location.includes(tab)) {
-          return tab;
+      // match /containers/owners/_content/owners but not /containers/owners
+      // also handles /containers/:name/_content/images/:digest
+      if (index !== -1) {
+        const loc = location[index + 1];
+        for (const tab of tabs) {
+          if (loc === tab) {
+            return tab;
+          }
         }
       }
 

--- a/test/cypress/integration/group_roles.js
+++ b/test/cypress/integration/group_roles.js
@@ -50,5 +50,18 @@ describe('add roles to a group', () => {
     // check group detail page for added roles/permissions.
     cy.get('button[aria-label="Details"]').click();
     cy.contains('Add namespace');
+
+    // delete role (cleanup)
+    cy.menuGo('User Access > Roles');
+    cy.get('[data-cy=compound_filter] input[aria-label=name__icontains]').type(
+      `alpha${num}{enter}`,
+    );
+    cy.get(`[data-cy=RoleListTable] tr`)
+      .contains(`galaxy.alpha${num}`)
+      .parent('tr')
+      .find('[data-cy=kebab-toggle]')
+      .click();
+    cy.get('.pf-c-dropdown__menu-item').contains('Delete').click();
+    cy.get(`[data-cy=delete-button]`).click();
   });
 });

--- a/test/cypress/integration/rbac_owners.js
+++ b/test/cypress/integration/rbac_owners.js
@@ -115,9 +115,13 @@ function testOwnersTab({
   cy.get('.hub-permission').contains(permission);
 
   cy.get('footer button').contains('Add').click();
-  cy.get('.pf-c-alert__title').contains(
-    `Group "owners_group" has been successfully added to "rbac_owners_${num}".`,
-  );
+  cy.get('.pf-c-alert__title')
+    .contains(
+      `Group "owners_group" has been successfully added to "rbac_owners_${num}".`,
+    )
+    .parent('.pf-c-alert')
+    .find('button')
+    .click();
   cy.get('tr[data-cy="OwnersTab-row-owners_group"]');
 
   // group list view, try modal, open group
@@ -135,9 +139,13 @@ function testOwnersTab({
     .click();
   cy.get('footer button').contains('Next').click();
   cy.get('footer button').contains('Add').click();
-  cy.get('.pf-c-alert__title').contains(
-    `Group "owners_group" roles successfully updated in "rbac_owners_${num}".`,
-  );
+  cy.get('.pf-c-alert__title')
+    .contains(
+      `Group "owners_group" roles successfully updated in "rbac_owners_${num}".`,
+    )
+    .parent('.pf-c-alert')
+    .find('button')
+    .click();
 
   // role list view, expand
   cy.get('tbody[role=rowgroup]').should('have.length', 2);
@@ -155,9 +163,13 @@ function testOwnersTab({
   cy.get('.pf-c-modal-box__body b').contains(role);
   cy.get('.pf-c-modal-box__body b').contains(`rbac_owners_${num}`);
   cy.get('[data-cy=delete-button]').click();
-  cy.get('.pf-c-alert__title').contains(
-    `Group "owners_group" roles successfully updated in "rbac_owners_${num}".`,
-  );
+  cy.get('.pf-c-alert__title')
+    .contains(
+      `Group "owners_group" roles successfully updated in "rbac_owners_${num}".`,
+    )
+    .parent('.pf-c-alert')
+    .find('button')
+    .click();
 
   // breadcrumb back to group list
   cy.get('.pf-c-breadcrumb__item a').last().click();
@@ -170,8 +182,12 @@ function testOwnersTab({
   cy.get('.pf-c-modal-box__body b').contains('owners_group');
   cy.get('.pf-c-modal-box__body b').contains(role);
   cy.get('[data-cy=delete-button]').click();
-  cy.get('.pf-c-alert__title').contains(
-    `Group "owners_group" has been successfully removed from "rbac_owners_${num}".`,
-  );
+  cy.get('.pf-c-alert__title')
+    .contains(
+      `Group "owners_group" has been successfully removed from "rbac_owners_${num}".`,
+    )
+    .parent('.pf-c-alert')
+    .find('button')
+    .click();
   cy.get('.pf-c-empty-state');
 }

--- a/test/cypress/integration/rbac_owners.js
+++ b/test/cypress/integration/rbac_owners.js
@@ -1,0 +1,169 @@
+describe('Namespace owners tab', () => {
+  const num = (~~(Math.random() * 1000000)).toString();
+
+  before(() => {
+    cy.deleteNamespacesAndCollections();
+    cy.galaxykit(`-i namespace create rbac_owners_${num}`);
+  });
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit(`/ui/repo/published/rbac_owners_${num}`);
+    cy.get('.pf-c-tabs__item-text').contains('Namespace owners').click();
+  });
+
+  it('add and remove group and roles', () => {
+    testOwnersTab({
+      num,
+      permission: 'change_namespace',
+      permissionGroup: 'Galaxy',
+      permissionLabel: 'Change namespace',
+      role: 'galaxy.collection_publisher',
+      roleFilter: 'publish',
+    });
+  });
+});
+
+describe('Execution Environment Owners tab', () => {
+  const num = (~~(Math.random() * 1000000)).toString();
+
+  before(() => {
+    cy.login();
+    cy.deleteRegistries();
+    cy.deleteContainers();
+
+    cy.galaxykit(
+      'registry create',
+      `rbac_owners_${num}_registry`,
+      'https://registry.hub.docker.com/',
+    );
+    cy.galaxykit(
+      'container create',
+      `rbac_owners_${num}`,
+      'library/alpine',
+      `rbac_owners_${num}_registry`,
+    );
+  });
+
+  beforeEach(() => {
+    cy.login();
+    cy.visit(`/ui/containers/rbac_owners_${num}`);
+    cy.get('.pf-c-tabs__item-text').contains('Owners').click();
+  });
+
+  it('add and remove group and roles', () => {
+    testOwnersTab({
+      num,
+      permission: 'change_containernamespace',
+      permissionGroup: 'Container',
+      permissionLabel: 'Change container namespace permissions',
+      role: 'galaxy.execution_environment_publisher',
+      roleFilter: 'publish',
+    });
+  });
+});
+
+function testOwnersTab({
+  num,
+  permission,
+  permissionGroup,
+  permissionLabel,
+  role,
+  roleFilter,
+}) {
+  // new thing, expect no owners
+  cy.get('.pf-c-empty-state');
+  cy.get('button').contains('Select a group').click();
+
+  // group role modal
+  // find partner-engineers, select, check indicator, next
+  cy.get('[data-cy=compound_filter] input[aria-label=name__contains]').type(
+    'system{enter}',
+  );
+  cy.get(
+    '[data-cy="GroupListTable-CheckboxRow-row-system:partner-engineers"] input[type=radio]',
+  ).click();
+
+  cy.get('strong').contains('Selected group');
+  cy.get('.hub-permission').contains('system:partner-engineers');
+
+  cy.get('footer button').contains('Next').click();
+
+  // find collection_publisher, select, check indicator, next
+  cy.get('[data-cy=compound_filter] input[aria-label=name__icontains]').type(
+    `${roleFilter}{enter}`,
+  );
+  cy.get(
+    `[data-cy="RoleListTable-CheckboxRow-row-${role}"] input[type=checkbox]`,
+  ).click();
+
+  cy.get('strong').contains('Selected roles');
+  cy.get('.hub-permission').contains(role);
+
+  cy.get('footer button').contains('Next').click();
+
+  // see preview, add
+  cy.get('strong').contains('system:partner-engineers');
+  cy.get('strong').contains(role);
+
+  cy.get('.hub-permission strong').contains(permissionGroup);
+  cy.get('.hub-permission').contains(permission);
+
+  cy.get('footer button').contains('Add').click();
+  cy.get('.pf-c-alert__title').contains(
+    `Group "system:partner-engineers" has been successfully added to "rbac_owners_${num}".`,
+  );
+  cy.get('tr[data-cy="OwnersTab-row-system:partner-engineers"]');
+
+  // group list view, try modal, open group
+  cy.get('button').contains('Select a group').click();
+  cy.get('.pf-c-wizard__footer-cancel').click();
+
+  cy.get('tr[data-cy="OwnersTab-row-system:partner-engineers"] a').click();
+
+  // role list view, use modal
+  cy.get(`[data-cy="RoleListTable-ExpandableRow-row-${role}"]`);
+  cy.get('button').contains('Add roles').click();
+  cy.get('.pf-c-table__check input[type=checkbox]').not('[disabled]').click();
+  cy.get('footer button').contains('Next').click();
+  cy.get('footer button').contains('Add').click();
+  cy.get('.pf-c-alert__title').contains(
+    `Group "system:partner-engineers" roles successfully updated in "rbac_owners_${num}".`,
+  );
+
+  // role list view, expand
+  cy.get('tbody[role=rowgroup]').should('have.length', 2);
+  cy.get(
+    `[data-cy="RoleListTable-ExpandableRow-row-${role}"] .pf-c-table__toggle button`,
+  ).click();
+  cy.get('.pf-c-label').contains(permissionLabel);
+
+  // role list view, remove
+  cy.get(
+    `[data-cy="RoleListTable-ExpandableRow-row-${role}"] [data-cy=kebab-toggle] button`,
+  ).click();
+  cy.get('.pf-c-dropdown__menu-item').contains('Remove role').click();
+  cy.get('.pf-c-modal-box__body strong').contains('system:partner-engineers');
+  cy.get('.pf-c-modal-box__body strong').contains(role);
+  cy.get('.pf-c-modal-box__body strong').contains(`rbac_owners_${num}`);
+  cy.get('[data-cy=delete_button]').click();
+  cy.get('.pf-c-alert__title').contains(
+    `Group "system:partner-engineers" roles successfully updated in "rbac_owners_${num}".`,
+  );
+
+  // breadcrumb back to group list
+  cy.get('.pf-c-breadcrumb__item a').last().click();
+
+  // list view, delete, see empty
+  cy.get(
+    'tr[data-cy="OwnersTab-row-system:partner-engineers"] [data-cy=kebab-toggle] button',
+  ).click();
+  cy.get('.pf-c-dropdown__menu-item').contains('Remove group').click();
+  cy.get('.pf-c-modal-box__body strong').contains('system:partner-engineers');
+  cy.get('.pf-c-modal-box__body strong').contains(role);
+  cy.get('[data-cy=delete_button]').click();
+  cy.get('.pf-c-alert__title').contains(
+    `Group "system:partner-engineers" has been successfully removed from "rbac_owners_${num}".`,
+  );
+  cy.get('.pf-c-empty-state');
+}

--- a/test/cypress/integration/rbac_owners.js
+++ b/test/cypress/integration/rbac_owners.js
@@ -3,7 +3,10 @@ describe('Namespace owners tab', () => {
 
   before(() => {
     cy.deleteNamespacesAndCollections();
+    cy.deleteTestGroups();
+
     cy.galaxykit(`-i namespace create rbac_owners_${num}`);
+    cy.galaxykit('-i group create', `owners_group`);
   });
 
   beforeEach(() => {
@@ -31,6 +34,7 @@ describe('Execution Environment Owners tab', () => {
     cy.login();
     cy.deleteRegistries();
     cy.deleteContainers();
+    cy.deleteTestGroups();
 
     cy.galaxykit(
       'registry create',
@@ -43,6 +47,7 @@ describe('Execution Environment Owners tab', () => {
       'library/alpine',
       `rbac_owners_${num}_registry`,
     );
+    cy.galaxykit('-i group create', `owners_group`);
   });
 
   beforeEach(() => {
@@ -78,14 +83,14 @@ function testOwnersTab({
   // group role modal
   // find partner-engineers, select, check indicator, next
   cy.get('[data-cy=compound_filter] input[aria-label=name__contains]').type(
-    'system{enter}',
+    'owners{enter}',
   );
   cy.get(
-    '[data-cy="GroupListTable-CheckboxRow-row-system:partner-engineers"] input[type=radio]',
+    '[data-cy="GroupListTable-CheckboxRow-row-owners_group"] input[type=radio]',
   ).click();
 
   cy.get('strong').contains('Selected group');
-  cy.get('.hub-permission').contains('system:partner-engineers');
+  cy.get('.hub-permission').contains('owners_group');
 
   cy.get('footer button').contains('Next').click();
 
@@ -103,7 +108,7 @@ function testOwnersTab({
   cy.get('footer button').contains('Next').click();
 
   // see preview, add
-  cy.get('strong').contains('system:partner-engineers');
+  cy.get('strong').contains('owners_group');
   cy.get('strong').contains(role);
 
   cy.get('.hub-permission strong').contains(permissionGroup);
@@ -111,15 +116,15 @@ function testOwnersTab({
 
   cy.get('footer button').contains('Add').click();
   cy.get('.pf-c-alert__title').contains(
-    `Group "system:partner-engineers" has been successfully added to "rbac_owners_${num}".`,
+    `Group "owners_group" has been successfully added to "rbac_owners_${num}".`,
   );
-  cy.get('tr[data-cy="OwnersTab-row-system:partner-engineers"]');
+  cy.get('tr[data-cy="OwnersTab-row-owners_group"]');
 
   // group list view, try modal, open group
   cy.get('button').contains('Select a group').click();
   cy.get('.pf-c-wizard__footer-cancel').click();
 
-  cy.get('tr[data-cy="OwnersTab-row-system:partner-engineers"] a').click();
+  cy.get('tr[data-cy="OwnersTab-row-owners_group"] a').click();
 
   // role list view, use modal
   cy.get(`[data-cy="RoleListTable-ExpandableRow-row-${role}"]`);
@@ -128,7 +133,7 @@ function testOwnersTab({
   cy.get('footer button').contains('Next').click();
   cy.get('footer button').contains('Add').click();
   cy.get('.pf-c-alert__title').contains(
-    `Group "system:partner-engineers" roles successfully updated in "rbac_owners_${num}".`,
+    `Group "owners_group" roles successfully updated in "rbac_owners_${num}".`,
   );
 
   // role list view, expand
@@ -143,12 +148,12 @@ function testOwnersTab({
     `[data-cy="RoleListTable-ExpandableRow-row-${role}"] [data-cy=kebab-toggle] button`,
   ).click();
   cy.get('.pf-c-dropdown__menu-item').contains('Remove role').click();
-  cy.get('.pf-c-modal-box__body strong').contains('system:partner-engineers');
+  cy.get('.pf-c-modal-box__body strong').contains('owners_group');
   cy.get('.pf-c-modal-box__body strong').contains(role);
   cy.get('.pf-c-modal-box__body strong').contains(`rbac_owners_${num}`);
   cy.get('[data-cy=delete_button]').click();
   cy.get('.pf-c-alert__title').contains(
-    `Group "system:partner-engineers" roles successfully updated in "rbac_owners_${num}".`,
+    `Group "owners_group" roles successfully updated in "rbac_owners_${num}".`,
   );
 
   // breadcrumb back to group list
@@ -156,14 +161,14 @@ function testOwnersTab({
 
   // list view, delete, see empty
   cy.get(
-    'tr[data-cy="OwnersTab-row-system:partner-engineers"] [data-cy=kebab-toggle] button',
+    'tr[data-cy="OwnersTab-row-owners_group"] [data-cy=kebab-toggle] button',
   ).click();
   cy.get('.pf-c-dropdown__menu-item').contains('Remove group').click();
-  cy.get('.pf-c-modal-box__body strong').contains('system:partner-engineers');
+  cy.get('.pf-c-modal-box__body strong').contains('owners_group');
   cy.get('.pf-c-modal-box__body strong').contains(role);
   cy.get('[data-cy=delete_button]').click();
   cy.get('.pf-c-alert__title').contains(
-    `Group "system:partner-engineers" has been successfully removed from "rbac_owners_${num}".`,
+    `Group "owners_group" has been successfully removed from "rbac_owners_${num}".`,
   );
   cy.get('.pf-c-empty-state');
 }

--- a/test/cypress/integration/rbac_owners.js
+++ b/test/cypress/integration/rbac_owners.js
@@ -180,7 +180,7 @@ function testOwnersTab({
   ).click();
   cy.get('.pf-c-dropdown__menu-item').contains('Remove group').click();
   cy.get('.pf-c-modal-box__body b').contains('owners_group');
-  cy.get('.pf-c-modal-box__body b').contains(role);
+  cy.get('.pf-c-modal-box__body b').contains(`rbac_owners_${num}`);
   cy.get('[data-cy=delete-button]').click();
   cy.get('.pf-c-alert__title')
     .contains(

--- a/test/cypress/integration/rbac_owners.js
+++ b/test/cypress/integration/rbac_owners.js
@@ -129,7 +129,10 @@ function testOwnersTab({
   // role list view, use modal
   cy.get(`[data-cy="RoleListTable-ExpandableRow-row-${role}"]`);
   cy.get('button').contains('Add roles').click();
-  cy.get('.pf-c-table__check input[type=checkbox]').not('[disabled]').click();
+  cy.get('.pf-c-table__check input[type=checkbox]')
+    .not('[disabled]')
+    .first()
+    .click();
   cy.get('footer button').contains('Next').click();
   cy.get('footer button').contains('Add').click();
   cy.get('.pf-c-alert__title').contains(

--- a/test/cypress/integration/rbac_owners.js
+++ b/test/cypress/integration/rbac_owners.js
@@ -151,10 +151,10 @@ function testOwnersTab({
     `[data-cy="RoleListTable-ExpandableRow-row-${role}"] [data-cy=kebab-toggle] button`,
   ).click();
   cy.get('.pf-c-dropdown__menu-item').contains('Remove role').click();
-  cy.get('.pf-c-modal-box__body strong').contains('owners_group');
-  cy.get('.pf-c-modal-box__body strong').contains(role);
-  cy.get('.pf-c-modal-box__body strong').contains(`rbac_owners_${num}`);
-  cy.get('[data-cy=delete_button]').click();
+  cy.get('.pf-c-modal-box__body b').contains('owners_group');
+  cy.get('.pf-c-modal-box__body b').contains(role);
+  cy.get('.pf-c-modal-box__body b').contains(`rbac_owners_${num}`);
+  cy.get('[data-cy=delete-button]').click();
   cy.get('.pf-c-alert__title').contains(
     `Group "owners_group" roles successfully updated in "rbac_owners_${num}".`,
   );
@@ -167,9 +167,9 @@ function testOwnersTab({
     'tr[data-cy="OwnersTab-row-owners_group"] [data-cy=kebab-toggle] button',
   ).click();
   cy.get('.pf-c-dropdown__menu-item').contains('Remove group').click();
-  cy.get('.pf-c-modal-box__body strong').contains('owners_group');
-  cy.get('.pf-c-modal-box__body strong').contains(role);
-  cy.get('[data-cy=delete_button]').click();
+  cy.get('.pf-c-modal-box__body b').contains('owners_group');
+  cy.get('.pf-c-modal-box__body b').contains(role);
+  cy.get('[data-cy=delete-button]').click();
   cy.get('.pf-c-alert__title').contains(
     `Group "owners_group" has been successfully removed from "rbac_owners_${num}".`,
   );


### PR DESCRIPTION
Depends on https://github.com/ansible/ansible-hub-ui/pull/2092, will fail until then

Tests Namespace owners tab and EE Owners tab:
 * empty state,
 * add group and role,
 * open group, add role,
 * expand role,
 * remove role,
 * breadcrumbs back,
 * remove group

Also fixes a bug in EE tab detection - when a container is named "anything_owners_anything", the Owners tab becomes active by default, breaking the Detail tab.