### PR TITLE
[stable-4.5] EE list: filter by name__icontains, not name exact (#2570)

### DIFF
--- a/CHANGES/1913.bug
+++ b/CHANGES/1913.bug
@@ -1,0 +1,1 @@
+EE list: filter by name__icontains, not name exact

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -127,7 +127,9 @@ class ExecutionEnvironmentList extends React.Component<
       selectedItem,
     } = this.state;
 
-    const noData = items.length === 0 && !filterIsSet(params, ['name']);
+    const noData =
+      items.length === 0 && !filterIsSet(params, ['name__icontains']);
+
     const pushImagesButton = (
       <Button
         variant='link'
@@ -227,7 +229,7 @@ class ExecutionEnvironmentList extends React.Component<
                             params={params}
                             filterConfig={[
                               {
-                                id: 'name',
+                                id: 'name__icontains',
                                 title: t`Container repository name`,
                               },
                             ]}
@@ -256,6 +258,9 @@ class ExecutionEnvironmentList extends React.Component<
                     }}
                     params={params}
                     ignoredParams={['page_size', 'page', 'sort']}
+                    niceNames={{
+                      name__icontains: t`Name`,
+                    }}
                   />
                 </div>
                 {this.renderTable(params)}


### PR DESCRIPTION
Manual stable-4.5 backport of #2570.

---

Fixes: AAH-1913

Sort by name__icontains instead of exact name.

Before:

![20220913152933](https://user-images.githubusercontent.com/289743/189943363-49521b02-8f89-4abf-af1d-7eceaf684cb3.png)

After:

![20220913152324](https://user-images.githubusercontent.com/289743/189943175-6f5900de-fbcd-4a37-ad17-9a39d9dfa732.png)
![20220913152344](https://user-images.githubusercontent.com/289743/189943178-a545e4d7-81c5-45f2-b7d5-031704df0e2e.png)
