### PR TITLE
/ui/login/: fix navbar and headers appearing on default login screen in standalone

### DIFF
--- a/CHANGES/1973.bug
+++ b/CHANGES/1973.bug
@@ -1,1 +1,1 @@
-Slash at the end of the url of dependencies of collections. 
+Ensure trailing slash in collection dependencies urls

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -307,6 +307,7 @@ class App extends React.Component<RouteComponentProps, IState> {
     // Hide navs on login page
     if (
       this.props.location.pathname === Paths.login ||
+      this.props.location.pathname === formatPath(Paths.login, {}) ||
       this.props.location.pathname === UI_EXTERNAL_LOGIN_URI
     ) {
       return this.ctx(<Routes updateInitialData={this.updateInitialData} />);


### PR DESCRIPTION
Only affects standalone mode, with `/ui/login/` (with a trailing slash):

before: /ui/login works, /ui/login/ works but has navbar and menu
after: both work without navbars or menus

(related to  AAH-1973 and https://github.com/ansible/ansible-hub-ui/pull/2712 in that using formatPath with Paths.login exposed this problem - no need to backport)