### PR TITLE
Update README, dependabot, i18n config for stable-4.6 existence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
 
   - package-ecosystem: 'npm'
     directory: '/'
+    target-branch: 'stable-4.6'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: '[stable-4.6] '
+
+  - package-ecosystem: 'npm'
+    directory: '/'
     target-branch: 'stable-4.5'
     schedule:
       interval: 'weekly'

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -17,6 +17,7 @@ jobs:
         - 'master'
         - 'stable-4.4'
         - 'stable-4.5'
+        - 'stable-4.6'
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ List by branches:
 - `stable-4.4`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
 - `stable-4.5`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
 
+### Version mapping
+
+Our branches, backport labels, releases and tags use AAH versions, but Jira uses AAP versions.
+To map between the two:
+
+|AAP version|AAH version|
+|-|-|
+|1.2|4.2|
+|2.0|4.3 (obsolete)|
+|2.1|4.4|
+|2.2|4.5|
+|2.3|4.6|
+
 ## Patternfly
 
 - This project imports Patternfly components:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ List by branches:
 - `stable-4.2`: `backported-labels`, `pr-checks`, `stable-release`
 - `stable-4.4`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
 - `stable-4.5`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
+- `stable-4.6`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
 
 ### Version mapping
 


### PR DESCRIPTION
The `stable-4.6` branch was created (#2603), this:

* enables dependabot for the new branch,
* mentions it in README,
* enables i18n extraction workflow for 4.6