### PR TITLE
Cypress: run galaxykit collection list before the tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -175,6 +175,10 @@ jobs:
         echo 'expecting /static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
         curl http://localhost:8002/static/galaxy_ng/index.html | tee /dev/stderr | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
 
+    - name: "Ensure galaxykit can connect to the server"
+      run: |
+        galaxykit -s 'http://localhost:8002/api/galaxy/' -u admin -p admin collection list
+
     - name: "Run cypress"
       working-directory: 'ansible-hub-ui/test'
       run: |


### PR DESCRIPTION
to make sure galaxykit can talk to the server first

(and testing if it tells us more about the failures in https://github.com/ansible/ansible-hub-ui/runs/7006316031?check_suite_focus=true#step:17:3071)