### PR TITLE
Fix additional perms

### DIFF
--- a/src/components/rbac/owners-tab.tsx
+++ b/src/components/rbac/owners-tab.tsx
@@ -9,6 +9,8 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+
 import { GroupType, RoleType } from 'src/api';
 import {
   DeleteModal,
@@ -23,8 +25,10 @@ import {
   SelectRoles,
   SortTable,
   WizardModal,
+  EmptyStateCustom,
 } from 'src/components';
 import { ParamHelper, errorMessage } from 'src/utilities';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IProps {
   addAlert: (alert) => void;
@@ -82,7 +86,13 @@ export class OwnersTab extends React.Component<IProps, IState> {
         {showGroupRemoveModal ? this.renderGroupRemoveModal() : null}
         {showGroupSelectWizard ? this.renderGroupSelectWizard() : null}
 
-        {noData ? (
+        {!this.context.user.is_superuser ? (
+          <EmptyStateCustom
+            title={t`You do not have the required permissions.`}
+            description={t`Please contact the server administrator for elevated permissions.`}
+            icon={ExclamationTriangleIcon}
+          />
+        ) : noData ? (
           <EmptyStateNoData
             title={t`There are currently no owners assigned.`}
             description={t`Please add an owner by using the button below.`}
@@ -504,3 +514,4 @@ export class OwnersTab extends React.Component<IProps, IState> {
     });
   }
 }
+OwnersTab.contextType = AppContext;

--- a/src/components/rbac/owners-tab.tsx
+++ b/src/components/rbac/owners-tab.tsx
@@ -86,7 +86,8 @@ export class OwnersTab extends React.Component<IProps, IState> {
         {showGroupRemoveModal ? this.renderGroupRemoveModal() : null}
         {showGroupSelectWizard ? this.renderGroupSelectWizard() : null}
 
-        {!this.context.user.is_superuser ? (
+        {!this.context.user.is_superuser &&
+        !this.context.user.model_permissions.view_group ? (
           <EmptyStateCustom
             title={t`You do not have the required permissions.`}
             description={t`Please contact the server administrator for elevated permissions.`}
@@ -154,16 +155,18 @@ export class OwnersTab extends React.Component<IProps, IState> {
     const { urlPrefix } = this.props;
 
     const dropdownItems = [
-      <DropdownItem
-        key='remove'
-        onClick={() => {
-          this.setState({
-            showGroupRemoveModal: group,
-          });
-        }}
-      >
-        <Trans>Remove group</Trans>
-      </DropdownItem>,
+      this.context.user.model_permissions.change_containernamespace && (
+        <DropdownItem
+          key='remove'
+          onClick={() => {
+            this.setState({
+              showGroupRemoveModal: group,
+            });
+          }}
+        >
+          <Trans>Remove group</Trans>
+        </DropdownItem>
+      ),
     ];
 
     return (
@@ -194,7 +197,7 @@ export class OwnersTab extends React.Component<IProps, IState> {
       return null;
     }
 
-    const buttonAdd = (
+    const buttonAdd = this.context.user.is_superuser && (
       <Button
         onClick={() =>
           this.setState({
@@ -252,12 +255,16 @@ export class OwnersTab extends React.Component<IProps, IState> {
               <td>{role}</td>
               <ListItemActions
                 kebabItems={[
-                  <DropdownItem
-                    key='remove-role'
-                    onClick={() => this.setState({ showRoleRemoveModal: role })}
-                  >
-                    {t`Remove role`}
-                  </DropdownItem>,
+                  this.context.user.is_superuser && (
+                    <DropdownItem
+                      key='remove-role'
+                      onClick={() =>
+                        this.setState({ showRoleRemoveModal: role })
+                      }
+                    >
+                      {t`Remove role`}
+                    </DropdownItem>
+                  ),
                 ]}
               />
             </ExpandableRow>

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -97,8 +97,12 @@ export function withContainerRepo(WrappedComponent) {
         permissions.includes(
           'container.namespace_change_containerdistribution',
         ) || permissions.includes('container.change_containernamespace');
+      const canSync = permissions.includes(
+        'container.change_containernamespace',
+      );
+
       const dropdownItems = [
-        this.state.repo.pulp.repository.remote && (
+        this.state.repo.pulp.repository.remote && canSync && (
           <DropdownItem
             key='sync'
             onClick={() => this.sync(this.state.repo.name)}

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -13,6 +13,7 @@ import {
   getHumanSize,
   waitForTask,
 } from 'src/utilities';
+import { AppContext } from 'src/loaders/app-context';
 
 import { Link, withRouter } from 'react-router-dom';
 
@@ -396,14 +397,16 @@ class ExecutionEnvironmentDetailImages extends React.Component<
       >
         {t`Use in Controller`}
       </DropdownItem>,
-      <DropdownItem
-        key='delete-image'
-        onClick={() => {
-          this.setState({ deleteModalVisible: true, selectedImage: image });
-        }}
-      >
-        {t`Delete`}
-      </DropdownItem>,
+      this.context.user.model_permissions.delete_containerrepository && (
+        <DropdownItem
+          key='delete-image'
+          onClick={() => {
+            this.setState({ deleteModalVisible: true, selectedImage: image });
+          }}
+        >
+          {t`Delete`}
+        </DropdownItem>
+      ),
     ].filter((truthy) => truthy);
 
     return (
@@ -615,3 +618,4 @@ class ExecutionEnvironmentDetailImages extends React.Component<
 }
 
 export default withRouter(withContainerRepo(ExecutionEnvironmentDetailImages));
+ExecutionEnvironmentDetailImages.contextType = AppContext;


### PR DESCRIPTION
No Issue

- hide `sync from registry` button in EE detail for users without permission (list view fixed in [#2189](https://github.com/ansible/ansible-hub-ui/pull/2189))
before:
![Screenshot from 2022-06-28 17-41-29](https://user-images.githubusercontent.com/19647757/176424195-6e69c5eb-4316-4462-b9b2-db6ba2c4a1a1.png)
after:
![Screenshot from 2022-06-28 17-42-06](https://user-images.githubusercontent.com/19647757/176424202-b936cb05-3ccb-41ad-b13b-e638331a2e7a.png)

- hide the delete button in the EE image tab for users without permission
![Screenshot from 2022-06-28 18-32-39](https://user-images.githubusercontent.com/19647757/176425858-d8626f58-dc82-4aea-a329-789fc1a6dab7.png)


### Owner's tab 
If the user doesn't have group permissions (`view_group`), he can't load roles in the list or modal (at the moment, `select roles` keeps loading in the modal), therefore should we limit visiting this tab? @himdel 

missing permissions (infinite loading) errors:
![Screenshot from 2022-06-29 14-00-04](https://user-images.githubusercontent.com/19647757/176438010-e5afd802-7cef-4be8-9ea1-854b83416621.png)

![Screenshot from 2022-06-29 14-00-31](https://user-images.githubusercontent.com/19647757/176438037-7f3362ac-37e6-4ebd-86bd-77ff58342132.png)

and only the superuser and users with group permissions should be display tab: 
![Screenshot from 2022-06-28 19-48-44](https://user-images.githubusercontent.com/19647757/176426598-d121978e-2670-4819-98ec-5d50274f792d.png)

- hide kebab button `Remove group` if user doesn't have `change_containernamespace` permission
![Screenshot from 2022-06-29 15-18-33](https://user-images.githubusercontent.com/19647757/176450339-22751db7-bfdb-426c-b552-3181f4a6948d.png)

- hide kebab button `Remove role` and `Add roles` button if user isn't superuser
![Screenshot from 2022-06-29 15-02-11](https://user-images.githubusercontent.com/19647757/176451116-b24ea125-2479-433e-afae-7e1cffc623f3.png)


