### PR TITLE
hasPermission - add a context helper to check user permissions

### DIFF
--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -124,11 +124,9 @@ class GroupDetail extends React.Component<RouteComponentProps, IState> {
   }
 
   componentDidMount() {
-    if (
-      !this.context.user ||
-      this.context.user.is_anonymous ||
-      !this.context.user.model_permissions.view_group
-    ) {
+    const { user, hasPermission } = this.context;
+
+    if (!user || user.is_anonymous || !hasPermission('view_group')) {
       this.setState({ unauthorised: true });
     } else {
       this.queryGroup();

--- a/src/loaders/app-context.ts
+++ b/src/loaders/app-context.ts
@@ -11,6 +11,7 @@ export interface IAppContextType {
   alerts?: AlertType[];
   setAlerts?: (alerts: AlertType[]) => void;
   settings: SettingsType;
+  hasPermission: (name: string) => boolean;
 }
 
 export const AppContext = React.createContext<IAppContextType>(undefined);

--- a/src/loaders/insights/insights-loader.tsx
+++ b/src/loaders/insights/insights-loader.tsx
@@ -10,6 +10,7 @@ import { loadContext } from '../load-context';
 import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { Paths } from 'src/paths';
 import { AlertType, UIVersion } from 'src/components';
+import { hasPermission } from 'src/utilities';
 
 const DEFAULT_REPO = 'published';
 
@@ -129,6 +130,15 @@ class App extends Component<IProps, IState> {
           setUser: this.setUser,
           settings: this.state.settings,
           user: this.state.user,
+          hasPermission: (name) =>
+            hasPermission(
+              {
+                user: this.state.user,
+                settings: this.state.settings,
+                featureFlags: this.state.featureFlags,
+              },
+              name,
+            ),
         }}
       >
         <Alert

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -44,6 +44,7 @@ import {
   SmallLogo,
   StatefulDropdown,
 } from 'src/components';
+import { hasPermission } from 'src/utilities';
 import { AppContext } from '../app-context';
 import Logo from 'src/../static/images/logo_large.svg';
 
@@ -466,6 +467,15 @@ class App extends React.Component<RouteComponentProps, IState> {
           setUser: this.setUser,
           settings: this.state.settings,
           user: this.state.user,
+          hasPermission: (name) =>
+            hasPermission(
+              {
+                user: this.state.user,
+                settings: this.state.settings,
+                featureFlags: this.state.featureFlags,
+              },
+              name,
+            ),
         }}
       >
         {component}

--- a/src/utilities/has-permission.ts
+++ b/src/utilities/has-permission.ts
@@ -1,0 +1,8 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function hasPermission({ user, settings, featureFlags }, name) {
+  if (!user?.model_permissions) {
+    return false;
+  }
+
+  return !!user.model_permissions[name];
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -12,6 +12,7 @@ export {
 export { filterIsSet } from './filter-is-set';
 export { truncateSha } from './truncate_sha';
 export { getHumanSize } from './get_human_size';
+export { hasPermission } from './has-permission';
 export { parsePulpIDFromURL } from './parse-pulp-id';
 export { lastSynced, lastSyncStatus } from './last-sync-task';
 export { waitForTask, waitForTaskUrl } from './wait-for-task';


### PR DESCRIPTION
Cc @ShaiahWren 

Something like this should help split up the https://github.com/ansible/galaxy_ng/pull/1430 work into 2 phases:

1. refactor UI to use the `hasPermission` function for every `model_permissions` check
  * (possibly adding a temporary `const oldNames = { "new_name": "old_name" }; name = oldNames[name];` mapping)
  * merge, part by part, without any api dependencies
2. change `hasPermission` to consume the format returned by https://github.com/ansible/galaxy_ng/pull/1430 instead of the original
  * merge together with the API change