### PR TITLE
Use "updated" instead of "released" for Collection versions

### DIFF
--- a/CHANGES/1575.misc
+++ b/CHANGES/1575.misc
@@ -1,0 +1,1 @@
+Use "updated" instead of "released" for Collection versions

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -370,7 +370,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                 >
                   v{v.version}
                 </Button>{' '}
-                {t`released ${isLatestVersion(v)}`}
+                {t`updated ${isLatestVersion(v)}`}
               </ListItem>
             ))}
           </List>
@@ -509,7 +509,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                       }
                     >
                       <Trans>
-                        {v.version} released {isLatestVersion(v)}
+                        {v.version} updated {isLatestVersion(v)}
                       </Trans>
                     </SelectOption>
                   ))}


### PR DESCRIPTION
it seems the `created` field actually means "uploaded/synced to this pulp instance", which is misleading.
=> changing from "version 1.2.3 released 5 minutes ago" to "version 1.2.3 updated 5 minutes ago".

Before:

![20220707183709](https://user-images.githubusercontent.com/289743/177845266-cd061e34-b9fe-4a5b-8b5b-810f446e5b98.png)

After:

![20220707183557](https://user-images.githubusercontent.com/289743/177845148-b086049a-0582-4fe7-ad89-3cc5f93f5fee.png)

Issue: AAH-1575