### PR TITLE
Create test for repository management

### DIFF
--- a/CHANGES/626.misc
+++ b/CHANGES/626.misc
@@ -1,0 +1,1 @@
+More test for repository management (collections). An user sees buttons in kebab according to RBAC rights. 

--- a/test/cypress/e2e/repo_management.js
+++ b/test/cypress/e2e/repo_management.js
@@ -26,8 +26,9 @@ describe('Repo Management tests', () => {
 
   it('admin user sees download_concurrency in remote config', () => {
     cy.visit(remoteRepoUrl);
-    cy.contains('.title-box', 'Repo Management');
+    cy.contains('.body', 'community'); // without this, sporadic failures
     cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
+    cy.contains('Edit'); // without this, sporadic failures
     cy.contains('Edit').click();
     cy.contains('Show advanced options').click();
     cy.get('#download_concurrency').should('exist');

--- a/test/cypress/e2e/repo_management.js
+++ b/test/cypress/e2e/repo_management.js
@@ -94,10 +94,7 @@ describe('Repo Management tests', () => {
     cy.visit(localRepoUrl);
     cy.contains('.hub-tab-link-container span', 'Remote').click();
     cy.contains('.body', 'rh-certified');
-
-    cy.contains('.body button', 'Configure');
     cy.contains('.body button', 'Sync');
-
     cy.get('.body button[aria-label="Actions"]').eq(0).click();
     cy.contains('.body a', 'Edit');
     cy.get('.body button[aria-label="Actions"]').eq(1).click();
@@ -109,10 +106,7 @@ describe('Repo Management tests', () => {
     cy.visit(localRepoUrl);
     cy.contains('.hub-tab-link-container span', 'Remote').click();
     cy.contains('.body', 'rh-certified');
-
-    cy.contains('.body button', 'Configure').should('not.exist');
     cy.contains('.body button', 'Sync').should('not.exist');
-
     cy.get('.body button[aria-label="Actions"]').should('not.exist');
   });
 

--- a/test/cypress/e2e/repo_management.js
+++ b/test/cypress/e2e/repo_management.js
@@ -2,12 +2,31 @@ describe('Repo Management tests', () => {
   let remoteRepoUrl = '/ui/repositories?tab=remote';
   let localRepoUrl = '/ui/repositories';
 
+  let noPrivilegesUser0 = 'noPrivilegesUser0';
+  //let somePrivilegesUser0 = 'somePrivilegesUser0';
+
+  before(() => {
+    cy.deleteTestGroups();
+    cy.deleteTestUsers();
+    cy.galaxykit('user create', noPrivilegesUser0, noPrivilegesUser0);
+
+    /*cy.galaxykit('user create', somePrivilegesUser0, somePrivilegesUser0);
+    cy.galaxykit('group create', 'Group0');
+    cy.galaxykit('user group add', somePrivilegesUser0, 'Group0');*/
+    //cy.galaxykit('group perm add', 'group0', 'galaxy.view_user');
+  });
+
+  after(() => {
+    cy.deleteTestUsers();
+  });
+
   beforeEach(() => {
     cy.login();
   });
 
   it('admin user sees download_concurrency in remote config', () => {
     cy.visit(remoteRepoUrl);
+    cy.contains('.title-box', 'Repo Management');
     cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
     cy.contains('Edit').click();
     cy.contains('Show advanced options').click();
@@ -62,6 +81,38 @@ describe('Repo Management tests', () => {
     ).contains(Cypress.env('prefix') + 'content/community/'); // check content of input
 
     cy.get('button[aria-label="Copy to clipboard"]').eq(1).should('be.enabled');
+  });
+
+  it('can see both default repos.', () => {
+    cy.visit(localRepoUrl);
+    cy.contains('.hub-tab-link-container', 'Local');
+    cy.contains('.hub-tab-link-container', 'Remote');
+  });
+
+  it('can see all buttons as admin.', () => {
+    cy.visit(localRepoUrl);
+    cy.contains('.hub-tab-link-container span', 'Remote').click();
+    cy.contains('.body', 'rh-certified');
+
+    cy.contains('.body button', 'Configure');
+    cy.contains('.body button', 'Sync');
+
+    cy.get('.body button[aria-label="Actions"]').eq(0).click();
+    cy.contains('.body a', 'Edit');
+    cy.get('.body button[aria-label="Actions"]').eq(1).click();
+    cy.contains('.body a', 'Edit');
+  });
+
+  it('can see no buttons as user without privilleges.', () => {
+    cy.login(noPrivilegesUser0, noPrivilegesUser0);
+    cy.visit(localRepoUrl);
+    cy.contains('.hub-tab-link-container span', 'Remote').click();
+    cy.contains('.body', 'rh-certified');
+
+    cy.contains('.body button', 'Configure').should('not.exist');
+    cy.contains('.body button', 'Sync').should('not.exist');
+
+    cy.get('.body button[aria-label="Actions"]').should('not.exist');
   });
 
   it.skip('starts remote repo sync', () => {

--- a/test/cypress/e2e/repo_management.js
+++ b/test/cypress/e2e/repo_management.js
@@ -3,21 +3,16 @@ describe('Repo Management tests', () => {
   let localRepoUrl = '/ui/repositories';
 
   let noPrivilegesUser0 = 'noPrivilegesUser0';
-  //let somePrivilegesUser0 = 'somePrivilegesUser0';
 
   before(() => {
     cy.deleteTestGroups();
     cy.deleteTestUsers();
     cy.galaxykit('user create', noPrivilegesUser0, noPrivilegesUser0);
-
-    /*cy.galaxykit('user create', somePrivilegesUser0, somePrivilegesUser0);
-    cy.galaxykit('group create', 'Group0');
-    cy.galaxykit('user group add', somePrivilegesUser0, 'Group0');*/
-    //cy.galaxykit('group perm add', 'group0', 'galaxy.view_user');
   });
 
   after(() => {
     cy.deleteTestUsers();
+    cy.deleteTestGroups();
   });
 
   beforeEach(() => {
@@ -28,7 +23,6 @@ describe('Repo Management tests', () => {
     cy.visit(remoteRepoUrl);
     cy.contains('.body', 'community'); // without this, sporadic failures
     cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
-    cy.contains('Edit'); // without this, sporadic failures
     cy.contains('Edit').click();
     cy.contains('Show advanced options').click();
     cy.get('#download_concurrency').should('exist');

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -1,6 +1,7 @@
 // https://on.cypress.io/custom-commands
 
 import shell from 'shell-escape-tag';
+import { range } from 'lodash';
 
 Cypress.Commands.add('findnear', { prevSubject: true }, (subject, selector) => {
   return subject.closest(`*:has(${selector})`).find(selector);
@@ -306,8 +307,12 @@ Cypress.Commands.add('deleteTestUsers', {}, () => {
 });
 
 Cypress.Commands.add('deleteTestGroups', {}, () => {
-  cy.galaxykit('group list').then((lines) => {
-    lines.map(col1).forEach((group) => cy.galaxykit('-i group delete', group));
+  range(4).forEach(() => {
+    cy.galaxykit('group list').then((lines) => {
+      lines
+        .map(col1)
+        .forEach((group) => cy.galaxykit('-i group delete', group));
+    });
   });
 });
 


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-626



Collections -> Repository management

Test:

    Both tabs contains default repos
    An user sees buttons in kebab according to RBAC rights

Two users - admin and no privilleges user are tested.
Admin sees all buttons, other user none of them.

Additionaly - command for delete test groups was enhanced - it now loops 4 times to delete at least 40 groups.