### PR TITLE
Bump @redhat-cloud-services/frontend-components-config-utilities to 1.5.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
                 "@lingui/macro": "^3.14.0",
                 "@ls-lint/ls-lint": "^1.11.2",
                 "@redhat-cloud-services/frontend-components-config": "^4.6.31",
-                "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.23",
+                "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.25",
                 "@typescript-eslint/eslint-plugin": "^5.42.0",
                 "@typescript-eslint/parser": "^5.40.1",
                 "babel-core": "^7.0.0-bridge.0",
@@ -2809,9 +2809,9 @@
             }
         },
         "node_modules/@redhat-cloud-services/frontend-components-config-utilities": {
-            "version": "1.5.24",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.24.tgz",
-            "integrity": "sha512-rFjhzgPYCG2xBiQH0NqbtXuRr6jRV4Z+ef04HRlyYVYO8Wdti7wAlU8hG0VBNFRyJuWKdMSq1EA9/4bHfLuDeQ==",
+            "version": "1.5.25",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.25.tgz",
+            "integrity": "sha512-bjviVgey6HpzbGqLNgS233qMClC38nwP1IQEMtkSyjD7Bxe1GOuPG5EHrbwkVCj22g4g7lh87UF6/fFuV8+Q+Q==",
             "dev": true,
             "dependencies": {
                 "node-fetch": "2.6.7"
@@ -17593,9 +17593,9 @@
             }
         },
         "@redhat-cloud-services/frontend-components-config-utilities": {
-            "version": "1.5.24",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.24.tgz",
-            "integrity": "sha512-rFjhzgPYCG2xBiQH0NqbtXuRr6jRV4Z+ef04HRlyYVYO8Wdti7wAlU8hG0VBNFRyJuWKdMSq1EA9/4bHfLuDeQ==",
+            "version": "1.5.25",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.25.tgz",
+            "integrity": "sha512-bjviVgey6HpzbGqLNgS233qMClC38nwP1IQEMtkSyjD7Bxe1GOuPG5EHrbwkVCj22g4g7lh87UF6/fFuV8+Q+Q==",
             "dev": true,
             "requires": {
                 "node-fetch": "2.6.7"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@lingui/macro": "^3.14.0",
         "@ls-lint/ls-lint": "^1.11.2",
         "@redhat-cloud-services/frontend-components-config": "^4.6.31",
-        "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.23",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.25",
         "@typescript-eslint/eslint-plugin": "^5.42.0",
         "@typescript-eslint/parser": "^5.40.1",
         "babel-core": "^7.0.0-bridge.0",


### PR DESCRIPTION
Needed for #2740 as the new version of frontend-component-config-utilities has the fix for token auth (https://github.com/RedHatInsights/frontend-components/pull/1659).