### PR TITLE
[stable-4.5] Approvals: don't show success alert on `updateCertification` failure, `waitForTask` first (#2312)

### DIFF
--- a/CHANGES/1769.bug
+++ b/CHANGES/1769.bug
@@ -1,0 +1,1 @@
+Fix success alert after signature upload failure

--- a/src/utilities/wait-for-task.ts
+++ b/src/utilities/wait-for-task.ts
@@ -1,7 +1,15 @@
 import { t } from '@lingui/macro';
 import { TaskAPI } from 'src/api';
 
-export function waitForTask(task, bailAfter = 10) {
+interface Options {
+  bailAfter?: number;
+  waitMs?: number;
+}
+
+export function waitForTask(task, options: Options = {}) {
+  // default to 5s wait with max 10 attempts
+  const { waitMs = 5000, bailAfter = 10 } = options;
+
   return TaskAPI.get(task).then((result) => {
     if (result.data.state !== 'completed') {
       if (!bailAfter) {
@@ -10,8 +18,8 @@ export function waitForTask(task, bailAfter = 10) {
         );
       }
 
-      return new Promise((r) => setTimeout(r, 5000)).then(() =>
-        waitForTask(task, bailAfter - 1),
+      return new Promise((r) => setTimeout(r, waitMs)).then(() =>
+        waitForTask(task, { ...options, bailAfter: bailAfter - 1 }),
       );
     }
   });


### PR DESCRIPTION
Manual backport of #2312 (no certificate upload in 4.5, only sign&approve),
including the subsequent #2598 fix.

---

* Failed signature upload shows both success and failure messages

Issue: AAH-1769

* waitForTask - accept a waitMs wait time argument, default to 5s

* certification-dashboard: use waitForTask insted of custom loop in waitForUpdate

* updateCertification - merge with updateList and waitForUpdate to make the promise then/catch tree clear

* use finally for updatingVersions reset

* submitCertificate: drop async/await when the rest deals with raw promises, add updateList code without updateRepositories

* submitCertificate, updateCertification - use the same pattern, addAlert, be explicit about nullable state var

* submitCertificate, updateCertification - use queryCollections, handle failure separately from main action failure

* collection_approval - ensure we retry checking for Rejected/Approved

(cherry picked from commit 917346a264629b9437dd78f1fc33be5f0a672848)