### PR TITLE
Fixed group filter

### DIFF
--- a/CHANGES/1846.bug
+++ b/CHANGES/1846.bug
@@ -1,0 +1,1 @@
+Fixed group filter - added icontains to name parameter. 

--- a/src/components/rbac/select-group.tsx
+++ b/src/components/rbac/select-group.tsx
@@ -60,7 +60,7 @@ export const SelectGroup: React.FC<IProps> = ({
 
   const noData = groups.length === 0;
 
-  if (noData && !filterIsSet(localParams, ['name__contains'])) {
+  if (noData && !filterIsSet(localParams, ['name__icontains'])) {
     return (
       <div className='hub-custom-wizard-layout hub-no-data'>
         <EmptyStateNoData
@@ -140,7 +140,7 @@ export const SelectGroup: React.FC<IProps> = ({
                   updateParams={(p) => setLocalParams(p)}
                   filterConfig={[
                     {
-                      id: 'name__contains',
+                      id: 'name__icontains',
                       title: t`Name`,
                     },
                   ]}
@@ -153,14 +153,14 @@ export const SelectGroup: React.FC<IProps> = ({
                   setInputText('');
                 }}
                 params={localParams}
-                niceNames={{ name__contains: t`Name` }}
+                niceNames={{ name__icontains: t`Name` }}
                 ignoredParams={['sort', 'page_size', 'page']}
                 style={{ marginTop: '8px' }}
               />
             </FlexItem>
 
             <FlexItem style={{ flexGrow: 1 }}>
-              {noData && filterIsSet(localParams, ['name__contains']) ? (
+              {noData && filterIsSet(localParams, ['name__icontains']) ? (
                 <div className='hub-no-filter-data'>
                   <EmptyStateFilter />
                 </div>

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -127,7 +127,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
 
     const { user } = this.context;
     const noData =
-      groups.length === 0 && !filterIsSet(params, ['name__contains']);
+      groups.length === 0 && !filterIsSet(params, ['name__icontains']);
 
     if (redirect) {
       return <Redirect push to={redirect} />;
@@ -180,7 +180,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
                           params={params}
                           filterConfig={[
                             {
-                              id: 'name__contains',
+                              id: 'name__icontains',
                               title: t`Group name`,
                             },
                           ]}
@@ -221,7 +221,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
                   params={params}
                   ignoredParams={['page_size', 'page', 'sort']}
                   niceNames={{
-                    name__contains: t`Group name`,
+                    name__icontains: t`Group name`,
                   }}
                 />
               </div>

--- a/test/cypress/e2e/misc/rbac_owners.js
+++ b/test/cypress/e2e/misc/rbac_owners.js
@@ -82,7 +82,7 @@ function testOwnersTab({
 
   // group role modal
   // find partner-engineers, select, check indicator, next
-  cy.get('[data-cy=compound_filter] input[aria-label=name__contains]').type(
+  cy.get('[data-cy=compound_filter] input[aria-label=name__icontains]').type(
     'owners{enter}',
   );
   cy.get(


### PR DESCRIPTION
AAH-1846

https://issues.redhat.com/browse/AAH-1846

Depends on: https://github.com/ansible/galaxy_ng/pull/1400 (merged)

It also corrects another icontains missing in /src/containers/group-management/group-list.tsx
Accessible through menu: Execution environments -> select one (EE detail) -> tab Owners -> Select a group button -> filter by name 


