### PR TITLE
[stable-4.5] Bump @redhat-cloud-services/frontend-components-config to 4.6.9+ (#1975)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The app will run on http://localhost:8002 and proxy requests for `api/automation
 
 ## Insights Components
 
-Insights Platform will deliver components and static assets through [npm](https://www.npmjs.com/package/@red-hat-insights/insights-frontend-components). ESI tags are used to import the [chroming](https://github.com/RedHatInsights/insights-chrome) which takes care of the header, sidebar, and footer.
+Insights Platform will deliver components and static assets through [npm](https://www.npmjs.com/package/@red-hat-insights/insights-frontend-components). [insights-chrome](https://github.com/RedHatInsights/insights-chrome) takes care of the header, sidebar, and footer.
 
 ## UI Testing
 

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -1,6 +1,5 @@
 const { resolve } = require('path'); // node:path
 const config = require('@redhat-cloud-services/frontend-components-config');
-const webpack = require('webpack');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { execSync } = require('child_process'); // node:child_process
@@ -77,6 +76,7 @@ module.exports = (inputConfigs) => {
 
   const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
+    definePlugin: globals,
     htmlPlugin: htmlPluginConfig,
     debug: customConfigs.UI_DEBUG,
     https: customConfigs.UI_USE_HTTPS,
@@ -85,6 +85,9 @@ module.exports = (inputConfigs) => {
 
     // frontend-components-config 4.5.0+: don't remove patternfly from non-insights builds
     bundlePfModules: isStandalone,
+
+    // frontend-components-config 4.6.9+: keep HtmlWebpackPlugin for standalone
+    useChromeTemplate: !isStandalone,
   });
 
   // Override sections of the webpack config to work with TypeScript
@@ -156,7 +159,6 @@ module.exports = (inputConfigs) => {
     newWebpackConfig.entry.App = newEntry;
   }
 
-  plugins.push(new webpack.DefinePlugin(globals));
   plugins.push(new ForkTsCheckerWebpackPlugin());
 
   if (customConfigs.DEPLOYMENT_MODE === 'insights') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
                 "@lingui/cli": "^3.13.3",
                 "@lingui/macro": "^3.13.3",
                 "@ls-lint/ls-lint": "^1.11.2",
-                "@redhat-cloud-services/frontend-components-config": "^4.6.6",
+                "@redhat-cloud-services/frontend-components-config": "^4.6.14",
                 "@typescript-eslint/eslint-plugin": "^5.22.0",
                 "@typescript-eslint/parser": "^5.28.0",
                 "babel-core": "^7.0.0-bridge.0",
@@ -5385,6 +5385,12 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "node_modules/@leichtgewicht/ip-codec": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+            "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
+            "dev": true
+        },
         "node_modules/@lingui/babel-plugin-extract-messages": {
             "version": "3.13.3",
             "resolved": "https://registry.npmjs.org/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-3.13.3.tgz",
@@ -5986,9 +5992,9 @@
             "integrity": "sha512-WyEcV9jiMZzscQMBhlDkypHw9qg0wbX7r/fe8HcWws+jnYWGVjwUdnr18ktI9aw/h/oQS46sirf8xbNTlIiQFg=="
         },
         "node_modules/@redhat-cloud-services/frontend-components-config": {
-            "version": "4.6.6",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.6.tgz",
-            "integrity": "sha512-aOOwpFhfKxb+OEWNp92fFR/52AwgOXK+l3A3tZBQPcJL2aRS+WMOooqya0vhmSvRmQWAZYawY+aq4xdDpXMkNg==",
+            "version": "4.6.14",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.14.tgz",
+            "integrity": "sha512-/TRXW0CQFCmKfNQ7y/mb62j4XSAmUtJJoNfZIdqeDzS/FvtLkGPU/w8K9R+fqzR2497TtcbVluo0o7eWSBbTyQ==",
             "dev": true,
             "dependencies": {
                 "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.17",
@@ -6024,7 +6030,7 @@
                 "util": "^0.12.4",
                 "webpack": "^5.55.1",
                 "webpack-cli": "^4.8.0",
-                "webpack-dev-server": "4.3.1",
+                "webpack-dev-server": "4.8.1",
                 "write-file-webpack-plugin": "^4.5.1",
                 "yargs": "^17.2.1"
             },
@@ -6359,6 +6365,44 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@types/body-parser": {
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+            "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+            "dev": true,
+            "dependencies": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/bonjour": {
+            "version": "3.5.10",
+            "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.10.tgz",
+            "integrity": "sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/connect": {
+            "version": "3.4.35",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+            "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/connect-history-api-fallback": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz",
+            "integrity": "sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==",
+            "dev": true,
+            "dependencies": {
+                "@types/express-serve-static-core": "*",
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/debounce-promise": {
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.4.tgz",
@@ -6397,6 +6441,29 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
             "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
             "dev": true
+        },
+        "node_modules/@types/express": {
+            "version": "4.17.13",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+            "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+            "dev": true,
+            "dependencies": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^4.17.18",
+                "@types/qs": "*",
+                "@types/serve-static": "*"
+            }
+        },
+        "node_modules/@types/express-serve-static-core": {
+            "version": "4.17.29",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
+            "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*"
+            }
         },
         "node_modules/@types/glob": {
             "version": "7.2.0",
@@ -6437,9 +6504,9 @@
             "dev": true
         },
         "node_modules/@types/http-proxy": {
-            "version": "1.17.8",
-            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.8.tgz",
-            "integrity": "sha512-5kPLG5BKpWYkw/LVOGWpiq3nEVqxiN32rTgI53Sk12/xHFQ2rG3ehI9IO+O3W2QoKeyB92dJkoka8SUm6BX1pA==",
+            "version": "1.17.9",
+            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.9.tgz",
+            "integrity": "sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
@@ -6488,6 +6555,12 @@
             "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
             "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
         },
+        "node_modules/@types/mime": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+            "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+            "dev": true
+        },
         "node_modules/@types/minimatch": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -6527,6 +6600,18 @@
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
             "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
         },
+        "node_modules/@types/qs": {
+            "version": "6.9.7",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+            "dev": true
+        },
+        "node_modules/@types/range-parser": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+            "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+            "dev": true
+        },
         "node_modules/@types/react": {
             "version": "16.14.24",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.24.tgz",
@@ -6565,15 +6650,43 @@
             }
         },
         "node_modules/@types/retry": {
-            "version": "0.12.1",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-            "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
             "dev": true
         },
         "node_modules/@types/scheduler": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
             "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+        },
+        "node_modules/@types/serve-index": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.1.tgz",
+            "integrity": "sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==",
+            "dev": true,
+            "dependencies": {
+                "@types/express": "*"
+            }
+        },
+        "node_modules/@types/serve-static": {
+            "version": "1.13.10",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+            "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/mime": "^1",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/sockjs": {
+            "version": "0.3.33",
+            "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.33.tgz",
+            "integrity": "sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/source-list-map": {
             "version": "0.1.2",
@@ -6656,6 +6769,15 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@types/ws": {
+            "version": "8.5.3",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+            "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@types/yargs": {
@@ -7361,27 +7483,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/accepts/node_modules/mime-db": {
-            "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
-        "node_modules/accepts/node_modules/mime-types": {
-            "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-            "dev": true,
-            "dependencies": {
-                "mime-db": "1.52.0"
-            },
-            "engines": {
-                "node": ">= 0.6"
-            }
-        },
         "node_modules/acorn": {
             "version": "8.7.1",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
@@ -7424,19 +7525,6 @@
                 "node": ">= 6.0.0"
             }
         },
-        "node_modules/aggregate-error": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "dev": true,
-            "dependencies": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -7471,9 +7559,9 @@
             }
         },
         "node_modules/ajv-formats/node_modules/ajv": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
-            "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+            "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
@@ -7589,7 +7677,7 @@
         "node_modules/array-flatten": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
             "dev": true
         },
         "node_modules/array-includes": {
@@ -8286,7 +8374,7 @@
         "node_modules/batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-            "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+            "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
             "dev": true
         },
         "node_modules/bcp-47": {
@@ -8349,24 +8437,27 @@
             }
         },
         "node_modules/body-parser": {
-            "version": "1.19.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
-            "integrity": "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
             "dev": true,
             "dependencies": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "http-errors": "1.8.1",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
-                "on-finished": "~2.3.0",
-                "qs": "6.9.7",
-                "raw-body": "2.4.3",
-                "type-is": "~1.6.18"
+                "on-finished": "2.4.1",
+                "qs": "6.10.3",
+                "raw-body": "2.5.1",
+                "type-is": "~1.6.18",
+                "unpipe": "1.0.0"
             },
             "engines": {
-                "node": ">= 0.8"
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
             }
         },
         "node_modules/body-parser/node_modules/debug": {
@@ -8393,24 +8484,22 @@
         "node_modules/body-parser/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
-        "node_modules/bonjour": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
-            "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+        "node_modules/bonjour-service": {
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.0.13.tgz",
+            "integrity": "sha512-LWKRU/7EqDUC9CTAQtuZl5HzBALoCYwtLhffW3et7vZMwv3bWLpJf8bRYlMD5OCcDpTfnPgNCV4yo9ZIaJGMiA==",
             "dev": true,
             "dependencies": {
-                "array-flatten": "^2.1.0",
-                "deep-equal": "^1.0.1",
+                "array-flatten": "^2.1.2",
                 "dns-equal": "^1.0.0",
-                "dns-txt": "^2.0.2",
-                "multicast-dns": "^6.0.1",
-                "multicast-dns-service-types": "^1.1.0"
+                "fast-deep-equal": "^3.1.3",
+                "multicast-dns": "^7.2.5"
             }
         },
-        "node_modules/bonjour/node_modules/array-flatten": {
+        "node_modules/bonjour-service/node_modules/array-flatten": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
             "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
@@ -8510,12 +8599,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
-        },
-        "node_modules/buffer-indexof": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-            "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
             "dev": true
         },
         "node_modules/bytes": {
@@ -8631,10 +8714,16 @@
             "dev": true
         },
         "node_modules/chokidar": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -8684,15 +8773,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/clean-stack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "dev": true,
-            "engines": {
-                "node": ">=6"
             }
         },
         "node_modules/clean-webpack-plugin": {
@@ -8905,7 +8985,7 @@
         "node_modules/compression/node_modules/bytes": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+            "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
             "dev": true,
             "engines": {
                 "node": ">= 0.8"
@@ -8923,7 +9003,7 @@
         "node_modules/compression/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
         "node_modules/concat-map": {
@@ -9117,9 +9197,9 @@
             }
         },
         "node_modules/cookie": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
@@ -9128,7 +9208,7 @@
         "node_modules/cookie-signature": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+            "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
             "dev": true
         },
         "node_modules/core-js": {
@@ -9440,23 +9520,6 @@
             "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
             "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
         },
-        "node_modules/deep-equal": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-            "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-            "dev": true,
-            "dependencies": {
-                "is-arguments": "^1.0.4",
-                "is-date-object": "^1.0.1",
-                "is-regex": "^1.0.4",
-                "object-is": "^1.0.1",
-                "object-keys": "^1.1.1",
-                "regexp.prototype.flags": "^1.2.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -9541,12 +9604,12 @@
             }
         },
         "node_modules/depd": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
             "dev": true,
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
         "node_modules/dequal": {
@@ -9558,10 +9621,14 @@
             }
         },
         "node_modules/destroy": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-            "dev": true
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.8",
+                "npm": "1.2.8000 || >= 1.4.16"
+            }
         },
         "node_modules/detect-browser": {
             "version": "5.3.0",
@@ -9598,26 +9665,19 @@
         "node_modules/dns-equal": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-            "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+            "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
             "dev": true
         },
         "node_modules/dns-packet": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
-            "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
+            "integrity": "sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==",
             "dev": true,
             "dependencies": {
-                "ip": "^1.1.0",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "node_modules/dns-txt": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
-            "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-            "dev": true,
-            "dependencies": {
-                "buffer-indexof": "^1.0.0"
+                "@leichtgewicht/ip-codec": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/doctrine": {
@@ -9724,7 +9784,7 @@
         "node_modules/ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
             "dev": true
         },
         "node_modules/electron-to-chromium": {
@@ -9751,7 +9811,7 @@
         "node_modules/encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
             "dev": true,
             "engines": {
                 "node": ">= 0.8"
@@ -9903,7 +9963,7 @@
         "node_modules/escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
             "dev": true
         },
         "node_modules/escape-string-regexp": {
@@ -10352,7 +10412,7 @@
         "node_modules/etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
@@ -10409,38 +10469,39 @@
             }
         },
         "node_modules/express": {
-            "version": "4.17.3",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
-            "integrity": "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+            "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.19.2",
+                "body-parser": "1.20.0",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.4.2",
+                "cookie": "0.5.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
+                "depd": "2.0.0",
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "~1.1.2",
+                "finalhandler": "1.2.0",
                 "fresh": "0.5.2",
+                "http-errors": "2.0.0",
                 "merge-descriptors": "1.0.1",
                 "methods": "~1.1.2",
-                "on-finished": "~2.3.0",
+                "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "0.1.7",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.9.7",
+                "qs": "6.10.3",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
-                "send": "0.17.2",
-                "serve-static": "1.14.2",
+                "send": "0.18.0",
+                "serve-static": "1.15.0",
                 "setprototypeof": "1.2.0",
-                "statuses": "~1.5.0",
+                "statuses": "2.0.1",
                 "type-is": "~1.6.18",
                 "utils-merge": "1.0.1",
                 "vary": "~1.1.2"
@@ -10461,13 +10522,13 @@
         "node_modules/express/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
         "node_modules/express/node_modules/path-to-regexp": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-            "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+            "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
             "dev": true
         },
         "node_modules/express/node_modules/safe-buffer": {
@@ -10652,17 +10713,17 @@
             }
         },
         "node_modules/finalhandler": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-            "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+            "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
             "dev": true,
             "dependencies": {
                 "debug": "2.6.9",
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
-                "on-finished": "~2.3.0",
+                "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
-                "statuses": "~1.5.0",
+                "statuses": "2.0.1",
                 "unpipe": "~1.0.0"
             },
             "engines": {
@@ -10681,7 +10742,7 @@
         "node_modules/finalhandler/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
         "node_modules/find-cache-dir": {
@@ -10906,33 +10967,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/fork-ts-checker-webpack-plugin/node_modules/chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
-            "dependencies": {
-                "anymatch": "~3.1.2",
-                "braces": "~3.0.2",
-                "glob-parent": "~5.1.2",
-                "is-binary-path": "~2.1.0",
-                "is-glob": "~4.0.1",
-                "normalize-path": "~3.0.0",
-                "readdirp": "~3.6.0"
-            },
-            "engines": {
-                "node": ">= 8.10.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "~2.3.2"
-            }
-        },
         "node_modules/fork-ts-checker-webpack-plugin/node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -11057,7 +11091,7 @@
         "node_modules/fresh": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
@@ -11655,7 +11689,7 @@
         "node_modules/hpack.js": {
             "version": "2.1.6",
             "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-            "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+            "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
             "dev": true,
             "dependencies": {
                 "inherits": "^2.0.1",
@@ -11667,7 +11701,7 @@
         "node_modules/hpack.js/node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
             "dev": true
         },
         "node_modules/hpack.js/node_modules/readable-stream": {
@@ -11793,29 +11827,29 @@
         "node_modules/http-deceiver": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-            "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+            "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
             "dev": true
         },
         "node_modules/http-errors": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-            "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
             "dev": true,
             "dependencies": {
-                "depd": "~1.1.2",
+                "depd": "2.0.0",
                 "inherits": "2.0.4",
                 "setprototypeof": "1.2.0",
-                "statuses": ">= 1.5.0 < 2",
+                "statuses": "2.0.1",
                 "toidentifier": "1.0.1"
             },
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
         "node_modules/http-parser-js": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.6.tgz",
-            "integrity": "sha512-vDlkRPDJn93swjcjqMSaGSPABbIarsr1TLAui/gLDXzV5VsJNdXNzMYDyNBLQkjWQCJ1uizu8T2oDMhmGt0PRA==",
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.7.tgz",
+            "integrity": "sha512-8gQM8ZcewlONQLnik2AKzS13euQhaZcu4rK5QBSYOszW0T1upLW9VA2MdWvTvMmRo42HjXp7igFmdROoBCCrfg==",
             "dev": true
         },
         "node_modules/http-proxy": {
@@ -11833,9 +11867,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.4.tgz",
-            "integrity": "sha512-m/4FxX17SUvz4lJ5WPXOHDUuCwIqXLfLHs1s0uZ3oYjhoXlx9csYxaOa0ElDEJ+h8Q4iJ1s+lTMbiCa4EXIJqg==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+            "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
             "dev": true,
             "dependencies": {
                 "@types/http-proxy": "^1.17.8",
@@ -12237,24 +12271,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/internal-ip": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
-            "integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
-            "dev": true,
-            "dependencies": {
-                "default-gateway": "^6.0.0",
-                "ipaddr.js": "^1.9.1",
-                "is-ip": "^3.1.0",
-                "p-event": "^4.2.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/internal-ip?sponsor=1"
-            }
-        },
         "node_modules/internal-slot": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -12276,21 +12292,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/ip": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-            "dev": true
-        },
-        "node_modules/ip-regex": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-            "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/ipaddr.js": {
@@ -12530,18 +12531,6 @@
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
             "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
             "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/is-ip": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-            "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-            "dev": true,
-            "dependencies": {
-                "ip-regex": "^4.0.0"
-            },
             "engines": {
                 "node": ">=8"
             }
@@ -13496,19 +13485,19 @@
         "node_modules/media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/memfs": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.1.tgz",
-            "integrity": "sha512-1c9VPVvW5P7I85c35zAdEr1TD5+F11IToIHIlrVIcflfnzPkJa0ZoYEoEdYDP8KgPFoSZ/opDrUsAoZWym3mtw==",
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.7.tgz",
+            "integrity": "sha512-ygaiUSNalBX85388uskeCyhSAoOSgzBbtVCr9jA2RROssFL9Q19/ZXFqS+2Th2sr1ewNIWgFdLzLC3Yl1Zv+lw==",
             "dev": true,
             "dependencies": {
-                "fs-monkey": "1.0.3"
+                "fs-monkey": "^1.0.3"
             },
             "engines": {
                 "node": ">= 4.0.0"
@@ -13649,7 +13638,7 @@
         "node_modules/merge-descriptors": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
             "dev": true
         },
         "node_modules/merge-stream": {
@@ -13675,7 +13664,7 @@
         "node_modules/methods": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+            "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
             "dev": true,
             "engines": {
                 "node": ">= 0.6"
@@ -14129,19 +14118,19 @@
             }
         },
         "node_modules/mime-db": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-            "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
-            "version": "2.1.32",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-            "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "dependencies": {
-                "mime-db": "1.49.0"
+                "mime-db": "1.52.0"
             },
             "engines": {
                 "node": ">= 0.6"
@@ -14288,23 +14277,17 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/multicast-dns": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
-            "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+            "version": "7.2.5",
+            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+            "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
             "dev": true,
             "dependencies": {
-                "dns-packet": "^1.3.1",
+                "dns-packet": "^5.2.2",
                 "thunky": "^1.0.2"
             },
             "bin": {
                 "multicast-dns": "cli.js"
             }
-        },
-        "node_modules/multicast-dns-service-types": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-            "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
-            "dev": true
         },
         "node_modules/mute-stream": {
             "version": "0.0.8",
@@ -14368,12 +14351,12 @@
             "dev": true
         },
         "node_modules/node-forge": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+            "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
             "dev": true,
             "engines": {
-                "node": ">= 6.0.0"
+                "node": ">= 6.13.0"
             }
         },
         "node_modules/node-gettext": {
@@ -15339,9 +15322,9 @@
             "dev": true
         },
         "node_modules/on-finished": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
             "dev": true,
             "dependencies": {
                 "ee-first": "1.1.1"
@@ -15528,30 +15511,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/p-event": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
-            "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
-            "dev": true,
-            "dependencies": {
-                "p-timeout": "^3.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-finally": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/p-limit": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -15589,25 +15548,13 @@
             }
         },
         "node_modules/p-retry": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-            "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+            "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
             "dev": true,
             "dependencies": {
-                "@types/retry": "^0.12.0",
+                "@types/retry": "0.12.0",
                 "retry": "^0.13.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/p-timeout": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-            "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-            "dev": true,
-            "dependencies": {
-                "p-finally": "^1.0.0"
             },
             "engines": {
                 "node": ">=8"
@@ -16272,10 +16219,13 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.9.7",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
-            "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
+            "version": "6.10.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
             "dev": true,
+            "dependencies": {
+                "side-channel": "^1.0.4"
+            },
             "engines": {
                 "node": ">=0.6"
             },
@@ -16286,7 +16236,7 @@
         "node_modules/querystring": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
             "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
             "dev": true,
             "engines": {
@@ -16347,13 +16297,13 @@
             }
         },
         "node_modules/raw-body": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
-            "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
             "dev": true,
             "dependencies": {
                 "bytes": "3.1.2",
-                "http-errors": "1.8.1",
+                "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "unpipe": "1.0.0"
             },
@@ -16752,22 +16702,6 @@
                 "@babel/runtime": "^7.8.4"
             }
         },
-        "node_modules/regexp.prototype.flags": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-            "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/regexpp": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -17146,16 +17080,19 @@
         "node_modules/select-hose": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-            "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+            "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
             "dev": true
         },
         "node_modules/selfsigned": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.14.tgz",
-            "integrity": "sha512-lkjaiAye+wBZDCBsu5BGi0XiLRxeUlsGod5ZP924CRSEoGuZAw/f7y9RKu28rwTfiHVhdavhB0qH0INV6P1lEA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.1.tgz",
+            "integrity": "sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==",
             "dev": true,
             "dependencies": {
-                "node-forge": "^0.10.0"
+                "node-forge": "^1"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/semver": {
@@ -17168,24 +17105,24 @@
             }
         },
         "node_modules/send": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-            "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
             "dev": true,
             "dependencies": {
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "destroy": "~1.0.4",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "1.8.1",
+                "http-errors": "2.0.0",
                 "mime": "1.6.0",
                 "ms": "2.1.3",
-                "on-finished": "~2.3.0",
+                "on-finished": "2.4.1",
                 "range-parser": "~1.2.1",
-                "statuses": "~1.5.0"
+                "statuses": "2.0.1"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -17203,7 +17140,7 @@
         "node_modules/send/node_modules/debug/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
         "node_modules/send/node_modules/ms": {
@@ -17224,7 +17161,7 @@
         "node_modules/serve-index": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-            "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+            "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.4",
@@ -17248,10 +17185,19 @@
                 "ms": "2.0.0"
             }
         },
+        "node_modules/serve-index/node_modules/depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/serve-index/node_modules/http-errors": {
             "version": "1.6.3",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+            "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
             "dev": true,
             "dependencies": {
                 "depd": "~1.1.2",
@@ -17266,13 +17212,13 @@
         "node_modules/serve-index/node_modules/inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
             "dev": true
         },
         "node_modules/serve-index/node_modules/ms": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
         "node_modules/serve-index/node_modules/setprototypeof": {
@@ -17281,16 +17227,25 @@
             "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
             "dev": true
         },
+        "node_modules/serve-index/node_modules/statuses": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
         "node_modules/serve-static": {
-            "version": "1.14.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-            "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+            "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
             "dev": true,
             "dependencies": {
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.3",
-                "send": "0.17.2"
+                "send": "0.18.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -17582,12 +17537,12 @@
             }
         },
         "node_modules/statuses": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
             "dev": true,
             "engines": {
-                "node": ">= 0.6"
+                "node": ">= 0.8"
             }
         },
         "node_modules/stream-browserify": {
@@ -18946,7 +18901,7 @@
         "node_modules/unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
             "dev": true,
             "engines": {
                 "node": ">= 0.8"
@@ -18964,7 +18919,7 @@
         "node_modules/url": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
             "dev": true,
             "dependencies": {
                 "punycode": "1.3.2",
@@ -18980,7 +18935,7 @@
         "node_modules/url/node_modules/punycode": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+            "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
             "dev": true
         },
         "node_modules/use-sync-external-store": {
@@ -19020,7 +18975,7 @@
         "node_modules/utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
             "dev": true,
             "engines": {
                 "node": ">= 0.4.0"
@@ -19084,7 +19039,7 @@
         "node_modules/vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
             "dev": true,
             "engines": {
                 "node": ">= 0.8"
@@ -19263,13 +19218,13 @@
             }
         },
         "node_modules/webpack-dev-middleware": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.1.tgz",
-            "integrity": "sha512-81EujCKkyles2wphtdrnPg/QqegC/AtqNH//mQkBYSMqwFVCQrxM6ktB2O/SPlZy7LqeEfTbV3cZARGQz6umhg==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
+            "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
             "dev": true,
             "dependencies": {
                 "colorette": "^2.0.10",
-                "memfs": "^3.4.1",
+                "memfs": "^3.4.3",
                 "mime-types": "^2.1.31",
                 "range-parser": "^1.2.1",
                 "schema-utils": "^4.0.0"
@@ -19314,9 +19269,9 @@
             }
         },
         "node_modules/webpack-dev-middleware/node_modules/colorette": {
-            "version": "2.0.16",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-            "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
             "dev": true
         },
         "node_modules/webpack-dev-middleware/node_modules/json-schema-traverse": {
@@ -19345,36 +19300,40 @@
             }
         },
         "node_modules/webpack-dev-server": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.3.1.tgz",
-            "integrity": "sha512-qNXQCVYo1kYhH9pgLtm8LRNkXX3XzTfHSj/zqzaqYzGPca+Qjr+81wj1jgPMCHhIhso9WEQ+kX9z23iG9PzQ7w==",
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.8.1.tgz",
+            "integrity": "sha512-dwld70gkgNJa33czmcj/PlKY/nOy/BimbrgZRaR9vDATBQAYgLzggR0nxDtPLJiLrMgZwbE6RRfJ5vnBBasTyg==",
             "dev": true,
             "dependencies": {
+                "@types/bonjour": "^3.5.9",
+                "@types/connect-history-api-fallback": "^1.3.5",
+                "@types/express": "^4.17.13",
+                "@types/serve-index": "^1.9.1",
+                "@types/sockjs": "^0.3.33",
+                "@types/ws": "^8.5.1",
                 "ansi-html-community": "^0.0.8",
-                "bonjour": "^3.5.0",
-                "chokidar": "^3.5.1",
+                "bonjour-service": "^1.0.11",
+                "chokidar": "^3.5.3",
                 "colorette": "^2.0.10",
                 "compression": "^1.7.4",
                 "connect-history-api-fallback": "^1.6.0",
-                "del": "^6.0.0",
-                "express": "^4.17.1",
+                "default-gateway": "^6.0.3",
+                "express": "^4.17.3",
                 "graceful-fs": "^4.2.6",
                 "html-entities": "^2.3.2",
-                "http-proxy-middleware": "^2.0.0",
-                "internal-ip": "^6.2.0",
+                "http-proxy-middleware": "^2.0.3",
                 "ipaddr.js": "^2.0.1",
                 "open": "^8.0.9",
                 "p-retry": "^4.5.0",
                 "portfinder": "^1.0.28",
-                "schema-utils": "^3.1.0",
-                "selfsigned": "^1.10.11",
+                "rimraf": "^3.0.2",
+                "schema-utils": "^4.0.0",
+                "selfsigned": "^2.0.1",
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.21",
                 "spdy": "^4.0.2",
-                "strip-ansi": "^7.0.0",
-                "url": "^0.11.0",
-                "webpack-dev-middleware": "^5.2.1",
-                "ws": "^8.1.0"
+                "webpack-dev-middleware": "^5.3.1",
+                "ws": "^8.4.2"
             },
             "bin": {
                 "webpack-dev-server": "bin/webpack-dev-server.js"
@@ -19391,83 +19350,39 @@
                 }
             }
         },
-        "node_modules/webpack-dev-server/node_modules/ansi-regex": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-            "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+        "node_modules/webpack-dev-server/node_modules/ajv": {
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+            "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
             "dev": true,
-            "engines": {
-                "node": ">=12"
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
+                "uri-js": "^4.2.2"
             },
             "funding": {
-                "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/webpack-dev-server/node_modules/array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+        "node_modules/webpack-dev-server/node_modules/ajv-keywords": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
             "dev": true,
-            "engines": {
-                "node": ">=8"
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3"
+            },
+            "peerDependencies": {
+                "ajv": "^8.8.2"
             }
         },
         "node_modules/webpack-dev-server/node_modules/colorette": {
-            "version": "2.0.16",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-            "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+            "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
             "dev": true
-        },
-        "node_modules/webpack-dev-server/node_modules/del": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
-            "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
-            "dev": true,
-            "dependencies": {
-                "globby": "^11.0.1",
-                "graceful-fs": "^4.2.4",
-                "is-glob": "^4.0.1",
-                "is-path-cwd": "^2.2.0",
-                "is-path-inside": "^3.0.2",
-                "p-map": "^4.0.0",
-                "rimraf": "^3.0.2",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/ignore": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-            "dev": true,
-            "engines": {
-                "node": ">= 4"
-            }
         },
         "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
             "version": "2.0.1",
@@ -19478,29 +19393,11 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/webpack-dev-server/node_modules/is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/p-map": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-            "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-            "dev": true,
-            "dependencies": {
-                "aggregate-error": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+        "node_modules/webpack-dev-server/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true
         },
         "node_modules/webpack-dev-server/node_modules/rimraf": {
             "version": "3.0.2",
@@ -19518,36 +19415,22 @@
             }
         },
         "node_modules/webpack-dev-server/node_modules/schema-utils": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-            "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
+            "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
             "dev": true,
             "dependencies": {
-                "@types/json-schema": "^7.0.8",
-                "ajv": "^6.12.5",
-                "ajv-keywords": "^3.5.2"
+                "@types/json-schema": "^7.0.9",
+                "ajv": "^8.8.0",
+                "ajv-formats": "^2.1.1",
+                "ajv-keywords": "^5.0.0"
             },
             "engines": {
-                "node": ">= 10.13.0"
+                "node": ">= 12.13.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
-            }
-        },
-        "node_modules/webpack-dev-server/node_modules/strip-ansi": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-            "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/strip-ansi?sponsor=1"
             }
         },
         "node_modules/webpack-merge": {
@@ -19824,9 +19707,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-            "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+            "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
             "dev": true,
             "engines": {
                 "node": ">=10.0.0"
@@ -23845,6 +23728,12 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "@leichtgewicht/ip-codec": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+            "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
+            "dev": true
+        },
         "@lingui/babel-plugin-extract-messages": {
             "version": "3.13.3",
             "resolved": "https://registry.npmjs.org/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-3.13.3.tgz",
@@ -24300,9 +24189,9 @@
             "integrity": "sha512-WyEcV9jiMZzscQMBhlDkypHw9qg0wbX7r/fe8HcWws+jnYWGVjwUdnr18ktI9aw/h/oQS46sirf8xbNTlIiQFg=="
         },
         "@redhat-cloud-services/frontend-components-config": {
-            "version": "4.6.6",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.6.tgz",
-            "integrity": "sha512-aOOwpFhfKxb+OEWNp92fFR/52AwgOXK+l3A3tZBQPcJL2aRS+WMOooqya0vhmSvRmQWAZYawY+aq4xdDpXMkNg==",
+            "version": "4.6.14",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.14.tgz",
+            "integrity": "sha512-/TRXW0CQFCmKfNQ7y/mb62j4XSAmUtJJoNfZIdqeDzS/FvtLkGPU/w8K9R+fqzR2497TtcbVluo0o7eWSBbTyQ==",
             "dev": true,
             "requires": {
                 "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.17",
@@ -24338,7 +24227,7 @@
                 "util": "^0.12.4",
                 "webpack": "^5.55.1",
                 "webpack-cli": "^4.8.0",
-                "webpack-dev-server": "4.3.1",
+                "webpack-dev-server": "4.8.1",
                 "write-file-webpack-plugin": "^4.5.1",
                 "yargs": "^17.2.1"
             },
@@ -24575,6 +24464,44 @@
                 "tslib": "^1.9.3"
             }
         },
+        "@types/body-parser": {
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+            "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+            "dev": true,
+            "requires": {
+                "@types/connect": "*",
+                "@types/node": "*"
+            }
+        },
+        "@types/bonjour": {
+            "version": "3.5.10",
+            "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.10.tgz",
+            "integrity": "sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/connect": {
+            "version": "3.4.35",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+            "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/connect-history-api-fallback": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz",
+            "integrity": "sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==",
+            "dev": true,
+            "requires": {
+                "@types/express-serve-static-core": "*",
+                "@types/node": "*"
+            }
+        },
         "@types/debounce-promise": {
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.4.tgz",
@@ -24613,6 +24540,29 @@
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
             "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
             "dev": true
+        },
+        "@types/express": {
+            "version": "4.17.13",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+            "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+            "dev": true,
+            "requires": {
+                "@types/body-parser": "*",
+                "@types/express-serve-static-core": "^4.17.18",
+                "@types/qs": "*",
+                "@types/serve-static": "*"
+            }
+        },
+        "@types/express-serve-static-core": {
+            "version": "4.17.29",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.29.tgz",
+            "integrity": "sha512-uMd++6dMKS32EOuw1Uli3e3BPgdLIXmezcfHv7N4c1s3gkhikBplORPpMq3fuWkxncZN1reb16d5n8yhQ80x7Q==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*",
+                "@types/qs": "*",
+                "@types/range-parser": "*"
+            }
         },
         "@types/glob": {
             "version": "7.2.0",
@@ -24653,9 +24603,9 @@
             "dev": true
         },
         "@types/http-proxy": {
-            "version": "1.17.8",
-            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.8.tgz",
-            "integrity": "sha512-5kPLG5BKpWYkw/LVOGWpiq3nEVqxiN32rTgI53Sk12/xHFQ2rG3ehI9IO+O3W2QoKeyB92dJkoka8SUm6BX1pA==",
+            "version": "1.17.9",
+            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.9.tgz",
+            "integrity": "sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
@@ -24704,6 +24654,12 @@
             "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.2.tgz",
             "integrity": "sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA=="
         },
+        "@types/mime": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+            "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
+            "dev": true
+        },
         "@types/minimatch": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -24743,6 +24699,18 @@
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
             "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
         },
+        "@types/qs": {
+            "version": "6.9.7",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+            "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
+            "dev": true
+        },
+        "@types/range-parser": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+            "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
+            "dev": true
+        },
         "@types/react": {
             "version": "16.14.24",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.24.tgz",
@@ -24781,15 +24749,43 @@
             }
         },
         "@types/retry": {
-            "version": "0.12.1",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
-            "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
             "dev": true
         },
         "@types/scheduler": {
             "version": "0.16.2",
             "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
             "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+        },
+        "@types/serve-index": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.1.tgz",
+            "integrity": "sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==",
+            "dev": true,
+            "requires": {
+                "@types/express": "*"
+            }
+        },
+        "@types/serve-static": {
+            "version": "1.13.10",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+            "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
+            "dev": true,
+            "requires": {
+                "@types/mime": "^1",
+                "@types/node": "*"
+            }
+        },
+        "@types/sockjs": {
+            "version": "0.3.33",
+            "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.33.tgz",
+            "integrity": "sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@types/source-list-map": {
             "version": "0.1.2",
@@ -24869,6 +24865,15 @@
                     "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
                     "dev": true
                 }
+            }
+        },
+        "@types/ws": {
+            "version": "8.5.3",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.3.tgz",
+            "integrity": "sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
             }
         },
         "@types/yargs": {
@@ -25362,23 +25367,6 @@
             "requires": {
                 "mime-types": "~2.1.34",
                 "negotiator": "0.6.3"
-            },
-            "dependencies": {
-                "mime-db": {
-                    "version": "1.52.0",
-                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-                    "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-                    "dev": true
-                },
-                "mime-types": {
-                    "version": "2.1.35",
-                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-                    "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-                    "dev": true,
-                    "requires": {
-                        "mime-db": "1.52.0"
-                    }
-                }
             }
         },
         "acorn": {
@@ -25410,16 +25398,6 @@
                 "debug": "4"
             }
         },
-        "aggregate-error": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-            "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-            "dev": true,
-            "requires": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-            }
-        },
         "ajv": {
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -25442,9 +25420,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.10.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
-                    "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+                    "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -25531,7 +25509,7 @@
         "array-flatten": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-            "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+            "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
             "dev": true
         },
         "array-includes": {
@@ -26036,7 +26014,7 @@
         "batch": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
-            "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+            "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
             "dev": true
         },
         "bcp-47": {
@@ -26080,21 +26058,23 @@
             }
         },
         "body-parser": {
-            "version": "1.19.2",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.2.tgz",
-            "integrity": "sha512-SAAwOxgoCKMGs9uUAUFHygfLAyaniaoun6I8mFY9pRAJL9+Kec34aU+oIjDhTycub1jozEfEwx1W1IuOYxVSFw==",
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+            "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
             "dev": true,
             "requires": {
                 "bytes": "3.1.2",
                 "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "http-errors": "1.8.1",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
+                "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
-                "on-finished": "~2.3.0",
-                "qs": "6.9.7",
-                "raw-body": "2.4.3",
-                "type-is": "~1.6.18"
+                "on-finished": "2.4.1",
+                "qs": "6.10.3",
+                "raw-body": "2.5.1",
+                "type-is": "~1.6.18",
+                "unpipe": "1.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -26118,23 +26098,21 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
                     "dev": true
                 }
             }
         },
-        "bonjour": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
-            "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
+        "bonjour-service": {
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.0.13.tgz",
+            "integrity": "sha512-LWKRU/7EqDUC9CTAQtuZl5HzBALoCYwtLhffW3et7vZMwv3bWLpJf8bRYlMD5OCcDpTfnPgNCV4yo9ZIaJGMiA==",
             "dev": true,
             "requires": {
-                "array-flatten": "^2.1.0",
-                "deep-equal": "^1.0.1",
+                "array-flatten": "^2.1.2",
                 "dns-equal": "^1.0.0",
-                "dns-txt": "^2.0.2",
-                "multicast-dns": "^6.0.1",
-                "multicast-dns-service-types": "^1.1.0"
+                "fast-deep-equal": "^3.1.3",
+                "multicast-dns": "^7.2.5"
             },
             "dependencies": {
                 "array-flatten": {
@@ -26212,12 +26190,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-            "dev": true
-        },
-        "buffer-indexof": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz",
-            "integrity": "sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==",
             "dev": true
         },
         "bytes": {
@@ -26306,9 +26278,9 @@
             "dev": true
         },
         "chokidar": {
-            "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-            "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
             "dev": true,
             "requires": {
                 "anymatch": "~3.1.2",
@@ -26348,12 +26320,6 @@
                     "dev": true
                 }
             }
-        },
-        "clean-stack": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-            "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-            "dev": true
         },
         "clean-webpack-plugin": {
             "version": "3.0.0",
@@ -26516,7 +26482,7 @@
                 "bytes": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-                    "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+                    "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
                     "dev": true
                 },
                 "debug": {
@@ -26531,7 +26497,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
                     "dev": true
                 }
             }
@@ -26674,15 +26640,15 @@
             }
         },
         "cookie": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
-            "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+            "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
             "dev": true
         },
         "cookie-signature": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-            "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+            "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
             "dev": true
         },
         "core-js": {
@@ -26906,20 +26872,6 @@
             "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
             "integrity": "sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ="
         },
-        "deep-equal": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
-            "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
-            "dev": true,
-            "requires": {
-                "is-arguments": "^1.0.4",
-                "is-date-object": "^1.0.1",
-                "is-regex": "^1.0.4",
-                "object-is": "^1.0.1",
-                "object-keys": "^1.1.1",
-                "regexp.prototype.flags": "^1.2.0"
-            }
-        },
         "deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -26986,9 +26938,9 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "depd": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
             "dev": true
         },
         "dequal": {
@@ -26997,9 +26949,9 @@
             "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug=="
         },
         "destroy": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
             "dev": true
         },
         "detect-browser": {
@@ -27031,26 +26983,16 @@
         "dns-equal": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/dns-equal/-/dns-equal-1.0.0.tgz",
-            "integrity": "sha1-s55/HabrCnW6nBcySzR1PEfgZU0=",
+            "integrity": "sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==",
             "dev": true
         },
         "dns-packet": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.4.tgz",
-            "integrity": "sha512-BQ6F4vycLXBvdrJZ6S3gZewt6rcrks9KBgM9vrhW+knGRqc8uEdT7fuCwloc7nny5xNoMJ17HGH0R/6fpo8ECA==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
+            "integrity": "sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==",
             "dev": true,
             "requires": {
-                "ip": "^1.1.0",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "dns-txt": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
-            "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-            "dev": true,
-            "requires": {
-                "buffer-indexof": "^1.0.0"
+                "@leichtgewicht/ip-codec": "^2.0.1"
             }
         },
         "doctrine": {
@@ -27138,7 +27080,7 @@
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
             "dev": true
         },
         "electron-to-chromium": {
@@ -27162,7 +27104,7 @@
         "encodeurl": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+            "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
             "dev": true
         },
         "enhanced-resolve": {
@@ -27280,7 +27222,7 @@
         "escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
             "dev": true
         },
         "escape-string-regexp": {
@@ -27615,7 +27557,7 @@
         "etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+            "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
             "dev": true
         },
         "eventemitter3": {
@@ -27657,38 +27599,39 @@
             }
         },
         "express": {
-            "version": "4.17.3",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
-            "integrity": "sha512-yuSQpz5I+Ch7gFrPCk4/c+dIBKlQUxtgwqzph132bsT6qhuzss6I8cLJQz7B3rFblzd6wtcI0ZbGltH/C4LjUg==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
+            "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.19.2",
+                "body-parser": "1.20.0",
                 "content-disposition": "0.5.4",
                 "content-type": "~1.0.4",
-                "cookie": "0.4.2",
+                "cookie": "0.5.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
+                "depd": "2.0.0",
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "~1.1.2",
+                "finalhandler": "1.2.0",
                 "fresh": "0.5.2",
+                "http-errors": "2.0.0",
                 "merge-descriptors": "1.0.1",
                 "methods": "~1.1.2",
-                "on-finished": "~2.3.0",
+                "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
                 "path-to-regexp": "0.1.7",
                 "proxy-addr": "~2.0.7",
-                "qs": "6.9.7",
+                "qs": "6.10.3",
                 "range-parser": "~1.2.1",
                 "safe-buffer": "5.2.1",
-                "send": "0.17.2",
-                "serve-static": "1.14.2",
+                "send": "0.18.0",
+                "serve-static": "1.15.0",
                 "setprototypeof": "1.2.0",
-                "statuses": "~1.5.0",
+                "statuses": "2.0.1",
                 "type-is": "~1.6.18",
                 "utils-merge": "1.0.1",
                 "vary": "~1.1.2"
@@ -27706,13 +27649,13 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
                     "dev": true
                 },
                 "path-to-regexp": {
                     "version": "0.1.7",
                     "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-                    "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+                    "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
                     "dev": true
                 },
                 "safe-buffer": {
@@ -27859,17 +27802,17 @@
             }
         },
         "finalhandler": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
-            "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+            "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
-                "on-finished": "~2.3.0",
+                "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
-                "statuses": "~1.5.0",
+                "statuses": "2.0.1",
                 "unpipe": "~1.0.0"
             },
             "dependencies": {
@@ -27885,7 +27828,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
                     "dev": true
                 }
             }
@@ -28045,22 +27988,6 @@
                         }
                     }
                 },
-                "chokidar": {
-                    "version": "3.5.3",
-                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-                    "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-                    "dev": true,
-                    "requires": {
-                        "anymatch": "~3.1.2",
-                        "braces": "~3.0.2",
-                        "fsevents": "~2.3.2",
-                        "glob-parent": "~5.1.2",
-                        "is-binary-path": "~2.1.0",
-                        "is-glob": "~4.0.1",
-                        "normalize-path": "~3.0.0",
-                        "readdirp": "~3.6.0"
-                    }
-                },
                 "color-convert": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -28153,7 +28080,7 @@
         "fresh": {
             "version": "0.5.2",
             "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+            "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "dev": true
         },
         "fs-extra": {
@@ -28597,7 +28524,7 @@
         "hpack.js": {
             "version": "2.1.6",
             "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
-            "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
+            "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
             "dev": true,
             "requires": {
                 "inherits": "^2.0.1",
@@ -28609,7 +28536,7 @@
                 "isarray": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
                     "dev": true
                 },
                 "readable-stream": {
@@ -28707,26 +28634,26 @@
         "http-deceiver": {
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
-            "integrity": "sha1-+nFolEq5pRnTN8sL7HKE3D5yPYc=",
+            "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
             "dev": true
         },
         "http-errors": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-            "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+            "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
             "dev": true,
             "requires": {
-                "depd": "~1.1.2",
+                "depd": "2.0.0",
                 "inherits": "2.0.4",
                 "setprototypeof": "1.2.0",
-                "statuses": ">= 1.5.0 < 2",
+                "statuses": "2.0.1",
                 "toidentifier": "1.0.1"
             }
         },
         "http-parser-js": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.6.tgz",
-            "integrity": "sha512-vDlkRPDJn93swjcjqMSaGSPABbIarsr1TLAui/gLDXzV5VsJNdXNzMYDyNBLQkjWQCJ1uizu8T2oDMhmGt0PRA==",
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.7.tgz",
+            "integrity": "sha512-8gQM8ZcewlONQLnik2AKzS13euQhaZcu4rK5QBSYOszW0T1upLW9VA2MdWvTvMmRo42HjXp7igFmdROoBCCrfg==",
             "dev": true
         },
         "http-proxy": {
@@ -28741,9 +28668,9 @@
             }
         },
         "http-proxy-middleware": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.4.tgz",
-            "integrity": "sha512-m/4FxX17SUvz4lJ5WPXOHDUuCwIqXLfLHs1s0uZ3oYjhoXlx9csYxaOa0ElDEJ+h8Q4iJ1s+lTMbiCa4EXIJqg==",
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+            "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
             "dev": true,
             "requires": {
                 "@types/http-proxy": "^1.17.8",
@@ -29027,18 +28954,6 @@
                 }
             }
         },
-        "internal-ip": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-6.2.0.tgz",
-            "integrity": "sha512-D8WGsR6yDt8uq7vDMu7mjcR+yRMm3dW8yufyChmszWRjcSHuxLBkR3GdS2HZAjodsaGuCvXeEJpueisXJULghg==",
-            "dev": true,
-            "requires": {
-                "default-gateway": "^6.0.0",
-                "ipaddr.js": "^1.9.1",
-                "is-ip": "^3.1.0",
-                "p-event": "^4.2.0"
-            }
-        },
         "internal-slot": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -29054,18 +28969,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
             "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
-            "dev": true
-        },
-        "ip": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
-            "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
-            "dev": true
-        },
-        "ip-regex": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
-            "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
             "dev": true
         },
         "ipaddr.js": {
@@ -29215,15 +29118,6 @@
             "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
             "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
             "dev": true
-        },
-        "is-ip": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-3.1.0.tgz",
-            "integrity": "sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==",
-            "dev": true,
-            "requires": {
-                "ip-regex": "^4.0.0"
-            }
         },
         "is-nan": {
             "version": "1.3.2",
@@ -29930,16 +29824,16 @@
         "media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
             "dev": true
         },
         "memfs": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.1.tgz",
-            "integrity": "sha512-1c9VPVvW5P7I85c35zAdEr1TD5+F11IToIHIlrVIcflfnzPkJa0ZoYEoEdYDP8KgPFoSZ/opDrUsAoZWym3mtw==",
+            "version": "3.4.7",
+            "resolved": "https://registry.npmjs.org/memfs/-/memfs-3.4.7.tgz",
+            "integrity": "sha512-ygaiUSNalBX85388uskeCyhSAoOSgzBbtVCr9jA2RROssFL9Q19/ZXFqS+2Th2sr1ewNIWgFdLzLC3Yl1Zv+lw==",
             "dev": true,
             "requires": {
-                "fs-monkey": "1.0.3"
+                "fs-monkey": "^1.0.3"
             }
         },
         "memory-fs": {
@@ -30051,7 +29945,7 @@
         "merge-descriptors": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-            "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+            "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
             "dev": true
         },
         "merge-stream": {
@@ -30074,7 +29968,7 @@
         "methods": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-            "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+            "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
             "dev": true
         },
         "micromark": {
@@ -30306,16 +30200,16 @@
             "dev": true
         },
         "mime-db": {
-            "version": "1.49.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-            "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
         "mime-types": {
-            "version": "2.1.32",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
-            "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "requires": {
-                "mime-db": "1.49.0"
+                "mime-db": "1.52.0"
             }
         },
         "mimic-fn": {
@@ -30416,20 +30310,14 @@
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "multicast-dns": {
-            "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
-            "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
+            "version": "7.2.5",
+            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+            "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
             "dev": true,
             "requires": {
-                "dns-packet": "^1.3.1",
+                "dns-packet": "^5.2.2",
                 "thunky": "^1.0.2"
             }
-        },
-        "multicast-dns-service-types": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/multicast-dns-service-types/-/multicast-dns-service-types-1.1.0.tgz",
-            "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
-            "dev": true
         },
         "mute-stream": {
             "version": "0.0.8",
@@ -30486,9 +30374,9 @@
             }
         },
         "node-forge": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+            "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
             "dev": true
         },
         "node-gettext": {
@@ -31203,9 +31091,9 @@
             "dev": true
         },
         "on-finished": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
             "dev": true,
             "requires": {
                 "ee-first": "1.1.1"
@@ -31340,21 +31228,6 @@
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
-        "p-event": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
-            "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
-            "dev": true,
-            "requires": {
-                "p-timeout": "^3.1.0"
-            }
-        },
-        "p-finally": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-            "dev": true
-        },
         "p-limit": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -31380,22 +31253,13 @@
             "dev": true
         },
         "p-retry": {
-            "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-            "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+            "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
             "dev": true,
             "requires": {
-                "@types/retry": "^0.12.0",
+                "@types/retry": "0.12.0",
                 "retry": "^0.13.1"
-            }
-        },
-        "p-timeout": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-            "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-            "dev": true,
-            "requires": {
-                "p-finally": "^1.0.0"
             }
         },
         "p-try": {
@@ -31893,15 +31757,18 @@
             "dev": true
         },
         "qs": {
-            "version": "6.9.7",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
-            "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
-            "dev": true
+            "version": "6.10.3",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+            "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+            "dev": true,
+            "requires": {
+                "side-channel": "^1.0.4"
+            }
         },
         "querystring": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
             "dev": true
         },
         "queue-microtask": {
@@ -31938,13 +31805,13 @@
             "dev": true
         },
         "raw-body": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.3.tgz",
-            "integrity": "sha512-UlTNLIcu0uzb4D2f4WltY6cVjLi+/jEN4lgEUj3E04tpMDpUlkBo/eSn6zou9hum2VMNpCCUone0O0WeJim07g==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+            "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
             "dev": true,
             "requires": {
                 "bytes": "3.1.2",
-                "http-errors": "1.8.1",
+                "http-errors": "2.0.0",
                 "iconv-lite": "0.4.24",
                 "unpipe": "1.0.0"
             },
@@ -32248,16 +32115,6 @@
                 "@babel/runtime": "^7.8.4"
             }
         },
-        "regexp.prototype.flags": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-            "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
-            "dev": true,
-            "requires": {
-                "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3"
-            }
-        },
         "regexpp": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -32520,16 +32377,16 @@
         "select-hose": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-            "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+            "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
             "dev": true
         },
         "selfsigned": {
-            "version": "1.10.14",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.14.tgz",
-            "integrity": "sha512-lkjaiAye+wBZDCBsu5BGi0XiLRxeUlsGod5ZP924CRSEoGuZAw/f7y9RKu28rwTfiHVhdavhB0qH0INV6P1lEA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.0.1.tgz",
+            "integrity": "sha512-LmME957M1zOsUhG+67rAjKfiWFox3SBxE/yymatMZsAx+oMrJ0YQ8AToOnyCm7xbeg2ep37IHLxdu0o2MavQOQ==",
             "dev": true,
             "requires": {
-                "node-forge": "^0.10.0"
+                "node-forge": "^1"
             }
         },
         "semver": {
@@ -32539,24 +32396,24 @@
             "dev": true
         },
         "send": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.17.2.tgz",
-            "integrity": "sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==",
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+            "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "depd": "~1.1.2",
-                "destroy": "~1.0.4",
+                "depd": "2.0.0",
+                "destroy": "1.2.0",
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "1.8.1",
+                "http-errors": "2.0.0",
                 "mime": "1.6.0",
                 "ms": "2.1.3",
-                "on-finished": "~2.3.0",
+                "on-finished": "2.4.1",
                 "range-parser": "~1.2.1",
-                "statuses": "~1.5.0"
+                "statuses": "2.0.1"
             },
             "dependencies": {
                 "debug": {
@@ -32571,7 +32428,7 @@
                         "ms": {
                             "version": "2.0.0",
                             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                            "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
                             "dev": true
                         }
                     }
@@ -32596,7 +32453,7 @@
         "serve-index": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-            "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+            "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.4",
@@ -32617,10 +32474,16 @@
                         "ms": "2.0.0"
                     }
                 },
+                "depd": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+                    "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+                    "dev": true
+                },
                 "http-errors": {
                     "version": "1.6.3",
                     "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-                    "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+                    "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
                     "dev": true,
                     "requires": {
                         "depd": "~1.1.2",
@@ -32632,13 +32495,13 @@
                 "inherits": {
                     "version": "2.0.3",
                     "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
                     "dev": true
                 },
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
                     "dev": true
                 },
                 "setprototypeof": {
@@ -32646,19 +32509,25 @@
                     "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
                     "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
                     "dev": true
+                },
+                "statuses": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+                    "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+                    "dev": true
                 }
             }
         },
         "serve-static": {
-            "version": "1.14.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.2.tgz",
-            "integrity": "sha512-+TMNA9AFxUEGuC0z2mevogSnn9MXKb4fa7ngeRMJaaGv8vTwnIEkKi+QGvPt33HSnf8pRS+WGM0EbMtCJLKMBQ==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+            "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
             "dev": true,
             "requires": {
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "parseurl": "~1.3.3",
-                "send": "0.17.2"
+                "send": "0.18.0"
             }
         },
         "setprototypeof": {
@@ -32892,9 +32761,9 @@
             "dev": true
         },
         "statuses": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
             "dev": true
         },
         "stream-browserify": {
@@ -33881,7 +33750,7 @@
         "unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
             "dev": true
         },
         "uri-js": {
@@ -33896,7 +33765,7 @@
         "url": {
             "version": "0.11.0",
             "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
             "dev": true,
             "requires": {
                 "punycode": "1.3.2",
@@ -33906,7 +33775,7 @@
                 "punycode": {
                     "version": "1.3.2",
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
                     "dev": true
                 }
             }
@@ -33952,7 +33821,7 @@
         "utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+            "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
             "dev": true
         },
         "uuid": {
@@ -34003,7 +33872,7 @@
         "vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-            "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+            "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
             "dev": true
         },
         "vfile": {
@@ -34164,13 +34033,13 @@
             }
         },
         "webpack-dev-middleware": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.1.tgz",
-            "integrity": "sha512-81EujCKkyles2wphtdrnPg/QqegC/AtqNH//mQkBYSMqwFVCQrxM6ktB2O/SPlZy7LqeEfTbV3cZARGQz6umhg==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz",
+            "integrity": "sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==",
             "dev": true,
             "requires": {
                 "colorette": "^2.0.10",
-                "memfs": "^3.4.1",
+                "memfs": "^3.4.3",
                 "mime-types": "^2.1.31",
                 "range-parser": "^1.2.1",
                 "schema-utils": "^4.0.0"
@@ -34198,9 +34067,9 @@
                     }
                 },
                 "colorette": {
-                    "version": "2.0.16",
-                    "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-                    "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+                    "version": "2.0.19",
+                    "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+                    "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
                     "dev": true
                 },
                 "json-schema-traverse": {
@@ -34224,90 +34093,67 @@
             }
         },
         "webpack-dev-server": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.3.1.tgz",
-            "integrity": "sha512-qNXQCVYo1kYhH9pgLtm8LRNkXX3XzTfHSj/zqzaqYzGPca+Qjr+81wj1jgPMCHhIhso9WEQ+kX9z23iG9PzQ7w==",
+            "version": "4.8.1",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.8.1.tgz",
+            "integrity": "sha512-dwld70gkgNJa33czmcj/PlKY/nOy/BimbrgZRaR9vDATBQAYgLzggR0nxDtPLJiLrMgZwbE6RRfJ5vnBBasTyg==",
             "dev": true,
             "requires": {
+                "@types/bonjour": "^3.5.9",
+                "@types/connect-history-api-fallback": "^1.3.5",
+                "@types/express": "^4.17.13",
+                "@types/serve-index": "^1.9.1",
+                "@types/sockjs": "^0.3.33",
+                "@types/ws": "^8.5.1",
                 "ansi-html-community": "^0.0.8",
-                "bonjour": "^3.5.0",
-                "chokidar": "^3.5.1",
+                "bonjour-service": "^1.0.11",
+                "chokidar": "^3.5.3",
                 "colorette": "^2.0.10",
                 "compression": "^1.7.4",
                 "connect-history-api-fallback": "^1.6.0",
-                "del": "^6.0.0",
-                "express": "^4.17.1",
+                "default-gateway": "^6.0.3",
+                "express": "^4.17.3",
                 "graceful-fs": "^4.2.6",
                 "html-entities": "^2.3.2",
-                "http-proxy-middleware": "^2.0.0",
-                "internal-ip": "^6.2.0",
+                "http-proxy-middleware": "^2.0.3",
                 "ipaddr.js": "^2.0.1",
                 "open": "^8.0.9",
                 "p-retry": "^4.5.0",
                 "portfinder": "^1.0.28",
-                "schema-utils": "^3.1.0",
-                "selfsigned": "^1.10.11",
+                "rimraf": "^3.0.2",
+                "schema-utils": "^4.0.0",
+                "selfsigned": "^2.0.1",
                 "serve-index": "^1.9.1",
                 "sockjs": "^0.3.21",
                 "spdy": "^4.0.2",
-                "strip-ansi": "^7.0.0",
-                "url": "^0.11.0",
-                "webpack-dev-middleware": "^5.2.1",
-                "ws": "^8.1.0"
+                "webpack-dev-middleware": "^5.3.1",
+                "ws": "^8.4.2"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-                    "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-                    "dev": true
+                "ajv": {
+                    "version": "8.11.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+                    "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
+                    }
                 },
-                "array-union": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-                    "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-                    "dev": true
+                "ajv-keywords": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+                    "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.3"
+                    }
                 },
                 "colorette": {
-                    "version": "2.0.16",
-                    "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-                    "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
-                    "dev": true
-                },
-                "del": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/del/-/del-6.0.0.tgz",
-                    "integrity": "sha512-1shh9DQ23L16oXSZKB2JxpL7iMy2E0S9d517ptA1P8iw0alkPtQcrKH7ru31rYtKwF499HkTu+DRzq3TCKDFRQ==",
-                    "dev": true,
-                    "requires": {
-                        "globby": "^11.0.1",
-                        "graceful-fs": "^4.2.4",
-                        "is-glob": "^4.0.1",
-                        "is-path-cwd": "^2.2.0",
-                        "is-path-inside": "^3.0.2",
-                        "p-map": "^4.0.0",
-                        "rimraf": "^3.0.2",
-                        "slash": "^3.0.0"
-                    }
-                },
-                "globby": {
-                    "version": "11.1.0",
-                    "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-                    "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-                    "dev": true,
-                    "requires": {
-                        "array-union": "^2.1.0",
-                        "dir-glob": "^3.0.1",
-                        "fast-glob": "^3.2.9",
-                        "ignore": "^5.2.0",
-                        "merge2": "^1.4.1",
-                        "slash": "^3.0.0"
-                    }
-                },
-                "ignore": {
-                    "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-                    "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+                    "version": "2.0.19",
+                    "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+                    "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
                     "dev": true
                 },
                 "ipaddr.js": {
@@ -34316,20 +34162,11 @@
                     "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
                     "dev": true
                 },
-                "is-path-inside": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-                    "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
                     "dev": true
-                },
-                "p-map": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
-                    "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-                    "dev": true,
-                    "requires": {
-                        "aggregate-error": "^3.0.0"
-                    }
                 },
                 "rimraf": {
                     "version": "3.0.2",
@@ -34341,23 +34178,15 @@
                     }
                 },
                 "schema-utils": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
-                    "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
+                    "integrity": "sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==",
                     "dev": true,
                     "requires": {
-                        "@types/json-schema": "^7.0.8",
-                        "ajv": "^6.12.5",
-                        "ajv-keywords": "^3.5.2"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "7.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.0.1.tgz",
-                    "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-regex": "^6.0.1"
+                        "@types/json-schema": "^7.0.9",
+                        "ajv": "^8.8.0",
+                        "ajv-formats": "^2.1.1",
+                        "ajv-keywords": "^5.0.0"
                     }
                 }
             }
@@ -34545,9 +34374,9 @@
             }
         },
         "ws": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-            "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.8.0.tgz",
+            "integrity": "sha512-JDAgSYQ1ksuwqfChJusw1LSJ8BizJ2e/vVu5Lxjq3YvNJNlROv1ui4i+c/kUUrPheBvQl4c5UbERhTwKa6QBJQ==",
             "dev": true,
             "requires": {}
         },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "@lingui/cli": "^3.13.3",
         "@lingui/macro": "^3.13.3",
         "@ls-lint/ls-lint": "^1.11.2",
-        "@redhat-cloud-services/frontend-components-config": "^4.6.6",
+        "@redhat-cloud-services/frontend-components-config": "^4.6.14",
         "@typescript-eslint/eslint-plugin": "^5.22.0",
         "@typescript-eslint/parser": "^5.28.0",
         "babel-core": "^7.0.0-bridge.0",

--- a/src/index.html
+++ b/src/index.html
@@ -3,9 +3,8 @@
     <head>
         <meta charset="UTF-8">
         <title><%= htmlWebpackPlugin.options.applicationName %></title>
-        <%= htmlWebpackPlugin.options.targetEnv === 'insights' ? '<esi:include src="/@@env/chrome/snippets/head.html"/>' : null %>
     </head>
     <body>
-        <%= htmlWebpackPlugin.options.targetEnv === 'insights' ? '<esi:include src="/@@env/chrome/snippets/body.html"/>' : '<div id="root"></div>' %>
+        <div id="root"></div>
     </body>
 </html>


### PR DESCRIPTION
This is a manual backport of #1975,
except without `@redhat-cloud-services/frontend-components-config-utilities` (only relevant to insights dev mode),
and using #2260 for the bump itself.

---

Manually bumping `@redhat-cloud-services/frontend-components-config` to 4.6.14.

> #### Disabling ESI tags in insights mode
>
> We will be dropping the support and soon your development environments will stop working if you don't upgrade your shared webpack config to [@redhat-cloud-services/frontend-components-config/v/4.6.9](https://www.npmjs.com/package/@redhat-cloud-services/frontend-components-config/v/4.6.9) 
>
> If you are not using the shared config, and only using the proxy from utilities you will have to add a new webpack dev server middleware setup. You can check an example here: https://github.com/project-koku/koku-ui/blob/main/webpack.config.js#L253
>
> I would like to ask you to finish with this change ASAP.

(Also related to https://github.com/ansible/ansible-hub-ui/pull/1893)

---

Also dropping mentions of ESI from README and index.html, which is now only used by standalone.