### PR TITLE
Ensure sorting, filtering, and resetting filters resets to page 1

### DIFF
--- a/CHANGES/1848.bug
+++ b/CHANGES/1848.bug
@@ -1,0 +1,1 @@
+Ensure sorting, filtering, and resetting filters resets to page 1

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -371,7 +371,6 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
                   inputText={this.state.inputText}
                   onChange={(text) => this.setState({ inputText: text })}
                   updateParams={(controllerParams) => {
-                    controllerParams.page = 1;
                     this.setState({ controllerParams }, () =>
                       this.fetchControllers(),
                     );

--- a/src/components/my-imports/import-list.tsx
+++ b/src/components/my-imports/import-list.tsx
@@ -70,10 +70,7 @@ export class ImportList extends React.Component<IProps, IState> {
           <CompoundFilter
             inputText={this.state.inputText}
             onChange={(text) => this.setState({ inputText: text })}
-            updateParams={(p) => {
-              p['page'] = 1;
-              this.props.updateParams(p);
-            }}
+            updateParams={(p) => this.props.updateParams(p)}
             params={params}
             filterConfig={[
               {
@@ -109,7 +106,6 @@ export class ImportList extends React.Component<IProps, IState> {
 
         <AppliedFilters
           updateParams={(p) => {
-            p['page'] = 1;
             this.props.updateParams(p);
             this.setState({ inputText: '' });
           }}

--- a/src/components/patternfly-wrappers/applied-filters.tsx
+++ b/src/components/patternfly-wrappers/applied-filters.tsx
@@ -68,7 +68,10 @@ export class AppliedFilters extends React.Component<IProps> {
             <Chip
               key={i}
               onClick={() =>
-                updateParams(ParamHelper.deleteParam(params, key, v))
+                updateParams({
+                  ...ParamHelper.deleteParam(params, key, v),
+                  page: 1,
+                })
               }
             >
               {niceValues?.[key]?.[v] || v}

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -185,23 +185,25 @@ export class CompoundFilter extends React.Component<IProps, IState> {
   }
 
   private submitMultiple(newValues: string[]) {
-    this.props.updateParams(
-      ParamHelper.setParam(
+    this.props.updateParams({
+      ...ParamHelper.setParam(
         this.props.params,
         this.state.selectedFilter.id,
         newValues,
       ),
-    );
+      page: 1,
+    });
   }
 
   private submitFilter(id = undefined) {
-    this.props.updateParams(
-      ParamHelper.setParam(
+    this.props.updateParams({
+      ...ParamHelper.setParam(
         this.props.params,
         this.state.selectedFilter.id,
         id ? id : this.props.inputText,
       ),
-    );
+      page: 1,
+    });
   }
 
   private onToggle = () => {

--- a/src/components/patternfly-wrappers/sort.tsx
+++ b/src/components/patternfly-wrappers/sort.tsx
@@ -69,13 +69,14 @@ export class Sort extends React.Component<IProps, IState> {
     const desc = isDescending ? '-' : '';
 
     this.setState({ isExpanded: false }, () =>
-      this.props.updateParams(
-        ParamHelper.setParam(
+      this.props.updateParams({
+        ...ParamHelper.setParam(
           this.props.params,
           this.props.sortParamName,
           desc + option.id,
         ),
-      ),
+        page: 1,
+      }),
     );
   }
 
@@ -83,13 +84,14 @@ export class Sort extends React.Component<IProps, IState> {
     const field = this.getSelected(this.props.params);
     const descending = !this.getIsDescending(this.props.params);
 
-    this.props.updateParams(
-      ParamHelper.setParam(
+    this.props.updateParams({
+      ...ParamHelper.setParam(
         this.props.params,
         this.props.sortParamName,
         (descending ? '-' : '') + field.id,
       ),
-    );
+      page: 1,
+    });
   }
 
   private getIsDescending(params) {

--- a/src/components/sort-table/sort-table.tsx
+++ b/src/components/sort-table/sort-table.tsx
@@ -26,13 +26,14 @@ export class SortTable extends React.Component<IProps> {
     // Alphabetical sorting is inverted in Django, so flip it here to make
     // things match up with the UI.
     isMinus = !isMinus;
-    this.props.updateParams(
-      ParamHelper.setParam(
+    this.props.updateParams({
+      ...ParamHelper.setParam(
         this.props.params,
         'sort',
         (isMinus ? '-' : '') + id,
       ),
-    );
+      page: 1,
+    });
   }
   private getIcon(type, id) {
     if (type == 'none') {

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -221,12 +221,11 @@ class ExecutionEnvironmentList extends React.Component<
                             onChange={(text) =>
                               this.setState({ inputText: text })
                             }
-                            updateParams={(p) => {
-                              p['page'] = 1;
+                            updateParams={(p) =>
                               this.updateParams(p, () =>
                                 this.queryEnvironments(),
-                              );
-                            }}
+                              )
+                            }
                             params={params}
                             filterConfig={[
                               {

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -251,12 +251,9 @@ class ExecutionEnvironmentRegistryList extends React.Component<
                             onChange={(text) =>
                               this.setState({ inputText: text })
                             }
-                            updateParams={(p) => {
-                              p['page'] = 1;
-                              this.updateParams(p, () =>
-                                this.queryRegistries(),
-                              );
-                            }}
+                            updateParams={(p) =>
+                              this.updateParams(p, () => this.queryRegistries())
+                            }
                             params={params}
                             filterConfig={[
                               {

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -157,11 +157,6 @@ export class NamespaceList extends React.Component<IProps, IState> {
     // Namespaces or Partners
     const title = i18n._(namespaceBreadcrumb.name);
 
-    const updateParams = (p) => {
-      p['page'] = 1;
-      this.updateParams(p, () => this.loadNamespaces());
-    };
-
     return (
       <div className='hub-namespace-page'>
         <NamespaceModal
@@ -210,14 +205,16 @@ export class NamespaceList extends React.Component<IProps, IState> {
                       <CompoundFilter
                         inputText={inputText}
                         onChange={(text) => this.setState({ inputText: text })}
-                        updateParams={updateParams}
+                        updateParams={(p) =>
+                          this.updateParams(p, () => this.loadNamespaces())
+                        }
                         params={params}
                         filterConfig={[{ id: 'keywords', title: t`keywords` }]}
                       />
                       <AppliedFilters
                         style={{ marginTop: '16px' }}
                         updateParams={(p) => {
-                          updateParams(p);
+                          this.updateParams(p, () => this.loadNamespaces());
                           this.setState({ inputText: '' });
                         }}
                         params={params}
@@ -232,7 +229,9 @@ export class NamespaceList extends React.Component<IProps, IState> {
                           { title: t`Name`, id: 'name', type: 'alpha' },
                         ]}
                         params={params}
-                        updateParams={updateParams}
+                        updateParams={(p) =>
+                          this.updateParams(p, () => this.loadNamespaces())
+                        }
                       />
                     </ToolbarItem>
                     {user?.model_permissions?.add_namespace && (

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -249,10 +249,9 @@ export class RoleList extends React.Component<RouteComponentProps, IState> {
                             onChange={(text) =>
                               this.setState({ inputText: text })
                             }
-                            updateParams={(p) => {
-                              p['page'] = 1;
-                              this.updateParams(p, () => this.queryRoles());
-                            }}
+                            updateParams={(p) =>
+                              this.updateParams(p, () => this.queryRoles())
+                            }
                             params={params}
                             filterConfig={[
                               {

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -143,10 +143,9 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
                             onChange={(text) =>
                               this.setState({ inputText: text })
                             }
-                            updateParams={(p) => {
-                              p['page'] = 1;
-                              this.updateParams(p, () => this.queryTasks());
-                            }}
+                            updateParams={(p) =>
+                              this.updateParams(p, () => this.queryTasks())
+                            }
                             params={params}
                             filterConfig={[
                               {
@@ -265,10 +264,7 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
         <SortTable
           options={sortTableOptions}
           params={params}
-          updateParams={(p) => {
-            p['page'] = 1;
-            this.updateParams(p, () => this.queryTasks());
-          }}
+          updateParams={(p) => this.updateParams(p, () => this.queryTasks())}
         />
         <tbody>{items.map((item, i) => this.renderTableRow(item, i))}</tbody>
       </table>

--- a/src/utilities/param-helper.tsx
+++ b/src/utilities/param-helper.tsx
@@ -151,7 +151,7 @@ export class ParamHelper {
       params = ParamHelper.deleteParam(params, key);
     }
 
-    updateParams(params);
+    updateParams({ ...params, page: 1 });
   }
 
   // check if params are valid for sorting


### PR DESCRIPTION
Issue: AAH-1848

moving the `page: 1` reset from individual containers to the shared `AppliedFilters`, `CompoundFilter`, `SortTable` and `Sort` components.

This should ensure filtering and sorting always resets to page one, while pagination still works.
(Perpage change already sets page 1 everywhere.)
