### PR TITLE
webpack: fix isBuild when NODE_ENV is not provided

### DIFF
--- a/config/community.prod.webpack.config.js
+++ b/config/community.prod.webpack.config.js
@@ -1,5 +1,5 @@
-const webpackBase = require('./webpack.base.config');
 process.env.NODE_ENV = 'production';
+const webpackBase = require('./webpack.base.config');
 
 // Compile configuration for stnadalone mode
 module.exports = webpackBase({

--- a/config/insights.prod.webpack.config.js
+++ b/config/insights.prod.webpack.config.js
@@ -1,6 +1,6 @@
+process.env.NODE_ENV = 'production';
 const webpackBase = require('./webpack.base.config');
 const cloudBeta = process.env.HUB_CLOUD_BETA; // "true" | "false" | undefined (=default)
-process.env.NODE_ENV = 'production';
 
 // Compile configuration for deploying to insights
 module.exports = webpackBase({

--- a/config/standalone.prod.webpack.config.js
+++ b/config/standalone.prod.webpack.config.js
@@ -1,5 +1,5 @@
-const webpackBase = require('./webpack.base.config');
 process.env.NODE_ENV = 'production';
+const webpackBase = require('./webpack.base.config');
 
 // Compile configuration for stnadalone mode
 module.exports = webpackBase({


### PR DESCRIPTION
Follow-up to config changes in #2815 ...

ensure `isBuild` is set correctly in shared webpack conf even if NODE_ENV is not provided.
(This should only affect the webpack CI check, the var is always there in real builds.)