### PR TITLE
galaxykit: use main branch, instead of feature branch

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -26,8 +26,8 @@ jobs:
 
     - name: "Install galaxykit dependency"
       run: |
-        # FIXME(rbac): pip install git+https://github.com/ansible/galaxykit.git
-        pip install git+https://github.com/himdel/galaxykit.git@object_roles
+        # pip install git+https://github.com/ansible/galaxykit.git@branch_name
+        pip install git+https://github.com/ansible/galaxykit.git
 
     - name: "Set env.SHORT_BRANCH, env.GALAXY_NG_COMMIT"
       run: |


### PR DESCRIPTION
now that rbac is merged, we can use galaxykit main again :).

(#2239 & ansible/galaxykit#39)