### PR TITLE
getContainersURL: support generating full url, reuse, fix :latest in detail, fix missing name@ before digest

### DIFF
--- a/CHANGES/1988.bug
+++ b/CHANGES/1988.bug
@@ -1,0 +1,1 @@
+Fix podman pull URLs when latest tag not present, fix digest urls

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -184,7 +184,6 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
   renderControllers() {
     const { image, isOpen } = this.props;
     const { controllers, digest, tag } = this.state;
-    const url = getContainersURL();
     const unsafeLinksSupported = !Object.keys(window).includes('chrome');
 
     if (!isOpen || !controllers) {
@@ -200,13 +199,18 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
       return t`No tag or digest selected.`;
     }
 
+    const imageUrl = encodeURIComponent(
+      getContainersURL({
+        name: image,
+        tag,
+        digest,
+      }),
+    );
+
     return (
       <List isPlain isBordered>
         {controllers.map((host) => {
-          const imageUrl = `${url}/${tag ? `${image}:${tag}` : digest}`;
-          const href = `${host}/#/execution_environments/add?image=${encodeURIComponent(
-            imageUrl,
-          )}`;
+          const href = `${host}/#/execution_environments/add?image=${imageUrl}`;
 
           return (
             <ListItem style={{ paddingTop: '8px' }} key={host}>

--- a/src/containers/execution-environment-detail/execution_environment_detail.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail.tsx
@@ -56,18 +56,16 @@ class ExecutionEnvironmentDetail extends React.Component<
   }
 
   renderDetail() {
-    const url = getContainersURL();
-    const instructions =
-      'podman pull ' +
-      url +
-      '/' +
-      this.props.containerRepository.name +
-      ':latest';
-
     const { containerRepository } = this.props;
     const canEdit = containerRepository.namespace.my_permissions.includes(
       'container.change_containernamespace',
     );
+
+    const instructions =
+      'podman pull ' +
+      getContainersURL({
+        name: containerRepository.name,
+      });
 
     return (
       <Flex direction={{ default: 'column' }}>

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -346,9 +346,10 @@ class ExecutionEnvironmentDetailImages extends React.Component<
     cols: number,
   ) {
     const { hasPermission } = this.context;
+    const container = this.props.match.params['container'];
     const manifestLink = (digestOrTag) =>
       formatPath(Paths.executionEnvironmentManifest, {
-        container: this.props.match.params['container'],
+        container,
         digest: digestOrTag,
       });
 
@@ -363,11 +364,13 @@ class ExecutionEnvironmentDetailImages extends React.Component<
       </Link>
     );
 
-    const url = getContainersURL();
-    const instruction =
-      image.tags.length === 0
-        ? image.digest
-        : this.props.match.params['container'] + ':' + image.tags[0];
+    const instructions =
+      'podman pull ' +
+      getContainersURL({
+        name: container,
+        tag: image.tags?.[0],
+        digest: image.digest,
+      });
 
     const isRemote = !!this.props.containerRepository.pulp.repository.remote;
     const { isManifestList } = image;
@@ -457,9 +460,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
             )}
           </td>
           <td>
-            <ClipboardCopy isReadOnly>
-              {'podman pull ' + url + '/' + instruction}
-            </ClipboardCopy>
+            <ClipboardCopy isReadOnly>{instructions}</ClipboardCopy>
           </td>
           <ListItemActions kebabItems={dropdownItems} />
         </tr>

--- a/src/utilities/get-repo-url.ts
+++ b/src/utilities/get-repo-url.ts
@@ -10,6 +10,19 @@ export function getRepoUrl(distributionPath: string) {
 }
 
 // returns the server name for (protocol-less) container urls
-export function getContainersURL() {
-  return window.location.href.split('://')[1].split('/ui')[0];
+// url/image, url/image:tag, url/image@digest (including sha256: prefix)
+export function getContainersURL({
+  name,
+  tag,
+  digest,
+}: {
+  name: string;
+  tag?: string;
+  digest?: string;
+}) {
+  const host = window.location.host;
+
+  return `${host}/${name}${tag ? `:${tag}` : ''}${
+    digest && !tag ? `@${digest}` : ''
+  }`;
 }

--- a/test/cypress/e2e/execution_environments/execution_environments.js
+++ b/test/cypress/e2e/execution_environments/execution_environments.js
@@ -41,7 +41,7 @@ describe('execution environments', () => {
     cy.get('.title-box').should('have.text', `remotepine${num}`);
     cy.get('.pf-c-form-control').should(
       'have.value',
-      `podman pull localhost:8002/remotepine${num}:latest`,
+      `podman pull localhost:8002/remotepine${num}`,
     );
   });
 


### PR DESCRIPTION
Issue: AAH-1988

Merge logic for generating podman image urls into getContainersURL, only add tag when passed, only add digest when passed with an empty tag, don't skip name and @ for digest mode

stop assuming :latest on detail screen

before/after:

detail screen:

```diff
-localhost:8002/alpine:latest
+localhost:8002/alpine
```

tag:

```diff
-localhost:8002/alpine:latest
+localhost:8002/alpine:latest
```

digest:

```diff
-localhost:8002/sha256:abcdef
+localhost:8002/alpine@sha256:abcdef
```

---

Before:

![20221120041516](https://user-images.githubusercontent.com/289743/202885457-f9890535-dab3-4a6c-bde0-43d254549349.png)

url-decoded urls in "use in controller":
`https://test.example.com/#/execution_environments/add?image=localhost:8002/remotepine:3.15`
`https://test.example.com/#/execution_environments/add?image=localhost:8002/sha256:cf34c62ee8eb3fe8aa24c1fab45d7e9d12768d945c3f5a6fd6a63d901e898479`

After:
![20221120041537](https://user-images.githubusercontent.com/289743/202885461-4df4b52f-4525-4eeb-a966-967be3e634e8.png)

url-decoded urls in "use in controller":
`https://test.example.com/#/execution_environments/add?image=localhost:8002/remotepine:3.15`
`https://test.example.com/#/execution_environments/add?image=localhost:8002/remotepine@sha256:cf34c62ee8eb3fe8aa24c1fab45d7e9d12768d945c3f5a6fd6a63d901e898479`