### PR TITLE
EE edit - only make the Owners tab link clickable when editing

### DIFF
--- a/CHANGES/1792.fix
+++ b/CHANGES/1792.fix
@@ -1,0 +1,1 @@
+Moved to the *owners tab only clickable when already created

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -369,18 +369,24 @@ export class RepositoryForm extends React.Component<IProps, IState> {
               isInline
               variant='info'
               title={
-                <Trans>
-                  Moved to the{' '}
-                  <Link
-                    target='_blank'
-                    to={formatPath(Paths.executionEnvironmentDetailOwners, {
-                      container: name,
-                    })}
-                  >
-                    Owners
-                  </Link>{' '}
-                  <ExternalLinkAltIcon /> tab
-                </Trans>
+                isNew ? (
+                  <Trans>
+                    Moved to the <b>Owners</b> tab
+                  </Trans>
+                ) : (
+                  <Trans>
+                    Moved to the{' '}
+                    <Link
+                      target='_blank'
+                      to={formatPath(Paths.executionEnvironmentDetailOwners, {
+                        container: name,
+                      })}
+                    >
+                      Owners
+                    </Link>{' '}
+                    <ExternalLinkAltIcon /> tab
+                  </Trans>
+                )
               }
             />
           </FormGroup>


### PR DESCRIPTION
Issue: AAH-1792

When creating a new EE, the "Owner tab" link is clickable leading to a 404 because the EE doesn't exist yet.

Make the link only clickable when editing an already existing EE.

![20220726051054](https://user-images.githubusercontent.com/289743/180928357-c60a13f4-968c-484c-bc84-0e7bc8676b6a.png)
![20220726051004](https://user-images.githubusercontent.com/289743/180928351-a6001e05-a236-4a4d-a88f-392ca8cfbf50.png)

(namespaces are not affected, as new namespace uses a separate form and redirects to the tab on save)