### PR TITLE
deploy-cloud: allow custom manual deploys given a target branch name, source commit ref, and a bool for /beta/ vs /

### DIFF
--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -14,10 +14,10 @@ on:
         required: true
         type: choice
         options:
-          - prod-beta
-          - prod-stable
-          - qa-beta
-          - qa-stable
+        - prod-beta
+        - prod-stable
+        - qa-beta
+        - qa-stable
       commit:
         description: 'deploy custom commit'
         required: true

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,9 +1,26 @@
 name: "Deploy cloud.redhat.com"
 
 on:
-  workflow_dispatch: # allow running manually
   push:
     branches: [ "master", "prod-beta", "prod-stable" ]
+  workflow_dispatch: # allow running manually
+    inputs:
+      beta:
+        description: 'build for /beta/ urls'
+        required: true
+        type: boolean
+      branch:
+        description: 'target branch'
+        required: true
+        type: choice
+        options:
+          - prod-beta
+          - prod-stable
+          - qa-beta
+          - qa-stable
+      commit:
+        description: 'deploy custom commit'
+        required: true
 
 concurrency:
   group: deploy-cloud-${{ github.ref }}
@@ -15,6 +32,8 @@ jobs:
     env:
       COMMIT_AUTHOR_EMAIL: ansible-hub-ui+cloud@example.com
       COMMIT_AUTHOR_USERNAME: rh-galaxy-droid
+      CUSTOM_BETA: ${{ inputs.beta }}
+      CUSTOM_BRANCH: ${{ inputs.branch }}
       NODE_OPTIONS: "--max-old-space-size=4096 --max_old_space_size=4096"
       REPO: "git@github.com:RedHatInsights/ansible-hub-ui-build.git"
       TRAVIS_EVENT_TYPE: "push"
@@ -27,14 +46,22 @@ jobs:
 
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v2
+      if: ${{ ! inputs.commit }}
+
+    - name: "Checkout ansible-hub-ui (${{ inputs.commit }})"
+      uses: actions/checkout@v3
+      if: ${{ inputs.commit }}
+      with:
+        ref: ${{ inputs.commit }}
 
     - name: "Set BRANCH, TRAVIS_BRANCH, TRAVIS_BUILD_NUMBER, TRAVIS_WEB_URL, TRAVIS_COMMIT_MESSAGE"
       run: |
         TRAVIS_BRANCH=`sed 's/^refs\/heads\///' <<< $GITHUB_REF`
+        [ -n "$CUSTOM_BRANCH" ] && TRAVIS_BRANCH="custom"
         TRAVIS_BUILD_NUMBER=$GITHUB_RUN_NUMBER
         TRAVIS_BUILD_WEB_URL=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
         TRAVIS_COMMIT_MESSAGE=`git log -1 --format=%B`
-        echo "BRANCH=${TRAVIS_BRANCH}" >> $GITHUB_ENV
+        echo "BRANCH=${CUSTOM_BRANCH:-$TRAVIS_BRANCH}" >> $GITHUB_ENV
         echo "TRAVIS_BRANCH=${TRAVIS_BRANCH}" >> $GITHUB_ENV
         echo "TRAVIS_BUILD_NUMBER=${TRAVIS_BUILD_NUMBER}" >> $GITHUB_ENV
         echo "TRAVIS_BUILD_WEB_URL=${TRAVIS_BUILD_WEB_URL}" >> $GITHUB_ENV

--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -2,6 +2,15 @@
 set -e
 set -x
 
+# triggered by workflow_dispatch
+if [ "${TRAVIS_BRANCH}" = "custom" ]; then
+  HUB_CLOUD_BETA="$CUSTOM_BETA" npm run deploy
+  echo "PUSHING $CUSTOM_BRANCH"
+  rm -rf ./dist/.git
+  .travis/release.sh "$CUSTOM_BRANCH"
+  exit 0
+fi
+
 if [ "${TRAVIS_BRANCH}" = "master" ]; then
     # always push to stage-beta
     HUB_CLOUD_BETA="true" npm run deploy


### PR DESCRIPTION
The intent is to be able to deploy a custom commit to a cloud branch, so we can notify users of any upcoming changes.

This updates the workflow_dispatch event to take user inputs specifying the source, taget and wheteher to build for /beta/ urls or not.

In the event of a custom run, `TRAVIS_BRANCH` is set to `custom` (used by the `custom_release.sh` script only (except when set to `"nightly"` which we don't)), `BRANCH` is set to the target branch name in case there's any webpack logic still looking there,  and `CUSTOM_BRANCH` is the name of the target branch used by the `release.sh` script.