### PR TITLE
[stable-4.5] Update collection signing feature flags (#2211)

### DIFF
--- a/CHANGES/1710.misc
+++ b/CHANGES/1710.misc
@@ -1,0 +1,1 @@
+Update collection signing feature flags

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -1,3 +1,5 @@
+type SignState = 'signed' | 'unsigned' | 'partial';
+
 export class CollectionUploadType {
   id: string;
   file: File;
@@ -18,7 +20,7 @@ export class CollectionVersion {
   namespace: string;
   name: string;
   repository_list: string[];
-  sign_state: 'signed' | 'unsigned' | 'partial';
+  sign_state: SignState;
 }
 
 class RenderedFile {
@@ -45,7 +47,7 @@ export class CollectionVersionDetail extends CollectionVersion {
       pulp_created: string;
     }[];
   };
-  sign_state: 'signed' | 'unsigned' | 'partial';
+  sign_state: SignState;
   requires_ansible?: string;
   docs_blob: DocsBlobType;
 }
@@ -57,7 +59,7 @@ export class CollectionListType {
   // download_count: number;
   deprecated: boolean;
   latest_version: CollectionVersion;
-  sign_state: 'unsigned' | 'signed' | 'partial';
+  sign_state: SignState;
 
   namespace: {
     id: number;
@@ -112,13 +114,14 @@ export class CollectionDetailType {
     id: string;
     version: string;
     created: string;
+    sign_state: SignState;
   }[];
   latest_version: CollectionVersionDetail;
 
   id: string;
   name: string;
   description: string;
-  sign_state: 'unsigned' | 'signed' | 'partial';
+  sign_state: SignState;
   // download_count: number;
 
   namespace: {

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -114,7 +114,7 @@ export class CollectionDetailType {
     id: string;
     version: string;
     created: string;
-    sign_state: SignState;
+    sign_state?: SignState;
   }[];
   latest_version: CollectionVersionDetail;
 

--- a/src/api/response-types/feature-flags.ts
+++ b/src/api/response-types/feature-flags.ts
@@ -1,5 +1,13 @@
 export class FeatureFlagsType {
+  execution_environments: boolean;
+  external_authentication: boolean;
+
+  // signing
+  can_create_signatures: boolean;
+  can_upload_signatures: boolean;
   collection_auto_sign: boolean;
   collection_signing: boolean;
-  execution_environments: boolean;
+  display_signatures: boolean;
+  require_upload_signatures: boolean;
+  signatures_enabled: boolean;
 }

--- a/src/components/collection-detail/download-signature-grid-item.tsx
+++ b/src/components/collection-detail/download-signature-grid-item.tsx
@@ -18,12 +18,11 @@ interface Props {
 }
 
 export const DownloadSignatureGridItem: FC<Props> = ({ version }) => {
-  const signingEnabled =
-    useContext()?.featureFlags?.collection_signing === true;
+  const { display_signatures } = useContext()?.featureFlags || {};
   const [show, setShow] = useState(false);
 
   // No signature object or the signatures is empty
-  if (!signingEnabled || version.metadata.signatures?.length < 1) {
+  if (!display_signatures || version.metadata.signatures?.length < 1) {
     return null;
   }
 

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -47,6 +47,8 @@ export class CollectionFilter extends React.Component<IProps, IState> {
 
   render() {
     const { ignoredParams, params, updateParams } = this.props;
+    const { display_signatures } = this.context?.featureFlags || {};
+
     const filterConfig = [
       {
         id: 'keywords',
@@ -61,7 +63,7 @@ export class CollectionFilter extends React.Component<IProps, IState> {
           title: tag,
         })),
       },
-      this.context?.featureFlags?.collection_signing === true && {
+      display_signatures && {
         id: 'sign_state',
         title: t`Sign state`,
         inputType: 'select' as const,

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -162,8 +162,10 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     const latestVersion = collection.latest_version.created_at;
 
+    const { display_signatures } = this.context?.featureFlags || {};
+
     const signedString = (v) => {
-      if ('sign_state' in v) {
+      if (display_signatures && 'sign_state' in v) {
         return v.sign_state === 'signed' ? t`(signed)` : t`(unsigned)`;
       } else {
         return '';

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -158,6 +158,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
   private renderForm(requiredFields, disabledFields) {
     const { remote, errorMessages } = this.props;
     const { filenames } = this.state;
+    const { signatures_enabled } = this.context?.featureFlags || {};
 
     const docsAnsibleLink = (
       <a
@@ -230,8 +231,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
           />
         </FormGroup>
 
-        {!disabledFields.includes('signed_only') &&
-        this.context.featureFlags?.collection_signing ? (
+        {!disabledFields.includes('signed_only') && signatures_enabled ? (
           <FormGroup
             fieldId={'signed_only'}
             name={t`Signed only`}

--- a/src/components/signing/signature-badge.tsx
+++ b/src/components/signing/signature-badge.tsx
@@ -16,10 +16,9 @@ export const SignatureBadge: FC<Props> = ({
   isCompact = false,
   ...props
 }) => {
-  const signingEnabled =
-    useContext()?.featureFlags?.collection_signing === true;
+  const { display_signatures } = useContext()?.featureFlags || {};
 
-  if (!signingEnabled) {
+  if (!display_signatures) {
     return null;
   }
 

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -364,11 +364,8 @@ class CertificationDashboard extends React.Component<
 
   private renderButtons(version: CollectionVersion) {
     // not checking namespace permissions here, auto_sign happens API side, so is the permission check
-    const {
-      can_upload_signatures,
-      collection_auto_sign,
-      require_upload_signatures,
-    } = this.context?.featureFlags || {};
+    const { collection_auto_sign, require_upload_signatures } =
+      this.context?.featureFlags || {};
     if (this.state.updatingVersions.includes(version)) {
       return <ListItemActions />; // empty td;
     }

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -296,9 +296,10 @@ class CertificationDashboard extends React.Component<
       return <span className='fa fa-lg fa-spin fa-spinner' />;
     }
     if (version.repository_list.includes(Constants.PUBLISHED)) {
+      const { display_signatures } = this.context?.featureFlags || {};
       return (
         <Label variant='outline' color='green' icon={<CheckCircleIcon />}>
-          {version.sign_state === 'signed'
+          {display_signatures && version.sign_state === 'signed'
             ? t`Signed and approved`
             : t`Approved`}
         </Label>
@@ -312,13 +313,19 @@ class CertificationDashboard extends React.Component<
       );
     }
     if (version.repository_list.includes(Constants.NEEDSREVIEW)) {
+      const { can_upload_signatures, require_upload_signatures } =
+        this.context?.featureFlags || {};
       return (
         <Label
           variant='outline'
           color='orange'
           icon={<ExclamationTriangleIcon />}
         >
-          {t`Needs Review`}
+          {version.sign_state === 'unsigned' &&
+          can_upload_signatures &&
+          require_upload_signatures
+            ? t`Needs signature and review`
+            : t`Needs review`}
         </Label>
       );
     }
@@ -356,14 +363,17 @@ class CertificationDashboard extends React.Component<
   }
 
   private renderButtons(version: CollectionVersion) {
-    const { featureFlags } = this.context;
     // not checking namespace permissions here, auto_sign happens API side, so is the permission check
-    const canSign =
-      featureFlags?.collection_signing && featureFlags?.collection_auto_sign;
-
+    const {
+      can_upload_signatures,
+      collection_auto_sign,
+      require_upload_signatures,
+    } = this.context?.featureFlags || {};
     if (this.state.updatingVersions.includes(version)) {
       return <ListItemActions />; // empty td;
     }
+
+    const autoSign = collection_auto_sign && !require_upload_signatures;
 
     const approveButton = [
       <Button
@@ -376,9 +386,10 @@ class CertificationDashboard extends React.Component<
           )
         }
       >
-        <span>{canSign ? t`Sign and approve` : t`Approve`}</span>
+        {autoSign ? t`Sign and approve` : t`Approve`}
       </Button>,
-    ];
+    ].filter(Boolean);
+
     const importsLink = (
       <DropdownItem
         key='imports'
@@ -408,7 +419,7 @@ class CertificationDashboard extends React.Component<
         isDisabled={isDisabled}
         key='certify'
       >
-        {canSign ? t`Sign and approve` : t`Approve`}
+        {autoSign ? t`Sign and approve` : t`Approve`}
       </DropdownItem>
     );
 

--- a/src/utilities/can-sign.tsx
+++ b/src/utilities/can-sign.tsx
@@ -1,7 +1,8 @@
 export const canSign = ({ featureFlags }, namespace) => {
+  const { can_create_signatures } = featureFlags || {};
   const permissions = namespace?.related_fields?.my_permissions || [];
   return (
-    featureFlags?.collection_signing &&
+    can_create_signatures &&
     permissions.includes('galaxy.change_namespace') &&
     permissions.includes('galaxy.upload_to_namespace')
   );


### PR DESCRIPTION
This is a manual backport of #2211 for stable-4.5 (conflicts because https://github.com/ansible/ansible-hub-ui/pull/1892 is not backported).

Depends on https://github.com/ansible/galaxy_ng/pull/1417 (backport of https://github.com/ansible/galaxy_ng/pull/1318)

---

* Update collection signing feature flags

Issue: AAH-1710

* use new signing feature flags

* remove signing_enabled where other featureFlags are also present

* sign state - add display_signatures check around Signed and approved

* ~~Sign and approve only unless require_upload_signatures~~

(cherry picked from commit fd92aeac74c0a659bc7070e9a0673691e47cb1eb)