### PR TITLE
ci: multiple fixes

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -173,6 +173,7 @@ jobs:
         mv -v dist/ ../pulp_galaxy_ng/static/galaxy_ng
 
         # apply changes, runs collectstatic and serves static assets
+        podman exec --user pulp:pulp pulp bash -c "PULP_STATIC_ROOT=/var/lib/operator/static/ PULP_CONTENT_ORIGIN=localhost /usr/local/bin/pulpcore-manager collectstatic --clear --noinput --link"
         podman exec pulp bash -c "s6-svc -r /var/run/s6-rc/servicedirs/pulpcore-api"
 
     - name: "Reset admin password"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -84,7 +84,8 @@ jobs:
 
           RUN pip3 install --upgrade \
             requests \
-            git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
+            git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }} && \
+            rm -rf /root/.cache/pip
 
           RUN mkdir -p /etc/nginx/pulp/
           RUN ln /usr/local/lib/python*/site-packages/pulp_ansible/app/webserver_snippets/nginx.conf /etc/nginx/pulp/pulp_ansible.conf

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -182,7 +182,7 @@ jobs:
 
     - name: "Enable signing service"
       run: |
-        podman exec pulp /tmp/signing-setup.sh
+        podman exec --user pulp:pulp pulp /tmp/signing-setup.sh
 
     - name: "Install Cypress & test dependencies"
       working-directory: 'ansible-hub-ui/test'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -57,13 +57,13 @@ jobs:
 
     - name: "Cache container image for pulp_galaxy_ng ${{ env.SHORT_BRANCH }} ${{ env.GALAXY_NG_COMMIT }}"
       id: cache-container
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: pulp_galaxy_ng/image
         key: ${{ runner.os }}-container-${{ env.GALAXY_NG_COMMIT }}-post2547
 
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: 'ansible-hub-ui'
 
@@ -139,12 +139,12 @@ jobs:
              localhost/pulp/pulp-galaxy-ng:latest
 
     - name: "Install node 16"
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '16'
 
     - name: "Cache ~/.npm & ~/.cache/Cypress"
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ~/.npm
@@ -235,7 +235,7 @@ jobs:
         cat cypress.config.js
         npm run cypress:chrome
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: screenshots_and_videos

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -60,7 +60,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: pulp_galaxy_ng/image
-        key: ${{ runner.os }}-container-${{ env.GALAXY_NG_COMMIT }}-post2547
+        key: pulp-galaxy-ng-${{ env.SHORT_BRANCH }}-${{ env.GALAXY_NG_COMMIT }}
 
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v3
@@ -149,10 +149,10 @@ jobs:
         path: |
           ~/.npm
           ~/.cache/Cypress
-        key: ${{ runner.os }}-node-${{ env.SHORT_BRANCH }}-${{ hashFiles('ansible-hub-ui/**/package-lock.json') }}
+        key: npm-${{ env.SHORT_BRANCH }}-${{ hashFiles('ansible-hub-ui/**/package-lock.json') }}
         restore-keys: |
-          ${{ runner.os }}-node-${{ env.SHORT_BRANCH }}-
-          ${{ runner.os }}-node-
+          npm-${{ env.SHORT_BRANCH }}-
+          npm-
 
     - name: "Build standalone UI"
       working-directory: 'ansible-hub-ui'

--- a/.github/workflows/scripts/collection-sign.sh
+++ b/.github/workflows/scripts/collection-sign.sh
@@ -10,7 +10,7 @@ PASSWORD="Galaxy2022"
 # Create a detached signature
 gpg --quiet --batch --pinentry-mode loopback --yes --passphrase "$PASSWORD" \
     --homedir "~/.gnupg/" --detach-sign --default-key "$ADMIN_ID" \
-    --no-default-keyring --keyring "${KEYRING:-/etc/pulp/certs/galaxy.kbx}" \
+    --no-default-keyring --keyring "${KEYRING:-/tmp/galaxy.kbx}" \
     --armor --output "$SIGNATURE_PATH" "$FILE_PATH"
 
 echo {\"file\": \"$FILE_PATH\", \"signature\": \"$SIGNATURE_PATH\"}

--- a/.github/workflows/scripts/signing-setup.sh
+++ b/.github/workflows/scripts/signing-setup.sh
@@ -4,8 +4,8 @@ set -e
 # Signing keyring
 export KEY_FINGERPRINT=$(gpg --show-keys --with-colons --with-fingerprint /tmp/ansible-sign.key | awk -F: '$1 == "fpr" {print $10;}' | head -n1)
 export KEY_ID=${KEY_FINGERPRINT: -16}
-gpg --batch --no-default-keyring --keyring /etc/pulp/certs/galaxy.kbx --import /tmp/ansible-sign.key
-echo "${KEY_FINGERPRINT}:6:" | gpg --batch --no-default-keyring --keyring /etc/pulp/certs/galaxy.kbx --import-ownertrust
+gpg --batch --no-default-keyring --keyring /tmp/galaxy.kbx --import /tmp/ansible-sign.key
+echo "${KEY_FINGERPRINT}:6:" | gpg --batch --no-default-keyring --keyring /tmp/galaxy.kbx --import-ownertrust
 
 # Collection signing service
 gpg --batch --import /tmp/ansible-sign.key

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -125,7 +125,7 @@ class ExecutionEnvironmentRegistryList extends React.Component<
     }
 
     const { hasPermission } = this.context;
-    const addButton = hasPermission('galaxy.add_containerregistry') ? (
+    const addButton = hasPermission('galaxy.add_containerregistryremote') ? (
       <Button
         onClick={() =>
           this.setState({


### PR DESCRIPTION
Distilled from #2765 , #2769, #2770, #2771 

Fixes multiple CI issues:

* run `collectatic` manually - api restart no longer does it by default
* runs signing setup as pulp user - because signing itself will get run as pulp
* fix permission typo
* removes warnings from using old versions of github actions
* update cache keys to be more descriptive
* add pip cleanup from vanilla pulp-galaxy-ng