### PR TITLE
waitForTask - fix retry count

### DIFF
--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -579,7 +579,9 @@ class CertificationDashboard extends React.Component<
       originalRepo,
       destinationRepo,
     )
-      .then((result) => waitForTask(result.data.remove_task_id, 500))
+      .then((result) =>
+        waitForTask(result.data.remove_task_id, { waitMs: 500 }),
+      )
       .then(() =>
         this.addAlert(
           t`Certification status for collection "${version.namespace} ${version.name} v${version.version}" has been successfully updated.`,

--- a/src/utilities/wait-for-task.ts
+++ b/src/utilities/wait-for-task.ts
@@ -20,7 +20,7 @@ export function waitForTask(task, waitMs = 5000, bailAfter = 10) {
       }
 
       return new Promise((r) => setTimeout(r, waitMs)).then(() =>
-        waitForTask(task, bailAfter - 1),
+        waitForTask(task, waitMs, bailAfter - 1),
       );
     }
   });

--- a/src/utilities/wait-for-task.ts
+++ b/src/utilities/wait-for-task.ts
@@ -2,7 +2,15 @@ import { t } from '@lingui/macro';
 import { TaskAPI } from 'src/api';
 import { parsePulpIDFromURL } from './parse-pulp-id';
 
-export function waitForTask(task, waitMs = 5000, bailAfter = 10) {
+interface Options {
+  bailAfter?: number;
+  waitMs?: number;
+}
+
+export function waitForTask(task, options: Options = {}) {
+  // default to 5s wait with max 10 attempts
+  const { waitMs = 5000, bailAfter = 10 } = options;
+
   return TaskAPI.get(task).then((result) => {
     const failing = ['skipped', 'failed', 'canceled'];
 
@@ -20,12 +28,12 @@ export function waitForTask(task, waitMs = 5000, bailAfter = 10) {
       }
 
       return new Promise((r) => setTimeout(r, waitMs)).then(() =>
-        waitForTask(task, waitMs, bailAfter - 1),
+        waitForTask(task, { ...options, bailAfter: bailAfter - 1 }),
       );
     }
   });
 }
 
-export function waitForTaskUrl(taskUrl, bailAfter = 10) {
-  return waitForTask(parsePulpIDFromURL(taskUrl), bailAfter);
+export function waitForTaskUrl(taskUrl, options = {}) {
+  return waitForTask(parsePulpIDFromURL(taskUrl), options);
 }


### PR DESCRIPTION
introduced in #2312, when retrying, `waitForTask` will be called with `(task, waitMs=9, bailAfter=undefined)` instead of `(task, waitMs=5000, bailAfter=9)`, causing a 9ms wait before trying again .. likely forever

fixing to pass the right param order again.

(also fixed in the 4.5 backport or #2312 - https://github.com/ansible/ansible-hub-ui/pull/2597)