### PR TITLE
Remove unexpected digest value

### DIFF
--- a/src/api/container-tag.ts
+++ b/src/api/container-tag.ts
@@ -10,9 +10,8 @@ class API extends PulpAPI {
     });
   }
 
-  untag(repositoryID: string, tag: string, digest: string) {
+  untag(repositoryID: string, tag: string) {
     return this.http.post(`${this.apiPath}${repositoryID}/untag/`, {
-      digest: digest,
       tag: tag,
     });
   }

--- a/src/components/execution-environment/tag-manifest-modal.tsx
+++ b/src/components/execution-environment/tag-manifest-modal.tsx
@@ -266,7 +266,6 @@ export class TagManifestModal extends React.Component<IProps, IState> {
           promise: ContainerTagAPI.untag(
             repository.pulp.repository.pulp_id,
             tag,
-            containerManifest.digest,
           ).catch((e) => this.handleFailedTag(tag, e, 'remove')),
         });
       }


### PR DESCRIPTION
Description
Cannot untag execution environment

Steps to Reproduce
Create execution environment by pushing an image to galaxy_ng

Go to Execution Environments - Image you just pushed, images tab, select Manage Tags and Tag the image.  Try to remove the Tag you just added.

Issue: AAH-1841