### PR TITLE
SignAllCertificatesModal - drop numberOfAffected, affectedUnsigned props

### DIFF
--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -56,7 +56,6 @@ export class CollectionListType {
   id: string;
   name: string;
   description: string;
-  // download_count: number;
   deprecated: boolean;
   latest_version: CollectionVersion;
   sign_state: SignState;
@@ -68,9 +67,6 @@ export class CollectionListType {
     avatar_url: string;
     company: string;
   };
-  total_versions: number;
-  signed_versions: number;
-  unsigned_versions: number;
 }
 
 export class PluginContentType {
@@ -129,10 +125,6 @@ export class CollectionDetailType {
   name: string;
   description: string;
   sign_state: SignState;
-  total_versions: number;
-  signed_versions: number;
-  unsigned_versions: number;
-  // download_count: number;
 
   namespace: {
     id: number;

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -37,7 +37,6 @@ export class CollectionListItem extends React.Component<IProps> {
   render() {
     const {
       name,
-      // download_count,
       latest_version,
       namespace,
       showNamespace,

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -296,8 +296,6 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             />
             <SignAllCertificatesModal
               name={collectionName}
-              numberOfAffected={collection.total_versions}
-              affectedUnsigned={collection.unsigned_versions}
               isOpen={this.state.isOpenSignAllModal}
               onSubmit={this.signCollection}
               onCancel={() => {

--- a/src/components/signing/sign-all-certificates-modal.tsx
+++ b/src/components/signing/sign-all-certificates-modal.tsx
@@ -17,8 +17,6 @@ import React from 'react';
 
 interface Props {
   name: string;
-  numberOfAffected: number;
-  affectedUnsigned: number;
   isOpen: boolean;
   onSubmit: () => void;
   onCancel: () => void;

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -240,16 +240,6 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       'view_type',
     ];
 
-    const total_versions = collections.reduce(
-      (acc, c) => acc + c.total_versions,
-      0,
-    );
-
-    const unsigned_versions = collections.reduce(
-      (acc, c) => acc + c.unsigned_versions,
-      0,
-    );
-
     return (
       <React.Fragment>
         <AlertList alerts={alerts} closeAlert={(i) => this.closeAlert(i)} />
@@ -447,8 +437,6 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
         {canSign && (
           <SignAllCertificatesModal
             name={this.state.namespace.name}
-            numberOfAffected={total_versions}
-            affectedUnsigned={unsigned_versions}
             isOpen={this.state.isOpenSignModal}
             onSubmit={() => {
               this.signAllCertificates(namespace);


### PR DESCRIPTION
Follow-up to #2414
No-Issue

Just dropping some unused props, and the field types for unused fields that were previously used for these.