### PR TITLE
Update build_deploy.sh

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -9,7 +9,7 @@ export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build'
 export APP_ROOT=$(pwd)
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
-export NODE_BUILD_VERSION=14
+export NODE_BUILD_VERSION=16
 export IMAGE="quay.io/cloudservices/ansible-hub-ui"
 
 set -exv


### PR DESCRIPTION
Hello! Jenkins builds for master are failing because the node version is wrong in the script. This one liner switches it to 16 to match your project.