### PR TITLE
[rbac] cypress: install galaxykit branch with roles

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: "Install galaxykit dependency"
       run: |
-        pip install git+https://github.com/ansible/galaxykit.git
+        pip install git+https://github.com/himdel/galaxykit.git@object_roles
 
     - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |


### PR DESCRIPTION
So that we can use `galaxykit role create/remove`, `galaxykit group role add/remove` etc. before this is merged in master.

AAH-1691, AAH-1692, https://github.com/ansible/galaxykit/pull/39