### PR TITLE
ci: build backend container with UI

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -72,6 +72,40 @@ jobs:
       with:
         path: 'ansible-hub-ui'
 
+    - name: "Build pulp-galaxy-ng"
+      if: steps.cache-container.outputs.cache-hit != 'true'
+      working-directory: 'pulp_galaxy_ng'
+      run: |
+        cp -iv ../ansible-hub-ui/.github/workflows/scripts/* .
+
+        echo '# Containerfile'
+        echo '\
+          FROM ghcr.io/pulp/pulp-ci-centos:latest
+
+          COPY --chmod=644 ansible-sign.key /tmp/
+          COPY --chmod=755 collection-sign.sh /var/lib/pulp/scripts/
+          COPY --chmod=755 container-sign.sh /var/lib/pulp/scripts/
+          COPY --chmod=755 signing-setup.sh /tmp/
+
+          RUN pip3 install --upgrade \
+            requests \
+            git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
+
+          RUN mkdir -p /etc/nginx/pulp/
+          RUN ln /usr/local/lib/python*/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+          RUN ln /usr/local/lib/python*/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+          RUN ln /usr/local/lib/python*/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
+        ' | tee Containerfile
+
+        buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:noui .
+        rm -f image # ensure older version is gone, podman save errors otherwise
+        podman save localhost/pulp/pulp-galaxy-ng:noui -o image
+
+    - name: "Load pulp-galaxy-ng from cache"
+      if: steps.cache-container.outputs.cache-hit == 'true'
+      working-directory: 'pulp_galaxy_ng'
+      run: podman load -i image
+
     - name: "Cache ~/.npm & ~/.cache/Cypress"
       uses: actions/cache@v3
       with:
@@ -98,48 +132,24 @@ jobs:
         BUILD_HASH=`ls dist/js/App*js | cut -d. -f2,3`
         echo "BUILD_HASH=${BUILD_HASH}" >> $GITHUB_ENV
 
-    - name: "Build pulp-galaxy-ng"
-      if: steps.cache-container.outputs.cache-hit != 'true'
+    - name: "Rebuild container with UI"
       working-directory: 'pulp_galaxy_ng'
       run: |
-        cp -iv ../ansible-hub-ui/.github/workflows/scripts/* .
         mv -v ../ansible-hub-ui/dist galaxy_ng_static
 
-        echo '# Containerfile'
         echo '\
-          FROM ghcr.io/pulp/pulp-ci-centos:latest
+          FROM localhost/pulp/pulp-galaxy-ng:noui
 
-          COPY --chmod=644 ansible-sign.key /tmp/
-          COPY --chmod=755 collection-sign.sh /var/lib/pulp/scripts/
-          COPY --chmod=755 container-sign.sh /var/lib/pulp/scripts/
-          COPY --chmod=755 signing-setup.sh /tmp/
-
-          RUN pip3 install --upgrade \
-            requests \
-            git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
-
-          RUN mkdir -p /etc/nginx/pulp/
-          RUN ln /usr/local/lib/python*/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-          RUN ln /usr/local/lib/python*/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-          RUN ln /usr/local/lib/python*/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
-
-          RUN rm -rf /usr/local/lib/python*/site-packages/galaxy_ng/app/static/
-          RUN ln -sv /galaxy_ng_static `ls -d /usr/local/lib/python*/site-packages/galaxy_ng/app/`static
           COPY --chmod=644 galaxy_ng_static /galaxy_ng_static
+          RUN rm -rf /usr/local/lib/python*/site-packages/galaxy_ng/app/static/
+          RUN mv /galaxy_ng_static `ls -d /usr/local/lib/python*/site-packages/galaxy_ng/app/`static/
 
           USER pulp:pulp
           RUN PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost /usr/local/bin/pulpcore-manager collectstatic --clear --noinput --link
           USER root:root
-        ' | tee Containerfile
+        ' | tee Containerfile2
 
-        buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .
-        rm -f image # ensure older version is gone, podman save errors otherwise
-        podman save localhost/pulp/pulp-galaxy-ng:latest -o image
-
-    - name: "Load pulp-galaxy-ng from cache"
-      if: steps.cache-container.outputs.cache-hit == 'true'
-      working-directory: 'pulp_galaxy_ng'
-      run: podman load -i image
+        buildah bud --file Containerfile2 --tag localhost/pulp/pulp-galaxy-ng:latest .
 
     - name: "Configure and run pulp-galaxy-ng"
       working-directory: 'pulp_galaxy_ng'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -178,6 +178,7 @@ jobs:
           GALAXY_COLLECTION_SIGNING_SERVICE='ansible-default'
           GALAXY_CONTAINER_SIGNING_SERVICE='container-default'
           GALAXY_FEATURE_FLAGS__container_signing=True
+          PULP_STATIC_ROOT='/var/lib/operator/static/'
         " | sed 's/^\s\+//' | tee settings/settings.py
 
         podman run \

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -62,11 +62,6 @@ jobs:
         path: pulp_galaxy_ng/image
         key: ${{ runner.os }}-container-${{ env.GALAXY_NG_COMMIT }}-post2765
 
-    - name: "Install node 16"
-      uses: actions/setup-node@v3
-      with:
-        node-version: '16'
-
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v3
       with:
@@ -89,7 +84,13 @@ jobs:
 
           RUN pip3 install --upgrade \
             requests \
-            git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
+            git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }} && \
+            rm -rf /root/.cache/pip
+
+          USER pulp:pulp
+          RUN PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost \
+            /usr/local/bin/pulpcore-manager collectstatic --clear --noinput --link
+          USER root:root
 
           RUN mkdir -p /etc/nginx/pulp/
           RUN ln /usr/local/lib/python*/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
@@ -97,14 +98,19 @@ jobs:
           RUN ln /usr/local/lib/python*/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
         ' | tee Containerfile
 
-        buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:noui .
+        buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .
         rm -f image # ensure older version is gone, podman save errors otherwise
-        podman save localhost/pulp/pulp-galaxy-ng:noui -o image
+        podman save localhost/pulp/pulp-galaxy-ng:latest -o image
 
     - name: "Load pulp-galaxy-ng from cache"
       if: steps.cache-container.outputs.cache-hit == 'true'
       working-directory: 'pulp_galaxy_ng'
       run: podman load -i image
+
+    - name: "Install node 16"
+      uses: actions/setup-node@v3
+      with:
+        node-version: '16'
 
     - name: "Cache ~/.npm & ~/.cache/Cypress"
       uses: actions/cache@v3
@@ -138,18 +144,19 @@ jobs:
         mv -v ../ansible-hub-ui/dist galaxy_ng_static
 
         echo '\
-          FROM localhost/pulp/pulp-galaxy-ng:noui
+          FROM localhost/pulp/pulp-galaxy-ng:latest
 
-          COPY --chmod=644 galaxy_ng_static /galaxy_ng_static
+          COPY galaxy_ng_static /galaxy_ng_static
           RUN rm -rf /usr/local/lib/python*/site-packages/galaxy_ng/app/static/
           RUN mv /galaxy_ng_static `ls -d /usr/local/lib/python*/site-packages/galaxy_ng/app/`static/
 
           USER pulp:pulp
-          RUN PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost /usr/local/bin/pulpcore-manager collectstatic --clear --noinput --link
+          RUN PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost \
+            /usr/local/bin/pulpcore-manager collectstatic --clear --noinput --link
           USER root:root
         ' | tee Containerfile2
 
-        buildah bud --file Containerfile2 --tag localhost/pulp/pulp-galaxy-ng:latest .
+        buildah bud --file Containerfile2 --tag localhost/pulp/pulp-galaxy-ng-ui:latest .
 
     - name: "Configure and run pulp-galaxy-ng"
       working-directory: 'pulp_galaxy_ng'
@@ -182,7 +189,7 @@ jobs:
              --tmpfs /var/lib/pgsql \
              --tmpfs /var/lib/containers \
              --device /dev/fuse \
-             localhost/pulp/pulp-galaxy-ng:latest
+             localhost/pulp/pulp-galaxy-ng-ui:latest
 
     - name: "Reset admin password"
       run: |

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -57,94 +57,23 @@ jobs:
 
     - name: "Cache container image for pulp_galaxy_ng ${{ env.SHORT_BRANCH }} ${{ env.GALAXY_NG_COMMIT }}"
       id: cache-container
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: pulp_galaxy_ng/image
-        key: ${{ runner.os }}-container-${{ env.GALAXY_NG_COMMIT }}-post2547
-
-    - name: "Checkout ansible-hub-ui (${{ github.ref }})"
-      uses: actions/checkout@v2
-      with:
-        path: 'ansible-hub-ui'
-
-    - name: "Build pulp-galaxy-ng"
-      if: steps.cache-container.outputs.cache-hit != 'true'
-      working-directory: 'pulp_galaxy_ng'
-      run: |
-        cp -iv ../ansible-hub-ui/.github/workflows/scripts/* .
-
-        echo '# Containerfile'
-        echo '\
-          FROM ghcr.io/pulp/pulp-ci-centos:latest
-
-          COPY --chmod=644 ansible-sign.key /tmp/
-          COPY --chmod=755 collection-sign.sh /var/lib/pulp/scripts/
-          COPY --chmod=755 container-sign.sh /var/lib/pulp/scripts/
-          COPY --chmod=755 signing-setup.sh /tmp/
-
-          RUN pip3 install --upgrade \
-            requests \
-            git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
-
-          RUN mkdir -p /etc/nginx/pulp/
-          RUN ln /usr/local/lib/python*/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-          RUN ln /usr/local/lib/python*/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-          RUN ln /usr/local/lib/python*/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
-
-          RUN rm -rf /usr/local/lib/python*/site-packages/galaxy_ng/app/static/
-          RUN ln -sv /galaxy_ng_static `ls -d /usr/local/lib/python*/site-packages/galaxy_ng/app/`static
-        ' | tee Containerfile
-
-        buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .
-        rm -f image # ensure older version is gone, podman save errors otherwise
-        podman save localhost/pulp/pulp-galaxy-ng:latest -o image
-
-    - name: "Load pulp-galaxy-ng from cache"
-      if: steps.cache-container.outputs.cache-hit == 'true'
-      working-directory: 'pulp_galaxy_ng'
-      run: podman load -i image
-
-    - name: "Configure and run pulp-galaxy-ng"
-      working-directory: 'pulp_galaxy_ng'
-      run: |
-        mkdir settings static
-        echo '# settings/settings.py'
-        echo "\
-          ANSIBLE_API_HOSTNAME='http://localhost:8002'
-          ANSIBLE_CONTENT_HOSTNAME='http://localhost:8002/api/galaxy/v3/artifacts/collections'
-          CONTENT_ORIGIN='http://localhost:8002'
-          GALAXY_API_PATH_PREFIX='/api/galaxy/'
-          GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication']
-          GALAXY_DEPLOYMENT_MODE='standalone'
-          PULP_CONTENT_PATH_PREFIX='/api/galaxy/v3/artifacts/collections/'
-          RH_ENTITLEMENT_REQUIRED='insights'
-          TOKEN_AUTH_DISABLED=True
-          X_PULP_CONTENT_HOST='localhost'
-          GALAXY_REQUIRE_CONTENT_APPROVAL=False
-          GALAXY_COLLECTION_SIGNING_SERVICE='ansible-default'
-          GALAXY_CONTAINER_SIGNING_SERVICE='container-default'
-          GALAXY_FEATURE_FLAGS__container_signing=True
-        " | sed 's/^\s\+//' | tee settings/settings.py
-
-        podman run \
-             --detach \
-             --publish 8002:80 \
-             --name pulp \
-             --volume "$(pwd)/settings":/etc/pulp \
-             --volume "$(pwd)/static":/galaxy_ng_static \
-             --tmpfs /var/lib/pulp \
-             --tmpfs /var/lib/pgsql \
-             --tmpfs /var/lib/containers \
-             --device /dev/fuse \
-             localhost/pulp/pulp-galaxy-ng:latest
+        key: ${{ runner.os }}-container-${{ env.GALAXY_NG_COMMIT }}-post2765
 
     - name: "Install node 16"
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
 
+    - name: "Checkout ansible-hub-ui (${{ github.ref }})"
+      uses: actions/checkout@v3
+      with:
+        path: 'ansible-hub-ui'
+
     - name: "Cache ~/.npm & ~/.cache/Cypress"
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.npm
@@ -169,11 +98,81 @@ jobs:
         BUILD_HASH=`ls dist/js/App*js | cut -d. -f2,3`
         echo "BUILD_HASH=${BUILD_HASH}" >> $GITHUB_ENV
 
-        rm -rf ../pulp_galaxy_ng/static/galaxy_ng/ || true
-        mv -v dist/ ../pulp_galaxy_ng/static/galaxy_ng
+    - name: "Build pulp-galaxy-ng"
+      if: steps.cache-container.outputs.cache-hit != 'true'
+      working-directory: 'pulp_galaxy_ng'
+      run: |
+        cp -iv ../ansible-hub-ui/.github/workflows/scripts/* .
+        mv -v ../ansible-hub-ui/dist galaxy_ng_static
 
-        # apply changes, runs collectstatic and serves static assets
-        podman exec pulp bash -c "s6-svc -r /var/run/s6-rc/servicedirs/pulpcore-api"
+        echo '# Containerfile'
+        echo '\
+          FROM ghcr.io/pulp/pulp-ci-centos:latest
+
+          COPY --chmod=644 ansible-sign.key /tmp/
+          COPY --chmod=755 collection-sign.sh /var/lib/pulp/scripts/
+          COPY --chmod=755 container-sign.sh /var/lib/pulp/scripts/
+          COPY --chmod=755 signing-setup.sh /tmp/
+
+          RUN pip3 install --upgrade \
+            requests \
+            git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
+
+          RUN mkdir -p /etc/nginx/pulp/
+          RUN ln /usr/local/lib/python*/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
+          RUN ln /usr/local/lib/python*/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
+          RUN ln /usr/local/lib/python*/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
+
+          RUN rm -rf /usr/local/lib/python*/site-packages/galaxy_ng/app/static/
+          RUN ln -sv /galaxy_ng_static `ls -d /usr/local/lib/python*/site-packages/galaxy_ng/app/`static
+          COPY --chmod=644 galaxy_ng_static /galaxy_ng_static
+
+          USER pulp:pulp
+          RUN PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost /usr/local/bin/pulpcore-manager collectstatic --clear --noinput --link
+          USER root:root
+        ' | tee Containerfile
+
+        buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .
+        rm -f image # ensure older version is gone, podman save errors otherwise
+        podman save localhost/pulp/pulp-galaxy-ng:latest -o image
+
+    - name: "Load pulp-galaxy-ng from cache"
+      if: steps.cache-container.outputs.cache-hit == 'true'
+      working-directory: 'pulp_galaxy_ng'
+      run: podman load -i image
+
+    - name: "Configure and run pulp-galaxy-ng"
+      working-directory: 'pulp_galaxy_ng'
+      run: |
+        mkdir settings
+        echo '# settings/settings.py'
+        echo "\
+          ANSIBLE_API_HOSTNAME='http://localhost:8002'
+          ANSIBLE_CONTENT_HOSTNAME='http://localhost:8002/api/galaxy/v3/artifacts/collections'
+          CONTENT_ORIGIN='http://localhost:8002'
+          GALAXY_API_PATH_PREFIX='/api/galaxy/'
+          GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication']
+          GALAXY_DEPLOYMENT_MODE='standalone'
+          PULP_CONTENT_PATH_PREFIX='/api/galaxy/v3/artifacts/collections/'
+          RH_ENTITLEMENT_REQUIRED='insights'
+          TOKEN_AUTH_DISABLED=True
+          X_PULP_CONTENT_HOST='localhost'
+          GALAXY_REQUIRE_CONTENT_APPROVAL=False
+          GALAXY_COLLECTION_SIGNING_SERVICE='ansible-default'
+          GALAXY_CONTAINER_SIGNING_SERVICE='container-default'
+          GALAXY_FEATURE_FLAGS__container_signing=True
+        " | sed 's/^\s\+//' | tee settings/settings.py
+
+        podman run \
+             --detach \
+             --publish 8002:80 \
+             --name pulp \
+             --volume "$(pwd)/settings":/etc/pulp \
+             --tmpfs /var/lib/pulp \
+             --tmpfs /var/lib/pgsql \
+             --tmpfs /var/lib/containers \
+             --device /dev/fuse \
+             localhost/pulp/pulp-galaxy-ng:latest
 
     - name: "Reset admin password"
       run: |
@@ -206,7 +205,12 @@ jobs:
     - name: "Ensure index.html uses the new js"
       run: |
         echo 'expecting /static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
-        curl http://localhost:8002/static/galaxy_ng/index.html | tee /dev/stderr | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
+        echo GET /
+        curl http://localhost:8002/ | tee /dev/stderr | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js' && echo OK || echo ERR
+        echo GET /ui/
+        curl http://localhost:8002/ui/ | tee /dev/stderr | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js' && echo OK || echo ERR
+        echo GET /static/galaxy_ng/index.html
+        curl http://localhost:8002/static/galaxy_ng/index.html | tee /dev/stderr | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js' && echo OK
 
     - name: "Ensure galaxykit can connect to the server"
       run: |

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: pulp_galaxy_ng/image
-        key: ${{ runner.os }}-container-${{ env.GALAXY_NG_COMMIT }}-post2765
+        key: pulp-galaxy-ng-${{ env.GALAXY_NG_COMMIT }}
 
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v3
@@ -118,10 +118,10 @@ jobs:
         path: |
           ~/.npm
           ~/.cache/Cypress
-        key: ${{ runner.os }}-node-${{ env.SHORT_BRANCH }}-${{ hashFiles('ansible-hub-ui/**/package-lock.json') }}
+        key: npm-${{ env.SHORT_BRANCH }}-${{ hashFiles('ansible-hub-ui/**/package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-${{ env.SHORT_BRANCH }}-
-          ${{ runner.os }}-node-
+          npm-${{ env.SHORT_BRANCH }}-
+          npm-
 
     - name: "Build standalone UI"
       working-directory: 'ansible-hub-ui'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -191,6 +191,9 @@ jobs:
              --device /dev/fuse \
              localhost/pulp/pulp-galaxy-ng-ui:latest
 
+        # everything breaks if reset-admin-password interrupts migrations
+        sleep 1m
+
     - name: "Reset admin password"
       run: |
         # podman exec pulp pip install django_extensions
@@ -198,7 +201,7 @@ jobs:
 
     - name: "Enable signing service"
       run: |
-        podman exec pulp /tmp/signing-setup.sh
+        podman exec --user pulp:pulp pulp /tmp/signing-setup.sh
 
     - name: "Install Cypress & test dependencies"
       working-directory: 'ansible-hub-ui/test'

--- a/.github/workflows/scripts/collection-sign.sh
+++ b/.github/workflows/scripts/collection-sign.sh
@@ -10,7 +10,7 @@ PASSWORD="Galaxy2022"
 # Create a detached signature
 gpg --quiet --batch --pinentry-mode loopback --yes --passphrase "$PASSWORD" \
     --homedir "~/.gnupg/" --detach-sign --default-key "$ADMIN_ID" \
-    --no-default-keyring --keyring "${KEYRING:-/etc/pulp/certs/galaxy.kbx}" \
+    --no-default-keyring --keyring "${KEYRING:-/tmp/galaxy.kbx}" \
     --armor --output "$SIGNATURE_PATH" "$FILE_PATH"
 
 echo {\"file\": \"$FILE_PATH\", \"signature\": \"$SIGNATURE_PATH\"}

--- a/.github/workflows/scripts/signing-setup.sh
+++ b/.github/workflows/scripts/signing-setup.sh
@@ -4,8 +4,8 @@ set -e
 # Signing keyring
 export KEY_FINGERPRINT=$(gpg --show-keys --with-colons --with-fingerprint /tmp/ansible-sign.key | awk -F: '$1 == "fpr" {print $10;}' | head -n1)
 export KEY_ID=${KEY_FINGERPRINT: -16}
-gpg --batch --no-default-keyring --keyring /etc/pulp/certs/galaxy.kbx --import /tmp/ansible-sign.key
-echo "${KEY_FINGERPRINT}:6:" | gpg --batch --no-default-keyring --keyring /etc/pulp/certs/galaxy.kbx --import-ownertrust
+gpg --batch --no-default-keyring --keyring /tmp/galaxy.kbx --import /tmp/ansible-sign.key
+echo "${KEY_FINGERPRINT}:6:" | gpg --batch --no-default-keyring --keyring /tmp/galaxy.kbx --import-ownertrust
 
 # Collection signing service
 gpg --batch --import /tmp/ansible-sign.key

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -125,7 +125,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
     }
 
     const { hasPermission } = this.context;
-    const addButton = hasPermission('galaxy.add_containerregistry') ? (
+    const addButton = hasPermission('galaxy.add_containerregistryremote') ? (
       <Button
         onClick={() =>
           this.setState({


### PR DESCRIPTION
Master tests are failing (https://github.com/ansible/ansible-hub-ui/actions/runs/3276489348/jobs/5477502564), originally seen in #2741

```
$ echo 'expecting /static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
$ curl http://localhost:8002/static/galaxy_ng/index.html | tee /dev/stderr | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'

expecting /static/galaxy_ng/js/App.1666644881606.ef88a718cd5f9228a206.js
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   179  100   179    0     0   2671      0 --:--:-- --:--:-- --:--:--  2632
100   179  100   179    0     0   2632      0 --:--:-- --:--:-- --:--:--  2594

<!doctype html>
<html lang="en">
<head>
  <title>Not Found</title>
</head>
<body>
  <h1>Not Found</h1><p>The requested resource was not found on this server.</p>
</body>
</html>

Error: Process completed with exit code 1.
##[debug]Finishing: Ensure index.html uses the new js
```

---

https://github.com/pulp/pulp-oci-images/pull/311 - `collectstatic` no longer happens on api restart, only build time, which is too soon for us
=> moving this to build time as well, losing caching (TODO clean up caching more)

---

Except this doesn't help, there doesn't seem to be a pulp oci container that serves UI now. Will find out if intentional or not.
Opening #2769 as backup.

---

```
django.db.utils.ProgrammingError: relation "galaxy_user" does not exist
LINE 1: ...er"."is_active", "galaxy_user"."date_joined" FROM "galaxy_us...`
```

I guess the container fails to run galaxy migrations.

But that doesn't happen for vanilla pulp/pulp-galaxy-ng , that one just doesn't serve the UI (https://github.com/pulp/pulp-oci-images/issues/340).

Maybe we should just use the container for APIs and take the "static server/proxy outside the container" logic from #2769.
But then again oci-env has signing working out of the box.