### PR TITLE
Fix roles and roles/create screens for user with group perms

### DIFF
--- a/CHANGES/1698.misc
+++ b/CHANGES/1698.misc
@@ -1,0 +1,1 @@
+fix roles and roles/create screens for user with group permissions

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -151,6 +151,12 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
       });
     }
 
+    const addRoles = this.context.user.is_superuser && (
+      <Link to={Paths.createRole}>
+        <Button variant={'primary'}>{t`Add roles`}</Button>
+      </Link>
+    );
+
     return (
       <React.Fragment>
         <AlertList
@@ -183,11 +189,7 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
           <EmptyStateNoData
             title={t`There are currently no roles`}
             description={t`Please add a role by using the button below.`}
-            button={
-              <Link to={Paths.createRole}>
-                <Button variant={'primary'}>{t`Add roles`}</Button>
-              </Link>
-            }
+            button={addRoles}
           />
         ) : (
           <Main>
@@ -234,11 +236,7 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
                             ]}
                           />
                         </ToolbarItem>
-                        <ToolbarItem>
-                          <Link to={Paths.createRole}>
-                            <Button variant={'primary'}>{t`Add roles`}</Button>
-                          </Link>
-                        </ToolbarItem>
+                        <ToolbarItem>{addRoles}</ToolbarItem>
                       </ToolbarGroup>
                     </ToolbarContent>
                   </Toolbar>

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -166,7 +166,7 @@ export class Routes extends React.Component<IRoutesProps> {
 
   // Note: must be ordered from most specific to least specific
   getRoutes(): IRouteConfig[] {
-    const { featureFlags } = this.context;
+    const { featureFlags, user } = this.context;
     let isContainerDisabled = true;
     let isUserMgmtDisabled = false;
     if (featureFlags) {
@@ -217,7 +217,11 @@ export class Routes extends React.Component<IRoutesProps> {
       { comp: GroupDetail, path: Paths.groupDetail },
       { comp: TaskDetail, path: Paths.taskDetail },
       { comp: EditRole, path: Paths.roleEdit },
-      { comp: RoleCreate, path: Paths.createRole },
+      {
+        comp: RoleCreate,
+        path: Paths.createRole,
+        isDisabled: !user?.is_superuser,
+      },
       { comp: RoleList, path: Paths.roleList },
       { comp: RepositoryList, path: Paths.repositories },
       { comp: UserProfile, path: Paths.userProfileSettings },


### PR DESCRIPTION
Issue: [AAH-1698](https://issues.redhat.com/browse/AAH-1698)

- if a user isn't `superuser` then redirect to 404 on the `ui/roles/create` screen
- hide the `add roles` button for non-superuser on the `ui/roles` screen