### PR TITLE
Add signature fingerprint labels

### DIFF
--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -6,6 +6,13 @@ export class CollectionUploadType {
   sha256: string;
 }
 
+export class SignatureType {
+  signature: string;
+  pubkey_fingerprint: string;
+  signing_service: string;
+  pulp_created: string;
+}
+
 export class CollectionVersion {
   id: string;
   version: string;
@@ -14,6 +21,7 @@ export class CollectionVersion {
     description: string;
     tags: string[];
     dependencies: DependencyType[];
+    signatures: SignatureType[];
   };
   created_at: string;
   // contents: ContentSummaryType[]; // deprecated
@@ -40,12 +48,7 @@ export class CollectionVersionDetail extends CollectionVersion {
     issues: string;
     repository: string;
     dependencies: DependencyType[];
-    signatures: {
-      signature: string;
-      pubkey_fingerprint: string;
-      signing_service: string;
-      pulp_created: string;
-    }[];
+    signatures: SignatureType[];
   };
   sign_state: SignState;
   requires_ansible?: string;

--- a/src/api/response-types/settings.ts
+++ b/src/api/response-types/settings.ts
@@ -6,4 +6,5 @@ export class SettingsType {
   GALAXY_AUTO_SIGN_COLLECTIONS: boolean;
   GALAXY_REQUIRE_SIGNATURE_FOR_APPROVAL: boolean;
   GALAXY_SIGNATURE_UPLOAD_ENABLED: boolean;
+  SIGNATURE_FINGERPRINT_LABELS: { [key: string]: string[] };
 }

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -13,6 +13,8 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 
+import { AppContext } from 'src/loaders/app-context';
+
 import { Link } from 'react-router-dom';
 
 import { CollectionNumericLabel, Logo, SignatureBadge } from 'src/components';
@@ -30,6 +32,7 @@ interface IProps extends CollectionListType {
 
 export class CollectionCard extends React.Component<IProps> {
   MAX_DESCRIPTION_LENGTH = 60;
+  static contextType = AppContext;
 
   render() {
     const {
@@ -99,6 +102,22 @@ export class CollectionCard extends React.Component<IProps> {
   }
 
   private getCertification(repo) {
+    const { latest_version } = this.props;
+    const fingerprints =
+      this.context?.settings.SIGNATURE_FINGERPRINT_LABELS || {};
+
+    for (const i of Object.keys(fingerprints)) {
+      for (const signature of latest_version.metadata.signatures) {
+        if (fingerprints[i].includes(signature.pubkey_fingerprint)) {
+          return (
+            <Text component={TextVariants.small}>
+              <Badge isRead>{i}</Badge>
+            </Text>
+          );
+        }
+      }
+    }
+
     if (repo === Constants.CERTIFIED_REPO) {
       return (
         <Text component={TextVariants.small}>

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -20,6 +20,7 @@ interface IProps {
     page_size?: number;
     tags?: string[];
     view_type?: string;
+    fingerprint?: string;
   };
   updateParams: (p) => void;
 }
@@ -49,6 +50,9 @@ export class CollectionFilter extends React.Component<IProps, IState> {
     const { ignoredParams, params, updateParams } = this.props;
     const { display_signatures } = this.context?.featureFlags || {};
 
+    const fingerprints =
+      this.context?.settings.SIGNATURE_FINGERPRINT_LABELS || {};
+
     const filterConfig = [
       {
         id: 'keywords',
@@ -61,6 +65,15 @@ export class CollectionFilter extends React.Component<IProps, IState> {
         options: Constants.COLLECTION_FILTER_TAGS.map((tag) => ({
           id: tag,
           title: tag,
+        })),
+      },
+      fingerprints && {
+        id: 'signature_fingerprint',
+        title: t`Signature Type`,
+        inputType: 'select' as const,
+        options: Object.keys(fingerprints).map((k) => ({
+          id: k,
+          title: k,
         })),
       },
       display_signatures && {


### PR DESCRIPTION
This is a proof of concept to validate the idea of using signatures to label validated content.

Adds:
- filter to collections view to allow filtering by a labelled signature fingerprint
- labels on collection card for collections that have a labelled signature

Requires: https://github.com/ansible/galaxy_ng/pull/1433

Screenshots:

<img width="473" alt="Screen Shot 2022-08-31 at 4 11 52 PM" src="https://user-images.githubusercontent.com/6063371/187773279-8879ce26-5a83-414b-936a-c465e6540218.png">
<img width="507" alt="Screen Shot 2022-08-31 at 4 11 59 PM" src="https://user-images.githubusercontent.com/6063371/187773285-73621d1d-8252-443b-a0c3-7062b37a5eca.png">
<img width="430" alt="Screen Shot 2022-08-31 at 4 12 11 PM" src="https://user-images.githubusercontent.com/6063371/187773290-d3d58e78-6a75-46de-a52d-aed80a685db2.png">
