### PR TITLE
Error messages aren't displaying on the remote container create form

### DIFF
--- a/CHANGES/1845.bug
+++ b/CHANGES/1845.bug
@@ -1,0 +1,1 @@
+ EE detail now shows error in name column, when there are duplicate names in adding new EE.

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -175,6 +175,7 @@ export class RepositoryForm extends React.Component<IProps, IState> {
                   isDisabled={true}
                   type='text'
                 />
+                {this.renderNameError(formError)}
               </FormGroup>
 
               <FormGroup
@@ -207,6 +208,7 @@ export class RepositoryForm extends React.Component<IProps, IState> {
                   onChange={(value) => this.setState({ name: value })}
                   validated={this.validateName(name)}
                 />
+                {this.renderNameError(formError)}
               </FormGroup>
 
               <FormGroup
@@ -580,5 +582,19 @@ export class RepositoryForm extends React.Component<IProps, IState> {
       });
     }
     return isEmpty(xorWith(original, newOne, isEqual)) && same;
+  }
+
+  private renderNameError(formError) {
+    const nameError = formError
+      ? formError.find((e) => e.field == 'name')
+      : null;
+
+    return (
+      nameError && (
+        <Alert title={nameError.title} variant='danger' isInline>
+          {nameError.detail}
+        </Alert>
+      )
+    );
   }
 }

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -213,6 +213,7 @@ export function withContainerRepo(WrappedComponent) {
                       this.setState({
                         editing: false,
                         loading: true,
+                        formError: [],
                         alerts: alerts.concat({
                           variant: 'success',
                           title: (
@@ -245,7 +246,9 @@ export function withContainerRepo(WrappedComponent) {
                       }),
                     );
                 }}
-                onCancel={() => this.setState({ editing: false })}
+                onCancel={() =>
+                  this.setState({ editing: false, formError: [] })
+                }
                 distributionPulpId={this.state.repo.pulp.distribution.pulp_id}
                 isRemote={!!this.state.repo.pulp.repository.remote}
                 isNew={false}

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -444,6 +444,7 @@ class ExecutionEnvironmentList extends React.Component<
                 {
                   showRemoteModal: false,
                   itemToEdit: null,
+                  formError: [],
                   alerts: alerts.concat({
                     variant: 'success',
                     title: isNew ? (
@@ -478,6 +479,7 @@ class ExecutionEnvironmentList extends React.Component<
           this.setState({
             showRemoteModal: false,
             itemToEdit: null,
+            formError: [],
           })
         }
         addAlert={(variant, title, description) =>

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -468,6 +468,7 @@ class ExecutionEnvironmentList extends React.Component<
                   return {
                     title: error.title,
                     detail: error.source.parameter + ': ' + error.detail,
+                    field: error.source.parameter,
                   };
                 }),
               });


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-1845

Messages were in fact displayed, but at the bottom of the form and many users dont have the bottom displayed without scrolling. Those errors could be easily missed.

This PR added the error message right under the name field.
And it also repairs another mistake - errors were not cleared when modal closed (on success or cancel).

Issue: AAH-1845


