### PR TITLE
[rbac] Add and fix permissions related to roles and group/roles

### DIFF
--- a/src/components/typeahead/typeahead.tsx
+++ b/src/components/typeahead/typeahead.tsx
@@ -19,6 +19,7 @@ interface IProps {
   };
   menuAppendTo?: 'parent' | 'inline';
   toggleIcon?: React.ReactElement;
+  style?: React.CSSProperties;
 }
 
 interface IState {
@@ -59,6 +60,7 @@ export class APISearchTypeAhead extends React.Component<IProps, IState> {
         placeholderText={this.props.placeholderText}
         isDisabled={this.props.isDisabled}
         toggleIcon={this.props.toggleIcon}
+        style={this.props.style}
       >
         {this.getOptions()}
       </Select>

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -336,9 +336,11 @@ class ExecutionEnvironmentList extends React.Component<
   private renderTableRow(item, index: number) {
     const description = item.description;
 
-    const canEdit = item.namespace.my_permissions.includes(
-      'container.change_containernamespace',
-    );
+    const permissions = item.namespace.my_permissions;
+
+    const canEdit =
+      permissions.includes('container.change_containernamespace') ||
+      permissions.includes('container.namespace_change_containerdistribution');
 
     const dropdownItems = [
       canEdit && (

--- a/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
+++ b/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
@@ -168,7 +168,7 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
     });
   }
 
-  const addRoles = user.is_superuser && (
+  const addRoles = user?.model_permissions?.change_group && (
     <Button
       onClick={() => setShowAddRolesModal(true)}
       variant='primary'

--- a/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
+++ b/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
@@ -373,7 +373,7 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
                     <td>{role.description}</td>
                     <ListItemActions
                       kebabItems={[
-                        user.is_superuser && (
+                        user.model_permissions.change_group && (
                           <DropdownItem
                             key='remove-role'
                             onClick={() => setSelectedDeleteRole(role)}

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -126,7 +126,11 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
   }
 
   componentDidMount() {
-    if (!this.context.user || this.context.user.is_anonymous) {
+    if (
+      !this.context.user ||
+      this.context.user.is_anonymous ||
+      !this.context.user.model_permissions.view_group
+    ) {
       this.setState({ unauthorised: true });
     } else {
       this.queryGroup();

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -415,7 +415,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         title={t`Remove user from group?`}
       >
         <Trans>
-          User <b>{username}</b> will be removed from group<b>{groupname}</b>.
+          User <b>{username}</b> will be removed from group <b>{groupname}</b>.
         </Trans>
       </DeleteModal>
     );

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -294,7 +294,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
         <APISearchTypeAhead
           results={this.state.options}
           loadResults={(name) =>
-            UserAPI.list({ username__contains: name, page_size: 5 })
+            UserAPI.list({ username__contains: name, page_size: 1000 })
               .then((result) => {
                 let filteredUsers = [];
                 result.data.data.forEach((user) => {
@@ -357,6 +357,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
             })
           }
           isDisabled={false}
+          style={{ overflowY: 'auto', maxHeight: '350px' }}
         />
       </Modal>
     );
@@ -453,7 +454,7 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
   }
 
   private loadOptions() {
-    UserAPI.list()
+    UserAPI.list({ page_size: 1000 })
       .then((result) => {
         const options = result.data.data
           .filter((user) => !this.state.users.find((u) => u.id === user.id))

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -403,22 +403,20 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
   private renderTableRow(group, index: number) {
     const { user } = this.context;
     const dropdownItems = [
-      <React.Fragment key='dropdown'>
-        {!!user && user.model_permissions.delete_group && (
-          <DropdownItem
-            aria-label='Delete'
-            key='delete'
-            onClick={() => {
-              this.setState({
-                selectedGroup: group,
-                deleteModalVisible: true,
-              });
-            }}
-          >
-            <Trans>Delete</Trans>
-          </DropdownItem>
-        )}
-      </React.Fragment>,
+      !!user && user.model_permissions.delete_group && (
+        <DropdownItem
+          aria-label='Delete'
+          key='delete'
+          onClick={() => {
+            this.setState({
+              selectedGroup: group,
+              deleteModalVisible: true,
+            });
+          }}
+        >
+          <Trans>Delete</Trans>
+        </DropdownItem>
+      ),
     ];
     return (
       <tr data-cy={`GroupList-row-${group.name}`} key={index}>

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -151,11 +151,51 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
       });
     }
 
-    const addRoles = this.context.user.is_superuser && (
+    const isSuperuser = this.context.user.is_superuser;
+
+    const addRoles = isSuperuser && (
       <Link to={Paths.createRole}>
         <Button variant={'primary'}>{t`Add roles`}</Button>
       </Link>
     );
+
+    let tableHeader = [
+      {
+        title: '',
+        type: 'none',
+        id: 'expander',
+      },
+      {
+        title: t`Role name`,
+        type: 'alpha',
+        id: 'name',
+      },
+      {
+        title: t`Description`,
+        type: 'none',
+        id: 'description',
+      },
+      {
+        title: t`Created`,
+        type: 'number',
+        id: 'pulp_created',
+      },
+      {
+        title: t`Editable`,
+        type: 'none',
+        id: 'locked',
+      },
+    ];
+    if (isSuperuser) {
+      tableHeader = [
+        ...tableHeader,
+        {
+          title: '',
+          type: 'none',
+          id: 'kebab',
+        },
+      ];
+    }
 
     return (
       <React.Fragment>
@@ -278,40 +318,7 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
                       updateParams={(p) => {
                         this.updateParams(p, () => this.queryRoles());
                       }}
-                      tableHeader={{
-                        headers: [
-                          {
-                            title: '',
-                            type: 'none',
-                            id: 'expander',
-                          },
-                          {
-                            title: t`Role name`,
-                            type: 'alpha',
-                            id: 'name',
-                          },
-                          {
-                            title: t`Description`,
-                            type: 'none',
-                            id: 'description',
-                          },
-                          {
-                            title: t`Created`,
-                            type: 'number',
-                            id: 'pulp_created',
-                          },
-                          {
-                            title: t`Editable`,
-                            type: 'none',
-                            id: 'locked',
-                          },
-                          {
-                            title: '',
-                            type: 'none',
-                            id: 'kebab',
-                          },
-                        ],
-                      }}
+                      tableHeader={{ headers: tableHeader }}
                     >
                       {roles.map((role, i) => (
                         <ExpandableRow
@@ -388,10 +395,11 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
                               t`Editable`
                             )}
                           </td>
-
-                          <ListItemActions
-                            kebabItems={this.renderDropdownItems(role)}
-                          />
+                          {isSuperuser && (
+                            <ListItemActions
+                              kebabItems={this.renderDropdownItems(role)}
+                            />
+                          )}
                         </ExpandableRow>
                       ))}
                     </RoleListTable>
@@ -468,24 +476,29 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
         {t`Delete`}
       </DropdownItem>
     );
-    const dropdownItems = [
-      // this.context.user.model_permissions.change_containerregistry &&
-      locked ? (
-        <Tooltip key='edit' content={t`Built-in roles cannot be edited.`}>
-          {editItem}
-        </Tooltip>
-      ) : (
-        editItem
-      ),
-      // this.context.user.model_permissions.delete_containerregistry &&
-      locked ? (
-        <Tooltip key='delete' content={t`Built-in roles cannot be deleted.`}>
-          {deleteItem}
-        </Tooltip>
-      ) : (
-        deleteItem
-      ),
-    ];
+    const dropdownItems = this.context.user.is_superuser
+      ? [
+          // this.context.user.model_permissions.change_containerregistry &&
+          locked ? (
+            <Tooltip key='edit' content={t`Built-in roles cannot be edited.`}>
+              {editItem}
+            </Tooltip>
+          ) : (
+            editItem
+          ),
+          // this.context.user.model_permissions.delete_containerregistry &&
+          locked ? (
+            <Tooltip
+              key='delete'
+              content={t`Built-in roles cannot be deleted.`}
+            >
+              {deleteItem}
+            </Tooltip>
+          ) : (
+            deleteItem
+          ),
+        ]
+      : null;
 
     return dropdownItems;
   };


### PR DESCRIPTION
Issue: [AAH-1766](https://issues.redhat.com/browse/AAH-1766)

Depends on [#1371](https://github.com/ansible/galaxy_ng/pull/1371) (merged)

Let non-superuser with `change_group` permission to add roles to the group. 

Issue: [AAH-1756](https://issues.redhat.com/browse/AAH-1756)
Hide the empty kebab button in the group-list table.
before:
![Screenshot from 2022-07-15 15-33-19](https://user-images.githubusercontent.com/19647757/179240626-ae5d6a98-ea28-4515-8f89-18494da15073.png)

after:
![Screenshot from 2022-07-15 15-33-56](https://user-images.githubusercontent.com/19647757/179240636-cc7b2d12-8232-4d19-82c6-beeb6f54dec3.png)

Issue: [AAH-1766](https://issues.redhat.com/browse/AAH-1729):
before:
![Screenshot from 2022-07-20 15-17-07](https://user-images.githubusercontent.com/19647757/179991755-1e335fbb-1491-4149-a4e1-aeab63598aea.png)

after:
![Screenshot from 2022-07-20 15-16-42](https://user-images.githubusercontent.com/19647757/179991765-8583549e-0627-4789-9ff9-12f3f83c4091.png)

Issue: [AAH-1752](https://issues.redhat.com/browse/AAH-1752):
Added unauth screen to group detail screen
![Screenshot from 2022-07-20 15-27-01](https://user-images.githubusercontent.com/19647757/179993879-7b3fd815-20b9-4b30-800d-f2e5c4bcf7d7.png)

Issue: [AAH-1754](https://issues.redhat.com/browse/AAH-1754):
Allowed the results to be scrollable in the typeahead component. To fix this issue, we need to set a greater `page_size` number.
```
UserAPI.list({ username__contains: name, page_size: 1000 })
```  
(typeahead works fine if the user types an exact name, the issue is with too many users with the same name prefix.)
![Screenshot from 2022-07-20 14-29-43](https://user-images.githubusercontent.com/19647757/179996679-847e2043-6cd8-442d-b577-cc9f7fc20ff9.png)

Issue: [AAH-1810](https://issues.redhat.com/browse/AAH-1810):
- added additional permission to `ee list` screen to match with permissions in `ee detail` screen
