### PR TITLE
Remove counter from collection signing UI

### DIFF
--- a/CHANGES/1852.misc
+++ b/CHANGES/1852.misc
@@ -1,0 +1,1 @@
+Remove signature counter and partially signed filter from UI.

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -1,4 +1,4 @@
-type SignState = 'signed' | 'unsigned' | 'partial';
+type SignState = 'signed' | 'unsigned';
 
 export class CollectionUploadType {
   id: string;

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -70,7 +70,6 @@ export class CollectionFilter extends React.Component<IProps, IState> {
         options: [
           { id: 'signed', title: t`Signed` },
           { id: 'unsigned', title: t`Unsigned` },
-          { id: 'partial', title: t`Partial` },
         ],
       },
     ].filter(Boolean);

--- a/src/components/signing/sign-all-certificates-modal.tsx
+++ b/src/components/signing/sign-all-certificates-modal.tsx
@@ -1,6 +1,5 @@
 import { t, Trans } from '@lingui/macro';
 import {
-  Badge,
   Button,
   ButtonVariant,
   Form,
@@ -27,8 +26,6 @@ interface Props {
 
 export const SignAllCertificatesModal: React.FC<Props> = ({
   name,
-  numberOfAffected,
-  affectedUnsigned,
   isOpen,
   onSubmit,
   onCancel,
@@ -57,8 +54,8 @@ export const SignAllCertificatesModal: React.FC<Props> = ({
         <GridItem span={12}>
           <p>
             <Trans>
-              You are about to sign <strong>{numberOfAffected}</strong>{' '}
-              version(s) under <strong>{name}</strong>.
+              You are about to sign <strong>all versions</strong> under{' '}
+              <strong>{name}</strong>.
             </Trans>
           </p>
         </GridItem>
@@ -70,11 +67,6 @@ export const SignAllCertificatesModal: React.FC<Props> = ({
             <SplitItem></SplitItem>
             <SplitItem>
               <Trans>Unsigned version(s)</Trans>
-            </SplitItem>
-            <SplitItem>
-              <Badge isRead data-cy='unsigned-number-badge'>
-                {affectedUnsigned}
-              </Badge>
             </SplitItem>
           </Split>
         </GridItem>

--- a/src/components/signing/sign-all-certificates-modal.tsx
+++ b/src/components/signing/sign-all-certificates-modal.tsx
@@ -67,11 +67,6 @@ export const SignAllCertificatesModal: React.FC<Props> = ({
             <SplitItem>
               <Trans>Signed version(s)</Trans>
             </SplitItem>
-            <SplitItem>
-              <Badge isRead data-cy='signed-number-badge'>
-                {numberOfAffected - affectedUnsigned}
-              </Badge>
-            </SplitItem>
             <SplitItem></SplitItem>
             <SplitItem>
               <Trans>Unsigned version(s)</Trans>

--- a/src/components/signing/signature-badge.tsx
+++ b/src/components/signing/signature-badge.tsx
@@ -8,7 +8,7 @@ import {
 import { useContext } from 'src/loaders/app-context';
 
 interface Props extends LabelProps {
-  signState: 'signed' | 'unsigned' | 'partial';
+  signState: 'signed' | 'unsigned';
 }
 
 export const SignatureBadge: FC<Props> = ({
@@ -28,8 +28,6 @@ export const SignatureBadge: FC<Props> = ({
         return t`Signed`;
       case 'unsigned':
         return t`Unsigned`;
-      case 'partial':
-        return t`Partially signed`;
     }
   };
 


### PR DESCRIPTION
Issue: AAH-1852

Connected to https://issues.redhat.com/browse/AAH-1794
Counters for signed and unsigned collections, as well as filters to search partially signed collections, have been removed.
These are the steps for signing collections:

1. Feed your local system with some collections
2. Add to your .compose.env the settings: 
ENABLE_SIGNING=1
PULP_GALAXY_COLLECTION_SIGNING_SERVICE='ansible-default'
PULP_GALAXY_REQUIRE_CONTENT_APPROVAL=true
PULP_GALAXY_AUTO_SIGN_COLLECTIONS=true
3. Run: ./compose exec api ./entrypoint.sh manage create-test-collections --strategy=faux --ns=1 --cols=10 --prefix=signing
4. Then you can go to approval dashboard and approve & sign some collections
5. browse http://0.0.0.0:8002/ui/repo/published and http://0.0.0.0:8002/ui/repo/staging and check if the badges are showing ok

Before:
![Screenshot_2022-08-02_19-22-54](https://user-images.githubusercontent.com/64337863/182699319-8a7479c4-8f37-47b4-be19-b93b319069de.png)
![Screenshot_2022-08-02_19-27-30](https://user-images.githubusercontent.com/64337863/182699323-28727ebc-e1b8-458c-aa9d-46d0bc76370f.png)

After:
![Screen Shot 2022-08-09 at 4 41 34 PM](https://user-images.githubusercontent.com/64337863/183756861-7febb85b-1aa5-499b-9f1e-b89d12e6a520.png)
![Screen Shot 2022-08-08 at 1 58 13 PM](https://user-images.githubusercontent.com/64337863/183483229-350a3a11-3d07-4bb6-aa54-1e7aaca2f5a6.png)


