### PR TITLE
PULP_API_BASE_PATH - hardcode to use API_BASE_PATH + 'pulp/api/v3/'

### DIFF
--- a/config/community.prod.webpack.config.js
+++ b/config/community.prod.webpack.config.js
@@ -4,7 +4,6 @@ const webpackBase = require('./webpack.base.config');
 module.exports = webpackBase({
   API_HOST: '',
   API_BASE_PATH: '/api/',
-  PULP_API_BASE_PATH: '/api/pulp/api/v3/',
   UI_BASE_PATH: '/ui/',
   DEPLOYMENT_MODE: 'standalone',
   NAMESPACE_TERM: 'namespaces',

--- a/config/insights.dev.webpack.config.js
+++ b/config/insights.dev.webpack.config.js
@@ -9,7 +9,6 @@ module.exports = webpackBase({
 
   // Path to the API on the API host. EX: /api/automation-hub
   API_BASE_PATH: '/api/automation-hub/',
-  PULP_API_BASE_PATH: '/api/automation-hub/pulp/api/v3/',
 
   // Value for standalone.api.target
   API_PROXY_TARGET: `http://${proxyHost}:${proxyPort}`,

--- a/config/insights.prod.webpack.config.js
+++ b/config/insights.prod.webpack.config.js
@@ -4,7 +4,6 @@ const webpackBase = require('./webpack.base.config');
 module.exports = webpackBase({
   API_HOST: '',
   API_BASE_PATH: '/api/automation-hub/',
-  PULP_API_BASE_PATH: '/api/automation-hub/pulp/api/v3/',
   UI_BASE_PATH: '',
   DEPLOYMENT_MODE: 'insights',
   NAMESPACE_TERM: 'partners',

--- a/config/standalone.dev.webpack.config.js
+++ b/config/standalone.dev.webpack.config.js
@@ -12,7 +12,6 @@ module.exports = webpackBase({
 
   // Path to the API on the API host. EX: /api/automation-hub
   API_BASE_PATH: apiBasePath,
-  PULP_API_BASE_PATH: apiBasePath + 'pulp/api/v3/',
 
   // Path on the host where the UI is found. EX: /apps/automation-hub
   UI_BASE_PATH: '/ui/',

--- a/config/standalone.prod.webpack.config.js
+++ b/config/standalone.prod.webpack.config.js
@@ -4,7 +4,6 @@ const webpackBase = require('./webpack.base.config');
 module.exports = webpackBase({
   API_HOST: '',
   API_BASE_PATH: '/api/galaxy/',
-  PULP_API_BASE_PATH: '/api/galaxy/pulp/api/v3/',
   UI_BASE_PATH: '/ui/',
   DEPLOYMENT_MODE: 'standalone',
   NAMESPACE_TERM: 'namespaces',

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -27,7 +27,6 @@ const defaultConfigs = [
   // as a constant after it is compiled
   { name: 'API_HOST', default: '', scope: 'global' },
   { name: 'API_BASE_PATH', default: '', scope: 'global' },
-  { name: 'PULP_API_BASE_PATH', default: '', scope: 'global' },
   { name: 'UI_BASE_PATH', default: '', scope: 'global' },
   { name: 'DEPLOYMENT_MODE', default: 'standalone', scope: 'global' },
   { name: 'NAMESPACE_TERM', default: 'namespaces', scope: 'global' },
@@ -64,6 +63,11 @@ module.exports = (inputConfigs) => {
       );
     }
   });
+
+  // 4.6+: pulp APIs live under API_BASE_PATH now, ignore previous overrides
+  globals.PULP_API_BASE_PATH = JSON.stringify(
+    customConfigs.API_BASE_PATH + 'pulp/api/v3/',
+  );
 
   const isStandalone = customConfigs.DEPLOYMENT_MODE !== 'insights';
 

--- a/test/cypress.env.json.template
+++ b/test/cypress.env.json.template
@@ -1,6 +1,6 @@
 {
   "prefix": "/api/automation-hub/",
-  "pulpPrefix":"/api/automation-hub/pulp/api/v3/",
+  "pulpPrefix": "/api/automation-hub/pulp/api/v3/",
   "username": "admin",
   "password": "admin",
   "settings": "../../galaxy_ng/galaxy_ng/app/settings.py",

--- a/test/cypress/e2e/task_status.js
+++ b/test/cypress/e2e/task_status.js
@@ -4,8 +4,8 @@ describe('test status filter label on list view', () => {
     cy.visit('/ui/tasks');
     cy.intercept(
       'GET',
-      Cypress.env('prefix') +
-        'pulp/api/v3/tasks/?ordering=-pulp_created&offset=0&limit=10',
+      Cypress.env('pulpPrefix') +
+        'tasks/?ordering=-pulp_created&offset=0&limit=10',
     ).as('tasks');
 
     cy.wait('@tasks');


### PR DESCRIPTION
related to packaging!11 (closed), #2135, https://github.com/ansible/galaxy_ng/pull/1247
mostly undoes #1857 (+packaging!10) config changes but not code changes

`packaging/roles/publish/files/config/downstream.webpack.config.js` can't easily have version-dependent logic,
so having individual webpack configs provide `PULP_API_BASE_PATH` doesn't quite work,
but having the constant available in code is still useful.

=> ignoring any PULP_API_BASE_PATH config options or env variables, hardcoding PULP_API_BASE_PATH global to be based on API_BASE_PATH in 4.6+
(for 4.5 and older, the url is just /pulp/api/v3/, no PULP_API_BASE_PATH, no changes needed)