### PR TITLE
Drop stable-4.3 support, dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,14 +28,6 @@ updates:
 
   - package-ecosystem: 'npm'
     directory: '/'
-    target-branch: 'stable-4.3'
-    schedule:
-      interval: 'monthly'
-    commit-message:
-      prefix: '[stable-4.3] '
-
-  - package-ecosystem: 'npm'
-    directory: '/'
     target-branch: 'stable-4.2'
     schedule:
       interval: 'monthly'

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ List by branches:
 - `prod-beta`: `deploy-cloud`
 - `prod-stable`: `deploy-cloud`
 - `stable-4.2`: `backported-labels`, `pr-checks`, `stable-release`
-- `stable-4.3`: `backported-labels`, `cypress`, `pr-checks`, `stable-release`
 - `stable-4.4`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
 - `stable-4.5`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
 


### PR DESCRIPTION
On the first of the month, dependabot will try to update stable-4.3 dependencies,
but according to https://access.redhat.com/support/policy/updates/ansible-automation-platform
4.3 (aka 2.0) is EOL as of August 26, 2022.

Dropping dependabot config for 4.3,
and any remaining 4.3 references in the master branch.
