### PR TITLE
Dependabot: enable github-actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,41 @@ updates:
       interval: 'monthly'
     commit-message:
       prefix: '[stable-4.2] '
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: 'stable-4.6'
+    commit-message:
+      prefix: '[stable-4.6] '
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: 'stable-4.5'
+    commit-message:
+      prefix: '[stable-4.5] '
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: 'stable-4.4'
+    commit-message:
+      prefix: '[stable-4.4] '
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: 'stable-4.2'
+    commit-message:
+      prefix: '[stable-4.2] '
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This should enable dependabot to update github actions version (`users: actions/...`).
should fix all the github action warning related to current versions of actions using node 16 when github switches to node 18
