### PR TITLE
Cloud collection detail: Create Issue button leading to prefilled access.redhat.com/support/cases

### DIFF
--- a/CHANGES/568.feature
+++ b/CHANGES/568.feature
@@ -1,0 +1,1 @@
+Create Issue button in collection detail screen, leading to prefilled access.redhat.com/support/cases

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -8,16 +8,18 @@ import { Redirect } from 'react-router-dom';
 import * as moment from 'moment';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import {
-  Select,
-  SelectOption,
-  SelectVariant,
+  Alert,
+  Button,
+  DropdownItem,
+  Flex,
+  FlexItem,
   List,
   ListItem,
   Modal,
-  Alert,
+  Select,
+  SelectOption,
+  SelectVariant,
   Text,
-  Button,
-  DropdownItem,
 } from '@patternfly/react-core';
 import { AppContext } from 'src/loaders/app-context';
 
@@ -266,6 +268,12 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       </DropdownItem>,
     ].filter(Boolean);
 
+    const issueUrl =
+      'https://access.redhat.com/support/cases/#/case/new/open-case/describe-issue/recommendations?caseCreate=true&product=Ansible%20Automation%20Hub&version=Online&summary=' +
+      encodeURIComponent(
+        `${namespace.name}-${collectionName}-${collection.latest_version.version}`,
+      );
+
     return (
       <React.Fragment>
         {showImportModal && (
@@ -477,11 +485,21 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             </div>
           }
           pageControls={
-            dropdownItems.length > 0 ? (
-              <div data-cy='kebab-toggle'>
-                <StatefulDropdown items={dropdownItems} />
-              </div>
-            ) : null
+            <Flex>
+              {DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE ? (
+                <FlexItem>
+                  <a href={issueUrl} target='_blank' rel='noreferrer'>
+                    {t`Create issue`}
+                  </a>{' '}
+                  <ExternalLinkAltIcon />
+                </FlexItem>
+              ) : null}
+              {dropdownItems.length > 0 ? (
+                <FlexItem data-cy='kebab-toggle'>
+                  <StatefulDropdown items={dropdownItems} />
+                </FlexItem>
+              ) : null}
+            </Flex>
           }
         >
           {collection.deprecated && (


### PR DESCRIPTION
Issue: AAH-568 (insights mode only)

This adds a "Create issue" link to the collection detail header:

![20221005215936](https://user-images.githubusercontent.com/289743/194171950-e69d6c6c-5a09-4e45-b053-2391ca5a3fa2.png)

opens

https://access.redhat.com/support/cases/#/case/new/open-case/describe-issue/recommendations?caseCreate=true&product=Ansible%20Automation%20Hub&version=Online&summary=arista-avd-3.3.3