### PR TITLE
Signing error alerts - switch title and description

### DIFF
--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -686,8 +686,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   private signCollection = () => {
     const errorAlert = (status: string | number = 500): AlertType => ({
       variant: 'danger',
-      title: t`API Error: ${status}`,
-      description: t`Failed to sign all versions in the collection.`,
+      title: t`Failed to sign all versions in the collection.`,
+      description: t`API Error: ${status}`,
     });
 
     this.setState({
@@ -737,8 +737,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   private signVersion = () => {
     const errorAlert = (status: string | number = 500): AlertType => ({
       variant: 'danger',
-      title: t`API Error: ${status}`,
-      description: t`Failed to sign the version.`,
+      title: t`Failed to sign the version.`,
+      description: t`API Error: ${status}`,
     });
 
     this.setState({

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -519,8 +519,8 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
   private signAllCertificates(namespace: NamespaceType) {
     const errorAlert = (status: string | number = 500): AlertType => ({
       variant: 'danger',
-      title: t`API Error: ${status}`,
-      description: t`Failed to sign all collections.`,
+      title: t`Failed to sign all collections.`,
+      description: t`API Error: ${status}`,
     });
 
     this.setState({


### PR DESCRIPTION
API Error details should be in the description, while the notification title should say which action failed

Cc @MilanPospisil 