### PR TITLE
Unify RolePermissions component - replace other versions

### DIFF
--- a/src/components/rbac/role-form.tsx
+++ b/src/components/rbac/role-form.tsx
@@ -1,27 +1,23 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import { i18n } from '@lingui/core';
-import { PermissionChipSelector } from 'src/components';
 import {
   ActionGroup,
   Button,
-  Flex,
-  FlexItem,
-  Form,
-  TextInput,
-  InputGroup,
-  FormGroup,
-  Title,
   Divider,
+  Form,
+  FormGroup,
+  InputGroup,
   Spinner,
+  TextInput,
+  Title,
 } from '@patternfly/react-core';
-
-import { twoWayMapper } from 'src/utilities';
-
 import { Constants } from 'src/constants';
+import { RolePermissions } from 'src/components';
+
 interface IState {
   permissions: string[];
 }
+
 interface IProps {
   nameDisabled?: boolean;
   name: string;
@@ -70,7 +66,6 @@ export class RoleForm extends React.Component<IProps, IState> {
       isSavingDisabled,
       saving,
     } = this.props;
-    const groups = Constants.PERMISSIONS;
 
     const filteredPermissions = { ...Constants.HUMAN_PERMISSIONS };
 
@@ -100,7 +95,7 @@ export class RoleForm extends React.Component<IProps, IState> {
                     onChange={onNameChange}
                     type='text'
                     validated={nameValidated}
-                    placeholder='Role name'
+                    placeholder={t`Role name`}
                   />
                 </InputGroup>
               </FormGroup>
@@ -120,7 +115,7 @@ export class RoleForm extends React.Component<IProps, IState> {
                   onChange={onDescriptionChange}
                   type='text'
                   validated={descriptionValidated}
-                  placeholder='Add a role description here'
+                  placeholder={t`Add a role description here`}
                 />
               </FormGroup>
             </div>
@@ -131,72 +126,13 @@ export class RoleForm extends React.Component<IProps, IState> {
             <br />
             <Title headingLevel='h2'>Permissions</Title>
 
-            {groups.map((group) => (
-              <Flex
-                style={{ marginTop: '16px' }}
-                alignItems={{ default: 'alignItemsCenter' }}
-                key={group.name}
-                className={group.name}
-                data-cy={`RoleForm-Permissions-row-${group.name}`}
-              >
-                <FlexItem style={{ minWidth: '200px' }}>
-                  {i18n._(group.label)}
-                </FlexItem>
-                <FlexItem grow={{ default: 'grow' }}>
-                  <PermissionChipSelector
-                    availablePermissions={group.object_permissions
-                      .filter(
-                        (perm) =>
-                          !selectedPermissions.find(
-                            (selected) => selected === perm,
-                          ),
-                      )
-                      .map((value) => twoWayMapper(value, filteredPermissions))
-                      .sort()}
-                    selectedPermissions={selectedPermissions
-                      .filter((selected) =>
-                        group.object_permissions.find(
-                          (perm) => selected === perm,
-                        ),
-                      )
-                      .map((value) => twoWayMapper(value, filteredPermissions))}
-                    setSelected={(perms) =>
-                      this.setState({ permissions: perms })
-                    }
-                    menuAppendTo='inline'
-                    multilingual={true}
-                    isViewOnly={false}
-                    onClear={() => {
-                      const clearedPerms = group.object_permissions;
-                      this.setState({
-                        permissions: this.state.permissions.filter(
-                          (x) => !clearedPerms.includes(x),
-                        ),
-                      });
-                    }}
-                    onSelect={(event, selection) => {
-                      const newPerms = new Set(this.state.permissions);
-                      if (
-                        newPerms.has(
-                          twoWayMapper(selection, filteredPermissions),
-                        )
-                      ) {
-                        newPerms.delete(
-                          twoWayMapper(selection, filteredPermissions),
-                        );
-                      } else {
-                        newPerms.add(
-                          twoWayMapper(selection, filteredPermissions),
-                        );
-                      }
-                      this.setState({
-                        permissions: Array.from(newPerms),
-                      });
-                    }}
-                  />
-                </FlexItem>
-              </Flex>
-            ))}
+            <RolePermissions
+              filteredPermissions={filteredPermissions}
+              selectedPermissions={selectedPermissions}
+              setPermissions={(permissions) => this.setState({ permissions })}
+              showCustom={false}
+              showEmpty={true}
+            />
           </div>
 
           <ActionGroup>

--- a/src/components/rbac/role-permissions.tsx
+++ b/src/components/rbac/role-permissions.tsx
@@ -114,3 +114,73 @@ export const RolePermissions: React.FC<IProps> = ({
     </>
   );
 };
+
+
+/* TODO update from .. changed during rbac .. probably start from scratch
+            {groups.map((group) => (
+              <Flex
+                style={{ marginTop: '16px' }}
+                alignItems={{ default: 'alignItemsCenter' }}
+                key={group.name}
+                className={group.name}
+                data-cy={`RoleForm-Permissions-row-${group.name}`}
+              >
+                <FlexItem style={{ minWidth: '200px' }}>
+                  {i18n._(group.label)}
+                </FlexItem>
+                <FlexItem grow={{ default: 'grow' }}>
+                  <PermissionChipSelector
+                    availablePermissions={group.object_permissions
+                      .filter(
+                        (perm) =>
+                          !selectedPermissions.find(
+                            (selected) => selected === perm,
+                          ),
+                      )
+                      .map((value) => twoWayMapper(value, filteredPermissions))
+                      .sort()}
+                    selectedPermissions={selectedPermissions
+                      .filter((selected) =>
+                        group.object_permissions.find(
+                          (perm) => selected === perm,
+                        ),
+                      )
+                      .map((value) => twoWayMapper(value, filteredPermissions))}
+                    setSelected={(perms) =>
+                      this.setState({ permissions: perms })
+                    }
+                    menuAppendTo='inline'
+                    multilingual={true}
+                    isViewOnly={false}
+                    onClear={() => {
+                      const clearedPerms = group.object_permissions;
+                      this.setState({
+                        permissions: this.state.permissions.filter(
+                          (x) => !clearedPerms.includes(x),
+                        ),
+                      });
+                    }}
+                    onSelect={(event, selection) => {
+                      const newPerms = new Set(this.state.permissions);
+                      if (
+                        newPerms.has(
+                          twoWayMapper(selection, filteredPermissions),
+                        )
+                      ) {
+                        newPerms.delete(
+                          twoWayMapper(selection, filteredPermissions),
+                        );
+                      } else {
+                        newPerms.add(
+                          twoWayMapper(selection, filteredPermissions),
+                        );
+                      }
+                      this.setState({
+                        permissions: Array.from(newPerms),
+                      });
+                    }}
+                  />
+                </FlexItem>
+              </Flex>
+            ))}
+=======*/

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { t, Trans } from '@lingui/macro';
-import { i18n } from '@lingui/core';
 import { AppContext } from 'src/loaders/app-context';
 import {
   Link,
@@ -23,9 +22,9 @@ import {
   AppliedFilters,
   DeleteModal,
   RoleListTable,
+  RolePermissions,
   ExpandableRow,
   ListItemActions,
-  PermissionChipSelector,
   DateComponent,
 } from 'src/components';
 import {
@@ -35,8 +34,6 @@ import {
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
-  Flex,
-  FlexItem,
   Tooltip,
 } from '@patternfly/react-core';
 import { RoleType } from 'src/api/response-types/role';
@@ -45,7 +42,6 @@ import {
   filterIsSet,
   ParamHelper,
   parsePulpIDFromURL,
-  twoWayMapper,
 } from 'src/utilities';
 
 import { RoleAPI } from 'src/api/role';
@@ -130,8 +126,6 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
 
     const noData =
       roleCount === 0 && !filterIsSet(params, ['name__icontains', 'locked']);
-
-    const groups = Constants.PERMISSIONS;
 
     const { featureFlags } = this.context;
     let isUserMgmtDisabled = false;
@@ -324,53 +318,12 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
                         <ExpandableRow
                           key={role.name}
                           expandableRowContent={
-                            <>
-                              {groups.map((group) => (
-                                <Flex
-                                  style={{ marginTop: '16px' }}
-                                  alignItems={{ default: 'alignItemsCenter' }}
-                                  key={group.name}
-                                  className={group.name}
-                                >
-                                  <FlexItem style={{ minWidth: '200px' }}>
-                                    {i18n._(group.label)}
-                                  </FlexItem>
-                                  <FlexItem grow={{ default: 'grow' }}>
-                                    <PermissionChipSelector
-                                      availablePermissions={group.object_permissions
-                                        .filter(
-                                          (perm) =>
-                                            !role.permissions.find(
-                                              (selected) => selected === perm,
-                                            ),
-                                        )
-                                        .map((value) =>
-                                          twoWayMapper(
-                                            value,
-                                            filteredPermissions,
-                                          ),
-                                        )
-                                        .sort()}
-                                      selectedPermissions={role.permissions
-                                        .filter((selected) =>
-                                          group.object_permissions.find(
-                                            (perm) => selected === perm,
-                                          ),
-                                        )
-                                        .map((value) =>
-                                          twoWayMapper(
-                                            value,
-                                            filteredPermissions,
-                                          ),
-                                        )}
-                                      menuAppendTo='inline'
-                                      multilingual={true}
-                                      isViewOnly={true}
-                                    />
-                                  </FlexItem>
-                                </Flex>
-                              ))}
-                            </>
+                            <RolePermissions
+                              filteredPermissions={filteredPermissions}
+                              selectedPermissions={role.permissions}
+                              showCustom={true}
+                              showEmpty={false}
+                            />
                           }
                           data-cy={`RoleListTable-ExpandableRow-row-${role.name}`}
                           colSpan={6}


### PR DESCRIPTION
Replaces https://github.com/ansible/ansible-hub-ui/pull/2246 now that rbac (#2239) is merged.

---

`RolePermissions` comes from d8e4f75446c5f3965ea24c0970c269bec9648311 (ansible/ansible-hub-ui#1863),
taken from `src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx`

But the same logic also appears in:
`src/components/role-management/role-form.tsx`
`src/components/role-management/role-permissions.tsx`
`src/containers/role-management/role-list.tsx`

with variations on editability, showing extra permissions, and hiding empty permission groups.

=> `setPermissions`, `showCustom`, `showEmpty` on `RolePermissions` :)


also TODO ensure changes from https://github.com/ansible/ansible-hub-ui/pull/2228 survive