### PR TITLE
Fix Owners tab permissions

### DIFF
--- a/CHANGES/1875.bug
+++ b/CHANGES/1875.bug
@@ -1,0 +1,1 @@
+Fix Owners tab permissions

--- a/src/api/namespace.ts
+++ b/src/api/namespace.ts
@@ -2,6 +2,10 @@ import { HubAPI } from './hub';
 
 class API extends HubAPI {
   apiPath = this.getUIPath('namespaces/');
+
+  get(id: string, params = {}) {
+    return this.http.get(this.apiPath + id + '/', { params });
+  }
 }
 
 export const NamespaceAPI = new API();

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -240,6 +240,11 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       'view_type',
     ];
 
+    const canEditOwners =
+      this.state.namespace.related_fields.my_permissions?.includes(
+        'galaxy.change_namespace',
+      ) || this.context.user.model_permissions.change_namespace;
+
     return (
       <React.Fragment>
         <AlertList alerts={alerts} closeAlert={(i) => this.closeAlert(i)} />
@@ -416,6 +421,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                   alerts: [...this.state.alerts, alert],
                 })
               }
+              canEditOwners={canEditOwners}
               groupId={params.group}
               groups={namespace.groups}
               name={namespace.name}
@@ -582,7 +588,9 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
         },
         this.context.selectedRepo,
       ),
-      NamespaceAPI.get(this.props.match.params['namespace']),
+      NamespaceAPI.get(this.props.match.params['namespace'], {
+        include_related: 'my_permissions',
+      }),
       MyNamespaceAPI.get(this.props.match.params['namespace'], {
         include_related: 'my_permissions',
       }).catch((e) => {

--- a/test/cypress/e2e/collection.js
+++ b/test/cypress/e2e/collection.js
@@ -53,7 +53,7 @@ describe('collection tests', () => {
     cy.menuGo('Collections > Collections');
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/namespaces/my_namespace/',
+      Cypress.env('prefix') + '_ui/v1/namespaces/my_namespace/?*',
     ).as('reload');
     cy.get('a[href*="ui/repo/published/my_namespace/my_collection"]').click();
     cy.get('[data-cy=kebab-toggle]').click();


### PR DESCRIPTION
https://github.com/ansible/ansible-hub-ui/pull/2378 got closed because the base branch went away during the rbac merge (#2239)

Reopening against master :)

---

Fixes AAH-1875

Set owners tab to use the permissions returned by my_permissions on container and collection namespaces, or user permissions.

Requires https://github.com/ansible/galaxy_ng/pull/1389 (merged)

the view for assigning roles to containers should use `change_containernamespace`,
the view for assigning roles to collection namespaces should use `change_namespace`.