### PR TITLE
[rbac] group-list: filter "Group name" by name__icontains, not exact name

### DIFF
--- a/CHANGES/1806.bug
+++ b/CHANGES/1806.bug
@@ -1,0 +1,1 @@
+Group list: filter by name__icontains, not name exact

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -128,7 +128,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
 
     const { user } = this.context;
     const noData =
-      groups.length === 0 && !filterIsSet(params, ['name__icontains']);
+      groups.length === 0 && !filterIsSet(params, ['name__contains']);
 
     if (redirect) {
       return <Redirect push to={redirect} />;
@@ -181,7 +181,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
                           params={params}
                           filterConfig={[
                             {
-                              id: 'name__icontains',
+                              id: 'name__contains',
                               title: t`Group name`,
                             },
                           ]}
@@ -222,7 +222,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
                   params={params}
                   ignoredParams={['page_size', 'page', 'sort']}
                   niceNames={{
-                    name__icontains: 'Group name',
+                    name__contains: 'Group name',
                   }}
                 />
               </div>

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -222,7 +222,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
                   params={params}
                   ignoredParams={['page_size', 'page', 'sort']}
                   niceNames={{
-                    name__contains: 'Group name',
+                    name__contains: t`Group name`,
                   }}
                 />
               </div>

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -127,7 +127,8 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
     } = this.state;
 
     const { user } = this.context;
-    const noData = groups.length === 0 && !filterIsSet(params, ['name']);
+    const noData =
+      groups.length === 0 && !filterIsSet(params, ['name__icontains']);
 
     if (redirect) {
       return <Redirect push to={redirect} />;
@@ -180,8 +181,8 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
                           params={params}
                           filterConfig={[
                             {
-                              id: 'name',
-                              title: t`Group`,
+                              id: 'name__icontains',
+                              title: t`Group name`,
                             },
                           ]}
                         />
@@ -220,6 +221,9 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
                   }}
                   params={params}
                   ignoredParams={['page_size', 'page', 'sort']}
+                  niceNames={{
+                    name__icontains: 'Group name',
+                  }}
                 />
               </div>
               {loading ? <LoadingPageSpinner /> : this.renderTable(params)}
@@ -373,7 +377,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
     const sortTableOptions = {
       headers: [
         {
-          title: t`Group`,
+          title: t`Group name`,
           type: 'alpha',
           id: 'name',
         },

--- a/test/cypress/integration/group_list.js
+++ b/test/cypress/integration/group_list.js
@@ -45,7 +45,7 @@ describe('Group list tests for sorting, paging and filtering', () => {
 
   it('filter is working', () => {
     cy.get('.body')
-      .get('[placeholder="Filter by group"]:first')
+      .get('[placeholder="Filter by group name"]:first')
       .type('group_test0{enter}');
     cy.get('.body').contains('group_test0');
     cy.get('.body').contains('group_test1').should('not.exist');


### PR DESCRIPTION
Issue: AAH-1806

Filtering by group name used an exact match .. changing to name__icontains for case insensitive partial match

Before:

![20220714140613](https://user-images.githubusercontent.com/289743/179001709-4a4776bd-5460-402a-bab6-1fd21a8b3a64.png)

After:

![20220714140409](https://user-images.githubusercontent.com/289743/179001795-09c5eb3c-317d-4d88-b69d-7e837bc359b5.png)


+ make sure the "Group name" is consistently used in the filter name and the column name
