### PR TITLE
Simplify toolbar css

### DIFF
--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -63,7 +63,7 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
 
     return (
       <>
-        <div className='hub-usedby-dependencies-header'>
+        <div className='hub-toolbar'>
           <Toolbar>
             <ToolbarGroup>
               <ToolbarItem>

--- a/src/containers/certification-dashboard/certification-dashboard.scss
+++ b/src/containers/certification-dashboard/certification-dashboard.scss
@@ -1,9 +1,3 @@
-.hub-certification-dashboard-toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
 .hub-certification-dashboard {
   .footer {
     padding-top: 16px;

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -148,7 +148,7 @@ class CertificationDashboard extends React.Component<
         ) : (
           <Main className='hub-certification-dashboard'>
             <section className='body' data-cy='body'>
-              <div className='toolbar hub-certification-dashboard-toolbar'>
+              <div className='toolbar hub-toolbar'>
                 <Toolbar>
                   <ToolbarGroup>
                     <ToolbarItem>

--- a/src/containers/collection-detail/collection-dependencies.scss
+++ b/src/containers/collection-detail/collection-dependencies.scss
@@ -1,9 +1,3 @@
-.hub-usedby-dependencies-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
 // resets to default, possible bug pagination shows disc list-style-type with 'pf-c-content' className
 .pf-c-options-menu__menu {
   padding-left: 0 !important;

--- a/src/containers/execution-environment-detail/execution-environment-detail_images.scss
+++ b/src/containers/execution-environment-detail/execution-environment-detail_images.scss
@@ -1,9 +1,3 @@
 .hub-c-label-group-tags-column {
   max-width: 250px;
 }
-
-.detail-images-toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -245,7 +245,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
           tag={publishToController?.tag}
         />
 
-        <div className='detail-images-toolbar toolbar'>
+        <div className='hub-toolbar toolbar'>
           <Toolbar>
             <ToolbarContent>
               <ToolbarGroup>

--- a/src/containers/execution-environment-list/execution-environment.scss
+++ b/src/containers/execution-environment-list/execution-environment.scss
@@ -1,13 +1,3 @@
-.hub-container-list-toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  .pf-c-toolbar__content {
-    padding-left: 0;
-  }
-}
-
 .delete-container-modal-message {
   padding-bottom: var(--pf-global--spacer--md);
 }

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -210,7 +210,7 @@ class ExecutionEnvironmentList extends React.Component<
               <LoadingPageSpinner />
             ) : (
               <section className='body'>
-                <div className='hub-container-list-toolbar'>
+                <div className='hub-list-toolbar'>
                   <Toolbar>
                     <ToolbarContent>
                       <ToolbarGroup>

--- a/src/containers/execution-environment/registry-list.scss
+++ b/src/containers/execution-environment/registry-list.scss
@@ -1,9 +1,0 @@
-.hub-container-list-toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  .pf-c-toolbar__content {
-    padding-left: 0;
-  }
-}

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { t, Trans } from '@lingui/macro';
 import { errorMessage } from 'src/utilities';
-import './registry-list.scss';
 
 import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
 import {
@@ -242,7 +241,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
               <LoadingPageSpinner />
             ) : (
               <section className='body'>
-                <div className='hub-container-list-toolbar'>
+                <div className='hub-list-toolbar'>
                   <Toolbar>
                     <ToolbarContent>
                       <ToolbarGroup>

--- a/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
+++ b/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
@@ -300,7 +300,7 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
         </section>
       ) : (
         <section className='body'>
-          <div className='hub-group-list-toolbar'>
+          <div className='hub-list-toolbar'>
             <Toolbar>
               <ToolbarContent>
                 <ToolbarGroup>

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -52,8 +52,6 @@ import {
 
 import { AppContext } from 'src/loaders/app-context';
 
-import './group-management.scss';
-
 import GroupDetailRoleManagement from './group-detail-role-management/group-detail-role-management';
 
 interface IState {

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -1,6 +1,5 @@
 import { t, Trans } from '@lingui/macro';
 import * as React from 'react';
-import './group-management.scss';
 import { errorMessage } from 'src/utilities';
 
 import {
@@ -167,7 +166,7 @@ class GroupList extends React.Component<RouteComponentProps, IState> {
         ) : (
           <Main>
             <section className='body'>
-              <div className='hub-group-list-toolbar'>
+              <div className='hub-list-toolbar'>
                 <Toolbar>
                   <ToolbarContent>
                     <ToolbarGroup>

--- a/src/containers/group-management/group-management.scss
+++ b/src/containers/group-management/group-management.scss
@@ -1,9 +1,0 @@
-.hub-group-list-toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  .pf-c-toolbar__content {
-    padding-left: 0;
-  }
-}

--- a/src/containers/role-management/role-create.tsx
+++ b/src/containers/role-management/role-create.tsx
@@ -7,7 +7,6 @@ import {
 } from 'src/containers/role-management/map-role-errors';
 import * as React from 'react';
 import { withRouter, RouteComponentProps, Redirect } from 'react-router-dom';
-import './role.scss';
 
 import {
   RoleForm,

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -238,7 +238,7 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
               <LoadingPageSpinner />
             ) : (
               <section className='body'>
-                <div className='role-list'>
+                <div className='hub-list-toolbar'>
                   <Toolbar>
                     <ToolbarContent>
                       <ToolbarGroup>

--- a/src/containers/role-management/role.scss
+++ b/src/containers/role-management/role.scss
@@ -1,9 +1,0 @@
-.role-list {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  .pf-c-toolbar__content {
-    padding-left: 0;
-  }
-}

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -133,7 +133,7 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
               <LoadingPageSpinner />
             ) : (
               <section className='body'>
-                <div className='hub-task-list'>
+                <div className='hub-list-toolbar'>
                   <Toolbar>
                     <ToolbarContent>
                       <ToolbarGroup>

--- a/src/containers/task-management/task.scss
+++ b/src/containers/task-management/task.scss
@@ -1,13 +1,3 @@
-.hub-task-list {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  .pf-c-toolbar__content {
-    padding-left: 0;
-  }
-}
-
 .hub-c-task-status {
   margin-left: 10px;
 }

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -1,6 +1,5 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import './user-management.scss';
 
 import {
   withRouter,
@@ -142,7 +141,7 @@ class UserList extends React.Component<RouteComponentProps, IState> {
         ) : (
           <Main>
             <section className='body'>
-              <div className='hub-user-list-toolbar'>
+              <div className='hub-list-toolbar'>
                 <Toolbar>
                   <ToolbarContent>
                     <ToolbarGroup>

--- a/src/containers/user-management/user-management.scss
+++ b/src/containers/user-management/user-management.scss
@@ -1,9 +1,0 @@
-.hub-user-list-toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-
-  .pf-c-toolbar__content {
-    padding-left: 0;
-  }
-}

--- a/src/loaders/app.scss
+++ b/src/loaders/app.scss
@@ -54,3 +54,21 @@ body,
     border-top: 0;
   }
 }
+
+// list screen toolbars
+// FIXME: merge these 2; also with search, namespace-list, namespace-details, hub-toolbar-wrapper
+.hub-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.hub-list-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .pf-c-toolbar__content {
+    padding-left: 0;
+  }
+}


### PR DESCRIPTION
Many containers use a div class wrapper around toolbar to set display flex, justify content, align items
some also set inner toolbar content padding
(and search+namespaces use a different structure not addressed here)

This is a minimal change to dedup these into `hub-toolbar` (doesn't reset padding) and `hub-list-toolbar` (does).
(I suspect we can merge the two as well, but not enough to do it right away)

(Pulled out of #2567.)

|from|to|
|-|-|
|`detail-images-toolbar`|`hub-toolbar`|
|`hub-certification-dashboard-toolbar`|`hub-toolbar`|
|`hub-usedby-dependencies-header`|`hub-toolbar`|
|`hub-container-list-toolbar`|`hub-list-toolbar`|
|`hub-group-list-toolbar`|`hub-list-toolbar`|
|`hub-task-list`|`hub-list-toolbar`|
|`hub-user-list-toolbar`|`hub-list-toolbar`|
|`role-list`|`hub-list-toolbar`|
