### PR TITLE
Use `/ui/:repo/:namespace` paths for namespace

### DIFF
--- a/CHANGES/1945.bug
+++ b/CHANGES/1945.bug
@@ -1,0 +1,1 @@
+Fix filtering by repository and update paths for namespace detail

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -20,6 +20,7 @@ import { NamespaceType } from 'src/api';
 import { NamespaceCard } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { ErrorMessagesType, validateURLHelper } from 'src/utilities';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IProps {
   namespace: NamespaceType;
@@ -29,6 +30,8 @@ interface IProps {
 }
 
 export class NamespaceForm extends React.Component<IProps> {
+  static contextType = AppContext;
+
   render() {
     const { namespace, errorMessages } = this.props;
 
@@ -84,7 +87,7 @@ export class NamespaceForm extends React.Component<IProps> {
                   to={formatPath(
                     Paths.namespaceByRepo,
                     {
-                      repo: 'published',
+                      repo: this.context.selectedRepo,
                       namespace: namespace.name,
                     },
                     { tab: 'owners' },

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -82,8 +82,9 @@ export class NamespaceForm extends React.Component<IProps> {
                 <Link
                   target='_blank'
                   to={formatPath(
-                    Paths.myCollections,
+                    Paths.namespaceByRepo,
                     {
+                      repo: 'published',
                       namespace: namespace.name,
                     },
                     { tab: 'owners' },

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -113,7 +113,8 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
             namespaceBreadcrumb,
             {
               name: namespace.name,
-              url: formatPath(Paths.myCollections, {
+              url: formatPath(Paths.namespaceByRepo, {
+                repo: this.context.selectedRepo,
                 namespace: namespace.name,
               }),
             },
@@ -222,7 +223,8 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
               errorMessages: {},
               saving: false,
               unsavedData: false,
-              redirect: formatPath(Paths.myCollections, {
+              redirect: formatPath(Paths.namespaceByRepo, {
+                repo: this.context.selectedRepo,
                 namespace: this.state.namespace.name,
               }),
             },
@@ -268,7 +270,8 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
 
   private cancel() {
     this.setState({
-      redirect: formatPath(Paths.myCollections, {
+      redirect: formatPath(Paths.namespaceByRepo, {
+        repo: this.context.selectedRepo,
         namespace: this.state.namespace.name,
       }),
     });

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -203,7 +203,10 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
         name: namespace.name,
         url:
           tab === 'owners'
-            ? formatPath(Paths.myCollections, { namespace: namespace.name })
+            ? formatPath(Paths.namespaceByRepo, {
+                repo: this.context.selectedRepo,
+                namespace: namespace.name,
+              })
             : null,
       },
       tab === 'owners'
@@ -211,8 +214,11 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             name: t`Namespace owners`,
             url: params.group
               ? formatPath(
-                  Paths.myCollections,
-                  { namespace: namespace.name },
+                  Paths.namespaceByRepo,
+                  {
+                    repo: this.context.selectedRepo,
+                    namespace: namespace.name,
+                  },
                   { tab: 'owners' },
                 )
               : null,
@@ -438,7 +444,8 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                   groups,
                 })
               }
-              urlPrefix={formatPath(Paths.myCollections, {
+              urlPrefix={formatPath(Paths.namespaceByRepo, {
+                repo: this.context.selectedRepo,
                 namespace: namespace.name,
               })}
             />

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -165,8 +165,9 @@ export class NamespaceList extends React.Component<IProps, IState> {
           onCreateSuccess={(result) =>
             this.setState({
               redirect: formatPath(
-                Paths.myCollections,
+                Paths.namespaceByRepo,
                 {
+                  repo: 'published',
                   namespace: result.name,
                 },
                 { tab: 'owners' },

--- a/test/cypress/e2e/namespaces/namespace_detail.js
+++ b/test/cypress/e2e/namespaces/namespace_detail.js
@@ -74,4 +74,29 @@ describe('Namespace detail screen', () => {
 
     // The test for success are impmeneted in the collection_upload file
   });
+
+  it('should filter by repositories', () => {
+    const namespace = 'coolestnamespace';
+    cy.galaxykit('-i namespace create', namespace);
+    cy.visit(`/ui/repo/published/${namespace}`);
+
+    cy.get('.nav-select').contains('Published').click();
+    cy.contains('Red Hat Certified').click();
+
+    cy.get('.nav-select').contains('Red Hat Certified');
+    cy.url().should('include', `/repo/rh-certified/${namespace}`);
+
+    cy.visit(`/ui/repo/community/${namespace}`);
+    cy.get('.nav-select').contains('Community');
+  });
+
+  it('repo selector should be disabled in collection detail ', () => {
+    const namespace = 'coolestnamespace';
+    const collection = 'coolestcollection';
+    cy.galaxykit('-i namespace create', namespace);
+    cy.galaxykit('collection upload', namespace, collection);
+
+    cy.visit(`/ui/repo/published/${namespace}/${collection}`);
+    cy.get('.nav-select').contains('Published').should('be.disabled');
+  });
 });

--- a/test/cypress/e2e/namespaces/namespace_edit.js
+++ b/test/cypress/e2e/namespaces/namespace_edit.js
@@ -70,7 +70,7 @@ describe('Edit a namespace', () => {
   it('saves a new company name', () => {
     cy.get('#company').clear().type('Company name');
     saveButton().click();
-    cy.url().should('match', /\/ui\/my-namespaces\/testns1/);
+    cy.url().should('match', /\/ui\/repo\/published\/testns1/);
     cy.get('.pf-c-title').should('contain', 'Company name');
   });
 

--- a/test/cypress/e2e/namespaces/namespace_form.js
+++ b/test/cypress/e2e/namespaces/namespace_form.js
@@ -84,6 +84,6 @@ describe('A namespace form', () => {
     let id = parseInt(Math.random() * 1000000);
     getInputBox().type(`testns_${id}`);
     getCreateButton().click();
-    getUrl().should('match', /\/ui\/my-namespaces\/testns_/);
+    getUrl().should('match', /\/ui\/repo\/published\/testns_/);
   });
 });


### PR DESCRIPTION
Issue: [AAH-1945](https://issues.redhat.com/browse/AAH-1945)

Filtering by repository doesn't work if user is on `/ui/namespaces/<namespace>` or `/ui/my-namespaces/<namespace>`. We should use `/ui/:repo/:namespace` paths for namespaces instead.

User was redirected to the wrong path after:
- creating namespace
- editing the namespace
- breadcrumbs

- I added a test `Filter by repository` to test correct functionality (could get handy in the future with new repo management features)