### PR TITLE
Display AAP version

### DIFF
--- a/CHANGES/1315.feature
+++ b/CHANGES/1315.feature
@@ -1,0 +1,1 @@
+Display Ansible Automation Platform version

--- a/src/components/about-modal/about-modal.tsx
+++ b/src/components/about-modal/about-modal.tsx
@@ -28,6 +28,7 @@ interface IState {
     galaxy_ng_commit: string;
     pulp_ansible_version: string;
     server_version: string;
+    aap_version: string;
   };
 }
 
@@ -39,6 +40,7 @@ export class AboutModalWindow extends React.Component<IProps, IState> {
         galaxy_ng_commit: '',
         pulp_ansible_version: '',
         server_version: '',
+        aap_version: '',
       },
     };
   }
@@ -50,6 +52,7 @@ export class AboutModalWindow extends React.Component<IProps, IState> {
           galaxy_ng_commit: result.data.galaxy_ng_commit,
           pulp_ansible_version: result.data.pulp_ansible_version,
           server_version: result.data.server_version,
+          aap_version: result.data?.aap_version,
         },
       });
     });
@@ -91,6 +94,13 @@ export class AboutModalWindow extends React.Component<IProps, IState> {
 
             <Label>{t`Pulp Ansible Version`}</Label>
             <Value>{this.state.applicationInfo.pulp_ansible_version}</Value>
+
+            {this.state.applicationInfo?.aap_version && (
+              <>
+                <Label>{t`Ansible Automation Platform`}</Label>
+                <Value>{this.state.applicationInfo.aap_version}</Value>
+              </>
+            )}
 
             <Label>{t`UI Version`}</Label>
             <Value>{UI_COMMIT_HASH}</Value>


### PR DESCRIPTION
Issue: AAH-1315

Display Ansible Automation Platform version in the About Modal. 
(The AAP version is included in the API only if the VERSION file is in the system (path to file `/etc/ansible-automation-platform/VERSION`) 

Depends on https://github.com/ansible/galaxy_ng/pull/1469


![Screenshot from 2022-11-09 16-18-31](https://user-images.githubusercontent.com/19647757/200904490-38e32e92-4d66-4035-b9a6-a9cb60cdf5bb.png)

