### PR TITLE
EE list - fix toolbar alignment

### DIFF
--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -126,8 +126,10 @@ class ExecutionEnvironmentList extends React.Component<
       showDeleteModal,
       selectedItem,
     } = this.state;
+    const { user } = this.context;
 
     const noData = items.length === 0 && !filterIsSet(params, ['name']);
+
     const pushImagesButton = (
       <Button
         variant='link'
@@ -142,22 +144,18 @@ class ExecutionEnvironmentList extends React.Component<
         <Trans>Push container images</Trans> <ExternalLinkAltIcon />
       </Button>
     );
-    const addRemoteButton = this.context.user?.model_permissions
-      ?.add_containernamespace && (
-      <>
-        <Button
-          onClick={() =>
-            this.setState({
-              showRemoteModal: true,
-              itemToEdit: {} as ExecutionEnvironmentType,
-            })
-          }
-          variant='primary'
-        >
-          <Trans>Add execution environment</Trans>
-        </Button>
-        <div>&nbsp;</div>
-      </>
+    const addRemoteButton = user?.model_permissions?.add_containernamespace && (
+      <Button
+        onClick={() =>
+          this.setState({
+            showRemoteModal: true,
+            itemToEdit: {} as ExecutionEnvironmentType,
+          })
+        }
+        variant='primary'
+      >
+        <Trans>Add execution environment</Trans>
+      </Button>
     );
 
     return (
@@ -201,6 +199,7 @@ class ExecutionEnvironmentList extends React.Component<
             button={
               <>
                 {addRemoteButton}
+                {addRemoteButton && pushImagesButton ? <div>&nbsp;</div> : null}
                 {pushImagesButton}
               </>
             }


### PR DESCRIPTION
comes from #2209, it was the right fix for empty state but now the "Add execution environment" button is misaligned in the toolbar (when there are data)

moving the `<div>&nbsp;</div>` bit to the empty state only

before:
![20220623223740](https://user-images.githubusercontent.com/289743/175426731-b5306760-fdad-4b81-b0bf-05510eff3ba7.png)
![20220623223820](https://user-images.githubusercontent.com/289743/175426735-3196077d-b296-4a5e-994e-284a828efa44.png)

after:
![20220623223712](https://user-images.githubusercontent.com/289743/175426729-f3cd6354-e563-43bb-9c8a-a1a34cbe6e76.png)
![20220623223840](https://user-images.githubusercontent.com/289743/175426738-d2b2f4a0-d02f-4f41-bbb8-36d749462513.png)

