### PR TITLE
custom_release: build prod-beta with HUB_CLOUD_BETA=true

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -2,25 +2,30 @@
 set -e
 set -x
 
+push () {
+    echo "PUSHING $1"
+    rm -rf dist/.git build/.git
+    .travis/release.sh "$1"
+}
+
 if [ "${TRAVIS_BRANCH}" = "master" ]; then
     # always push to stage-beta
     HUB_CLOUD_BETA="true" npm run deploy
-    echo "PUSHING qa-beta"
-    rm -rf ./dist/.git
-    .travis/release.sh "qa-beta"
+    push "qa-beta"
 
     # only push to stage-stable when enabled
     if [ -f .cloud-stage-cron.enabled ]; then
         HUB_CLOUD_BETA="false" npm run deploy
-        echo "PUSHING qa-stable"
-        rm -rf ./dist/.git
-        .travis/release.sh "qa-stable"
+        push "qa-stable"
     fi
 fi
 
-if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
-    npm run deploy
-    echo "PUSHING ${TRAVIS_BRANCH}"
-    rm -rf ./build/.git
-    .travis/release.sh "${TRAVIS_BRANCH}"
+if [ "${TRAVIS_BRANCH}" = "prod-beta" ]; then
+    HUB_CLOUD_BETA="true" npm run deploy
+    push "prod-beta"
+fi
+
+if [ "${TRAVIS_BRANCH}" = "prod-stable" ]; then
+    HUB_CLOUD_BETA="false" npm run deploy
+    push "prod-stable"
 fi


### PR DESCRIPTION
Cc @awcrosby - this was not needed for `prod-stable`, but I used a similar change for `prod-beta` -  https://github.com/ansible/ansible-hub-ui/commit/286fa013d802dd25c775d2d2d20ef53a1e8bdeb6

So making sure it's also on master for the next set of deploys :).