### PR TITLE
[stable-4.4] Remove unused react-table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
                 "@lingui/react": "^3.14.0",
                 "@patternfly/patternfly": "^4.217.1",
                 "@patternfly/react-core": "^4.250.1",
-                "@patternfly/react-table": "^4.111.4",
                 "@redhat-cloud-services/frontend-components-utilities": "^3.3.2",
                 "@types/node": "^16.18.0",
                 "@types/react": "^16.14.25",
@@ -2605,6 +2604,7 @@
             "version": "4.111.4",
             "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.111.4.tgz",
             "integrity": "sha512-ahACTGhP/Kve0aNSe9N66MSD/DTiaGDMw9eHFp0XSqD6I+OIxC8LJPOc4cgSHjS1LML2v/nS15lnN7rbJX7FgA==",
+            "peer": true,
             "dependencies": {
                 "@patternfly/react-core": "^4.250.1",
                 "@patternfly/react-icons": "^4.92.6",
@@ -2621,7 +2621,8 @@
         "node_modules/@patternfly/react-table/node_modules/tslib": {
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+            "peer": true
         },
         "node_modules/@patternfly/react-tokens": {
             "version": "4.93.6",
@@ -19945,6 +19946,7 @@
             "version": "4.111.4",
             "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-4.111.4.tgz",
             "integrity": "sha512-ahACTGhP/Kve0aNSe9N66MSD/DTiaGDMw9eHFp0XSqD6I+OIxC8LJPOc4cgSHjS1LML2v/nS15lnN7rbJX7FgA==",
+            "peer": true,
             "requires": {
                 "@patternfly/react-core": "^4.250.1",
                 "@patternfly/react-icons": "^4.92.6",
@@ -19957,7 +19959,8 @@
                 "tslib": {
                     "version": "2.4.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-                    "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+                    "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+                    "peer": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
         "@lingui/react": "^3.14.0",
         "@patternfly/patternfly": "^4.217.1",
         "@patternfly/react-core": "^4.250.1",
-        "@patternfly/react-table": "^4.111.4",
         "@redhat-cloud-services/frontend-components-utilities": "^3.3.2",
         "@types/node": "^16.18.0",
         "@types/react": "^16.14.25",

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -1,4 +1,3 @@
-import { cellWidth } from '@patternfly/react-table';
 import * as React from 'react';
 // had to declare *.svg in src/index.d.ts
 import DefaultLogo from 'src/../static/images/default-logo.svg';


### PR DESCRIPTION
`cellWidth` is no longer used in logo.tsx, dropping the import
=> `react-table` is no longer imported, dropping the dep

(We use react-table for rbac group role tables in 4.5+, but not 4.4)
(For 4.2, removed in #2413; 4.3 is EOL)