### PR TITLE
[prod-beta] insights - add maintenance notice (2022-11-15)

### DIFF
--- a/src/loaders/insights/insights-loader.tsx
+++ b/src/loaders/insights/insights-loader.tsx
@@ -145,6 +145,11 @@ class App extends Component<IProps, IState> {
       >
         <Alert
           isInline
+          variant='warning'
+          title={t`Automation Hub has a scheduled downtime between 8am-9am ET on 2022-11-15.`}
+        />
+        <Alert
+          isInline
           variant='info'
           title={t`The Automation Hub sync toggle is now only supported in AAP 2.0. Previous versions of AAP will continue automatically syncing all collections.`}
         />


### PR DESCRIPTION
Adds a "Automation Hub has a scheduled downtime between 8am-9am ET on 2022-10-26." banner to the top of all hub insights pages.

![20221019175326](https://user-images.githubusercontent.com/289743/196768090-44d4ea1b-ff01-44a9-8c7a-b6dc646547fe.png)

Cc @awcrosby @jlmitch5

--- 

EDIT: updated to Nov 15