### PR TITLE
webpack.base: don't query git for version when HUB_UI_VERSION is available

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -15,7 +15,10 @@ const isBuild = process.env.NODE_ENV === 'production';
 // a normal webpack config. See config/insights.prod.webpack.config.js for an
 // example
 
-const gitCommit = execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
+// only run git when HUB_UI_VERSION is NOT provided
+const gitCommit =
+  process.env.HUB_UI_VERSION ||
+  execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
 
 // Default user defined settings
 const defaultConfigs = [


### PR DESCRIPTION
Issue [AAP-4222](https://issues.redhat.com/browse/AAP-4222)

this allows us to display build versions instead of git commits in the "UI Version" about modal field (and the UiVersion html comment)

providing a HUB_UI_VERSION env string will stop the build from trying to run git