### PR TITLE
Cypress: install galaxykit 0.8.0

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,7 +26,8 @@ jobs:
 
     - name: "Install galaxykit dependency"
       run: |
-        pip install git+https://github.com/ansible/galaxykit.git
+        # FIXME(rbac): pip install git+https://github.com/ansible/galaxykit.git
+        pip install galaxykit==0.8.0
 
     - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |


### PR DESCRIPTION
galaxykit 0.8.0 (https://github.com/ansible/galaxykit/pull/60) is the last release without rbac, switching to that one until feature/rbac-roles is merged
this allows us to start merging rbac PRs in galaxykit main

Cc @hendersonreed 

---

Updated version table from #1969 :peace_symbol: :

|hub|galaxykit|
|-|-|
|4.2|-|
|4.3|0.1.0|
|4.4|0.7.0|
|4.5|0.8.0|
|master|~~main~~ 0.8.0 (until rbac is merged)|
|rbac-roles|https://github.com/ansible/galaxykit/pull/39 (switching to main once merged)|