### PR TITLE
Update repo management collection count

### DIFF
--- a/CHANGES/1677.misc
+++ b/CHANGES/1677.misc
@@ -1,0 +1,1 @@
+Update `content count` to `collection count` that reflects published minus excludes.

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -64,6 +64,29 @@ export class API extends HubAPI {
     }));
   }
 
+  getPublishedCount(repositoryPath: string) {
+    return new Promise((resolve, reject) => {
+      this.http
+        .get(`v3/plugin/ansible/content/${repositoryPath}/collections/index/`)
+        .then((result) => {
+          resolve(result.data.meta.count);
+        })
+        .catch((err) => reject(err));
+    });
+  }
+
+  getExcludesCount(repositoryPath: string) {
+    return new Promise((resolve, reject) => {
+      this.http
+        .get(`content/${repositoryPath}/v3/excludes/`)
+        .then((result) => {
+          resolve(result.data);
+          console.log('data: ', result.data);
+        })
+        .catch((err) => reject(err));
+    });
+  }
+
   setDeprecation(
     collection: CollectionListType,
     isDeprecated: boolean,

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -64,17 +64,17 @@ export class API extends HubAPI {
     }));
   }
 
-  getPublishedCount(repositoryPath: string) {
+  getPublishedCount(distributionPath: string) {
     return this.http
-      .get(`v3/plugin/ansible/content/${repositoryPath}/collections/index/`)
+      .get(`v3/plugin/ansible/content/${distributionPath}/collections/index/`)
       .then((result) => {
         return result.data.meta.count;
       });
   }
 
-  getExcludesCount(repositoryPath: string) {
+  getExcludesCount(distributionPath: string) {
     return this.http
-      .get(`content/${repositoryPath}/v3/excludes/`)
+      .get(`content/${distributionPath}/v3/excludes/`)
       .then((result) => {
         return result.data;
       });

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -81,7 +81,6 @@ export class API extends HubAPI {
         .get(`content/${repositoryPath}/v3/excludes/`)
         .then((result) => {
           resolve(result.data);
-          console.log('data: ', result.data);
         })
         .catch((err) => reject(err));
     });

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -65,25 +65,21 @@ export class API extends HubAPI {
   }
 
   getPublishedCount(repositoryPath: string) {
-    return new Promise((resolve, reject) => {
-      this.http
-        .get(`v3/plugin/ansible/content/${repositoryPath}/collections/index/`)
-        .then((result) => {
-          resolve(result.data.meta.count);
-        })
-        .catch((err) => reject(err));
-    });
+    return this.http
+      .get(`v3/plugin/ansible/content/${repositoryPath}/collections/index/`)
+      .then((result) => {
+        result.data.meta.count;
+      })
+      .catch((err) => err);
   }
 
   getExcludesCount(repositoryPath: string) {
-    return new Promise((resolve, reject) => {
-      this.http
-        .get(`content/${repositoryPath}/v3/excludes/`)
-        .then((result) => {
-          resolve(result.data);
-        })
-        .catch((err) => reject(err));
-    });
+    return this.http
+      .get(`content/${repositoryPath}/v3/excludes/`)
+      .then((result) => {
+        result.data;
+      })
+      .catch((err) => err);
   }
 
   setDeprecation(

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -68,18 +68,16 @@ export class API extends HubAPI {
     return this.http
       .get(`v3/plugin/ansible/content/${repositoryPath}/collections/index/`)
       .then((result) => {
-        result.data.meta.count;
-      })
-      .catch((err) => err);
+        return result.data.meta.count;
+      });
   }
 
   getExcludesCount(repositoryPath: string) {
     return this.http
       .get(`content/${repositoryPath}/v3/excludes/`)
       .then((result) => {
-        result.data;
-      })
-      .catch((err) => err);
+        return result.data;
+      });
   }
 
   setDeprecation(

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -8,6 +8,7 @@ export {
 export {
   CollectionListType,
   CollectionDetailType,
+  CollectionExcludesType,
   CollectionUsedByDependencies,
   DocsBlobType,
   PluginContentType,

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -112,7 +112,7 @@ export class ContentSummaryType {
 }
 
 export class CollectionExcludesType {
-  collections: Array<string>;
+  collections: string[];
 }
 
 export class CollectionDetailType {

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -111,6 +111,10 @@ export class ContentSummaryType {
   description: string;
 }
 
+export class CollectionExcludesType {
+  collections: Array<string>;
+}
+
 export class CollectionDetailType {
   deprecated: boolean;
   all_versions: {

--- a/src/components/collection-count/collection-count.tsx
+++ b/src/components/collection-count/collection-count.tsx
@@ -6,7 +6,7 @@ import { AlertType } from 'src/components';
 import { errorMessage } from 'src/utilities';
 
 interface IProps {
-  repositoryPath: string;
+  distributionPath: string;
 }
 interface IState {
   collectionCount: number;
@@ -25,7 +25,7 @@ export class CollectionCount extends React.Component<IProps, IState> {
   }
 
   componentDidMount() {
-    this.getCollectionCount(this.props.repositoryPath);
+    this.getCollectionCount(this.props.distributionPath);
   }
 
   render() {
@@ -34,7 +34,7 @@ export class CollectionCount extends React.Component<IProps, IState> {
   }
 
   private getCollectionCount(repo) {
-    const { repositoryPath } = this.props;
+    const { distributionPath } = this.props;
     const promises = [];
     promises.push(
       CollectionAPI.getPublishedCount(repo).then((count) => {
@@ -61,7 +61,7 @@ export class CollectionCount extends React.Component<IProps, IState> {
         this.setState({ loading: false });
         const { status, statusText } = err.response;
         this.addAlert(
-          t`Collection count for "${repositoryPath}" could not be displayed.`,
+          t`Collection count for "${distributionPath}" could not be displayed.`,
           'danger',
           errorMessage(status, statusText),
         );

--- a/src/components/collection-count/collection-count.tsx
+++ b/src/components/collection-count/collection-count.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { CollectionAPI, CollectionExcludesType } from 'src/api';
+import { Spinner } from '@patternfly/react-core';
+
+interface IProps {
+  repositoryPath: string;
+}
+interface IState {
+  collectionCount: string;
+}
+
+export class CollectionCount extends React.Component<IProps, IState> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      collectionCount: '',
+    };
+  }
+
+  componentDidMount() {
+    this.getCollectionCount(this.props.repositoryPath).then((count) => {
+      this.setState({ collectionCount: count });
+    });
+  }
+
+  render() {
+    const { collectionCount } = this.state;
+
+    return !collectionCount ? <Spinner /> : <td>{collectionCount}</td>;
+  }
+
+  private getCollectionCount(repo) {
+    const promises = [];
+    promises.push(
+      CollectionAPI.getPublishedCount(repo).then((count) => {
+        return count;
+      }),
+    );
+
+    promises.push(
+      CollectionAPI.getExcludesCount(repo).then(
+        (results: CollectionExcludesType) => {
+          const excludedCollections = results.collections;
+          const count = excludedCollections.length;
+          return count;
+        },
+      ),
+    );
+
+    Promise.all(promises).then((results) => {
+      const count = results[0] - results[1];
+      return count;
+    });
+  }
+}

--- a/src/components/collection-count/collection-count.tsx
+++ b/src/components/collection-count/collection-count.tsx
@@ -9,7 +9,7 @@ interface IProps {
   repositoryPath: string;
 }
 interface IState {
-  collectionCount: string;
+  collectionCount: number;
   alerts: AlertType[];
   loading: boolean;
 }
@@ -18,7 +18,7 @@ export class CollectionCount extends React.Component<IProps, IState> {
   constructor(props) {
     super(props);
     this.state = {
-      collectionCount: '',
+      collectionCount: null,
       alerts: [],
       loading: true,
     };
@@ -30,13 +30,7 @@ export class CollectionCount extends React.Component<IProps, IState> {
 
   render() {
     const { collectionCount, loading } = this.state;
-    return collectionCount && !loading ? (
-      <td>{collectionCount}</td>
-    ) : !collectionCount && loading ? (
-      <Spinner />
-    ) : (
-      <td></td>
-    );
+    return !loading ? <td>{collectionCount}</td> : <Spinner />;
   }
 
   private getCollectionCount(repo) {
@@ -61,7 +55,7 @@ export class CollectionCount extends React.Component<IProps, IState> {
     Promise.all(promises)
       .then((results) => {
         const count = results[0] - results[1];
-        this.setState({ collectionCount: count.toString(), loading: false });
+        this.setState({ collectionCount: count, loading: false });
       })
       .catch((err) => {
         this.setState({ loading: false });

--- a/src/components/collection-count/collection-count.tsx
+++ b/src/components/collection-count/collection-count.tsx
@@ -30,7 +30,7 @@ export class CollectionCount extends React.Component<IProps, IState> {
 
   render() {
     const { collectionCount, loading } = this.state;
-    return !loading ? <>{collectionCount}</> : <Spinner />;
+    return !loading ? <>{collectionCount}</> : <Spinner size='sm' />;
   }
 
   private getCollectionCount(repo) {

--- a/src/components/collection-count/collection-count.tsx
+++ b/src/components/collection-count/collection-count.tsx
@@ -30,7 +30,7 @@ export class CollectionCount extends React.Component<IProps, IState> {
 
   render() {
     const { collectionCount, loading } = this.state;
-    return !loading ? <td>{collectionCount}</td> : <Spinner />;
+    return !loading ? <>{collectionCount}</> : <Spinner />;
   }
 
   private getCollectionCount(repo) {

--- a/src/components/collection-count/collection-count.tsx
+++ b/src/components/collection-count/collection-count.tsx
@@ -1,12 +1,17 @@
 import * as React from 'react';
+import { t } from '@lingui/macro';
 import { CollectionAPI, CollectionExcludesType } from 'src/api';
 import { Spinner } from '@patternfly/react-core';
+import { AlertType } from 'src/components';
+import { errorMessage } from 'src/utilities';
 
 interface IProps {
   repositoryPath: string;
 }
 interface IState {
   collectionCount: string;
+  alerts: AlertType[];
+  loading: boolean;
 }
 
 export class CollectionCount extends React.Component<IProps, IState> {
@@ -14,22 +19,28 @@ export class CollectionCount extends React.Component<IProps, IState> {
     super(props);
     this.state = {
       collectionCount: '',
+      alerts: [],
+      loading: true,
     };
   }
 
   componentDidMount() {
-    this.getCollectionCount(this.props.repositoryPath).then((count) => {
-      this.setState({ collectionCount: count });
-    });
+    this.getCollectionCount(this.props.repositoryPath);
   }
 
   render() {
-    const { collectionCount } = this.state;
-
-    return !collectionCount ? <Spinner /> : <td>{collectionCount}</td>;
+    const { collectionCount, loading } = this.state;
+    return collectionCount && !loading ? (
+      <td>{collectionCount}</td>
+    ) : !collectionCount && loading ? (
+      <Spinner />
+    ) : (
+      <td></td>
+    );
   }
 
   private getCollectionCount(repo) {
+    const { repositoryPath } = this.props;
     const promises = [];
     promises.push(
       CollectionAPI.getPublishedCount(repo).then((count) => {
@@ -47,9 +58,32 @@ export class CollectionCount extends React.Component<IProps, IState> {
       ),
     );
 
-    Promise.all(promises).then((results) => {
-      const count = results[0] - results[1];
-      return count;
+    Promise.all(promises)
+      .then((results) => {
+        const count = results[0] - results[1];
+        this.setState({ collectionCount: count.toString(), loading: false });
+      })
+      .catch((err) => {
+        this.setState({ loading: false });
+        const { status, statusText } = err.response;
+        this.addAlert(
+          t`Collection count for "${repositoryPath}" could not be displayed.`,
+          'danger',
+          errorMessage(status, statusText),
+        );
+      });
+  }
+
+  private addAlert(title, variant, description?) {
+    this.setState({
+      alerts: [
+        ...this.state.alerts,
+        {
+          description,
+          title,
+          variant,
+        },
+      ],
     });
   }
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,6 +11,7 @@ export { Breadcrumbs } from './patternfly-wrappers/breadcrumbs';
 export { CardListSwitcher } from './card-list-switcher/card-list-switcher';
 export { CollectionCard } from './cards/collection-card';
 export { CollectionContentList } from './collection-detail/collection-content-list';
+export { CollectionCount } from './collection-count/collection-count';
 export { CollectionHeader } from './headers/collection-header';
 export { CollectionInfo } from './collection-detail/collection-info';
 export { CollectionFilter } from './collection-list/collection-filter';

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { DateComponent, EmptyStateNoData, SortTable, ClipboardCopy } from '..';
 import { Constants } from 'src/constants';
 import { getRepoUrl } from 'src/utilities';
+import { CollectionAPI } from 'src/api';
 
 interface IProps {
   repositories: {
@@ -94,6 +95,13 @@ export class LocalRepositoryTable extends React.Component<IProps> {
         </tbody>
       </table>
     );
+  }
+
+  private getCollectionCount(repo) {
+    CollectionAPI.getPublishedCount(repo).then((count) => {
+      console.log('pubCount: ', count);
+      return count;
+    });
   }
 
   private renderRow(distribution) {

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { DateComponent, EmptyStateNoData, SortTable, ClipboardCopy } from '..';
 import { Constants } from 'src/constants';
 import { getRepoUrl } from 'src/utilities';
-import { CollectionAPI, CollectionExcludesType } from 'src/api';
+import { CollectionCount } from 'src/components';
 
 interface IProps {
   repositories: {
@@ -97,30 +97,6 @@ export class LocalRepositoryTable extends React.Component<IProps> {
     );
   }
 
-  private getCollectionCount(repo) {
-    const promises = [];
-    promises.push(
-      CollectionAPI.getPublishedCount(repo).then((count) => {
-        return count;
-      }),
-    );
-
-    promises.push(
-      CollectionAPI.getExcludesCount(repo).then(
-        (results: CollectionExcludesType) => {
-          const excludedCollections = results.collections;
-          const count = excludedCollections.length;
-          return count;
-        },
-      ),
-    );
-
-    Promise.all(promises).then((results) => {
-      const count = results[0] - results[1];
-      return <td>{count}</td>;
-    });
-  }
-
   private renderRow(distribution) {
     const cliConfig = [
       '[galaxy]',
@@ -135,7 +111,7 @@ export class LocalRepositoryTable extends React.Component<IProps> {
       <tr key={distribution.name}>
         <td>{distribution.name}</td>
         <td>{distribution.repository.name}</td>
-        {this.getCollectionCount(distribution.base_path)}
+        <td>{<CollectionCount repositoryPath={distribution.base_path} />}</td>
         {DEPLOYMENT_MODE ===
         Constants.INSIGHTS_DEPLOYMENT_MODE ? null : distribution.repository
             .pulp_last_updated ? (

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -111,7 +111,9 @@ export class LocalRepositoryTable extends React.Component<IProps> {
       <tr key={distribution.name}>
         <td>{distribution.name}</td>
         <td>{distribution.repository.name}</td>
-        <td>{<CollectionCount repositoryPath={distribution.base_path} />}</td>
+        <td>
+          <CollectionCount repositoryPath={distribution.base_path} />
+        </td>
         {DEPLOYMENT_MODE ===
         Constants.INSIGHTS_DEPLOYMENT_MODE ? null : distribution.repository
             .pulp_last_updated ? (

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -112,7 +112,7 @@ export class LocalRepositoryTable extends React.Component<IProps> {
         <td>{distribution.name}</td>
         <td>{distribution.repository.name}</td>
         <td>
-          <CollectionCount repositoryPath={distribution.base_path} />
+          <CollectionCount distributionPath={distribution.base_path} />
         </td>
         {DEPLOYMENT_MODE ===
         Constants.INSIGHTS_DEPLOYMENT_MODE ? null : distribution.repository

--- a/test/cypress/integration/repo_management.js
+++ b/test/cypress/integration/repo_management.js
@@ -18,7 +18,7 @@ describe('Repo Management tests', () => {
     cy.visit(localRepoUrl);
     cy.get('[data-cy="SortTable-headers"]').contains('Distribution name');
     cy.get('[data-cy="SortTable-headers"]').contains('Repository name');
-    cy.get('[data-cy="SortTable-headers"]').contains('Content count');
+    cy.get('[data-cy="SortTable-headers"]').contains('Collection count');
     cy.get('[data-cy="SortTable-headers"]').contains('Last updated');
     cy.get('[data-cy="SortTable-headers"]').contains('Distribution URL');
     cy.get('[data-cy="SortTable-headers"]').contains('CLI configuration');


### PR DESCRIPTION
Issue: AAH-1677

This pr updates what used to be the `content count` for each repository to a `collection count` that reflects the excludes at `content/${repositoryPath}/v3/excludes/` subtracted from the published collections at `v3/plugin/ansible/content/${repositoryPath}/collections/index/`(meta.count).
