### PR TITLE
Added a download icon to the approval page

### DIFF
--- a/CHANGES/1621.feature
+++ b/CHANGES/1621.feature
@@ -1,0 +1,1 @@
+Add download icon to the aproval page.

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -19,12 +19,14 @@ import {
   Button,
   DropdownItem,
   Label,
+  ButtonVariant,
 } from '@patternfly/react-core';
 
 import {
   ExclamationTriangleIcon,
   ExclamationCircleIcon,
   CheckCircleIcon,
+  DownloadIcon,
 } from '@patternfly/react-icons';
 
 import {
@@ -33,6 +35,7 @@ import {
   TaskAPI,
   CertificateUploadAPI,
   Repositories,
+  CollectionAPI,
 } from 'src/api';
 import { errorMessage, filterIsSet, ParamHelper } from 'src/utilities';
 import {
@@ -368,6 +371,14 @@ class CertificationDashboard extends React.Component<
           >
             {version.version}
           </Link>
+          <Button
+            variant={ButtonVariant.link}
+            onClick={() => {
+              this.download(version.namespace, version.name, version.version);
+            }}
+          >
+            <DownloadIcon />
+          </Button>
         </td>
         <td>
           <DateComponent date={version.created_at} />
@@ -644,6 +655,14 @@ class CertificationDashboard extends React.Component<
           updatingVersions: [],
         });
       }),
+    );
+  }
+
+  private download(namespace: string, name: string, version: string) {
+    CollectionAPI.getDownloadURL('staging', namespace, name, version).then(
+      (downloadURL: string) => {
+        window.location.assign(downloadURL);
+      },
     );
   }
 


### PR DESCRIPTION
Issue: AAH-1621

The issue was created to make the signing process easier when user needs to download version - sign - upload signature. 

**After** 
![Screenshot from 2022-07-01 15-18-57](https://user-images.githubusercontent.com/8531681/176902781-101a4317-8bdb-43ad-afe1-28a0749395e3.png)
