### PR TITLE
deploy-cloud, base config: add explicit deployment config to build stage-stable and stage-beta both from master

### DIFF
--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -58,4 +58,4 @@ jobs:
       run: |
         npm cache verify
         npm ci || npm install
-        npm run deploy && curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh | bash -s
+        curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh | bash -s

--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -4,12 +4,14 @@ set -x
 
 if [ "${TRAVIS_BRANCH}" = "master" ]; then
     # always push to stage-beta
+    HUB_CLOUD_BETA="true" npm run deploy
     echo "PUSHING qa-beta"
     rm -rf ./dist/.git
     .travis/release.sh "qa-beta"
 
     # only push to stage-stable when enabled
     if [ -f .cloud-stage-cron.enabled ]; then
+        HUB_CLOUD_BETA="false" npm run deploy
         echo "PUSHING qa-stable"
         rm -rf ./dist/.git
         .travis/release.sh "qa-stable"
@@ -17,6 +19,7 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
 fi
 
 if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+    npm run deploy
     echo "PUSHING ${TRAVIS_BRANCH}"
     rm -rf ./build/.git
     .travis/release.sh "${TRAVIS_BRANCH}"

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -9,6 +9,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { execSync } = require('child_process'); // node:child_process
 
 const isBuild = process.env.NODE_ENV === 'production';
+const cloudBeta = process.env.HUB_CLOUD_BETA; // "true" | "false" | undefined (=default)
 
 // NOTE: This file is not meant to be consumed directly by weback. Instead it
 // should be imported, initialized with the following settings and exported like
@@ -111,6 +112,12 @@ module.exports = (inputConfigs) => {
           rbac,
           ...defaultServices,
         },
+      }),
+
+    // insights deployments from master
+    ...(!isStandalone &&
+      cloudBeta && {
+        deployment: cloudBeta === 'true' ? 'beta/apps' : 'apps',
       }),
   });
 


### PR DESCRIPTION
`npm run deploy` reads the current branch name (in cloud mode) and decides to build a beta version when the branch is `master`
but since #2308, we're deploying to stage-stable as well, leading to issues on stage-stable:

    Loading chunk 849 failed. (error: https://console.stage.redhat.com/beta/apps/automation-hub/js/849.1661953046888.a80f84b3e77abc4bde6d.js)

=> adding a `HUB_CLOUD_BETA` env var to override the autodetection,
and building with `HUB_CLOUD_BETA=true` for stage-beta, `HUB_CLOUD_BETA=false` for stage-stable,
and no override for prod builds, as before.

(and moving the `npm run deploy` call to `custom_release.sh` so we can run it twice from master)