### PR TITLE
Revert "cypress: pip install ansible"

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: "Install galaxykit dependency"
       run: |
-        pip install ansible git+https://github.com/ansible/galaxykit.git
+        pip install git+https://github.com/ansible/galaxykit.git
 
     - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |


### PR DESCRIPTION
Reverts ansible/ansible-hub-ui#2355

No longer needed, https://github.com/ansible/galaxykit/pull/55 removes the ansible dependency from galaxykit again :).

Cc @hendersonreed , thanks :)