### PR TITLE
insights: fix Collections menu click 404

### DIFF
--- a/src/loaders/insights/insights-loader.tsx
+++ b/src/loaders/insights/insights-loader.tsx
@@ -57,9 +57,11 @@ class App extends Component<IProps, IState> {
         return;
       }
 
-      // basename is either `/ansible/automation-hub` or `/beta/ansible/automation-hub`, no trailing /
+      // basename is either `/ansible/automation-hub` or `/beta/ansible/automation-hub`, remove trailing /
       // menu events don't have the /beta, converting
-      const basename = this.props.basename.replace(/^\/beta\//, '/');
+      const basename = this.props.basename
+        .replace(/^\/beta\//, '/')
+        .replace(/\/$/, '');
 
       // domEvent: has the right href, always starts with /ansible/ansible-hub, no /beta prefix
       // go to the href, relative to our *actual* basename (basename has no trailing /, so a path will start with / unless empty


### PR DESCRIPTION
Follow-up to #2744

which fixed 404s when coming from outside the app, but broke parsing chrome navigation events when the target url didn't have a slash after ansible/automation-hub

Normalizing the basename to a version without a traliing slash before parsing these hrefs.

Issue: AAH-1997