### PR TITLE
Add validated content repo

### DIFF
--- a/CHANGES/1943.feature
+++ b/CHANGES/1943.feature
@@ -1,0 +1,1 @@
+Add validated content repo.

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -250,9 +250,10 @@ export class Constants {
     published: defineMessage({ message: `Published` }),
     'rh-certified': defineMessage({ message: `Red Hat Certified` }),
     community: defineMessage({ message: `Community` }),
+    validated: defineMessage({ message: `Validated` }),
   };
 
-  static ALLOWEDREPOS = ['community', 'published', 'rh-certified'];
+  static ALLOWEDREPOS = ['community', 'published', 'rh-certified', 'validated'];
 
   static COLLECTION_FILTER_TAGS = [
     'application',


### PR DESCRIPTION
Display validated content repo in the repository selector.

Issue: AAH-1943

Requires: https://github.com/ansible/galaxy_ng/pull/1458