### PR TITLE
[stable-4.5] cypress: wait for pulp to start serving index

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -170,10 +170,26 @@ jobs:
           "containers": "localhost:8002"
         }' > cypress.env.json
 
+    - name: "Wait for pulp to start responding"
+      run: |
+        for attempt in {1..5}; do
+          curl -sf http://localhost:8002/static/galaxy_ng/index.html && break || true
+          echo attempt $attempt / 5 failed, trying again in 1m
+          sleep 1m
+        done
+
     - name: "Ensure index.html uses the new js"
       run: |
         echo 'expecting /static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
         curl http://localhost:8002/static/galaxy_ng/index.html | tee /dev/stderr | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
+
+    - name: "Ensure galaxykit can connect to the server"
+      run: |
+        galaxykit -s 'http://localhost:8002/api/galaxy/' -u admin -p admin collection list
+
+    - name: "Check initial feature flags"
+      run: |
+        curl -s -u admin:admin http://localhost:8002/api/galaxy/_ui/v1/feature-flags/ | jq
 
     - name: "Run cypress"
       working-directory: 'ansible-hub-ui/test'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -185,7 +185,7 @@ jobs:
 
     - name: "Ensure galaxykit can connect to the server"
       run: |
-        galaxykit -s 'http://localhost:8002/api/galaxy/' -u admin -p admin collection list
+        galaxykit -s 'http://localhost:8002/api/galaxy/' -u admin -p admin namespace list
 
     - name: "Check initial feature flags"
       run: |


### PR DESCRIPTION
should prevent 4.5 failures where we try loading index.html too soon and get a 502 instead

    expecting /static/galaxy_ng/js/App.1656338171157.5cfc891e6208762942a6.js
    ...
    <head><title>502 Bad Gateway</title></head>

(example https://github.com/ansible/ansible-hub-ui/runs/7074200208?check_suite_focus=true)

also adding a "galaxykit works" check and a "see feature flags" check from master