### PR TITLE
ci: use oci-env as backend

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
 
-    - name: "Install galaxykit dependency"
+    - name: "Install galaxykit"
       run: |
         # pip install git+https://github.com/ansible/galaxykit.git@branch_name
         pip install git+https://github.com/ansible/galaxykit.git
@@ -53,98 +53,71 @@ jobs:
         echo "SHORT_BRANCH=${SHORT_BRANCH}" >> $GITHUB_ENV
         echo "GALAXY_NG_COMMIT=${GALAXY_NG_COMMIT}" >> $GITHUB_ENV
 
-    - run: "mkdir pulp_galaxy_ng"
+    - name: "ansible-hub-ui ref ${{ github.ref }}"
+      run: 'true'
 
-    - name: "Cache container image for pulp_galaxy_ng ${{ env.SHORT_BRANCH }} ${{ env.GALAXY_NG_COMMIT }}"
-      id: cache-container
-      uses: actions/cache@v2
-      with:
-        path: pulp_galaxy_ng/image
-        key: ${{ runner.os }}-container-${{ env.GALAXY_NG_COMMIT }}-post2547
+    - name: "galaxy_ng branch ${{ env.SHORT_BRANCH }}"
+      run: 'true'
 
-    - name: "Checkout ansible-hub-ui (${{ github.ref }})"
-      uses: actions/checkout@v2
+    - name: "galaxy_ng commit ${{ env.GALAXY_NG_COMMIT }}"
+      run: 'true'
+
+    - name: "Checkout ansible-hub-ui"
+      uses: actions/checkout@v3
       with:
         path: 'ansible-hub-ui'
 
-    - name: "Build pulp-galaxy-ng"
-      if: steps.cache-container.outputs.cache-hit != 'true'
-      working-directory: 'pulp_galaxy_ng'
-      run: |
-        cp -iv ../ansible-hub-ui/.github/workflows/scripts/* .
+    - name: "Checkout galaxy_ng"
+      uses: actions/checkout@v3
+      with:
+        repository: 'ansible/galaxy_ng'
+        ref: '${{ env.SHORT_BRANCH }}'
+        path: 'galaxy_ng'
 
-        echo '# Containerfile'
+    - name: "Checkout oci_env"
+      uses: actions/checkout@v3
+      with:
+        repository: 'pulp/oci_env'
+        path: 'oci_env'
+
+    - name: "Checkout galaxy_ng#1423"
+      uses: actions/checkout@v3
+      with:
+        repository: 'ansible/galaxy_ng'
+        path: 'galaxy_ng_1423'
+        ref: 'refs/pull/1423/head'
+
+    - name: "Copy profiles/"
+      run: '[ -d galaxy_ng/profiles/ ] || mv galaxy_ng_1423/profiles/ galaxy_ng/'
+
+    - name: "Configure oci_env"
+      working-directory: 'oci_env'
+      run: |
+        pip3 install -e client
+
         echo '\
-          FROM ghcr.io/pulp/pulp-ci-centos:latest
+          COMPOSE_PROFILE=galaxy_ng/base
+          DEV_SOURCE_PATH=galaxy_ng
+          COMPOSE_BINARY=docker
+          DJANGO_SUPERUSER_USERNAME=admin
+          DJANGO_SUPERUSER_PASSWORD=admin
+        ' | sed 's/^\s\+//' | tee compose.env
 
-          COPY --chmod=644 ansible-sign.key /tmp/
-          COPY --chmod=755 collection-sign.sh /var/lib/pulp/scripts/
-          COPY --chmod=755 container-sign.sh /var/lib/pulp/scripts/
-          COPY --chmod=755 signing-setup.sh /tmp/
+    - name: "oci-env compose build"
+      working-directory: 'oci_env'
+      run: 'oci-env compose build'
 
-          RUN pip3 install --upgrade \
-            requests \
-            git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
-
-          RUN mkdir -p /etc/nginx/pulp/
-          RUN ln /usr/local/lib/python*/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf
-          RUN ln /usr/local/lib/python*/site-packages/pulp_container/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_container.conf
-          RUN ln /usr/local/lib/python*/site-packages/galaxy_ng/app/webserver_snippets/nginx.conf /etc/nginx/pulp/galaxy_ng.conf
-
-          RUN rm -rf /usr/local/lib/python*/site-packages/galaxy_ng/app/static/
-          RUN ln -sv /galaxy_ng_static `ls -d /usr/local/lib/python*/site-packages/galaxy_ng/app/`static
-        ' | tee Containerfile
-
-        buildah bud --file Containerfile --tag localhost/pulp/pulp-galaxy-ng:latest .
-        rm -f image # ensure older version is gone, podman save errors otherwise
-        podman save localhost/pulp/pulp-galaxy-ng:latest -o image
-
-    - name: "Load pulp-galaxy-ng from cache"
-      if: steps.cache-container.outputs.cache-hit == 'true'
-      working-directory: 'pulp_galaxy_ng'
-      run: podman load -i image
-
-    - name: "Configure and run pulp-galaxy-ng"
-      working-directory: 'pulp_galaxy_ng'
-      run: |
-        mkdir settings static
-        echo '# settings/settings.py'
-        echo "\
-          ANSIBLE_API_HOSTNAME='http://localhost:8002'
-          ANSIBLE_CONTENT_HOSTNAME='http://localhost:8002/api/galaxy/v3/artifacts/collections'
-          CONTENT_ORIGIN='http://localhost:8002'
-          GALAXY_API_PATH_PREFIX='/api/galaxy/'
-          GALAXY_AUTHENTICATION_CLASSES=['rest_framework.authentication.SessionAuthentication', 'rest_framework.authentication.TokenAuthentication']
-          GALAXY_DEPLOYMENT_MODE='standalone'
-          PULP_CONTENT_PATH_PREFIX='/api/galaxy/v3/artifacts/collections/'
-          RH_ENTITLEMENT_REQUIRED='insights'
-          TOKEN_AUTH_DISABLED=True
-          X_PULP_CONTENT_HOST='localhost'
-          GALAXY_REQUIRE_CONTENT_APPROVAL=False
-          GALAXY_COLLECTION_SIGNING_SERVICE='ansible-default'
-          GALAXY_CONTAINER_SIGNING_SERVICE='container-default'
-          GALAXY_FEATURE_FLAGS__container_signing=True
-        " | sed 's/^\s\+//' | tee settings/settings.py
-
-        podman run \
-             --detach \
-             --publish 8002:80 \
-             --name pulp \
-             --volume "$(pwd)/settings":/etc/pulp \
-             --volume "$(pwd)/static":/galaxy_ng_static \
-             --tmpfs /var/lib/pulp \
-             --tmpfs /var/lib/pgsql \
-             --tmpfs /var/lib/containers \
-             --device /dev/fuse \
-             localhost/pulp/pulp-galaxy-ng:latest
+    - name: "oci-env compose up"
+      working-directory: 'oci_env'
+      run: 'oci-env compose up &'
 
     - name: "Install node 16"
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
 
     - name: "Cache ~/.npm & ~/.cache/Cypress"
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.npm
@@ -169,20 +142,14 @@ jobs:
         BUILD_HASH=`ls dist/js/App*js | cut -d. -f2,3`
         echo "BUILD_HASH=${BUILD_HASH}" >> $GITHUB_ENV
 
-        rm -rf ../pulp_galaxy_ng/static/galaxy_ng/ || true
-        mv -v dist/ ../pulp_galaxy_ng/static/galaxy_ng
-
-        # apply changes, runs collectstatic and serves static assets
-        podman exec pulp bash -c "s6-svc -r /var/run/s6-rc/servicedirs/pulpcore-api"
-
-    - name: "Reset admin password"
+    - name: "Serve standalone UI"
       run: |
-        # podman exec pulp pip install django_extensions
-        podman exec pulp pulpcore-manager reset-admin-password --password admin
-
-    - name: "Enable signing service"
-      run: |
-        podman exec pulp /tmp/signing-setup.sh
+        mkdir -p www/static/
+        mv ansible-hub-ui/dist www/static/galaxy_ng
+        cd www
+        echo '{}' > package.json
+        npm install local-web-server
+        node_modules/.bin/ws --port 8002 --directory . --spa static/galaxy_ng/index.html --rewrite '/api/(.*) -> http://localhost:5001/api/$1' &
 
     - name: "Install Cypress & test dependencies"
       working-directory: 'ansible-hub-ui/test'
@@ -197,8 +164,8 @@ jobs:
           "pulpPrefix": "/api/galaxy/pulp/api/v3/",
           "username": "admin",
           "password": "admin",
-          "settings": "../../pulp_galaxy_ng/settings/settings.py",
-          "restart": "podman exec pulp bash -c \"s6-svc -r /var/run/s6-rc/servicedirs/pulpcore-api\"; sleep 10",
+          "settings": "../../galaxy_ng/galaxy_ng/app/settings.py",
+          "restart": "sleep 10",
           "containers": "localhost:8002",
           "galaxykit": "galaxykit --ignore-certs"
         }' > cypress.env.json
@@ -244,7 +211,8 @@ jobs:
 
     - name: "Kill container, show debug info"
       if: always()
+      working-directory: 'oci_env'
       run: |
-        podman exec pulp bash -c "pip3 list && pip3 install pipdeptree && pipdeptree"
-        podman logs pulp
-        podman kill pulp
+        oci-env exec bash -c "pip3 list && pip3 install pipdeptree && pipdeptree"
+        oci-env compose logs
+        oci-env compose down

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -125,7 +125,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
     }
 
     const { hasPermission } = this.context;
-    const addButton = hasPermission('galaxy.add_containerregistry') ? (
+    const addButton = hasPermission('galaxy.add_containerregistryremote') ? (
       <Button
         onClick={() =>
           this.setState({


### PR DESCRIPTION
Related to #2765.. tries to solve the same "no ui served by the container anymore" issue

But this time, by switching from a manual pulp-oci-images build to pulp/oci-env.