### PR TITLE
Revert "[stable-4.2] Bump @patternfly/react-table from 4.83.1 to 4.93.1"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@babel/runtime": "^7.18.6",
                 "@patternfly/patternfly": "^4.202.1",
                 "@patternfly/react-core": "^4.198.5",
-                "@patternfly/react-table": "^4.93.1",
+                "@patternfly/react-table": "^4.83.1",
                 "@redhat-cloud-services/frontend-components": "^3.5.1",
                 "@redhat-cloud-services/frontend-components-utilities": "^2.2.7",
                 "@types/node": "^16.11.41",
@@ -2136,14 +2136,14 @@
             "integrity": "sha512-cQiiPqmwJOm9onuTfLPQNRlpAZwDIJ/zVfDQeaFqMQyPJtxtKn3lkphz5xErY5dPs9rR4X94ytQ1I9pkVzaPJQ=="
         },
         "node_modules/@patternfly/react-core": {
-            "version": "4.224.1",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.224.1.tgz",
-            "integrity": "sha512-v8wGGNoMGndAScAoE5jeOA5jVgymlLSwttPjQk/Idr0k7roSpOrsM39oXUR5DEgkZee45DW00WKTgmg50PP3FQ==",
+            "version": "4.198.5",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.198.5.tgz",
+            "integrity": "sha512-LMpOYgaCp6W8+2nT12D4/9+6RnIJufBPzn5xtr8/0+gvBe16VMlpBfb9msC5ibX28fWqSKzlEic1Ovn1vhUYFw==",
             "dependencies": {
-                "@patternfly/react-icons": "^4.75.1",
-                "@patternfly/react-styles": "^4.74.1",
-                "@patternfly/react-tokens": "^4.76.1",
-                "focus-trap": "6.9.2",
+                "@patternfly/react-icons": "^4.49.5",
+                "@patternfly/react-styles": "^4.48.5",
+                "@patternfly/react-tokens": "^4.50.5",
+                "focus-trap": "6.2.2",
                 "react-dropzone": "9.0.0",
                 "tippy.js": "5.1.2",
                 "tslib": "^2.0.0"
@@ -2159,28 +2159,28 @@
             "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         },
         "node_modules/@patternfly/react-icons": {
-            "version": "4.75.1",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.75.1.tgz",
-            "integrity": "sha512-1ly8SVi/kcc0zkiViOjUd8D5BEr7GeqWGmDPuDSBtD60l1dYf3hZc44IWFVkRM/oHZML/musdrJkLfh4MDqX9w==",
+            "version": "4.49.5",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.49.5.tgz",
+            "integrity": "sha512-pR04R32KZAd4uPWeFf/pYXp0uUTwDotsM1iPbjJ6Rpl1sELM4LuQV4gaG22dWLy24VCRizFoP6BSzDxmq+GY4g==",
             "peerDependencies": {
                 "react": "^16.8.0 || ^17.0.0",
                 "react-dom": "^16.8.0 || ^17.0.0"
             }
         },
         "node_modules/@patternfly/react-styles": {
-            "version": "4.74.1",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.74.1.tgz",
-            "integrity": "sha512-9eWvKrjtrJ3qhJkhY2GQKyYA13u/J0mU1befH49SYbvxZtkbuHdpKmXBAeQoHmcx1hcOKtiYXeKb+dVoRRNx0A=="
+            "version": "4.48.5",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.48.5.tgz",
+            "integrity": "sha512-kXY2piAInTuv1PxuQbSuDYJ+ugIsEs9MnwWqZOMARGrcsElbRLn+vtSxShx7AQeJ9V9e0v64gdgP7pIJqisd1Q=="
         },
         "node_modules/@patternfly/react-table": {
-            "version": "4.93.1",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.93.1.tgz",
-            "integrity": "sha512-N/zHkNsY3X3yUXPg6COwdZKAFmTCbWm25qCY2aHjrXlIlE2OKWaYvVag0CcTwPiQhIuCumztr9Y2Uw9uvv0Fsw==",
+            "version": "4.83.1",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.83.1.tgz",
+            "integrity": "sha512-mkq13x9funh+Nh2Uzj2ZQBOacNYc+a60yUAHZMXgNcljCJ3LTQUoYy6EonvYrqwSrpC7vj8nLt8+/XbDNc0Aig==",
             "dependencies": {
-                "@patternfly/react-core": "^4.224.1",
-                "@patternfly/react-icons": "^4.75.1",
-                "@patternfly/react-styles": "^4.74.1",
-                "@patternfly/react-tokens": "^4.76.1",
+                "@patternfly/react-core": "^4.214.1",
+                "@patternfly/react-icons": "^4.65.1",
+                "@patternfly/react-styles": "^4.64.1",
+                "@patternfly/react-tokens": "^4.66.1",
                 "lodash": "^4.17.19",
                 "tslib": "^2.0.0"
             },
@@ -2189,15 +2189,52 @@
                 "react-dom": "^16.8.0 || ^17.0.0"
             }
         },
+        "node_modules/@patternfly/react-table/node_modules/@patternfly/react-core": {
+            "version": "4.214.1",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.214.1.tgz",
+            "integrity": "sha512-XHEqXpnBEDyLVdAEDOYlGqFHnN43eNLSD5HABB99xO6541JV9MRnbxs0+v9iYnfhcKh/8bhA9ITXnUi3f2PEvg==",
+            "dependencies": {
+                "@patternfly/react-icons": "^4.65.1",
+                "@patternfly/react-styles": "^4.64.1",
+                "@patternfly/react-tokens": "^4.66.1",
+                "focus-trap": "6.2.2",
+                "react-dropzone": "9.0.0",
+                "tippy.js": "5.1.2",
+                "tslib": "^2.0.0"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@patternfly/react-table/node_modules/@patternfly/react-icons": {
+            "version": "4.65.1",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.65.1.tgz",
+            "integrity": "sha512-CUYFRPztFkR7qrXq/0UAhLjeHd8FdjLe4jBjj8tfKc7OXwxDeZczqNFyRMATZpPaduTH7BU2r3OUjQrgAbquWg==",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0"
+            }
+        },
+        "node_modules/@patternfly/react-table/node_modules/@patternfly/react-styles": {
+            "version": "4.64.1",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.64.1.tgz",
+            "integrity": "sha512-+GxULkP2o5Vpr9w+J4NiGOGzhTfNniYzdPGEF/yC+oDoAXB6Q1HJyQnEj+kJH31xNvwmw3G3VFtwRLX4ZWr0oA=="
+        },
+        "node_modules/@patternfly/react-table/node_modules/@patternfly/react-tokens": {
+            "version": "4.66.1",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.66.1.tgz",
+            "integrity": "sha512-k0IWqpufM6ezT+3gWlEamqQ7LW9yi8e8cBBlude5IU8eIEqIG6AccwR1WNBEK1wCVWGwVxakLMdf0XBLl4k52Q=="
+        },
         "node_modules/@patternfly/react-table/node_modules/tslib": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
             "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
         },
         "node_modules/@patternfly/react-tokens": {
-            "version": "4.76.1",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.76.1.tgz",
-            "integrity": "sha512-gLEezRSzQeflaPu3SCgYmWtuiqDIRtxNNFP1+ES7P2o56YHXJ5o1Pki7LpNCPk/VOzHy2+vRFE/7l+hBEweugw=="
+            "version": "4.50.5",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.50.5.tgz",
+            "integrity": "sha512-u8+f4eevQdVC7w4jmy+ynIB9R7A9NlI2v5L8GMtkWLt3A0S4DBzNbU90MPSVwgfw0XHcvdFQjuK3OaS06M0bxw=="
         },
         "node_modules/@redhat-cloud-services/frontend-components": {
             "version": "3.5.1",
@@ -8698,11 +8735,11 @@
             }
         },
         "node_modules/focus-trap": {
-            "version": "6.9.2",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.2.tgz",
-            "integrity": "sha512-gBEuXOPNOKPrLdZpMFUSTyIo1eT2NSZRrwZ9r/0Jqw5tmT3Yvxfmu8KBHw8xW2XQkw6E/JoG+OlEq7UDtSUNgw==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.2.2.tgz",
+            "integrity": "sha512-qWovH9+LGoKqREvJaTCzJyO0hphQYGz+ap5Hc4NqXHNhZBdxCi5uBPPcaOUw66fHmzXLVwvETLvFgpwPILqKpg==",
             "dependencies": {
-                "tabbable": "^5.3.2"
+                "tabbable": "^5.1.4"
             }
         },
         "node_modules/follow-redirects": {
@@ -18428,9 +18465,9 @@
             "dev": true
         },
         "node_modules/tabbable": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-            "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.2.0.tgz",
+            "integrity": "sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg=="
         },
         "node_modules/table": {
             "version": "5.4.6",
@@ -22598,14 +22635,14 @@
             "integrity": "sha512-cQiiPqmwJOm9onuTfLPQNRlpAZwDIJ/zVfDQeaFqMQyPJtxtKn3lkphz5xErY5dPs9rR4X94ytQ1I9pkVzaPJQ=="
         },
         "@patternfly/react-core": {
-            "version": "4.224.1",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.224.1.tgz",
-            "integrity": "sha512-v8wGGNoMGndAScAoE5jeOA5jVgymlLSwttPjQk/Idr0k7roSpOrsM39oXUR5DEgkZee45DW00WKTgmg50PP3FQ==",
+            "version": "4.198.5",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.198.5.tgz",
+            "integrity": "sha512-LMpOYgaCp6W8+2nT12D4/9+6RnIJufBPzn5xtr8/0+gvBe16VMlpBfb9msC5ibX28fWqSKzlEic1Ovn1vhUYFw==",
             "requires": {
-                "@patternfly/react-icons": "^4.75.1",
-                "@patternfly/react-styles": "^4.74.1",
-                "@patternfly/react-tokens": "^4.76.1",
-                "focus-trap": "6.9.2",
+                "@patternfly/react-icons": "^4.49.5",
+                "@patternfly/react-styles": "^4.48.5",
+                "@patternfly/react-tokens": "^4.50.5",
+                "focus-trap": "6.2.2",
                 "react-dropzone": "9.0.0",
                 "tippy.js": "5.1.2",
                 "tslib": "^2.0.0"
@@ -22619,29 +22656,59 @@
             }
         },
         "@patternfly/react-icons": {
-            "version": "4.75.1",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.75.1.tgz",
-            "integrity": "sha512-1ly8SVi/kcc0zkiViOjUd8D5BEr7GeqWGmDPuDSBtD60l1dYf3hZc44IWFVkRM/oHZML/musdrJkLfh4MDqX9w==",
+            "version": "4.49.5",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.49.5.tgz",
+            "integrity": "sha512-pR04R32KZAd4uPWeFf/pYXp0uUTwDotsM1iPbjJ6Rpl1sELM4LuQV4gaG22dWLy24VCRizFoP6BSzDxmq+GY4g==",
             "requires": {}
         },
         "@patternfly/react-styles": {
-            "version": "4.74.1",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.74.1.tgz",
-            "integrity": "sha512-9eWvKrjtrJ3qhJkhY2GQKyYA13u/J0mU1befH49SYbvxZtkbuHdpKmXBAeQoHmcx1hcOKtiYXeKb+dVoRRNx0A=="
+            "version": "4.48.5",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.48.5.tgz",
+            "integrity": "sha512-kXY2piAInTuv1PxuQbSuDYJ+ugIsEs9MnwWqZOMARGrcsElbRLn+vtSxShx7AQeJ9V9e0v64gdgP7pIJqisd1Q=="
         },
         "@patternfly/react-table": {
-            "version": "4.93.1",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.93.1.tgz",
-            "integrity": "sha512-N/zHkNsY3X3yUXPg6COwdZKAFmTCbWm25qCY2aHjrXlIlE2OKWaYvVag0CcTwPiQhIuCumztr9Y2Uw9uvv0Fsw==",
+            "version": "4.83.1",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.83.1.tgz",
+            "integrity": "sha512-mkq13x9funh+Nh2Uzj2ZQBOacNYc+a60yUAHZMXgNcljCJ3LTQUoYy6EonvYrqwSrpC7vj8nLt8+/XbDNc0Aig==",
             "requires": {
-                "@patternfly/react-core": "^4.224.1",
-                "@patternfly/react-icons": "^4.75.1",
-                "@patternfly/react-styles": "^4.74.1",
-                "@patternfly/react-tokens": "^4.76.1",
+                "@patternfly/react-core": "^4.214.1",
+                "@patternfly/react-icons": "^4.65.1",
+                "@patternfly/react-styles": "^4.64.1",
+                "@patternfly/react-tokens": "^4.66.1",
                 "lodash": "^4.17.19",
                 "tslib": "^2.0.0"
             },
             "dependencies": {
+                "@patternfly/react-core": {
+                    "version": "4.214.1",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-4.214.1.tgz",
+                    "integrity": "sha512-XHEqXpnBEDyLVdAEDOYlGqFHnN43eNLSD5HABB99xO6541JV9MRnbxs0+v9iYnfhcKh/8bhA9ITXnUi3f2PEvg==",
+                    "requires": {
+                        "@patternfly/react-icons": "^4.65.1",
+                        "@patternfly/react-styles": "^4.64.1",
+                        "@patternfly/react-tokens": "^4.66.1",
+                        "focus-trap": "6.2.2",
+                        "react-dropzone": "9.0.0",
+                        "tippy.js": "5.1.2",
+                        "tslib": "^2.0.0"
+                    }
+                },
+                "@patternfly/react-icons": {
+                    "version": "4.65.1",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-4.65.1.tgz",
+                    "integrity": "sha512-CUYFRPztFkR7qrXq/0UAhLjeHd8FdjLe4jBjj8tfKc7OXwxDeZczqNFyRMATZpPaduTH7BU2r3OUjQrgAbquWg==",
+                    "requires": {}
+                },
+                "@patternfly/react-styles": {
+                    "version": "4.64.1",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-4.64.1.tgz",
+                    "integrity": "sha512-+GxULkP2o5Vpr9w+J4NiGOGzhTfNniYzdPGEF/yC+oDoAXB6Q1HJyQnEj+kJH31xNvwmw3G3VFtwRLX4ZWr0oA=="
+                },
+                "@patternfly/react-tokens": {
+                    "version": "4.66.1",
+                    "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.66.1.tgz",
+                    "integrity": "sha512-k0IWqpufM6ezT+3gWlEamqQ7LW9yi8e8cBBlude5IU8eIEqIG6AccwR1WNBEK1wCVWGwVxakLMdf0XBLl4k52Q=="
+                },
                 "tslib": {
                     "version": "2.4.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
@@ -22650,9 +22717,9 @@
             }
         },
         "@patternfly/react-tokens": {
-            "version": "4.76.1",
-            "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.76.1.tgz",
-            "integrity": "sha512-gLEezRSzQeflaPu3SCgYmWtuiqDIRtxNNFP1+ES7P2o56YHXJ5o1Pki7LpNCPk/VOzHy2+vRFE/7l+hBEweugw=="
+            "version": "4.50.5",
+            "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-4.50.5.tgz",
+            "integrity": "sha512-u8+f4eevQdVC7w4jmy+ynIB9R7A9NlI2v5L8GMtkWLt3A0S4DBzNbU90MPSVwgfw0XHcvdFQjuK3OaS06M0bxw=="
         },
         "@redhat-cloud-services/frontend-components": {
             "version": "3.5.1",
@@ -27869,11 +27936,11 @@
             }
         },
         "focus-trap": {
-            "version": "6.9.2",
-            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.2.tgz",
-            "integrity": "sha512-gBEuXOPNOKPrLdZpMFUSTyIo1eT2NSZRrwZ9r/0Jqw5tmT3Yvxfmu8KBHw8xW2XQkw6E/JoG+OlEq7UDtSUNgw==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.2.2.tgz",
+            "integrity": "sha512-qWovH9+LGoKqREvJaTCzJyO0hphQYGz+ap5Hc4NqXHNhZBdxCi5uBPPcaOUw66fHmzXLVwvETLvFgpwPILqKpg==",
             "requires": {
-                "tabbable": "^5.3.2"
+                "tabbable": "^5.1.4"
             }
         },
         "follow-redirects": {
@@ -35454,9 +35521,9 @@
             "dev": true
         },
         "tabbable": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-            "integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.2.0.tgz",
+            "integrity": "sha512-0uyt8wbP0P3T4rrsfYg/5Rg3cIJ8Shl1RJ54QMqYxm1TLdWqJD1u6+RQjr2Lor3wmfT7JRHkirIwy99ydBsyPg=="
         },
         "table": {
             "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "@babel/runtime": "^7.18.6",
         "@patternfly/patternfly": "^4.202.1",
         "@patternfly/react-core": "^4.198.5",
-        "@patternfly/react-table": "^4.93.1",
+        "@patternfly/react-table": "^4.83.1",
         "@redhat-cloud-services/frontend-components": "^3.5.1",
         "@redhat-cloud-services/frontend-components-utilities": "^2.2.7",
         "@types/node": "^16.11.41",


### PR DESCRIPTION
Reverts ansible/ansible-hub-ui#2289

```
ERROR in ./node_modules/@redhat-cloud-services/frontend-components/esm/FilterChips/FilterChips.js
Module not found: Error: Can't resolve '@patternfly/react-core/dist/esm/components/ChipGroup/Chip.js' in '/home/himdel/ansible-hub-ui-4.2/node_modules/@redhat-cloud-services/frontend-components/esm/FilterChips'
 @ ./node_modules/@redhat-cloud-services/frontend-components/esm/FilterChips/FilterChips.js 11:0-84 40:46-50 62:40-44
 @ ./node_modules/@redhat-cloud-services/frontend-components/esm/FilterChips/index.js
 @ ./node_modules/@redhat-cloud-services/frontend-components/esm/index.js
 @ ./src/containers/collection-detail/collection-content.tsx
 @ ./src/containers/index.ts
 @ ./src/loaders/standalone/standalone-loader.tsx
 @ ./src/entry-standalone.tsx
```

looks like this causes a version of react-core not compatible with frontend-components
but frontend-components interdepends with frontend config and thus webpack
reverting and not updating react-table in 4.2 anymore