### PR TITLE
Collection dependencies from community are broken links

### DIFF
--- a/CHANGES/1574.misc
+++ b/CHANGES/1574.misc
@@ -1,0 +1,1 @@
+Collection Dependencies From Community Are Broken Links - this PR loads dependencies collections repos and repairs the links.

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 
 import { List, ListItem, ListVariant } from '@patternfly/react-core';
 
-import { EmptyStateNoData } from 'src/components';
+import { EmptyStateNoData, HelperText } from 'src/components';
 
 import { CollectionDetailType } from 'src/api';
 
@@ -32,9 +32,22 @@ export class CollectionDependenciesList extends React.Component<IProps> {
     return (
       <List variant={ListVariant.inline} className='hub-c-list-dependencies'>
         {dependencies_repos.map((dependency, i) => (
-          <ListItem key={i} style={{ marginRight: '70px' }}>
-            <Link to={dependency.path}>{dependency.name}</Link>
-          </ListItem>
+          <>
+            {dependency.path && (
+              <ListItem key={i} style={{ marginRight: '70px' }}>
+                <Link to={dependency.path}>{dependency.name}</Link>
+              </ListItem>
+            )}
+
+            {!dependency.path && (
+              <ListItem key={i} style={{ marginRight: '70px' }}>
+                {dependency.name}
+                <HelperText
+                  content={t`Collection was not found in the system. You must upload it.`}
+                />
+              </ListItem>
+            )}
+          </>
         ))}
       </List>
     );

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -6,13 +6,13 @@ import { List, ListItem, ListVariant } from '@patternfly/react-core';
 
 import { EmptyStateNoData, HelperText } from 'src/components';
 
-import { CollectionDetailType } from 'src/api';
+import { CollectionDetailType, CollectionVersion } from 'src/api';
 
 import 'src/containers/collection-detail/collection-dependencies.scss';
 
 interface IProps {
   collection: CollectionDetailType;
-  dependencies_repos: any;
+  dependencies_repos: (CollectionVersion & { path?: string })[];
 }
 
 export class CollectionDependenciesList extends React.Component<IProps> {

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -7,19 +7,17 @@ import { List, ListItem, ListVariant } from '@patternfly/react-core';
 import { EmptyStateNoData } from 'src/components';
 
 import { CollectionDetailType } from 'src/api';
-import { formatPath, Paths } from 'src/paths';
 
 import 'src/containers/collection-detail/collection-dependencies.scss';
 
 interface IProps {
   collection: CollectionDetailType;
-  repo: string;
+  dependencies_repos: any;
 }
 
 export class CollectionDependenciesList extends React.Component<IProps> {
   render() {
-    const { collection, repo } = this.props;
-
+    const { collection, dependencies_repos } = this.props;
     const { dependencies } = collection.latest_version.metadata;
 
     if (!Object.keys(dependencies).length) {
@@ -33,34 +31,12 @@ export class CollectionDependenciesList extends React.Component<IProps> {
 
     return (
       <List variant={ListVariant.inline} className='hub-c-list-dependencies'>
-        {Object.keys(dependencies).map((dependency, i) => (
+        {dependencies_repos.map((dependency, i) => (
           <ListItem key={i} style={{ marginRight: '70px' }}>
-            <Link
-              to={formatPath(
-                Paths.collectionByRepo,
-                {
-                  collection: this.splitDependencyName(dependency).collection,
-                  namespace: this.splitDependencyName(dependency).namespace,
-                  repo,
-                },
-                this.separateVersion(dependencies[dependency]),
-              )}
-            >
-              {this.splitDependencyName(dependency).collection}
-            </Link>
+            <Link to={dependency.path}>{dependency.name}</Link>
           </ListItem>
         ))}
       </List>
     );
-  }
-
-  private splitDependencyName(dependency) {
-    const [namespace, collection] = dependency.split('.');
-    return { namespace, collection };
-  }
-
-  private separateVersion(version) {
-    const v = version.match(/((\d+\.*)+)/);
-    return v ? { version: v[0] } : {};
   }
 }

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -94,6 +94,6 @@ export class RepoSelector extends React.Component<IProps, IState> {
 
   private getRepoName(repoName) {
     const repo = Constants.REPOSITORYNAMES[repoName];
-    return i18n._(repo);
+    return repo ? i18n._(repo) : repoName;
   }
 }

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -155,7 +155,6 @@ class CollectionDependencies extends React.Component<
                   ) : (
                     <CollectionDependenciesList
                       collection={this.state.collection}
-                      /*repo={this.context.selectedRepo}*/
                       dependencies_repos={this.state.dependencies_repos}
                     />
                   )}

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -6,6 +6,7 @@ import {
   CollectionAPI,
   CollectionDetailType,
   CollectionUsedByDependencies,
+  CollectionVersionAPI,
 } from 'src/api';
 import {
   CollectionHeader,
@@ -27,6 +28,7 @@ import './collection-dependencies.scss';
 
 interface IState {
   collection: CollectionDetailType;
+  dependencies_repos: any;
   params: {
     page?: number;
     page_size?: number;
@@ -59,6 +61,7 @@ class CollectionDependencies extends React.Component<
 
     this.state = {
       collection: undefined,
+      dependencies_repos: [],
       params: params,
       usedByDependencies: [],
       usedByDependenciesCount: 0,
@@ -151,7 +154,8 @@ class CollectionDependencies extends React.Component<
                   ) : (
                     <CollectionDependenciesList
                       collection={this.state.collection}
-                      repo={this.context.selectedRepo}
+                      /*repo={this.context.selectedRepo}*/
+                      dependencies_repos={this.state.dependencies_repos}
                     />
                   )}
                   <p>{t`This collection is being used by`}</p>
@@ -178,7 +182,58 @@ class CollectionDependencies extends React.Component<
   }
 
   private loadData(forceReload = false) {
-    this.loadCollection(forceReload, () => this.loadUsedByDependencies());
+    this.loadCollection(forceReload, () =>
+      this.loadCollectionsDependenciesRepos(() =>
+        this.loadUsedByDependencies(),
+      ),
+    );
+  }
+
+  private loadCollectionsDependenciesRepos(callback) {
+    const dependencies =
+      this.state.collection.latest_version.metadata.dependencies;
+    const dependencies_repos = [];
+    const promises = [];
+
+    Object.keys(dependencies).forEach((dependency) => {
+      const [namespace, collection] = String(dependency).split('.');
+      const dependency_repo = {
+        name: collection,
+        namespace: namespace,
+        repo: '',
+      };
+      dependencies_repos.push(dependency_repo);
+
+      const promise = this.loadDependencyRepo(dependency_repo);
+      promises.push(promise);
+    });
+
+    Promise.all(promises).then(() => {
+      this.setState({ dependencies_repos: dependencies_repos }, callback());
+    });
+  }
+
+  private loadDependencyRepo(dependency_repo) {
+    return CollectionVersionAPI.list({
+      namespace: dependency_repo.namespace,
+      name: dependency_repo.name,
+    }).then((result) => {
+      dependency_repo.repo = result.data.data[0].repository_list[0];
+      const dependencies =
+        this.state.collection.latest_version.metadata.dependencies;
+
+      dependency_repo.path = formatPath(
+        Paths.collectionByRepo,
+        {
+          collection: dependency_repo.name,
+          namespace: dependency_repo.namespace,
+          repo: dependency_repo.repo,
+        },
+        this.separateVersion(
+          dependencies[dependency_repo.namespace + '.' + dependency_repo.name],
+        ),
+      );
+    });
   }
 
   private loadUsedByDependencies() {
@@ -250,6 +305,11 @@ class CollectionDependencies extends React.Component<
 
   get closeAlert() {
     return closeAlertMixin('alerts');
+  }
+
+  private separateVersion(version) {
+    const v = version.match(/((\d+\.*)+)/);
+    return v ? { version: v[0] } : {};
   }
 }
 

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -217,23 +217,29 @@ class CollectionDependencies extends React.Component<
     return CollectionVersionAPI.list({
       namespace: dependency_repo.namespace,
       name: dependency_repo.name,
-    }).then((result) => {
-      dependency_repo.repo = result.data.data[0].repository_list[0];
-      const dependencies =
-        this.state.collection.latest_version.metadata.dependencies;
+    })
+      .then((result) => {
+        dependency_repo.repo = result.data.data[0].repository_list[0];
+        const dependencies =
+          this.state.collection.latest_version.metadata.dependencies;
 
-      dependency_repo.path = formatPath(
-        Paths.collectionByRepo,
-        {
-          collection: dependency_repo.name,
-          namespace: dependency_repo.namespace,
-          repo: dependency_repo.repo,
-        },
-        this.separateVersion(
-          dependencies[dependency_repo.namespace + '.' + dependency_repo.name],
-        ),
-      );
-    });
+        dependency_repo.path = formatPath(
+          Paths.collectionByRepo,
+          {
+            collection: dependency_repo.name,
+            namespace: dependency_repo.namespace,
+            repo: dependency_repo.repo,
+          },
+          this.separateVersion(
+            dependencies[
+              dependency_repo.namespace + '.' + dependency_repo.name
+            ],
+          ),
+        );
+      })
+      .catch(() => {
+        // do nothing, dependency_repo.path stays empty
+      });
   }
 
   private loadUsedByDependencies() {

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -7,6 +7,7 @@ import {
   CollectionDetailType,
   CollectionUsedByDependencies,
   CollectionVersionAPI,
+  CollectionVersion,
 } from 'src/api';
 import {
   CollectionHeader,
@@ -28,7 +29,7 @@ import './collection-dependencies.scss';
 
 interface IState {
   collection: CollectionDetailType;
-  dependencies_repos: any;
+  dependencies_repos: CollectionVersion[];
   params: {
     page?: number;
     page_size?: number;
@@ -196,11 +197,12 @@ class CollectionDependencies extends React.Component<
     const promises = [];
 
     Object.keys(dependencies).forEach((dependency) => {
-      const [namespace, collection] = String(dependency).split('.');
+      const [namespace, collection] = dependency.split('.');
       const dependency_repo = {
         name: collection,
         namespace: namespace,
         repo: '',
+        path: '',
       };
       dependencies_repos.push(dependency_repo);
 
@@ -238,7 +240,9 @@ class CollectionDependencies extends React.Component<
         );
       })
       .catch(() => {
-        // do nothing, dependency_repo.path stays empty
+        // do nothing, dependency_repo.path and repo stays empty
+        // this may mean that collection was not found - thus is not in the system.
+        // user will be notified in the list of dependencies rather than alerts
       });
   }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -13,7 +13,8 @@ export function formatPath(
   }
 
   if (params) {
-    return `${url}?${ParamHelper.getQueryString(params)}`;
+    const path = `${url}?${ParamHelper.getQueryString(params)}`;
+    return path;
   } else {
     return url;
   }


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-1574

The problem was, that context repo was used in link path to collection, which was wrong.
Now, collections in dependencies list are loaded and info about their repo is used in link href path construction.

You can fill test data using:
./compose exec api django-admin create-test-collections --strategy=faux --ns=1 --cols=6 --prefix=deptest

This PR also includes fix of error, that was also present at master before this PR (but the situation cant be reproduced in UI, only by "hijacking" the URL. When you are for example on published repo and you will try to access collection detail in different repo (manualy by inserting URL), GUI will redirect you to Not Found Page (althrough API do returns the collection detail). This is also fixed in this PR, because user can now navigate to different repos, when there is collection in dependency lists with different repo than selected. 