### PR TITLE
standalone dev - proxy docker v2 APIs from port 8002 to 5001

### DIFF
--- a/config/standalone.dev.webpack.config.js
+++ b/config/standalone.dev.webpack.config.js
@@ -44,5 +44,6 @@ module.exports = webpackBase({
     '/api/': `http://${proxyHost}:${proxyPort}`,
     '/pulp/api/': `http://${proxyHost}:${proxyPort}`,
     '/v2/': `http://${proxyHost}:${proxyPort}`,
+    '/extensions/v2/': `http://${proxyHost}:${proxyPort}`,
   },
 });


### PR DESCRIPTION
allows docker/podman to talk to localhost:8002 instead of localhost:5001 in dev mode

Cc @rochacbruno if this helps? :)

---

Before:

```
$ docker login localhost:8002
Username: admin
Password: 
Error response from daemon: login attempt to http://localhost:8002/v2/ failed with status: 404 Not Found
```

After:

```
$ docker login localhost:8002
Username: admin
Password: 
Login Succeeded

$ docker pull alpine; docker image tag alpine localhost:8002/alpine:latest; docker push localhost:8002/alpine:latest
...
994393dc58e7: Pushed 

$ podman login localhost:8002 --tls-verify=false
Username: admin
Password: 
Login Succeeded!

$ podman pull localhost:8002/alpine --tls-verify=false
Trying to pull localhost:8002/alpine:latest...
Getting image source signatures
Checking if image destination supports signatures
Copying blob 213ec9aee27d done  
Copying config 9c6f072447 done  
Writing manifest to image destination
Storing signatures
9c6f0724472873bb50a2ae67a9e7adcb57673a183cea8b06eb778dca859181b5
```