### PR TITLE
Approvals: don't show success alert on `updateCertification` failure, `waitForTask` first

### DIFF
--- a/CHANGES/1769.bug
+++ b/CHANGES/1769.bug
@@ -1,0 +1,1 @@
+Fix success alert after signature upload failure

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -599,21 +599,19 @@ class CertificationDashboard extends React.Component<
         ),
       )
       .then(() => CollectionVersionAPI.list(this.state.params))
-      .then((result) =>
-        this.setState({ updatingVersions: [], versions: result.data.data }),
-      )
+      .then((result) => this.setState({ versions: result.data.data }))
       .catch((error) => {
         const description = !error.response
           ? error
           : errorMessage(error.response.status, error.response.statusText);
 
-        this.setState({ updatingVersions: [] });
         this.addAlert(
           t`Changes to certification status for collection "${version.namespace} ${version.name} v${version.version}" could not be saved.`,
           'danger',
           description,
         );
-      });
+      })
+      .finally(() => this.setState({ updatingVersions: [] }));
   }
 
   private queryCollections() {

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -554,8 +554,7 @@ class CertificationDashboard extends React.Component<
           'success',
         ),
       )
-      .then(() => CollectionVersionAPI.list(this.state.params))
-      .then((result) => this.setState({ versions: result.data.data }))
+      .then(() => this.queryCollections())
       .catch((error) => {
         const description = !error.response
           ? error
@@ -587,8 +586,7 @@ class CertificationDashboard extends React.Component<
           'success',
         ),
       )
-      .then(() => CollectionVersionAPI.list(this.state.params))
-      .then((result) => this.setState({ versions: result.data.data }))
+      .then(() => this.queryCollections())
       .catch((error) => {
         const description = !error.response
           ? error
@@ -599,20 +597,31 @@ class CertificationDashboard extends React.Component<
           'danger',
           description,
         );
-      })
-      .finally(() => this.setState({ updatingVersions: [] }));
+      });
   }
 
   private queryCollections() {
     this.setState({ loading: true }, () =>
-      CollectionVersionAPI.list(this.state.params).then((result) => {
-        this.setState({
-          versions: result.data.data,
-          itemCount: result.data.meta.count,
-          loading: false,
-          updatingVersions: [],
-        });
-      }),
+      CollectionVersionAPI.list(this.state.params)
+        .then((result) => {
+          this.setState({
+            versions: result.data.data,
+            itemCount: result.data.meta.count,
+            loading: false,
+            updatingVersions: [],
+          });
+        })
+        .catch((error) => {
+          this.addAlert(
+            t`Error loading collections.`,
+            'danger',
+            error?.message,
+          );
+          this.setState({
+            loading: false,
+            updatingVersions: [],
+          });
+        }),
     );
   }
 

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -526,22 +526,26 @@ class CertificationDashboard extends React.Component<
     });
   }
 
-  private async submitCertificate(file: File) {
+  private submitCertificate(file: File) {
     const version = this.state.versionToUploadCertificate;
-    const response = await Repositories.getRepository({
-      name: 'staging',
-    });
     const signed_collection = `${PULP_API_BASE_PATH}content/ansible/collection_versions/${version.id}/`;
 
-    CertificateUploadAPI.upload({
-      file,
-      repository: response.data.results[0].pulp_href,
-      signed_collection,
+    Repositories.getRepository({
+      name: 'staging',
     })
+      .then((response) =>
+        CertificateUploadAPI.upload({
+          file,
+          repository: response.data.results[0].pulp_href,
+          signed_collection,
+        }),
+      )
       .then((result) => {
         waitForTask(parsePulpIDFromURL(result.data.task))
           .then(() => {
-            this.updateList();
+            CollectionVersionAPI.list(this.state.params).then((result) =>
+              this.setState({ versions: result.data.data }),
+            );
             this.setState({
               alerts: this.state.alerts.concat({
                 variant: 'success',

--- a/src/utilities/wait-for-task.ts
+++ b/src/utilities/wait-for-task.ts
@@ -2,7 +2,7 @@ import { t } from '@lingui/macro';
 import { TaskAPI } from 'src/api';
 import { parsePulpIDFromURL } from './parse-pulp-id';
 
-export function waitForTask(task, bailAfter = 10) {
+export function waitForTask(task, waitMs = 5000, bailAfter = 10) {
   return TaskAPI.get(task).then((result) => {
     const failing = ['skipped', 'failed', 'canceled'];
 
@@ -19,7 +19,7 @@ export function waitForTask(task, bailAfter = 10) {
         );
       }
 
-      return new Promise((r) => setTimeout(r, 5000)).then(() =>
+      return new Promise((r) => setTimeout(r, waitMs)).then(() =>
         waitForTask(task, bailAfter - 1),
       );
     }

--- a/test/cypress/e2e/approval/collection_approval.js
+++ b/test/cypress/e2e/approval/collection_approval.js
@@ -29,16 +29,21 @@ describe('tests the approval list screen ', () => {
     cy.get('.pf-c-chip > button[aria-label="close"]').click();
     cy.wait('@reload');
 
-    //reject
-
+    // reject
     cy.get('button[aria-label="Actions"]:first').click();
     cy.contains('Reject').click();
-    cy.get('tr').eq(1).contains('Rejected');
+    cy.contains(
+      '[data-cy="CertificationDashboard-row"]:first-child',
+      'Rejected',
+    );
 
-    //approve
+    // approve
     cy.get('button[aria-label="Actions"]:first').click();
     cy.contains('Approve').click();
-    cy.get('tr').eq(1).contains('Approved');
+    cy.contains(
+      '[data-cy="CertificationDashboard-row"]:first-child',
+      'Approved',
+    );
   });
 
   it('view the imports logs', () => {


### PR DESCRIPTION
Fixes AAH-1769

Introduced in #1469, `.then(() => { setState(); waitForUpdate(); })` became `.then(() => { setState(); waitForUpdate(); }, addAlert())` instead of `.then(() => { setState(); waitForUpdate(); addAlert(); })` in `updateCertification()`, causing the success alert to appear even on failure, and definitely before any waiting was done.

Also the alerts were actually not waiting for the task, moving so this happens once the task was completed or failed.

Also, the `waitForUpdate` logic had extra copy of the failure alert because it was never rejecting the promise => replacing by the shared `waitForTask` + a single then to requery versions, and a compatible rejection.

And updated `submitCertificate` in very much the same way, though the issue there is already fixed since #2281.
