### PR TITLE
cypress: pip install ansible

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: "Install galaxykit dependency"
       run: |
-        pip install git+https://github.com/ansible/galaxykit.git
+        pip install ansible git+https://github.com/ansible/galaxykit.git
 
     - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |


### PR DESCRIPTION
seems to be needed since https://github.com/ansible/galaxykit/pull/54

attempts to fix tests failing with

```
Run galaxykit -s 'http://localhost:8002/api/galaxy/' -u admin -p admin collection list
Traceback (most recent call last):
  File "/home/runner/.local/bin/galaxykit", line 5, in <module>
    from galaxykit.command import main
  File "/home/runner/.local/lib/python3.8/site-packages/galaxykit/__init__.py", line 2, in <module>
    from .client import GalaxyClient
  File "/home/runner/.local/lib/python3.8/site-packages/galaxykit/client.py", line 16, in <module>
    from . import namespaces
  File "/home/runner/.local/lib/python3.8/site-packages/galaxykit/namespaces.py", line 2, in <module>
    from .utils import logger
  File "/home/runner/.local/lib/python3.8/site-packages/galaxykit/utils.py", line 6, in <module>
    from ansible.galaxy.api import GalaxyError
ModuleNotFoundError: No module named 'ansible'
Error: Process completed with exit code 1.
```