### PR TITLE
Upload signature on collection detail page

### DIFF
--- a/CHANGES/1369.feature
+++ b/CHANGES/1369.feature
@@ -1,1 +1,1 @@
-Add signature upload elements for Insights mode
+Add signature upload elements for Insights mode. Change the Sign buttons when upload certificate enabled

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -581,6 +581,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
   private renderPageControls() {
     const { canSign, collections } = this.state;
+    const { can_upload_signatures } = this.context?.featureFlags || {};
 
     const dropdownItems = [
       <DropdownItem
@@ -636,7 +637,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           </Link>
         }
       />,
-      canSign && (
+      canSign && !can_upload_signatures && (
         <DropdownItem
           key='sign-collections'
           onClick={() => this.setState({ isOpenSignModal: true })}

--- a/src/utilities/wait-for-task.ts
+++ b/src/utilities/wait-for-task.ts
@@ -3,6 +3,14 @@ import { TaskAPI } from 'src/api';
 
 export function waitForTask(task, bailAfter = 10) {
   return TaskAPI.get(task).then((result) => {
+    const failing = ['skipped', 'failed', 'canceled'];
+
+    if (failing.includes(result.data.state)) {
+      return Promise.reject(
+        result.data.error?.description ?? t`Task failed without error message.`,
+      );
+    }
+
     if (result.data.state !== 'completed') {
       if (!bailAfter) {
         return Promise.reject(


### PR DESCRIPTION
When the flag `can_upload_signatures` is set it takes precedence over the backend signing. Therefore we are hiding the `Sign all` buttons on the collection and namespace detail pages, and changing the `Sign version x.x` to bring up the certificate upload modal. 

In addition it fixes the `waitForTask` function to return error if the task is not `running` and not `completed` so we can report failures.

**After with the `can_upload_signatures = true`**:
![Screenshot from 2022-06-20 13-06-02](https://user-images.githubusercontent.com/8531681/174588976-44754a7b-947b-4df8-a9c5-af3351a110ac.png)
![Screenshot from 2022-06-20 13-06-42](https://user-images.githubusercontent.com/8531681/174588979-35235fd7-d5c0-48ab-bfd8-93ec72f7dfb7.png)
![Screenshot from 2022-06-20 13-07-09](https://user-images.githubusercontent.com/8531681/174588982-f1d8af35-0fa2-4240-8466-fe7c5d4cef68.png)
![Screenshot from 2022-06-20 13-07-15](https://user-images.githubusercontent.com/8531681/174588986-37885d6f-6ba7-401f-b9b0-ccddee7cd7f9.png)
![Screenshot from 2022-06-20 13-07-31](https://user-images.githubusercontent.com/8531681/174588988-23165c03-b05b-4f35-9897-c469133d681d.png)
![Screenshot from 2022-06-20 13-08-41](https://user-images.githubusercontent.com/8531681/174588990-aba9c7f4-98ac-4c98-aa57-cf5f438dc8d6.png)
)