### PR TITLE
Owners tab: go up to group list when clicking the tab

### DIFF
--- a/CHANGES/1733.fix
+++ b/CHANGES/1733.fix
@@ -1,0 +1,1 @@
+Owners tab - go up to group list when clicking the tab

--- a/src/components/execution-environment-header/execution-environment-header.tsx
+++ b/src/components/execution-environment-header/execution-environment-header.tsx
@@ -98,11 +98,9 @@ export class ExecutionEnvironmentHeader extends React.Component<IProps> {
             <Tabs
               tabs={tabs}
               params={{ tab }}
-              updateParams={(p) => {
-                if (tab !== p.tab) {
-                  this.props.updateState({ redirect: p.tab });
-                }
-              }}
+              updateParams={({ tab }) =>
+                this.props.updateState({ redirect: tab })
+              }
             />
           </div>
         </div>

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -72,6 +72,13 @@ export function withContainerRepo(WrappedComponent) {
       this.loadRepo();
     }
 
+    componentDidUpdate() {
+      // when reloading the same tab, state doesn't reset
+      if (this.state.redirect) {
+        this.setState({ redirect: null });
+      }
+    }
+
     render() {
       const container = this.props.match.params['container'];
       const redirect = {
@@ -98,6 +105,7 @@ export function withContainerRepo(WrappedComponent) {
       if (this.state.loading) {
         return <LoadingPageWithHeader />;
       }
+
       const permissions = this.state.repo.namespace.my_permissions;
       const showEdit =
         permissions.includes(
@@ -337,7 +345,7 @@ export function withContainerRepo(WrappedComponent) {
       });
     }
 
-    private addAlertObj(alert) {
+    private addAlertObj(alert: AlertType) {
       this.setState({
         alerts: [...this.state.alerts, alert],
       });

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -245,6 +245,10 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
         'galaxy.change_namespace',
       ) || this.context.user.model_permissions.change_namespace;
 
+    // remove ?group (owners tab) when switching tabs
+    const tabParams = { ...params };
+    delete tabParams.group;
+
     return (
       <React.Fragment>
         <AlertList alerts={alerts} closeAlert={(i) => this.closeAlert(i)} />
@@ -324,7 +328,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           namespace={namespace}
           breadcrumbs={breadcrumbs}
           tabs={tabs}
-          params={params}
+          params={tabParams}
           updateParams={(p) => this.updateParams(p)}
           pageControls={this.renderPageControls()}
           contextSelector={


### PR DESCRIPTION
Fixes: AAH-1733

when opening a group detail under an owners tab (EE or namespace),
it's not immediately obvious how to get back to the list of groups

there's no explicit back button, only the browser back button and breadcrumbs

this also makes it so clicking the owners tab again goes back to groups :)