### PR TITLE
Hardcode role description into UI and mark role description for translation

### DIFF
--- a/CHANGES/1654.misc
+++ b/CHANGES/1654.misc
@@ -1,0 +1,1 @@
+Hardcode role description into UI

--- a/src/components/rbac/group-role-permissions.tsx
+++ b/src/components/rbac/group-role-permissions.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { RoleAPI } from 'src/api';
 import { Constants } from 'src/constants';
 import { RolePermissions, LoadingPageSpinner } from 'src/components';
+import { translateLockedRolesDescription } from 'src/utilities';
 
 interface IProps {
   name: string;
@@ -31,7 +32,7 @@ export const GroupRolePermissions = ({ name, filteredPermissions }: IProps) => {
 
   return (
     <>
-      <p>{role.description}</p>
+      <p>{translateLockedRolesDescription(role.name, role.description)}</p>
       <RolePermissions
         filteredPermissions={filteredPermissions}
         selectedPermissions={role.permissions}

--- a/src/components/rbac/preview-roles.tsx
+++ b/src/components/rbac/preview-roles.tsx
@@ -4,6 +4,7 @@ import { Flex, FlexItem, Label, Divider } from '@patternfly/react-core';
 import { RoleType, GroupType } from 'src/api';
 import { Tooltip } from 'src/components';
 import { Constants } from 'src/constants';
+import { translateLockedRolesDescription } from 'src/utilities';
 
 interface Props {
   group: GroupType;
@@ -33,7 +34,11 @@ export const PreviewRoles = ({ group, selectedRoles }: Props) => (
         <React.Fragment key={role.name}>
           <FlexItem>
             <strong>{role.name}</strong>{' '}
-            {role?.description && `- ${role?.description}`}
+            {role?.description &&
+              `- ${translateLockedRolesDescription(
+                role.name,
+                role.description,
+              )}`}
             <Flex className='hub-permissions'>
               {role.permissions.map((permission) => (
                 <FlexItem

--- a/src/components/rbac/select-roles.tsx
+++ b/src/components/rbac/select-roles.tsx
@@ -12,7 +12,7 @@ import {
   EmptyStateFilter,
   EmptyStateNoData,
 } from 'src/components';
-import { filterIsSet } from 'src/utilities';
+import { filterIsSet, translateLockedRolesDescription } from 'src/utilities';
 
 interface SelectRolesProps {
   assignedRoles: { role: string }[];
@@ -228,7 +228,12 @@ export const SelectRoles: React.FC<SelectRolesProps> = ({
                         data-cy={`RoleListTable-CheckboxRow-row-${role.name}`}
                       >
                         <td>{role.name}</td>
-                        <td>{role.description}</td>
+                        <td>
+                          {translateLockedRolesDescription(
+                            role.name,
+                            role.description,
+                          )}
+                        </td>
                       </CheckboxRow>
                     ))}
                   </RoleListTable>

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -373,4 +373,25 @@ export class Constants {
     running: t`Running`,
     waiting: t`Waiting`,
   };
+
+  static LOCKED_ROLES_WITH_DESCRIPTION = {
+    // galaxy roles
+    'galaxy.content_admin': t`Manage all content types.`,
+    'galaxy.collection_admin': t`Create, delete and change collection namespaces. Upload and delete collections. Sync collections from remotes. Approve and reject collections.`,
+    'galaxy.collection_publisher': t`Upload and modify collections.`,
+    'galaxy.collection_curator': t`Approve, reject and sync collections from remotes.`,
+    'galaxy.collection_namespace_owner': t`Change and upload collections to namespaces.`,
+    'galaxy.execution_environment_admin': t`Push, delete, and change execution environments. Create, delete and change remote registries.`,
+    'galaxy.execution_environment_publisher': t`Push, and change execution environments.`,
+    'galaxy.execution_environment_namespace_owner': t`Create and update execution environments under existing container namespaces.`,
+    'galaxy.execution_environment_collaborator': t`Change existing execution environments.`,
+    'galaxy.group_admin': t`View, add, remove and change groups.`,
+    'galaxy.user_admin': t`View, add, remove and change users.`,
+    'galaxy.synclist_owner': t`View, add, remove and change synclists.`,
+    'galaxy.task_admin': t`View, and cancel any task.`,
+
+    // core roles
+    'core.task_owner': t`Allow all actions on a task.`,
+    'core.taskschedule_owner': t`Allow all actions on a taskschedule.`,
+  };
 }

--- a/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
+++ b/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
@@ -30,6 +30,7 @@ import {
   filterIsSet,
   ParamHelper,
   parsePulpIDFromURL,
+  translateLockedRolesDescription,
 } from 'src/utilities';
 import {
   Button,
@@ -370,7 +371,12 @@ const GroupDetailRoleManagement: React.FC<Props> = ({
                     data-cy={`RoleListTable-ExpandableRow-row-${role.role}`}
                   >
                     <td>{role.role}</td>
-                    <td>{role.description}</td>
+                    <td>
+                      {translateLockedRolesDescription(
+                        role.role,
+                        role.description,
+                      )}
+                    </td>
                     <ListItemActions
                       kebabItems={[
                         user.model_permissions.change_group && (

--- a/src/containers/role-management/role-edit.tsx
+++ b/src/containers/role-management/role-edit.tsx
@@ -5,6 +5,7 @@ import {
   parsePulpIDFromURL,
   errorMessage,
   ErrorMessagesType,
+  translateLockedRolesDescription,
 } from 'src/utilities';
 import {
   mapNetworkErrors,
@@ -157,7 +158,10 @@ class EditRole extends React.Component<RouteComponentProps, IState> {
         ></AlertList>
         <RoleHeader
           title={editPermissions ? t`Edit role permissions` : role.name}
-          subTitle={role.description}
+          subTitle={translateLockedRolesDescription(
+            role.name,
+            role.description,
+          )}
           breadcrumbs={breadcrumbs}
         />
         {unauthorised ? (

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -46,6 +46,7 @@ import {
   ParamHelper,
   parsePulpIDFromURL,
   twoWayMapper,
+  translateLockedRolesDescription,
 } from 'src/utilities';
 
 import { RoleAPI } from 'src/api/role';
@@ -377,7 +378,12 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
                           rowIndex={i}
                         >
                           <td data-cy='name-field'>{role.name}</td>
-                          <td>{role.description}</td>
+                          <td>
+                            {translateLockedRolesDescription(
+                              role.name,
+                              role.description,
+                            )}
+                          </td>
                           <td>
                             <DateComponent date={role.pulp_created} />
                           </td>

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -20,3 +20,4 @@ export { validateURLHelper } from './validateURLHelper';
 export { canSign, canSignEE } from './can-sign';
 export { DeleteCollectionUtils } from './delete-collection';
 export { RepoSigningUtils } from './repo-signing';
+export { translateLockedRolesDescription } from './translate-locked-roles-desc';

--- a/src/utilities/translate-locked-roles-desc.ts
+++ b/src/utilities/translate-locked-roles-desc.ts
@@ -1,0 +1,10 @@
+import { Constants } from 'src/constants';
+import { i18n } from '@lingui/core';
+
+// Locked roles description can't be translated on the API
+// To solve this problem, description for the locked roles
+// must be hardcoded into the UI
+export const translateLockedRolesDescription = (name, desc) =>
+  Constants.LOCKED_ROLES_WITH_DESCRIPTION[name]
+    ? i18n._(Constants.LOCKED_ROLES_WITH_DESCRIPTION[name])
+    : desc;


### PR DESCRIPTION
Issue: [AAH-1654](https://issues.redhat.com/browse/AAH-1654)

Added `galaxy` locked roles from [galaxy_ng/app/access_control/statements/roles.py](https://github.com/ansible/galaxy_ng/blob/feature/rbac-roles/galaxy_ng/app/access_control/statements/roles.py) and `core` roles from pulpcore



