### PR TITLE
Error messages aren't displaying on the remote container create form

### DIFF
--- a/CHANGES/1845.bug
+++ b/CHANGES/1845.bug
@@ -1,0 +1,1 @@
+Repair error mesages in EE form. 

--- a/src/api/execution-environment-registry.ts
+++ b/src/api/execution-environment-registry.ts
@@ -3,7 +3,7 @@ import { RemoteType } from '.';
 import { smartUpdate } from './remotes';
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('execution-environments/registries/');
+  apiPath = this.getUIPath('execution-environments/registries/typo');
 
   // list(params?)
   // create(data)

--- a/src/api/execution-environment-registry.ts
+++ b/src/api/execution-environment-registry.ts
@@ -3,7 +3,7 @@ import { RemoteType } from '.';
 import { smartUpdate } from './remotes';
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('execution-environments/registries/typo');
+  apiPath = this.getUIPath('execution-environments/registries/');
 
   // list(params?)
   // create(data)

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -39,7 +39,6 @@ interface IState {
   editing: boolean;
   alerts: AlertType[];
   showDeleteModal: boolean;
-  formError: { title: string; detail: string }[];
 }
 
 export interface IDetailSharedProps extends RouteComponentProps {
@@ -64,7 +63,6 @@ export function withContainerRepo(WrappedComponent) {
         editing: false,
         alerts: [],
         showDeleteModal: false,
-        formError: [],
       };
     }
 
@@ -223,45 +221,32 @@ export function withContainerRepo(WrappedComponent) {
                 namespace={this.state.repo.namespace.name}
                 description={this.state.repo.description}
                 permissions={permissions}
-                formError={this.state.formError}
                 onSave={(promise) => {
-                  promise
-                    .then((results) => {
-                      const task = results.find((x) => x.data && x.data.task);
-                      this.setState({
-                        editing: false,
-                        loading: true,
-                        alerts: alerts.concat({
-                          variant: 'success',
-                          title: (
-                            <Trans>
-                              Saved changes to execution environment &quot;
-                              {this.state.repo.name}&quot;.
-                            </Trans>
-                          ),
-                        }),
-                      });
-                      if (task) {
-                        waitForTask(
-                          task.data.task.split('tasks/')[1].replace('/', ''),
-                        ).then(() => {
-                          this.loadRepo();
-                        });
-                      } else {
-                        this.loadRepo();
-                      }
-                    })
-                    .catch((err) =>
-                      this.setState({
-                        formError: err.response.data.errors.map((error) => {
-                          return {
-                            title: error.title,
-                            detail:
-                              error.source.parameter + ': ' + error.detail,
-                          };
-                        }),
+                  promise.then((results) => {
+                    const task = results.find((x) => x.data && x.data.task);
+                    this.setState({
+                      editing: false,
+                      loading: true,
+                      alerts: alerts.concat({
+                        variant: 'success',
+                        title: (
+                          <Trans>
+                            Saved changes to execution environment &quot;
+                            {this.state.repo.name}&quot;.
+                          </Trans>
+                        ),
                       }),
-                    );
+                    });
+                    if (task) {
+                      waitForTask(
+                        task.data.task.split('tasks/')[1].replace('/', ''),
+                      ).then(() => {
+                        this.loadRepo();
+                      });
+                    } else {
+                      this.loadRepo();
+                    }
+                  });
                 }}
                 onCancel={() => this.setState({ editing: false })}
                 distributionPulpId={this.state.repo.pulp.distribution.id}

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -59,7 +59,6 @@ interface IState {
   showDeleteModal: boolean;
   selectedItem: ExecutionEnvironmentType;
   inputText: string;
-  formError: { title: string; detail: string }[];
 }
 
 class ExecutionEnvironmentList extends React.Component<
@@ -95,7 +94,6 @@ class ExecutionEnvironmentList extends React.Component<
       showDeleteModal: false,
       selectedItem: null,
       inputText: '',
-      formError: [],
     };
   }
 
@@ -450,51 +448,36 @@ class ExecutionEnvironmentList extends React.Component<
         permissions={namespace?.my_permissions || []}
         remoteId={remoteId}
         distributionPulpId={distributionPulpId}
-        formError={this.state.formError}
         onSave={(promise, form) => {
-          promise
-            .then(() => {
-              this.setState(
-                {
-                  showRemoteModal: false,
-                  itemToEdit: null,
-                  alerts: alerts.concat({
-                    variant: 'success',
-                    title: isNew ? (
-                      <Trans>
-                        Execution environment &quot;{form.name}&quot; has been
-                        added successfully.
-                      </Trans>
-                    ) : (
-                      <Trans>
-                        Saved changes to execution environment &quot;{form.name}
-                        &quot;.
-                      </Trans>
-                    ),
-                  }),
-                },
-                () => this.queryEnvironments(),
-              );
-            })
-            .catch((err) => {
-              this.setState({
-                formError: err.response.data.errors.map((error) => {
-                  return {
-                    title: error.title,
-                    detail: error.source.parameter + ': ' + error.detail,
-                  };
+          promise.then(() => {
+            this.setState(
+              {
+                showRemoteModal: false,
+                itemToEdit: null,
+                alerts: alerts.concat({
+                  variant: 'success',
+                  title: isNew ? (
+                    <Trans>
+                      Execution environment &quot;{form.name}&quot; has been
+                      added successfully.
+                    </Trans>
+                  ) : (
+                    <Trans>
+                      Saved changes to execution environment &quot;{form.name}
+                      &quot;.
+                    </Trans>
+                  ),
                 }),
-              });
-            });
+              },
+              () => this.queryEnvironments(),
+            );
+          });
         }}
         onCancel={() =>
           this.setState({
             showRemoteModal: false,
             itemToEdit: null,
           })
-        }
-        addAlert={(variant, title, description) =>
-          this.addAlert(title, variant, description)
         }
       />
     );

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -6,6 +6,7 @@ export {
   ErrorMessagesType,
   isFieldValid,
   isFormValid,
+  alertErrorsWithoutFields,
 } from './map-error-messages';
 export { getRepoUrl, getContainersURL } from './get-repo-url';
 export { twoWayMapper } from './two-way-mapper';

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,7 +1,12 @@
 export { convertContentSummaryCounts } from './content-summary';
 export { ParamHelper } from './param-helper';
 export { sanitizeDocsUrls } from './sanitize-docs-urls';
-export { mapErrorMessages, ErrorMessagesType } from './map-error-messages';
+export {
+  mapErrorMessages,
+  ErrorMessagesType,
+  isFieldValid,
+  isFormValid,
+} from './map-error-messages';
 export { getRepoUrl, getContainersURL } from './get-repo-url';
 export { twoWayMapper } from './two-way-mapper';
 export {

--- a/src/utilities/map-error-messages.ts
+++ b/src/utilities/map-error-messages.ts
@@ -8,6 +8,7 @@ export class ErrorMessagesType {
 export function mapErrorMessages(err): ErrorMessagesType {
   const messages = {};
 
+  debugger;
   // 500 errors only have err.response.data string
   if (typeof err.response.data === 'string') {
     messages['__nofield'] = err.response.data;
@@ -25,4 +26,29 @@ export function mapErrorMessages(err): ErrorMessagesType {
   }
 
   return messages;
+}
+
+export function isFieldValid(
+  errorMessagesType: ErrorMessagesType,
+  name: string,
+) {
+  if (!errorMessagesType) return 'default';
+  if (errorMessagesType[name]) return 'error';
+
+  return 'default';
+}
+
+export function isFormValid(errorMessagesType: ErrorMessagesType) {
+  debugger;
+  if (!errorMessagesType) return true;
+  if (Object.keys(errorMessagesType).length == 0) return true;
+
+  let valid = true;
+  // if any key contains error text inside, its invalid
+  Object.keys(errorMessagesType).forEach((error) => {
+    if (error) {
+      valid = false;
+    }
+  });
+  return valid;
 }

--- a/src/utilities/map-error-messages.ts
+++ b/src/utilities/map-error-messages.ts
@@ -8,7 +8,6 @@ export class ErrorMessagesType {
 export function mapErrorMessages(err): ErrorMessagesType {
   const messages = {};
 
-  debugger;
   // 500 errors only have err.response.data string
   if (typeof err.response.data === 'string') {
     messages['__nofield'] = err.response.data;
@@ -30,25 +29,65 @@ export function mapErrorMessages(err): ErrorMessagesType {
 
 export function isFieldValid(
   errorMessagesType: ErrorMessagesType,
-  name: string,
-) {
-  if (!errorMessagesType) return 'default';
-  if (errorMessagesType[name]) return 'error';
+  name,
+): 'default' | 'error' {
+  let names = [];
+  if (Array.isArray(name)) {
+    names = name;
+  } else {
+    names.push(name);
+  }
 
-  return 'default';
+  if (!errorMessagesType) {
+    return 'default';
+  }
+
+  return names.find((n) => errorMessagesType[n]) ? 'error' : 'default';
 }
 
-export function isFormValid(errorMessagesType: ErrorMessagesType) {
-  debugger;
-  if (!errorMessagesType) return true;
-  if (Object.keys(errorMessagesType).length == 0) return true;
+export function isFormValid(errorMessages: ErrorMessagesType) {
+  if (!errorMessages) {
+    return true;
+  }
 
-  let valid = true;
-  // if any key contains error text inside, its invalid
-  Object.keys(errorMessagesType).forEach((error) => {
-    if (error) {
-      valid = false;
-    }
-  });
-  return valid;
+  return !Object.values(errorMessages).find(Boolean);
+}
+
+export function alertErrorsWithoutFields(
+  errorMessages: ErrorMessagesType,
+  fields,
+  addAlert,
+  title,
+  setErrorMessages,
+) {
+  if (!errorMessages) {
+    return;
+  }
+
+  // select only errors without associated field
+  const errors = Object.keys(errorMessages)
+    .filter((field) => !fields.includes(field))
+    .map((field) => errorMessages[field]);
+
+  if (errors.length) {
+    // alert them
+    addAlert({
+      variant: 'danger',
+      title: title,
+      description: errors.join('\n'),
+    });
+
+    // filter only errors with field, rest will be removed from the state, because they were already alerted
+    const formErrors = {};
+
+    Object.keys(errorMessages).forEach((field) => {
+      if (fields.includes(field)) {
+        formErrors[field] = errorMessages[field];
+      }
+    });
+
+    setErrorMessages(formErrors);
+  }
+
+  return;
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-1845

This PR refactors error handling using utils. Every error (including field validation and server side validation together) is now in one associative array formErrors, which can hold error message per form field (for example formErrors['name']). 

Also, validation from server in attempt to save the form is now included.
