### PR TITLE
Rename branches from 4.2, 4.3, 4.4 and 4.5 to 1.2, 2.0, 2.1, 2.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,24 +12,24 @@ updates:
 
   - package-ecosystem: 'npm'
     directory: '/'
-    target-branch: 'stable-4.5'
+    target-branch: 'stable-2.2'
     schedule:
       interval: 'weekly'
     commit-message:
-      prefix: '[stable-4.5] '
+      prefix: '[stable-2.2] '
 
   - package-ecosystem: 'npm'
     directory: '/'
-    target-branch: 'stable-4.4'
+    target-branch: 'stable-2.1'
     schedule:
       interval: 'weekly'
     commit-message:
-      prefix: '[stable-4.4] '
+      prefix: '[stable-2.1] '
 
   - package-ecosystem: 'npm'
     directory: '/'
-    target-branch: 'stable-4.2'
+    target-branch: 'stable-1.2'
     schedule:
       interval: 'monthly'
     commit-message:
-      prefix: '[stable-4.2] '
+      prefix: '[stable-1.2] '

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -15,8 +15,8 @@ jobs:
       matrix:
         branch:
         - 'master'
-        - 'stable-4.4'
-        - 'stable-4.5'
+        - 'stable-2.1'
+        - 'stable-2.2'
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,22 @@ List by branches:
 - `master`: `backported-labels`, `cypress`, `deploy-cloud`, `dev-release`, `i18n`, `pr-checks`, `stable-release`, `update-manifest`
 - `prod-beta`: `deploy-cloud`
 - `prod-stable`: `deploy-cloud`
-- `stable-4.2`: `backported-labels`, `pr-checks`, `stable-release`
-- `stable-4.4`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
-- `stable-4.5`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
+- `stable-1.2`: `backported-labels`, `pr-checks`, `stable-release`
+- `stable-2.1`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
+- `stable-2.2`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
+
+### Version mapping
+
+Our branches and backport labels now use AAP versions, not AAH versions, while upstream releases (and tags) do use the AAH version.
+To map between the two:
+
+|branch|AAH version|
+|-|-|
+|stable-1.2|4.2|
+|stable-2.0|4.3 (obsolete)|
+|stable-2.1|4.4|
+|stable-2.2|4.5|
+|stable-2.3|4.6|
 
 ## Patternfly
 


### PR DESCRIPTION
What also needs to happen:

* (any similar CI updates needed on galaxy_ng?)
* rename branches in ansible-hub-ui 
* rename branches in galaxy_ng (CI tests won't work with different branch names in galaxy_ng)
* update `backport-*`/`backported-*` labels in https://github.com/ansible/ansible-hub-ui/labels and https://github.com/ansible/galaxy_ng/labels ; update descriptions to keep both kinds of versions there
