### PR TITLE
Enable FeatureFlagsAPI in insights mode

### DIFF
--- a/CHANGES/1800.misc
+++ b/CHANGES/1800.misc
@@ -1,0 +1,1 @@
+Read feature flags in insights mode

--- a/src/api/active-user.ts
+++ b/src/api/active-user.ts
@@ -1,22 +1,11 @@
 import { Constants } from 'src/constants';
 import { HubAPI } from './hub';
+import { UserType } from './response-types/user';
 
 class API extends HubAPI {
   apiPath = this.getUIPath('me/');
 
-  getUser() {
-    if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
-      // we don't care about entitlements stuff in the UI, so just
-      // return the user's identity
-      return window.insights.chrome.auth
-        .getUser()
-        .then((result) => result.identity);
-    } else if (DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE) {
-      return this.getActiveUser();
-    }
-  }
-
-  getActiveUser() {
+  getUser(): Promise<UserType> {
     return this.http.get(this.apiPath).then((result) => result.data);
   }
 

--- a/src/api/active-user.ts
+++ b/src/api/active-user.ts
@@ -16,14 +16,11 @@ class API extends HubAPI {
   // insights has some asinine way of loading tokens that involves forcing the
   // page to refresh before loading the token that can't be done witha single
   // API request.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getToken(): Promise<any> {
+  getToken(): Promise<{ data: { token: string } }> {
     if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
-      return new Promise((resolve, reject) => {
-        reject(
-          'Use window.insights.chrome.auth to get tokens for insights deployments',
-        );
-      });
+      return Promise.reject(
+        'Use window.insights.chrome.auth to get tokens for insights deployments',
+      );
     }
 
     return this.http.post('v3/auth/token/', {});
@@ -40,22 +37,14 @@ class API extends HubAPI {
   login(username, password) {
     const loginURL = this.getUIPath('auth/login/');
 
-    return new Promise((resolve, reject) => {
-      // Make a get request to the login endpoint to set CSRF tokens before making
-      // the authentication reqest
-      this.http
-        .get(loginURL)
-        .then(() => {
-          this.http
-            .post(loginURL, {
-              username: username,
-              password: password,
-            })
-            .then((response) => resolve(response))
-            .catch((err) => reject(err));
-        })
-        .catch((err) => reject(err));
-    });
+    // Make a get request to the login endpoint to set CSRF tokens before making
+    // the authentication reqest
+    return this.http.get(loginURL).then(() =>
+      this.http.post(loginURL, {
+        username,
+        password,
+      }),
+    );
   }
 }
 

--- a/src/api/active-user.ts
+++ b/src/api/active-user.ts
@@ -1,37 +1,23 @@
 import { Constants } from 'src/constants';
 import { HubAPI } from './hub';
 
-type GetUserReturn = Awaited<
-  Promise<ReturnType<typeof window.insights.chrome.auth.getUser>>
->;
-
 class API extends HubAPI {
   apiPath = this.getUIPath('me/');
 
-  getUser(): Promise<GetUserReturn['identity']> {
+  getUser() {
     if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
-      return new Promise((resolve, reject) => {
-        window.insights.chrome.auth
-          .getUser()
-          // we don't care about entitlements stuff in the UI, so just
-          // return the user's identity
-          .then((result) => resolve(result.identity))
-          .catch((result) => reject(result));
-      });
+      // we don't care about entitlements stuff in the UI, so just
+      // return the user's identity
+      return window.insights.chrome.auth
+        .getUser()
+        .then((result) => result.identity);
     } else if (DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE) {
-      return new Promise((resolve, reject) => {
-        this.http
-          .get(this.apiPath)
-          .then((result) => {
-            resolve(result.data);
-          })
-          .catch((result) => reject(result));
-      });
+      return this.getActiveUser();
     }
   }
 
   getActiveUser() {
-    return this.http.get(this.apiPath);
+    return this.http.get(this.apiPath).then((result) => result.data);
   }
 
   saveUser(data) {

--- a/src/api/response-types/user.ts
+++ b/src/api/response-types/user.ts
@@ -1,22 +1,3 @@
-export class InsightsUserType {
-  account_number: string;
-  internal: {
-    account_id: number;
-    org_id: string;
-  };
-  type: string;
-  user: {
-    email: string;
-    first_name: string;
-    is_active: boolean;
-    is_internal: boolean;
-    is_org_admin: boolean;
-    last_name: string;
-    locale: string;
-    username: string;
-  };
-}
-
 export class Permissions {
   add_group: boolean;
   add_namespace: boolean;

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import './header.scss';
 
 import { Title } from '@patternfly/react-core';
+import { Constants } from 'src/constants';
 
 interface IProps {
   title: string;
@@ -29,15 +30,19 @@ export class BaseHeader extends React.Component<IProps> {
       versionControl,
       status,
     } = this.props;
+
+    const showRepoSelector =
+      contextSelector && DEPLOYMENT_MODE !== Constants.INSIGHTS_DEPLOYMENT_MODE;
+
     return (
       <div className={cx('background', className)}>
-        {contextSelector && (
+        {showRepoSelector && (
           <div className='breadcrumb-container'>{contextSelector}</div>
         )}
         {breadcrumbs && (
           <div className='breadcrumb-container'>{breadcrumbs}</div>
         )}
-        {!breadcrumbs && !contextSelector && <div className='placeholder' />}
+        {!breadcrumbs && !showRepoSelector && <div className='placeholder' />}
 
         <div className='column-section'>
           <div className='title-box'>

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -23,7 +23,6 @@ import { errorMessage, ErrorMessagesType } from 'src/utilities';
 interface IProps {
   namespace: NamespaceType;
   errorMessages: ErrorMessagesType;
-  userId: string;
 
   updateNamespace: (namespace) => void;
 }

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -32,6 +32,7 @@ interface IState {
 
 export class RepoSelector extends React.Component<IProps, IState> {
   static contextType = AppContext;
+
   constructor(props) {
     super(props);
 
@@ -39,10 +40,6 @@ export class RepoSelector extends React.Component<IProps, IState> {
   }
 
   render() {
-    if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
-      return null;
-    }
-
     const repoNames = Constants.REPOSITORYNAMES;
 
     return (

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -14,12 +14,7 @@ import {
   EmptyStateUnauthorized,
   LoadingPageSpinner,
 } from 'src/components';
-import {
-  MyNamespaceAPI,
-  NamespaceType,
-  ActiveUserAPI,
-  NamespaceLinkType,
-} from 'src/api';
+import { MyNamespaceAPI, NamespaceType, NamespaceLinkType } from 'src/api';
 
 import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import {
@@ -43,7 +38,6 @@ interface IState {
   params: {
     tab?: string;
   };
-  userId: string;
   unauthorized: boolean;
 }
 
@@ -63,7 +57,6 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
       loading: false,
       alerts: [],
       namespace: null,
-      userId: '',
       newLinkURL: '',
       newLinkName: '',
       errorMessages: {},
@@ -76,36 +69,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
   }
 
   componentDidMount() {
-    this.setState({ loading: true }, () => {
-      ActiveUserAPI.getUser()
-        .then((result) => {
-          this.setState({ userId: result.account_number }, () =>
-            this.loadNamespace(),
-          );
-        })
-        .catch((e) => {
-          const { status, statusText } = e.response;
-          this.setState(
-            {
-              loading: false,
-              redirect: formatPath(Paths.namespaceByRepo, {
-                namespace: this.props.match.params['namespace'],
-                repo: this.context.selectedRepo,
-              }),
-            },
-            () => {
-              this.context.setAlerts([
-                ...this.context.alerts,
-                {
-                  variant: 'danger',
-                  title: t`Active user profile "${this.context.user?.username}" could not be displayed.`,
-                  description: errorMessage(status, statusText),
-                },
-              ]);
-            },
-          );
-        });
-    });
+    this.setState({ loading: true }, () => this.loadNamespace());
   }
 
   render() {
@@ -115,7 +79,6 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
       saving,
       redirect,
       params,
-      userId,
       unauthorized,
       loading,
     } = this.state;
@@ -166,7 +129,6 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
             <section className='body'>
               {params.tab.toLowerCase() === 'edit-details' ? (
                 <NamespaceForm
-                  userId={userId}
                   namespace={namespace}
                   errorMessages={errorMessages}
                   updateNamespace={(namespace) =>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -37,8 +37,22 @@ interface Window {
         getUser: () => Promise<{
           identity: {
             account_number: string;
-            username: string;
-            groups: { id: number; name: string }[];
+            internal: {
+              account_id: number;
+              org_id: string;
+            };
+            org_id: string;
+            type?: string;
+            user: {
+              email: string;
+              first_name: string;
+              is_active?: boolean;
+              is_internal: boolean;
+              is_org_admin: boolean;
+              last_name: string;
+              locale?: string;
+              username: string;
+            };
           };
         }>;
       };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -56,7 +56,7 @@ interface Window {
           };
         }>;
       };
-      identifyApp: (s: string) => void;
+      identifyApp: (s: string, title?: string) => void;
       init: () => void;
       on: (s: string, f: (event) => void) => () => void;
     };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -58,7 +58,7 @@ interface Window {
       };
       identifyApp: (s: string) => void;
       init: () => void;
-      on: (s: string, f: () => void) => void;
+      on: (s: string, f: (event) => void) => () => void;
     };
   };
 }

--- a/src/loaders/app-context.ts
+++ b/src/loaders/app-context.ts
@@ -3,7 +3,7 @@ import { UserType, FeatureFlagsType, SettingsType } from 'src/api';
 import { AlertType } from 'src/components';
 
 export interface IAppContextType {
-  user: UserType;
+  user?: UserType;
   setUser: (user: UserType) => void;
   selectedRepo?: string;
   setRepo: (repo: string) => void;

--- a/src/loaders/app.scss
+++ b/src/loaders/app.scss
@@ -47,3 +47,10 @@ body,
 #root {
   height: 100%;
 }
+
+// insights mode Sidenav/Navigation overrides this for all navitems, restoring in main
+.pf-c-page__main {
+  .pf-c-nav__list > .pf-c-nav__item:not(:first-child) {
+    border-top: 0;
+  }
+}

--- a/src/loaders/insights/Routes.tsx
+++ b/src/loaders/insights/Routes.tsx
@@ -4,130 +4,148 @@ import PropTypes from 'prop-types';
 import { Paths } from 'src/paths';
 import { LoadingPageWithHeader } from 'src/components';
 
-const EditNamespace = lazy(() =>
-  import(
-    /* webpackChunkName: "namespace_detail" */
-    '../../containers/edit-namespace/edit-namespace'
-  ),
+const EditNamespace = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "namespace_detail" */
+      '../../containers/edit-namespace/edit-namespace'
+    ),
 );
 
-const CollectionDetail = lazy(() =>
-  import(
-    /* webpackChunkName: "collection_detail" */
-    '../../containers/collection-detail/collection-detail'
-  ),
+const CollectionDetail = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "collection_detail" */
+      '../../containers/collection-detail/collection-detail'
+    ),
 );
 
-const CollectionContent = lazy(() =>
-  import(
-    /* webpackChunkName: "collection_detail" */
-    '../../containers/collection-detail/collection-content'
-  ),
+const CollectionContent = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "collection_detail" */
+      '../../containers/collection-detail/collection-content'
+    ),
 );
 
-const CollectionDocs = lazy(() =>
-  import(
-    /* webpackChunkName: "collection_detail" */
-    '../../containers/collection-detail/collection-docs'
-  ),
+const CollectionDocs = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "collection_detail" */
+      '../../containers/collection-detail/collection-docs'
+    ),
 );
 
-const CollectionImportLog = lazy(() =>
-  import(
-    /* webpackChunkName: "collection_detail" */
-    '../../containers/collection-detail/collection-import-log'
-  ),
+const CollectionImportLog = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "collection_detail" */
+      '../../containers/collection-detail/collection-import-log'
+    ),
 );
 
-const CollectionDependencies = lazy(() =>
-  import(
-    /* webpackChunkName: "collection_detail" */
-    '../../containers/collection-detail/collection-dependencies'
-  ),
+const CollectionDependencies = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "collection_detail" */
+      '../../containers/collection-detail/collection-dependencies'
+    ),
 );
 
-const NotFound = lazy(() =>
-  import(
-    /* webpackChunkName: "not_found" */
-    '../../containers/not-found/not-found'
-  ),
+const NotFound = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "not_found" */
+      '../../containers/not-found/not-found'
+    ),
 );
 
-const MyNamespaces = lazy(() =>
-  import(
-    /* webpackChunkName: "namespace_list" */
-    '../../containers/namespace-list/my-namespaces'
-  ),
+const MyNamespaces = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "namespace_list" */
+      '../../containers/namespace-list/my-namespaces'
+    ),
 );
 
-const ManageNamespace = lazy(() =>
-  import(
-    /* webpackChunkName: "namespace_detail" */
-    '../../containers/namespace-detail/namespace-detail'
-  ),
+const ManageNamespace = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "namespace_detail" */
+      '../../containers/namespace-detail/namespace-detail'
+    ),
 );
 
-const PartnerDetail = lazy(() =>
-  import(
-    /* webpackChunkName: "namespace_detail" */
-    '../../containers/namespace-detail/namespace-detail'
-  ),
+const PartnerDetail = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "namespace_detail" */
+      '../../containers/namespace-detail/namespace-detail'
+    ),
 );
 
-const Partners = lazy(() =>
-  import(
-    /* webpackChunkName: "namespace_list" */
-    '../../containers/namespace-list/' + NAMESPACE_TERM
-  ),
+const Partners = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "namespace_list" */
+      '../../containers/namespace-list/' + NAMESPACE_TERM
+    ),
 );
 
-const MyImports = lazy(() =>
-  import(
-    /* webpackChunkName: "my_imports" */
-    '../../containers/my-imports/my-imports'
-  ),
+const MyImports = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "my_imports" */
+      '../../containers/my-imports/my-imports'
+    ),
 );
 
-const Search = lazy(() =>
-  import(
-    /* webpackChunkName: "search" */
-    '../../containers/search/search'
-  ),
+const Search = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "search" */
+      '../../containers/search/search'
+    ),
 );
 
-const TokenPage = lazy(() =>
-  import(
-    /* webpackChunkName: "settings" */
-    '../../containers/token/token-insights'
-  ),
+const TokenPage = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "settings" */
+      '../../containers/token/token-insights'
+    ),
 );
 
-const TaskListView = lazy(() =>
-  import(
-    /* webpackChunkName: "settings" */
-    '../../containers/task-management/task-list-view'
-  ),
+const TaskListView = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "settings" */
+      '../../containers/task-management/task-list-view'
+    ),
 );
 
-const TaskDetail = lazy(() =>
-  import(
-    /* webpackChunkName: "settings" */
-    '../../containers/task-management/task_detail'
-  ),
+const TaskDetail = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "settings" */
+      '../../containers/task-management/task_detail'
+    ),
 );
 
-const CertificationDashboard = lazy(() =>
-  import(
-    /* webpackChunkName: "settings" */
-    '../../containers/certification-dashboard/certification-dashboard'
-  ),
+const CertificationDashboard = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "settings" */
+      '../../containers/certification-dashboard/certification-dashboard'
+    ),
 );
 
-const Repository = lazy(() =>
-  import(
-    /* webpackChunkName: "repository-list" */
-    '../../containers/repositories/repository-list'
-  ),
+const Repository = lazy(
+  () =>
+    import(
+      /* webpackChunkName: "repository-list" */
+      '../../containers/repositories/repository-list'
+    ),
 );
 
 /**

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -54,7 +54,7 @@ class App extends Component {
       ActiveUserAPI.getActiveUser(),
       SettingsAPI.get(),
       window.insights.chrome.auth.getUser(), // no output, just wait
-    ]).then(([{ data: activeUser }, { data: settings }]) =>
+    ]).then(([activeUser, { data: settings }]) =>
       this.setState({
         activeUser,
         settings,

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -1,3 +1,4 @@
+import { t } from '@lingui/macro';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { withRouter, matchPath } from 'react-router-dom';
@@ -137,7 +138,7 @@ class App extends Component {
         <Alert
           isInline
           variant='info'
-          title='The Automation Hub sync toggle is now only supported in AAP 2.0. Previous versions of AAP will continue automatically syncing all collections.'
+          title={t`The Automation Hub sync toggle is now only supported in AAP 2.0. Previous versions of AAP will continue automatically syncing all collections.`}
         />
         <Routes childProps={this.props} />
         <UIVersion />

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -65,7 +65,6 @@ class App extends Component {
       ActiveUserAPI.getUser(),
       SettingsAPI.get(),
       getFeatureFlags,
-      window.insights.chrome.auth.getUser(), // no output, just wait
     ]).then(([activeUser, { data: settings }, { alerts, featureFlags }]) =>
       this.setState({
         activeUser,

--- a/src/loaders/insights/insights-loader.js
+++ b/src/loaders/insights/insights-loader.js
@@ -62,7 +62,7 @@ class App extends Component {
     );
 
     Promise.all([
-      ActiveUserAPI.getActiveUser(),
+      ActiveUserAPI.getUser(),
       SettingsAPI.get(),
       getFeatureFlags,
       window.insights.chrome.auth.getUser(), // no output, just wait

--- a/src/loaders/insights/insights-loader.tsx
+++ b/src/loaders/insights/insights-loader.tsx
@@ -45,8 +45,7 @@ class App extends Component<IProps, IState> {
 
   componentDidMount() {
     window.insights.chrome.init();
-    window.insights.chrome.identifyApp('automation-hub');
-    document.title = APPLICATION_NAME; // change window title from automationHub
+    window.insights.chrome.identifyApp('automation-hub', APPLICATION_NAME);
 
     // This listens for insights navigation events, so this will fire
     // when items in the nav are clicked or the app is loaded for the first

--- a/src/loaders/insights/insights-loader.tsx
+++ b/src/loaders/insights/insights-loader.tsx
@@ -1,30 +1,53 @@
 import { t } from '@lingui/macro';
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { withRouter, matchPath } from 'react-router-dom';
+import { RouteComponentProps, withRouter, matchPath } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { Alert } from '@patternfly/react-core';
 import { Routes } from './Routes';
 import '../app.scss';
 import { AppContext } from '../app-context';
-import { ActiveUserAPI, FeatureFlagsAPI, SettingsAPI } from 'src/api';
+import {
+  ActiveUserAPI,
+  FeatureFlagsAPI,
+  FeatureFlagsType,
+  SettingsAPI,
+  SettingsType,
+  UserType,
+} from 'src/api';
 import { Paths } from 'src/paths';
-import { UIVersion } from 'src/components';
+import { AlertType, UIVersion } from 'src/components';
 
 const DEFAULT_REPO = 'published';
 
-class App extends Component {
+interface IProps {
+  basename: string;
+  history: RouteComponentProps['history'];
+  location: RouteComponentProps['location'];
+  match: RouteComponentProps['match'];
+}
+
+interface IState {
+  activeUser: UserType;
+  alerts: AlertType[];
+  featureFlags: FeatureFlagsType;
+  selectedRepo: string;
+  settings?: SettingsType;
+}
+
+class App extends Component<IProps, IState> {
   constructor(props) {
     super(props);
 
     this.state = {
       activeUser: null,
-      selectedRepo: DEFAULT_REPO,
       alerts: [],
-      settings: {},
-      featureFlags: {},
+      featureFlags: null,
+      selectedRepo: DEFAULT_REPO,
+      settings: null,
     };
   }
+
+  appNav: () => void;
 
   componentDidMount() {
     window.insights.chrome.init();
@@ -130,6 +153,7 @@ class App extends Component {
           featureFlags: this.state.featureFlags,
           selectedRepo: this.state.selectedRepo,
           setAlerts: this.setAlerts,
+          setRepo: this.setRepo,
           setUser: this.setActiveUser,
           settings: this.state.settings,
           user: this.state.activeUser,
@@ -159,15 +183,11 @@ class App extends Component {
       path: Paths.collectionByRepo,
     });
   };
-}
 
-App.propTypes = {
-  history: PropTypes.object,
-  basename: PropTypes.string.isRequired,
-  location: PropTypes.shape({
-    pathname: PropTypes.string,
-  }),
-};
+  setRepo = (_repo: string) => {
+    throw new Error('RepoSelector & setRepo only available in standalone');
+  };
+}
 
 /**
  * withRouter: https://reacttraining.com/react-router/web/api/withRouter

--- a/src/loaders/insights/insights-loader.tsx
+++ b/src/loaders/insights/insights-loader.tsx
@@ -27,11 +27,11 @@ interface IProps {
 }
 
 interface IState {
-  activeUser: UserType;
   alerts: AlertType[];
   featureFlags: FeatureFlagsType;
   selectedRepo: string;
   settings?: SettingsType;
+  user: UserType;
 }
 
 class App extends Component<IProps, IState> {
@@ -39,11 +39,11 @@ class App extends Component<IProps, IState> {
     super(props);
 
     this.state = {
-      activeUser: null,
       alerts: [],
       featureFlags: null,
       selectedRepo: DEFAULT_REPO,
       settings: null,
+      user: null,
     };
   }
 
@@ -88,12 +88,12 @@ class App extends Component<IProps, IState> {
       ActiveUserAPI.getUser(),
       SettingsAPI.get(),
       getFeatureFlags,
-    ]).then(([activeUser, { data: settings }, { alerts, featureFlags }]) =>
+    ]).then(([user, { data: settings }, { alerts, featureFlags }]) =>
       this.setState({
-        activeUser,
         alerts,
         featureFlags,
         settings,
+        user,
       }),
     );
   }
@@ -142,7 +142,7 @@ class App extends Component<IProps, IState> {
     // Wait for the user data to load before any of the child components are
     // rendered. This will prevent API calls from happening
     // before the app can authenticate
-    if (!this.state.activeUser) {
+    if (!this.state.user) {
       return null;
     }
 
@@ -154,9 +154,9 @@ class App extends Component<IProps, IState> {
           selectedRepo: this.state.selectedRepo,
           setAlerts: this.setAlerts,
           setRepo: this.setRepo,
-          setUser: this.setActiveUser,
+          setUser: this.setUser,
           settings: this.state.settings,
-          user: this.state.activeUser,
+          user: this.state.user,
         }}
       >
         <Alert
@@ -170,8 +170,8 @@ class App extends Component<IProps, IState> {
     );
   }
 
-  setActiveUser = (user) => {
-    this.setState({ activeUser: user });
+  setUser = (user) => {
+    this.setState({ user });
   };
 
   setAlerts = (alerts) => {

--- a/src/loaders/insights/insights-loader.tsx
+++ b/src/loaders/insights/insights-loader.tsx
@@ -6,14 +6,8 @@ import { Alert } from '@patternfly/react-core';
 import { Routes } from './Routes';
 import '../app.scss';
 import { AppContext } from '../app-context';
-import {
-  ActiveUserAPI,
-  FeatureFlagsAPI,
-  FeatureFlagsType,
-  SettingsAPI,
-  SettingsType,
-  UserType,
-} from 'src/api';
+import { loadContext } from '../load-context';
+import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { Paths } from 'src/paths';
 import { AlertType, UIVersion } from 'src/components';
 
@@ -31,7 +25,7 @@ interface IState {
   featureFlags: FeatureFlagsType;
   selectedRepo: string;
   settings?: SettingsType;
-  user: UserType;
+  user?: UserType;
 }
 
 class App extends Component<IProps, IState> {
@@ -74,28 +68,7 @@ class App extends Component<IProps, IState> {
       this.props.history.push(href);
     });
 
-    const getFeatureFlags = FeatureFlagsAPI.get().then(
-      ({ data: featureFlags }) => ({
-        featureFlags,
-        alerts: (featureFlags?._messages || []).map((msg) => ({
-          variant: 'warning',
-          title: msg.split(':')[1],
-        })),
-      }),
-    );
-
-    Promise.all([
-      ActiveUserAPI.getUser(),
-      SettingsAPI.get(),
-      getFeatureFlags,
-    ]).then(([user, { data: settings }, { alerts, featureFlags }]) =>
-      this.setState({
-        alerts,
-        featureFlags,
-        settings,
-        user,
-      }),
-    );
+    loadContext().then((data) => this.setState(data));
   }
 
   componentWillUnmount() {

--- a/src/loaders/load-context.ts
+++ b/src/loaders/load-context.ts
@@ -1,0 +1,47 @@
+import {
+  ActiveUserAPI,
+  FeatureFlagsAPI,
+  FeatureFlagsType,
+  SettingsAPI,
+  UserType,
+  SettingsType,
+} from 'src/api';
+import { AlertType } from 'src/components';
+
+type ContextFragment = {
+  alerts: AlertType[];
+  featureFlags: FeatureFlagsType;
+  settings?: SettingsType;
+  user?: UserType;
+};
+
+export function loadContext(): Promise<ContextFragment> {
+  const getFeatureFlags = FeatureFlagsAPI.get().then(
+    ({ data: featureFlags }) => ({
+      alerts: (featureFlags?._messages || []).map((msg) => ({
+        variant: 'warning',
+        title: msg.split(':')[1],
+      })),
+      featureFlags,
+    }),
+  );
+
+  return Promise.all([
+    ActiveUserAPI.getUser(),
+    SettingsAPI.get(),
+    getFeatureFlags,
+  ])
+    .then(([user, { data: settings }, { alerts, featureFlags }]) => ({
+      alerts,
+      featureFlags,
+      settings,
+      user,
+    }))
+    .catch(() => {
+      // we need this even if ActiveUserAPI fails, otherwise isExternalAuth will always be false, breaking keycloak redirect
+      return getFeatureFlags.then(({ alerts, featureFlags }) => ({
+        alerts,
+        featureFlags,
+      }));
+    });
+}

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -34,16 +34,9 @@ import {
   TaskListView,
   TaskDetail,
 } from 'src/containers';
-import {
-  ActiveUserAPI,
-  FeatureFlagsAPI,
-  FeatureFlagsType,
-  SettingsAPI,
-  UserType,
-  SettingsType,
-} from 'src/api';
+import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { AppContext } from '../app-context';
-
+import { loadContext } from '../load-context';
 import { Paths, formatPath } from 'src/paths';
 import { AlertType } from 'src/components';
 
@@ -102,31 +95,8 @@ class AuthHandler extends React.Component<
       return;
     }
 
-    const getFeatureFlags = FeatureFlagsAPI.get().then(
-      ({ data: featureFlags }) => ({
-        featureFlags,
-        alerts: (featureFlags?._messages || []).map((msg) => ({
-          variant: 'warning',
-          title: msg.split(':')[1],
-        })),
-      }),
-    );
-
-    Promise.all([ActiveUserAPI.getUser(), SettingsAPI.get(), getFeatureFlags])
-      .then(([user, { data: settings }, { alerts, featureFlags }]) => {
-        this.props.updateInitialData({
-          alerts,
-          featureFlags,
-          settings,
-          user,
-        });
-      })
-      .catch(() => {
-        // we need this even if ActiveUserAPI fails, otherwise isExternalAuth will always be false, breaking keycloak redirect
-        return getFeatureFlags.then(({ alerts, featureFlags }) =>
-          this.props.updateInitialData({ alerts, featureFlags }),
-        );
-      })
+    loadContext()
+      .then((data) => this.props.updateInitialData(data))
       .then(() => this.setState({ isLoading: false }));
   }
 

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -450,14 +450,14 @@ class App extends React.Component<RouteComponentProps, IState> {
     return (
       <AppContext.Provider
         value={{
-          user: this.state.user,
-          setUser: this.setUser,
-          selectedRepo: this.state.selectedRepo,
-          setRepo: this.setRepo,
-          featureFlags: this.state.featureFlags,
           alerts: this.state.alerts,
+          featureFlags: this.state.featureFlags,
+          selectedRepo: this.state.selectedRepo,
           setAlerts: this.setAlerts,
+          setRepo: this.setRepo,
+          setUser: this.setUser,
           settings: this.state.settings,
+          user: this.state.user,
         }}
       >
         {component}


### PR DESCRIPTION
Issue: AAH-1800

Until now, `featureFlags` is always empty in insights mode.

This brings standalone and insights a bit closer, adding `featureFlags` handling to `insights-loaders`, moving the logic to a shared `loadContext` function, making sure the list of args for `AppContext` is the same in both modes, and cleaning up some `getUser` / `getActiveUser` confusion - we wait for insights `getUser` before any API request, and the loader waits for out user API, achieving both. (Also we never use the insights user data, except for some dead code, so `ActivetUserAPI.getUser` should always return `UserType`.)
And converted insights loaders and routes to typescript, to match the rest, and to typecheck this has a chance of being right :)

Also found some extra top padding in insights mode and a navitem border outside the menu area, fixing both.