### PR TITLE
bump version to 4.6.0b1

### DIFF
--- a/ansible-hub-ui/__init__.py
+++ b/ansible-hub-ui/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "4.6.0dev"
+__version__ = "4.6.0b1"


### PR DESCRIPTION
No-Issue

Bumping version form 4.6.0dev => 4.6.0b1 as per the Preflight Checklist in the Release docs. 

Please review, thank you.