### PR TITLE
Automate cloud menu updates

### DIFF
--- a/src/loaders/insights/Routes.tsx
+++ b/src/loaders/insights/Routes.tsx
@@ -4,149 +4,48 @@ import PropTypes from 'prop-types';
 import { Paths } from 'src/paths';
 import { LoadingPageWithHeader } from 'src/components';
 
-const EditNamespace = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "namespace_detail" */
-      '../../containers/edit-namespace/edit-namespace'
-    ),
-);
-
-const CollectionDetail = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "collection_detail" */
-      '../../containers/collection-detail/collection-detail'
-    ),
-);
-
-const CollectionContent = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "collection_detail" */
-      '../../containers/collection-detail/collection-content'
-    ),
-);
-
-const CollectionDocs = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "collection_detail" */
-      '../../containers/collection-detail/collection-docs'
-    ),
-);
-
-const CollectionImportLog = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "collection_detail" */
-      '../../containers/collection-detail/collection-import-log'
-    ),
-);
-
-const CollectionDependencies = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "collection_detail" */
-      '../../containers/collection-detail/collection-dependencies'
-    ),
-);
-
-const NotFound = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "not_found" */
-      '../../containers/not-found/not-found'
-    ),
-);
-
-const MyNamespaces = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "namespace_list" */
-      '../../containers/namespace-list/my-namespaces'
-    ),
-);
-
-const ManageNamespace = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "namespace_detail" */
-      '../../containers/namespace-detail/namespace-detail'
-    ),
-);
-
-const PartnerDetail = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "namespace_detail" */
-      '../../containers/namespace-detail/namespace-detail'
-    ),
-);
-
-const Partners = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "namespace_list" */
-      '../../containers/namespace-list/' + NAMESPACE_TERM
-    ),
-);
-
-const MyImports = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "my_imports" */
-      '../../containers/my-imports/my-imports'
-    ),
-);
-
-const Search = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "search" */
-      '../../containers/search/search'
-    ),
-);
-
-const TokenPage = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "settings" */
-      '../../containers/token/token-insights'
-    ),
-);
-
-const TaskListView = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "settings" */
-      '../../containers/task-management/task-list-view'
-    ),
-);
-
-const TaskDetail = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "settings" */
-      '../../containers/task-management/task_detail'
-    ),
-);
-
 const CertificationDashboard = lazy(
   () =>
-    import(
-      /* webpackChunkName: "settings" */
-      '../../containers/certification-dashboard/certification-dashboard'
-    ),
+    import('src/containers/certification-dashboard/certification-dashboard'),
 );
-
+const CollectionContent = lazy(
+  () => import('src/containers/collection-detail/collection-content'),
+);
+const CollectionDependencies = lazy(
+  () => import('src/containers/collection-detail/collection-dependencies'),
+);
+const CollectionDetail = lazy(
+  () => import('src/containers/collection-detail/collection-detail'),
+);
+const CollectionDocs = lazy(
+  () => import('src/containers/collection-detail/collection-docs'),
+);
+const CollectionImportLog = lazy(
+  () => import('src/containers/collection-detail/collection-import-log'),
+);
+const EditNamespace = lazy(
+  () => import('src/containers/edit-namespace/edit-namespace'),
+);
+const MyImports = lazy(() => import('src/containers/my-imports/my-imports'));
+const MyNamespaces = lazy(
+  () => import('src/containers/namespace-list/my-namespaces'),
+);
+const NamespaceDetail = lazy(
+  () => import('src/containers/namespace-detail/namespace-detail'),
+);
+const Partners = lazy(() => import('src/containers/namespace-list/partners'));
+const NotFound = lazy(() => import('src/containers/not-found/not-found'));
 const Repository = lazy(
-  () =>
-    import(
-      /* webpackChunkName: "repository-list" */
-      '../../containers/repositories/repository-list'
-    ),
+  () => import('src/containers/repositories/repository-list'),
 );
+const Search = lazy(() => import('src/containers/search/search'));
+const TaskDetail = lazy(
+  () => import('src/containers/task-management/task_detail'),
+);
+const TaskListView = lazy(
+  () => import('src/containers/task-management/task-list-view'),
+);
+const TokenPage = lazy(() => import('src/containers/token/token-insights'));
 
 /**
  * the Switch component changes routes depending on the path.
@@ -169,8 +68,8 @@ export const Routes = () => {
         <Route path={Paths.token} component={TokenPage} />
         <Route path={Paths[NAMESPACE_TERM]} component={Partners} />
         <Route path={Paths.editNamespace} component={EditNamespace} />
-        <Route path={Paths.myCollections} component={ManageNamespace} />
-        <Route path={Paths.myCollectionsByRepo} component={ManageNamespace} />
+        <Route path={Paths.myCollections} component={NamespaceDetail} />
+        <Route path={Paths.myCollectionsByRepo} component={NamespaceDetail} />
         <Route path={Paths.myNamespaces} component={MyNamespaces} />
         <Route path={Paths.taskList} component={TaskListView} />
         <Route path={Paths.taskDetail} component={TaskDetail} />
@@ -199,7 +98,7 @@ export const Routes = () => {
           component={CollectionDependencies}
         />
         <Route path={Paths.collectionByRepo} component={CollectionDetail} />
-        <Route path={Paths.namespaceByRepo} component={PartnerDetail} />
+        <Route path={Paths.namespaceByRepo} component={NamespaceDetail} />
         <Route path={Paths.searchByRepo} component={Search} />
         <Route path={Paths.collectionDocsPage} component={CollectionDocs} />
         <Route path={Paths.collectionDocsIndex} component={CollectionDocs} />
@@ -214,7 +113,7 @@ export const Routes = () => {
         />
         <Route path={Paths.myImports} component={MyImports} />
         <Route path={Paths.collection} component={CollectionDetail} />
-        <Route path={Paths.namespace} component={PartnerDetail} />
+        <Route path={Paths.namespace} component={NamespaceDetail} />
         <Route path={Paths.search} component={Search} />
         <Route>
           <Redirect push to={Paths.notFound} />

--- a/src/loaders/insights/ansible-navigation.json
+++ b/src/loaders/insights/ansible-navigation.json
@@ -1,0 +1,38 @@
+// https://github.com/RedHatInsights/cloud-services-config/blob/ci-beta/chrome/ansible-navigation.json (ci-beta, ci-stable, prod-beta, prod-stable)
+
+{
+    "title": "Automation Hub",
+    "expandable": true,
+    "routes": [
+        {
+            "appId": "automationHub",
+            "title": "Collections",
+            "href": "/ansible/automation-hub/",
+            "product": "Ansible Automation Hub"
+        },
+        {
+            "appId": "automationHub",
+            "title": "Partners",
+            "href": "/ansible/automation-hub/partners",
+            "product": "Ansible Automation Hub"
+        },
+        {
+            "appId": "automationHub",
+            "title": "Repo Management",
+            "href": "/ansible/automation-hub/repositories",
+            "product": "Ansible Automation Hub"
+        },
+        {
+            "appId": "automationHub",
+            "title": "Task Management",
+            "href": "/ansible/automation-hub/tasks",
+            "product": "Ansible Automation Hub"
+        },
+        {
+            "appId": "automationHub",
+            "title": "Connect to Hub",
+            "href": "/ansible/automation-hub/token",
+            "product": "Ansible Automation Hub"
+        }
+    ]
+}

--- a/src/loaders/insights/main.yml
+++ b/src/loaders/insights/main.yml
@@ -1,0 +1,25 @@
+# https://github.com/RedHatInsights/cloud-services-config/blob/ci-beta/main.yml (ci-beta, ci-stable, prod-beta, prod-stable)
+
+automation-hub:
+  title: Automation Hub
+  api:
+    versions:
+      - v3
+  deployment_repo: https://github.com/RedHatInsights/ansible-hub-ui-build
+  productId: Ansible Automation Hub
+  frontend:
+    paths:
+      - /ansible/automation-hub
+    sub_apps:
+      - id: ''
+        title: Collections
+        default: true
+      - id: partners
+        title: Partners
+      - id: repositories
+        title: Repo Management
+      - id: tasks
+        title: Task Management
+      - id: token
+        title: Connect to Hub
+  source_repo: https://github.com/ansible/ansible-hub-ui


### PR DESCRIPTION
Cloud menu cleanup, TODO try to automate menu changes
(moved out of #2567 as unrelated)

also TODO: there's also deploy/frontend.yaml with its own copy of the menu