### PR TITLE
[prod-stable] insights - add maintenance notice (2022-11-15)

### DIFF
--- a/src/loaders/insights/insights-loader.tsx
+++ b/src/loaders/insights/insights-loader.tsx
@@ -145,6 +145,11 @@ class App extends Component<IProps, IState> {
       >
         <Alert
           isInline
+          variant='warning'
+          title={t`Automation Hub has a scheduled downtime between 8am-9am ET on 2022-11-15.`}
+        />
+        <Alert
+          isInline
           variant='info'
           title={t`The Automation Hub sync toggle is now only supported in AAP 2.0. Previous versions of AAP will continue automatically syncing all collections.`}
         />


### PR DESCRIPTION
Adds a "Automation Hub has a scheduled downtime between 8am-9am ET on 2022-11-15." banner to the top of all hub insights pages.

(same as prod-beta in #2743)

![20221110154448](https://user-images.githubusercontent.com/289743/201140462-640675fe-d6c7-4df4-8118-37b68cd64a68.png)
