### PR TITLE
labeler workflow: fix quoting issue

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,6 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v4
-      if: ${{ github.event.pull_request.user.login != "dependabot[bot]" }}
+      if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
from https://docs.github.com/en/actions/learn-github-actions/expressions

    string	You don't need to enclose strings in ${{ and }}. However, if you do, you must use single quotes (') around the string. To use a literal single quote, escape the literal single quote using an additional single quote (''). Wrapping with double quotes (") will throw an error.

indeed, https://github.com/ansible/ansible-hub-ui/actions/runs/3192998374

    Invalid workflow file: .github/workflows/labeler.yml#L19
    The workflow is not valid. .github/workflows/labeler.yml (Line: 19, Col: 11): Unexpected symbol: '"dependabot'. Located at position 41 within expression: github.event.pull_request.user.login != "dependabot[bot]"

fixing to use single quotes :)

Cc @awcrosby, sorry I missed that in #2574 :)