### PR TITLE
Pressing "enter" on the create namespace form doesn't create a namespace.

### DIFF
--- a/CHANGES/1878.misc
+++ b/CHANGES/1878.misc
@@ -1,0 +1,1 @@
+Pressing enter in namespace create modal now actualy creates namespace instead of reload and doing nothing. 

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -112,7 +112,12 @@ export class NamespaceModal extends React.Component<IProps, IState> {
           </Button>,
         ]}
       >
-        <Form>
+        <Form
+          onSubmit={(e) => {
+            e.preventDefault();
+            this.handleSubmit();
+          }}
+        >
           <FormGroup
             label={t`Name`}
             isRequired


### PR DESCRIPTION
Issue: AAH-1878

https://issues.redhat.com/browse/AAH-1878

Small fix, adding prevent default on submit form and calling create namespace function.