### PR TITLE
Insights tests - add uiPrefix, rename prefix to apiPrefix

### DIFF
--- a/.github/workflows/cypress/cypress.env.json.insights
+++ b/.github/workflows/cypress/cypress.env.json.insights
@@ -1,6 +1,6 @@
 {
-  "prefix": "/api/automation-hub/",
-  "pulpPrefix": "/api/automation-hub/pulp/api/v3/",
+  "apiPrefix": "/api/automation-hub/",
+  "uiPrefix": "/beta/ansible/automation-hub/",
   "username": "admin",
   "password": "admin",
   "galaxykit": "galaxykit --ignore-certs --auth-url 'http://localhost:8002/auth/realms/redhat-external/protocol/openid-connect/token'"

--- a/.github/workflows/cypress/cypress.env.json.insights
+++ b/.github/workflows/cypress/cypress.env.json.insights
@@ -1,5 +1,6 @@
 {
   "apiPrefix": "/api/automation-hub/",
+  "pulpPrefix": "/api/automation-hub/pulp/api/v3/",
   "uiPrefix": "/beta/ansible/automation-hub/",
   "username": "admin",
   "password": "admin",

--- a/.github/workflows/cypress/cypress.env.json.standalone
+++ b/.github/workflows/cypress/cypress.env.json.standalone
@@ -1,5 +1,6 @@
 {
   "apiPrefix": "/api/galaxy/",
+  "pulpPrefix": "/api/galaxy/pulp/api/v3/",
   "uiPrefix": "/ui/",
   "username": "admin",
   "password": "admin",

--- a/.github/workflows/cypress/cypress.env.json.standalone
+++ b/.github/workflows/cypress/cypress.env.json.standalone
@@ -1,6 +1,6 @@
 {
-  "prefix": "/api/galaxy/",
-  "pulpPrefix": "/api/galaxy/pulp/api/v3/",
+  "apiPrefix": "/api/galaxy/",
+  "uiPrefix": "/ui/",
   "username": "admin",
   "password": "admin",
   "settings": "../../pulp_galaxy_ng/settings/settings.py",

--- a/test/README.md
+++ b/test/README.md
@@ -38,6 +38,7 @@ The tests need to know details about the instance of Automation Hub that it's ru
 
     {
         "apiPrefix": "<api root>",
+        "pulpPrefix": "<pulp api root>",
         "uiPrefix": "<ui base path>",
         "username": "<your username here>",
         "password": "<your password here>",

--- a/test/README.md
+++ b/test/README.md
@@ -37,13 +37,14 @@ These are separate from the project's own dependencies. Run the following from t
 The tests need to know details about the instance of Automation Hub that it's running against. Create a file named `cypress.env.json` in the test/ directory, and use the below example as a template or start by copying `cypress.env.json.template`.
 
     {
-        "baseUrl": "http://localhost:8002/",
-        "prefix": "<api root>",
+        "apiPrefix": "<api root>",
+        "uiPrefix": "<ui base path>",
         "username": "<your username here>",
         "password": "<your password here>",
-        "settings": "../../galaxy_ng/galaxy_ng/app/settings.py",
-        "restart": "true",
-        "containers": "localhost:5001"
+        "settings": "<path to galaxy_ng settings.py>",
+        "restart": "<command to call to apply settings change>",
+        "containers": "<container push target>",
+        "galaxykit": "<galaxykit command>"
     }
 
 *note*: the api root for the docker development environment of ansible/galaxy\_ng is `/api/automation-hub/`, while pulp-oci-images uses `/api/galaxy/`.

--- a/test/cypress.env.json.template
+++ b/test/cypress.env.json.template
@@ -1,6 +1,6 @@
 {
-  "prefix": "/api/automation-hub/",
-  "pulpPrefix": "/api/automation-hub/pulp/api/v3/",
+  "apiPrefix": "/api/automation-hub/",
+  "uiPrefix": "/ui/",
   "username": "admin",
   "password": "admin",
   "settings": "../../galaxy_ng/galaxy_ng/app/settings.py",

--- a/test/cypress.env.json.template
+++ b/test/cypress.env.json.template
@@ -1,5 +1,6 @@
 {
   "apiPrefix": "/api/automation-hub/",
+  "pulpPrefix": "/api/automation-hub/pulp/api/v3/",
   "uiPrefix": "/ui/",
   "username": "admin",
   "password": "admin",

--- a/test/cypress/e2e/approval/approval_dashboard_list.js
+++ b/test/cypress/e2e/approval/approval_dashboard_list.js
@@ -31,11 +31,9 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
   function loadData() {
     // we cant delete all data using galaxykit right now, because when collection is rejected
     // it cant be deleted. So we must load the data, that are right now in the table
-    let intercept_url =
-      apiPrefix +
-      '_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=100';
+    let intercept_url = `${apiPrefix}_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=100`;
 
-    cy.visit(uiPrefix + 'approval-dashboard?page_size=100');
+    cy.visit(`${uiPrefix}approval-dashboard?page_size=100`);
     cy.intercept('GET', intercept_url).as('data');
     cy.contains('button', 'Clear all filters').click();
 
@@ -61,7 +59,7 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
 
   beforeEach(() => {
     cy.login();
-    cy.visit(uiPrefix + 'approval-dashboard');
+    cy.visit(`${uiPrefix}approval-dashboard`);
     cy.contains('button', 'Clear all filters').click();
   });
 

--- a/test/cypress/e2e/approval/approval_dashboard_list.js
+++ b/test/cypress/e2e/approval/approval_dashboard_list.js
@@ -1,5 +1,7 @@
 import { range, sortBy } from 'lodash';
 
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Approval Dashboard list tests for sorting, paging and filtering', () => {
   let items = [];
 
@@ -29,7 +31,7 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
     // we cant delete all data using galaxykit right now, because when collection is rejected
     // it cant be deleted. So we must load the data, that are right now in the table
     let intercept_url =
-      Cypress.env('prefix') +
+      apiPrefix +
       '_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=100';
 
     cy.visit('/ui/approval-dashboard?page_size=100');

--- a/test/cypress/e2e/approval/approval_dashboard_list.js
+++ b/test/cypress/e2e/approval/approval_dashboard_list.js
@@ -1,6 +1,7 @@
 import { range, sortBy } from 'lodash';
 
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Approval Dashboard list tests for sorting, paging and filtering', () => {
   let items = [];
@@ -34,7 +35,7 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
       apiPrefix +
       '_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=100';
 
-    cy.visit('/ui/approval-dashboard?page_size=100');
+    cy.visit(uiPrefix + 'approval-dashboard?page_size=100');
     cy.intercept('GET', intercept_url).as('data');
     cy.contains('button', 'Clear all filters').click();
 
@@ -60,7 +61,7 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
 
   beforeEach(() => {
     cy.login();
-    cy.visit('/ui/approval-dashboard');
+    cy.visit(uiPrefix + 'approval-dashboard');
     cy.contains('button', 'Clear all filters').click();
   });
 

--- a/test/cypress/e2e/approval/approval_process.js
+++ b/test/cypress/e2e/approval/approval_process.js
@@ -19,27 +19,27 @@ describe('Approval Dashboard process', () => {
   });
 
   it('should test the whole approval process.', () => {
-    cy.visit(uiPrefix + 'repo/published');
+    cy.visit(`${uiPrefix}repo/published`);
     cy.contains('No collections yet');
 
     // should approve
-    cy.visit(uiPrefix + 'approval-dashboard');
+    cy.visit(`${uiPrefix}approval-dashboard`);
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Needs review');
     cy.contains(
       '[data-cy="CertificationDashboard-row"] button',
       'Approve',
     ).click();
     cy.contains('.body', 'No results found', { timeout: 8000 });
-    cy.visit(uiPrefix + 'approval-dashboard');
+    cy.visit(`${uiPrefix}approval-dashboard`);
     cy.contains('button', 'Clear all filters').click();
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Approved');
 
     // should see item in collections
-    cy.visit(uiPrefix + 'repo/published?page_size=100');
+    cy.visit(`${uiPrefix}repo/published?page_size=100`);
     cy.contains('.collection-container', 'appp_c_test1');
 
     // should reject
-    cy.visit(uiPrefix + 'approval-dashboard');
+    cy.visit(`${uiPrefix}approval-dashboard`);
     cy.contains('button', 'Clear all filters').click();
     cy.get('[data-cy="kebab-toggle"]:first button[aria-label="Actions"]').click(
       { force: true },
@@ -48,7 +48,7 @@ describe('Approval Dashboard process', () => {
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Rejected');
 
     // should not see items in collections
-    cy.visit(uiPrefix + 'repo/published');
+    cy.visit(`${uiPrefix}repo/published`);
     cy.contains('No collections yet');
   });
 });

--- a/test/cypress/e2e/approval/approval_process.js
+++ b/test/cypress/e2e/approval/approval_process.js
@@ -1,3 +1,5 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('Approval Dashboard process', () => {
   before(() => {
     cy.settings({ GALAXY_REQUIRE_CONTENT_APPROVAL: true });
@@ -17,27 +19,27 @@ describe('Approval Dashboard process', () => {
   });
 
   it('should test the whole approval process.', () => {
-    cy.visit('/ui/repo/published');
+    cy.visit(uiPrefix + 'repo/published');
     cy.contains('No collections yet');
 
     // should approve
-    cy.visit('/ui/approval-dashboard');
+    cy.visit(uiPrefix + 'approval-dashboard');
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Needs review');
     cy.contains(
       '[data-cy="CertificationDashboard-row"] button',
       'Approve',
     ).click();
     cy.contains('.body', 'No results found', { timeout: 8000 });
-    cy.visit('/ui/approval-dashboard');
+    cy.visit(uiPrefix + 'approval-dashboard');
     cy.contains('button', 'Clear all filters').click();
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Approved');
 
     // should see item in collections
-    cy.visit('/ui/repo/published?page_size=100');
+    cy.visit(uiPrefix + 'repo/published?page_size=100');
     cy.contains('.collection-container', 'appp_c_test1');
 
     // should reject
-    cy.visit('/ui/approval-dashboard');
+    cy.visit(uiPrefix + 'approval-dashboard');
     cy.contains('button', 'Clear all filters').click();
     cy.get('[data-cy="kebab-toggle"]:first button[aria-label="Actions"]').click(
       { force: true },
@@ -46,7 +48,7 @@ describe('Approval Dashboard process', () => {
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Rejected');
 
     // should not see items in collections
-    cy.visit('/ui/repo/published');
+    cy.visit(uiPrefix + 'repo/published');
     cy.contains('No collections yet');
   });
 });

--- a/test/cypress/e2e/approval/collection_approval.js
+++ b/test/cypress/e2e/approval/collection_approval.js
@@ -1,4 +1,5 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('tests the approval list screen ', () => {
   before(() => {
@@ -11,7 +12,7 @@ describe('tests the approval list screen ', () => {
     cy.deleteNamespacesAndCollections();
     cy.galaxykit('-i namespace create', 'ansible');
     cy.galaxykit('-i collection upload ansible network');
-    cy.visit('/ui/approval-dashboard');
+    cy.visit(uiPrefix + 'approval-dashboard');
   });
 
   after(() => {

--- a/test/cypress/e2e/approval/collection_approval.js
+++ b/test/cypress/e2e/approval/collection_approval.js
@@ -12,7 +12,7 @@ describe('tests the approval list screen ', () => {
     cy.deleteNamespacesAndCollections();
     cy.galaxykit('-i namespace create', 'ansible');
     cy.galaxykit('-i collection upload ansible network');
-    cy.visit(uiPrefix + 'approval-dashboard');
+    cy.visit(`${uiPrefix}approval-dashboard`);
   });
 
   after(() => {
@@ -26,8 +26,7 @@ describe('tests the approval list screen ', () => {
   it('rejects certification status and approves it again', () => {
     cy.intercept(
       'GET',
-      apiPrefix +
-        '_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=10',
+      `${apiPrefix}_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=10`,
     ).as('reload');
     cy.get('.pf-c-chip > button[aria-label="close"]').click();
     cy.wait('@reload');
@@ -52,8 +51,7 @@ describe('tests the approval list screen ', () => {
   it('view the imports logs', () => {
     cy.intercept(
       'GET',
-      apiPrefix +
-        '_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=10',
+      `${apiPrefix}_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=10`,
     ).as('reload');
     cy.get('.pf-c-chip > button[aria-label="close"]').click();
     cy.wait('@reload');
@@ -63,8 +61,7 @@ describe('tests the approval list screen ', () => {
     cy.get('button[aria-label="Actions"]:first').click();
     cy.intercept(
       'GET',
-      apiPrefix +
-        '_ui/v1/imports/collections/?namespace=ansible&name=network&version=1.0.0&sort=-created&offset=0&limit=10',
+      `${apiPrefix}_ui/v1/imports/collections/?namespace=ansible&name=network&version=1.0.0&sort=-created&offset=0&limit=10`,
     ).as('imports');
     cy.contains('View Import Logs').click();
     cy.wait('@imports');

--- a/test/cypress/e2e/approval/collection_approval.js
+++ b/test/cypress/e2e/approval/collection_approval.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('tests the approval list screen ', () => {
   before(() => {
     cy.settings({
@@ -23,7 +25,7 @@ describe('tests the approval list screen ', () => {
   it('rejects certification status and approves it again', () => {
     cy.intercept(
       'GET',
-      Cypress.env('prefix') +
+      apiPrefix +
         '_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=10',
     ).as('reload');
     cy.get('.pf-c-chip > button[aria-label="close"]').click();
@@ -49,7 +51,7 @@ describe('tests the approval list screen ', () => {
   it('view the imports logs', () => {
     cy.intercept(
       'GET',
-      Cypress.env('prefix') +
+      apiPrefix +
         '_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=10',
     ).as('reload');
     cy.get('.pf-c-chip > button[aria-label="close"]').click();
@@ -60,7 +62,7 @@ describe('tests the approval list screen ', () => {
     cy.get('button[aria-label="Actions"]:first').click();
     cy.intercept(
       'GET',
-      Cypress.env('prefix') +
+      apiPrefix +
         '_ui/v1/imports/collections/?namespace=ansible&name=network&version=1.0.0&sort=-created&offset=0&limit=10',
     ).as('imports');
     cy.contains('View Import Logs').click();

--- a/test/cypress/e2e/collections/collection.js
+++ b/test/cypress/e2e/collections/collection.js
@@ -25,7 +25,7 @@ describe('collection tests', () => {
 
   it('deletes an entire collection', () => {
     cy.galaxykit('-i collection upload test_namespace test_collection');
-    cy.visit(uiPrefix + 'repo/published/test_namespace/test_collection');
+    cy.visit(`${uiPrefix}repo/published/test_namespace/test_collection`);
 
     cy.get('[data-cy=kebab-toggle]').click();
     cy.get('[data-cy=delete-collection-dropdown]').click();
@@ -33,10 +33,9 @@ describe('collection tests', () => {
 
     cy.intercept(
       'DELETE',
-      apiPrefix +
-        'v3/plugin/ansible/content/published/collections/index/test_namespace/test_collection',
+      `${apiPrefix}v3/plugin/ansible/content/published/collections/index/test_namespace/test_collection`,
     ).as('deleteCollection');
-    cy.intercept('GET', apiPrefix + 'v3/tasks/*').as('taskStatus');
+    cy.intercept('GET', `${apiPrefix}v3/tasks/*`).as('taskStatus');
 
     cy.get('button').contains('Delete').click();
 
@@ -54,7 +53,7 @@ describe('collection tests', () => {
   it('deletes a collection version', () => {
     cy.galaxykit('-i collection upload my_namespace my_collection');
     cy.menuGo('Collections > Collections');
-    cy.intercept('GET', apiPrefix + '_ui/v1/namespaces/my_namespace/?*').as(
+    cy.intercept('GET', `${apiPrefix}_ui/v1/namespaces/my_namespace/?*`).as(
       'reload',
     );
     cy.get(

--- a/test/cypress/e2e/collections/collection.js
+++ b/test/cypress/e2e/collections/collection.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 const waitForTaskToFinish = (task, maxRequests, level = 0) => {
   if (level === maxRequests) {
     throw `Maximum requests exceeded.`;
@@ -30,10 +32,10 @@ describe('collection tests', () => {
 
     cy.intercept(
       'DELETE',
-      Cypress.env('prefix') +
+      apiPrefix +
         'v3/plugin/ansible/content/published/collections/index/test_namespace/test_collection',
     ).as('deleteCollection');
-    cy.intercept('GET', Cypress.env('prefix') + '/v3/tasks/*').as('taskStatus');
+    cy.intercept('GET', apiPrefix + '/v3/tasks/*').as('taskStatus');
 
     cy.get('button').contains('Delete').click();
 
@@ -51,10 +53,9 @@ describe('collection tests', () => {
   it('deletes a collection version', () => {
     cy.galaxykit('-i collection upload my_namespace my_collection');
     cy.menuGo('Collections > Collections');
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') + '_ui/v1/namespaces/my_namespace/?*',
-    ).as('reload');
+    cy.intercept('GET', apiPrefix + '_ui/v1/namespaces/my_namespace/?*').as(
+      'reload',
+    );
     cy.get('a[href*="ui/repo/published/my_namespace/my_collection"]').click();
     cy.get('[data-cy=kebab-toggle]').click();
     cy.get('[data-cy=delete-version-dropdown]').click();

--- a/test/cypress/e2e/collections/collection.js
+++ b/test/cypress/e2e/collections/collection.js
@@ -1,4 +1,5 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 const waitForTaskToFinish = (task, maxRequests, level = 0) => {
   if (level === maxRequests) {
@@ -24,7 +25,7 @@ describe('collection tests', () => {
 
   it('deletes an entire collection', () => {
     cy.galaxykit('-i collection upload test_namespace test_collection');
-    cy.visit('/ui/repo/published/test_namespace/test_collection');
+    cy.visit(uiPrefix + 'repo/published/test_namespace/test_collection');
 
     cy.get('[data-cy=kebab-toggle]').click();
     cy.get('[data-cy=delete-collection-dropdown]').click();
@@ -35,7 +36,7 @@ describe('collection tests', () => {
       apiPrefix +
         'v3/plugin/ansible/content/published/collections/index/test_namespace/test_collection',
     ).as('deleteCollection');
-    cy.intercept('GET', apiPrefix + '/v3/tasks/*').as('taskStatus');
+    cy.intercept('GET', apiPrefix + 'v3/tasks/*').as('taskStatus');
 
     cy.get('button').contains('Delete').click();
 
@@ -56,7 +57,9 @@ describe('collection tests', () => {
     cy.intercept('GET', apiPrefix + '_ui/v1/namespaces/my_namespace/?*').as(
       'reload',
     );
-    cy.get('a[href*="ui/repo/published/my_namespace/my_collection"]').click();
+    cy.get(
+      `a[href*="${uiPrefix}repo/published/my_namespace/my_collection"]`,
+    ).click();
     cy.get('[data-cy=kebab-toggle]').click();
     cy.get('[data-cy=delete-version-dropdown]').click();
     cy.get('input[id=delete_confirm]').click();

--- a/test/cypress/e2e/collections/collection_detail.js
+++ b/test/cypress/e2e/collections/collection_detail.js
@@ -1,6 +1,9 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('Collection detail', () => {
   const baseURL =
-    '/ui/repo/published/collection_detail_test_namespace/collection_detail_test_collection';
+    uiPrefix +
+    'repo/published/collection_detail_test_namespace/collection_detail_test_collection';
 
   function deprecate() {
     cy.get('[aria-label=Actions]').click();
@@ -104,7 +107,7 @@ describe('Collection detail', () => {
     cy.get('.body').contains('Installation');
 
     cy.get('.body').contains(
-      'a[href="/ui/repo/published/collection_detail_test_namespace/collection_detail_test_collection/docs/"]',
+      `a[href="${uiPrefix}repo/published/collection_detail_test_namespace/collection_detail_test_collection/docs/"]`,
       'Go to documentation',
     );
 

--- a/test/cypress/e2e/collections/collection_detail.js
+++ b/test/cypress/e2e/collections/collection_detail.js
@@ -1,9 +1,7 @@
 const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Collection detail', () => {
-  const baseURL =
-    uiPrefix +
-    'repo/published/collection_detail_test_namespace/collection_detail_test_collection';
+  const baseURL = `${uiPrefix}repo/published/collection_detail_test_namespace/collection_detail_test_collection`;
 
   function deprecate() {
     cy.get('[aria-label=Actions]').click();

--- a/test/cypress/e2e/collections/collection_upload.js
+++ b/test/cypress/e2e/collections/collection_upload.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Collection Upload Tests', () => {
   const userName = 'testUser';
   const userPassword = 'I am a complicated passw0rd';
@@ -74,13 +76,11 @@ describe('Collection Upload Tests', () => {
   it('user should not be able to upload new collection without permissions', () => {
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
+      apiPrefix + '_ui/v1/collection-versions/?namespace=*',
     ).as('upload');
     cy.galaxykit('-i namespace create', 'ansible');
     cy.menuGo('Collections > Namespaces');
-    cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/repo/published/*').as(
-      'namespaces',
-    );
+    cy.intercept('GET', apiPrefix + '_ui/v1/repo/published/*').as('namespaces');
 
     cy.get('a[href="/ui/repo/published/ansible/"]').click();
     cy.wait('@namespaces');
@@ -91,13 +91,11 @@ describe('Collection Upload Tests', () => {
     cy.login();
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
+      apiPrefix + '_ui/v1/collection-versions/?namespace=*',
     ).as('upload');
     cy.galaxykit('-i namespace create', 'ansible');
     cy.menuGo('Collections > Namespaces');
-    cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/repo/published/*').as(
-      'namespaces',
-    );
+    cy.intercept('GET', apiPrefix + '_ui/v1/repo/published/*').as('namespaces');
 
     cy.get('a[href="/ui/repo/published/ansible/"]').click();
     cy.wait('@namespaces');

--- a/test/cypress/e2e/collections/collection_upload.js
+++ b/test/cypress/e2e/collections/collection_upload.js
@@ -1,4 +1,5 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Collection Upload Tests', () => {
   const userName = 'testUser';
@@ -20,7 +21,8 @@ describe('Collection Upload Tests', () => {
 
   it('should not upload new collection version in collection list when user does not have permissions', () => {
     cy.visit(
-      '/ui/repo/published?page_size=10&view_type=list&keywords=testcollection',
+      uiPrefix +
+        'repo/published?page_size=10&view_type=list&keywords=testcollection',
     );
     cy.contains('testcollection');
     cy.contains('Upload new version').click();
@@ -29,7 +31,8 @@ describe('Collection Upload Tests', () => {
 
   it('should not upload new collection version in collection list/cards when user does not have permissions', () => {
     cy.visit(
-      '/ui/repo/published?page_size=10&view_type=card&keywords=testcollection',
+      uiPrefix +
+        'repo/published?page_size=10&view_type=card&keywords=testcollection',
     );
     cy.contains('testcollection');
     cy.get('[aria-label=Actions]').click();
@@ -38,7 +41,7 @@ describe('Collection Upload Tests', () => {
   });
 
   it('should not upload new collection version in collection detail when user does not have permissions', () => {
-    cy.visit('/ui/repo/published/testspace/testcollection');
+    cy.visit(uiPrefix + 'repo/published/testspace/testcollection');
     cy.contains('testcollection');
     cy.get('button[aria-label=Actions]').click();
     cy.contains('Upload new version').click();
@@ -49,14 +52,16 @@ describe('Collection Upload Tests', () => {
     cy.login();
 
     cy.visit(
-      '/ui/repo/published?page_size=10&view_type=list&keywords=testcollection',
+      uiPrefix +
+        'repo/published?page_size=10&view_type=list&keywords=testcollection',
     );
     cy.contains('testcollection');
     cy.contains('Upload new version').click();
     cy.contains('New version of testcollection');
 
     cy.visit(
-      '/ui/repo/published?page_size=10&view_type=card&keywords=testcollection',
+      uiPrefix +
+        'repo/published?page_size=10&view_type=card&keywords=testcollection',
     );
     cy.contains('testcollection');
     cy.get('button[aria-label=Actions]').click();
@@ -66,7 +71,7 @@ describe('Collection Upload Tests', () => {
 
   it('should see upload new collection version in collection detail when user does have permissions', () => {
     cy.login();
-    cy.visit('/ui/repo/published/testspace/testcollection');
+    cy.visit(uiPrefix + 'repo/published/testspace/testcollection');
     cy.contains('testcollection');
     cy.get('button[aria-label=Actions]').click();
     cy.contains('Upload new version').click();
@@ -82,7 +87,7 @@ describe('Collection Upload Tests', () => {
     cy.menuGo('Collections > Namespaces');
     cy.intercept('GET', apiPrefix + '_ui/v1/repo/published/*').as('namespaces');
 
-    cy.get('a[href="/ui/repo/published/ansible/"]').click();
+    cy.get(`a[href="${uiPrefix}repo/published/ansible/"]`).click();
     cy.wait('@namespaces');
     cy.contains('Upload collection').should('not.exist');
   });
@@ -97,7 +102,7 @@ describe('Collection Upload Tests', () => {
     cy.menuGo('Collections > Namespaces');
     cy.intercept('GET', apiPrefix + '_ui/v1/repo/published/*').as('namespaces');
 
-    cy.get('a[href="/ui/repo/published/ansible/"]').click();
+    cy.get(`a[href="${uiPrefix}repo/published/ansible/"]`).click();
     cy.wait('@namespaces');
     cy.contains('Upload collection').click();
     cy.fixture('collections/ansible-posix-1.4.0.tar.gz', 'binary')
@@ -119,7 +124,7 @@ describe('Collection Upload Tests', () => {
   });
 
   it('should not upload new collection version when user does not have permissions', () => {
-    cy.visit('/ui/repo/published/testspace');
+    cy.visit(uiPrefix + 'repo/published/testspace');
 
     cy.get('[data-cy="CollectionList-name"]').contains('testcollection');
     cy.contains('Upload new version').should('not.exist');
@@ -127,16 +132,16 @@ describe('Collection Upload Tests', () => {
 
   it('should deprecate let user deprecate and undeprecate collections', () => {
     cy.login();
-    cy.visit('/ui/repo/published/testspace');
+    cy.visit(uiPrefix + 'repo/published/testspace');
     cy.get('[aria-label=collection-kebab]').first().click();
     cy.contains('Deprecate').click();
-    cy.visit('/ui/repo/published/testspace');
+    cy.visit(uiPrefix + 'repo/published/testspace');
     cy.contains('DEPRECATED');
 
-    cy.visit('/ui/repo/published/testspace');
+    cy.visit(uiPrefix + 'repo/published/testspace');
     cy.get('[aria-label=collection-kebab]').first().click();
     cy.contains('Undeprecate').click();
-    cy.visit('/ui/repo/published/testspace');
+    cy.visit(uiPrefix + 'repo/published/testspace');
     cy.contains('DEPRECATED').should('not.exist');
   });
 });

--- a/test/cypress/e2e/collections/collection_upload.js
+++ b/test/cypress/e2e/collections/collection_upload.js
@@ -21,8 +21,7 @@ describe('Collection Upload Tests', () => {
 
   it('should not upload new collection version in collection list when user does not have permissions', () => {
     cy.visit(
-      uiPrefix +
-        'repo/published?page_size=10&view_type=list&keywords=testcollection',
+      `${uiPrefix}repo/published?page_size=10&view_type=list&keywords=testcollection`,
     );
     cy.contains('testcollection');
     cy.contains('Upload new version').click();
@@ -31,8 +30,7 @@ describe('Collection Upload Tests', () => {
 
   it('should not upload new collection version in collection list/cards when user does not have permissions', () => {
     cy.visit(
-      uiPrefix +
-        'repo/published?page_size=10&view_type=card&keywords=testcollection',
+      `${uiPrefix}repo/published?page_size=10&view_type=card&keywords=testcollection`,
     );
     cy.contains('testcollection');
     cy.get('[aria-label=Actions]').click();
@@ -41,7 +39,7 @@ describe('Collection Upload Tests', () => {
   });
 
   it('should not upload new collection version in collection detail when user does not have permissions', () => {
-    cy.visit(uiPrefix + 'repo/published/testspace/testcollection');
+    cy.visit(`${uiPrefix}repo/published/testspace/testcollection`);
     cy.contains('testcollection');
     cy.get('button[aria-label=Actions]').click();
     cy.contains('Upload new version').click();
@@ -52,16 +50,14 @@ describe('Collection Upload Tests', () => {
     cy.login();
 
     cy.visit(
-      uiPrefix +
-        'repo/published?page_size=10&view_type=list&keywords=testcollection',
+      `${uiPrefix}repo/published?page_size=10&view_type=list&keywords=testcollection`,
     );
     cy.contains('testcollection');
     cy.contains('Upload new version').click();
     cy.contains('New version of testcollection');
 
     cy.visit(
-      uiPrefix +
-        'repo/published?page_size=10&view_type=card&keywords=testcollection',
+      `${uiPrefix}repo/published?page_size=10&view_type=card&keywords=testcollection`,
     );
     cy.contains('testcollection');
     cy.get('button[aria-label=Actions]').click();
@@ -71,7 +67,7 @@ describe('Collection Upload Tests', () => {
 
   it('should see upload new collection version in collection detail when user does have permissions', () => {
     cy.login();
-    cy.visit(uiPrefix + 'repo/published/testspace/testcollection');
+    cy.visit(`${uiPrefix}repo/published/testspace/testcollection`);
     cy.contains('testcollection');
     cy.get('button[aria-label=Actions]').click();
     cy.contains('Upload new version').click();
@@ -81,11 +77,11 @@ describe('Collection Upload Tests', () => {
   it('user should not be able to upload new collection without permissions', () => {
     cy.intercept(
       'GET',
-      apiPrefix + '_ui/v1/collection-versions/?namespace=*',
+      `${apiPrefix}_ui/v1/collection-versions/?namespace=*`,
     ).as('upload');
     cy.galaxykit('-i namespace create', 'ansible');
     cy.menuGo('Collections > Namespaces');
-    cy.intercept('GET', apiPrefix + '_ui/v1/repo/published/*').as('namespaces');
+    cy.intercept('GET', `${apiPrefix}_ui/v1/repo/published/*`).as('namespaces');
 
     cy.get(`a[href="${uiPrefix}repo/published/ansible/"]`).click();
     cy.wait('@namespaces');
@@ -96,11 +92,11 @@ describe('Collection Upload Tests', () => {
     cy.login();
     cy.intercept(
       'GET',
-      apiPrefix + '_ui/v1/collection-versions/?namespace=*',
+      `${apiPrefix}_ui/v1/collection-versions/?namespace=*`,
     ).as('upload');
     cy.galaxykit('-i namespace create', 'ansible');
     cy.menuGo('Collections > Namespaces');
-    cy.intercept('GET', apiPrefix + '_ui/v1/repo/published/*').as('namespaces');
+    cy.intercept('GET', `${apiPrefix}_ui/v1/repo/published/*`).as('namespaces');
 
     cy.get(`a[href="${uiPrefix}repo/published/ansible/"]`).click();
     cy.wait('@namespaces');
@@ -124,7 +120,7 @@ describe('Collection Upload Tests', () => {
   });
 
   it('should not upload new collection version when user does not have permissions', () => {
-    cy.visit(uiPrefix + 'repo/published/testspace');
+    cy.visit(`${uiPrefix}repo/published/testspace`);
 
     cy.get('[data-cy="CollectionList-name"]').contains('testcollection');
     cy.contains('Upload new version').should('not.exist');
@@ -132,16 +128,16 @@ describe('Collection Upload Tests', () => {
 
   it('should deprecate let user deprecate and undeprecate collections', () => {
     cy.login();
-    cy.visit(uiPrefix + 'repo/published/testspace');
+    cy.visit(`${uiPrefix}repo/published/testspace`);
     cy.get('[aria-label=collection-kebab]').first().click();
     cy.contains('Deprecate').click();
-    cy.visit(uiPrefix + 'repo/published/testspace');
+    cy.visit(`${uiPrefix}repo/published/testspace`);
     cy.contains('DEPRECATED');
 
-    cy.visit(uiPrefix + 'repo/published/testspace');
+    cy.visit(`${uiPrefix}repo/published/testspace`);
     cy.get('[aria-label=collection-kebab]').first().click();
     cy.contains('Undeprecate').click();
-    cy.visit(uiPrefix + 'repo/published/testspace');
+    cy.visit(`${uiPrefix}repo/published/testspace`);
     cy.contains('DEPRECATED').should('not.exist');
   });
 });

--- a/test/cypress/e2e/collections/collections_list.js
+++ b/test/cypress/e2e/collections/collections_list.js
@@ -1,6 +1,7 @@
 import { range } from 'lodash';
 
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Collections list Tests', () => {
   function deprecate(list) {
@@ -18,7 +19,7 @@ describe('Collections list Tests', () => {
   }
 
   function undeprecate() {
-    cy.visit('/ui/repo/published/my_namespace/my_collection0');
+    cy.visit(uiPrefix + 'repo/published/my_namespace/my_collection0');
     cy.contains('This collection has been deprecated.');
     cy.get('[aria-label=Actions]').click();
     cy.contains('Undeprecate').click();
@@ -59,7 +60,7 @@ describe('Collections list Tests', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit('/ui/repo/published');
+    cy.visit(uiPrefix + 'repo/published');
     cy.contains('Collections');
   });
 
@@ -156,7 +157,7 @@ describe('Collections list Tests', () => {
   });
 
   it('Can delete collection in namespace collection list', () => {
-    cy.visit('/ui/repo/published/my_namespace');
+    cy.visit(uiPrefix + 'repo/published/my_namespace');
     cy.get('.toolbar')
       .get('[aria-label="keywords"]:first')
       .type('my_collection1{enter}');

--- a/test/cypress/e2e/collections/collections_list.js
+++ b/test/cypress/e2e/collections/collections_list.js
@@ -19,7 +19,7 @@ describe('Collections list Tests', () => {
   }
 
   function undeprecate() {
-    cy.visit(uiPrefix + 'repo/published/my_namespace/my_collection0');
+    cy.visit(`${uiPrefix}repo/published/my_namespace/my_collection0`);
     cy.contains('This collection has been deprecated.');
     cy.get('[aria-label=Actions]').click();
     cy.contains('Undeprecate').click();
@@ -32,9 +32,7 @@ describe('Collections list Tests', () => {
     // undeprecate collection if deprecated from previous repeated run (otherwise, tests fails)
     // that is because when you deprecate, delete collection and upload it again, the collection
     // stays deprecated
-    let request_url =
-      apiPrefix +
-      '_ui/v1/repo/published/?limit=1&name=my_collection0&offset=0"';
+    let request_url = `${apiPrefix}_ui/v1/repo/published/?limit=1&name=my_collection0&offset=0"`;
 
     cy.request(request_url).then((data) => {
       const deprecated = data.body.data[0].deprecated;
@@ -60,7 +58,7 @@ describe('Collections list Tests', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit(uiPrefix + 'repo/published');
+    cy.visit(`${uiPrefix}repo/published`);
     cy.contains('Collections');
   });
 
@@ -157,7 +155,7 @@ describe('Collections list Tests', () => {
   });
 
   it('Can delete collection in namespace collection list', () => {
-    cy.visit(uiPrefix + 'repo/published/my_namespace');
+    cy.visit(`${uiPrefix}repo/published/my_namespace`);
     cy.get('.toolbar')
       .get('[aria-label="keywords"]:first')
       .type('my_collection1{enter}');

--- a/test/cypress/e2e/collections/collections_list.js
+++ b/test/cypress/e2e/collections/collections_list.js
@@ -1,5 +1,7 @@
 import { range } from 'lodash';
 
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Collections list Tests', () => {
   function deprecate(list) {
     const container = list ? '.hub-list' : '.hub-cards';
@@ -30,7 +32,7 @@ describe('Collections list Tests', () => {
     // that is because when you deprecate, delete collection and upload it again, the collection
     // stays deprecated
     let request_url =
-      Cypress.env('prefix') +
+      apiPrefix +
       '_ui/v1/repo/published/?limit=1&name=my_collection0&offset=0"';
 
     cy.request(request_url).then((data) => {

--- a/test/cypress/e2e/execution_environments/execution_environments_use_in_controller.js
+++ b/test/cypress/e2e/execution_environments/execution_environments_use_in_controller.js
@@ -1,3 +1,5 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('Execution Environments - Use in Controller', () => {
   let num = (~~(Math.random() * 1000000)).toString(); // FIXME: maybe drop everywhere once AAH-1095 is fixed
 
@@ -21,7 +23,7 @@ describe('Execution Environments - Use in Controller', () => {
       include_tags: 'latest',
     });
 
-    cy.visit('/ui/containers/');
+    cy.visit(uiPrefix + 'containers/');
     cy.contains('.body', `remotepine${num}`, { timeout: 10000 });
 
     cy.syncRemoteContainer(`remotepine${num}`);

--- a/test/cypress/e2e/execution_environments/execution_environments_use_in_controller.js
+++ b/test/cypress/e2e/execution_environments/execution_environments_use_in_controller.js
@@ -23,7 +23,7 @@ describe('Execution Environments - Use in Controller', () => {
       include_tags: 'latest',
     });
 
-    cy.visit(uiPrefix + 'containers/');
+    cy.visit(`${uiPrefix}containers/`);
     cy.contains('.body', `remotepine${num}`, { timeout: 10000 });
 
     cy.syncRemoteContainer(`remotepine${num}`);

--- a/test/cypress/e2e/groups_and_users/group_list.js
+++ b/test/cypress/e2e/groups_and_users/group_list.js
@@ -1,5 +1,7 @@
 import { range, sortBy } from 'lodash';
 
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('Group list tests for sorting, paging and filtering', () => {
   let items = [];
 
@@ -20,7 +22,7 @@ describe('Group list tests for sorting, paging and filtering', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit('/ui/group-list');
+    cy.visit(uiPrefix + 'group-list');
   });
 
   it('table contains all columns', () => {

--- a/test/cypress/e2e/groups_and_users/group_list.js
+++ b/test/cypress/e2e/groups_and_users/group_list.js
@@ -22,7 +22,7 @@ describe('Group list tests for sorting, paging and filtering', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit(uiPrefix + 'group-list');
+    cy.visit(`${uiPrefix}group-list`);
   });
 
   it('table contains all columns', () => {

--- a/test/cypress/e2e/groups_and_users/group_management.js
+++ b/test/cypress/e2e/groups_and_users/group_management.js
@@ -50,7 +50,7 @@ describe('Hub Group Management Tests', () => {
     cy.createRole(roleName, 'This role has all galaxy perms', [], true);
 
     // add role to group manually
-    cy.intercept('GET', apiPrefix + '_ui/v1/groups/*').as('groups');
+    cy.intercept('GET', `${apiPrefix}_ui/v1/groups/*`).as('groups');
     cy.menuGo('User Access > Groups');
     cy.get(`[data-cy="GroupList-row-${groupName}"] a`).click();
     cy.wait('@groups');
@@ -67,7 +67,7 @@ describe('Hub Group Management Tests', () => {
 
     cy.contains(roleName);
 
-    cy.intercept('GET', pulpPrefix + 'roles/*').as('roles');
+    cy.intercept('GET', `${pulpPrefix}roles/*`).as('roles');
 
     cy.get('.pf-c-wizard__footer > button').contains('Add').click();
 

--- a/test/cypress/e2e/groups_and_users/group_management.js
+++ b/test/cypress/e2e/groups_and_users/group_management.js
@@ -1,4 +1,5 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const pulpPrefix = Cypress.env('pulpPrefix');
 
 describe('Hub Group Management Tests', () => {
   before(() => {
@@ -66,7 +67,7 @@ describe('Hub Group Management Tests', () => {
 
     cy.contains(roleName);
 
-    cy.intercept('GET', Cypress.env('pulpPrefix') + 'roles/*').as('roles');
+    cy.intercept('GET', pulpPrefix + 'roles/*').as('roles');
 
     cy.get('.pf-c-wizard__footer > button').contains('Add').click();
 

--- a/test/cypress/e2e/groups_and_users/group_management.js
+++ b/test/cypress/e2e/groups_and_users/group_management.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Hub Group Management Tests', () => {
   before(() => {
     cy.deleteTestGroups();
@@ -47,7 +49,7 @@ describe('Hub Group Management Tests', () => {
     cy.createRole(roleName, 'This role has all galaxy perms', [], true);
 
     // add role to group manually
-    cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/groups/*').as('groups');
+    cy.intercept('GET', apiPrefix + '_ui/v1/groups/*').as('groups');
     cy.menuGo('User Access > Groups');
     cy.get(`[data-cy="GroupList-row-${groupName}"] a`).click();
     cy.wait('@groups');

--- a/test/cypress/e2e/groups_and_users/group_roles.js
+++ b/test/cypress/e2e/groups_and_users/group_roles.js
@@ -55,7 +55,7 @@ describe('Group Roles Tests', () => {
       Object.keys(testRole.permissions),
     );
 
-    cy.intercept('GET', apiPrefix + '_ui/v1/groups/*').as('groups');
+    cy.intercept('GET', `${apiPrefix}_ui/v1/groups/*`).as('groups');
     cy.menuGo('User Access > Groups');
     cy.get(`[data-cy="GroupList-row-${groupName}"] a`).click();
     cy.wait('@groups');

--- a/test/cypress/e2e/groups_and_users/group_roles.js
+++ b/test/cypress/e2e/groups_and_users/group_roles.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Group Roles Tests', () => {
   const num = (~~(Math.random() * 1000000)).toString();
   const groupName = `test_group_${num}`;
@@ -53,7 +55,7 @@ describe('Group Roles Tests', () => {
       Object.keys(testRole.permissions),
     );
 
-    cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/groups/*').as('groups');
+    cy.intercept('GET', apiPrefix + '_ui/v1/groups/*').as('groups');
     cy.menuGo('User Access > Groups');
     cy.get(`[data-cy="GroupList-row-${groupName}"] a`).click();
     cy.wait('@groups');

--- a/test/cypress/e2e/groups_and_users/user_detail.js
+++ b/test/cypress/e2e/groups_and_users/user_detail.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('user detail tests all fields, editing, and deleting', () => {
   const num = (~~(Math.random() * 1000000)).toString();
 
@@ -36,9 +38,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
     cy.get('button[type=submit]').click();
 
     cy.visit('/ui/users');
-    cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/users/*/').as(
-      'testUser',
-    );
+    cy.intercept('GET', apiPrefix + '_ui/v1/users/*/').as('testUser');
     cy.contains('testUser').click();
     cy.wait('@testUser');
 
@@ -66,7 +66,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
     cy.reload();
     //checks those fields
     cy.visit('/ui/users');
-    cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/users/*/').as('user');
+    cy.intercept('GET', apiPrefix + '_ui/v1/users/*/').as('user');
     cy.contains('testUser').click();
     cy.wait('@user');
     cy.get('[data-cy="DataForm-field-first_name"]').contains('new_first_name');
@@ -94,8 +94,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
     cy.get('button[type="submit"]').click();
     cy.intercept(
       'GET',
-      Cypress.env('prefix') +
-        '_ui/v1/repo/published/?deprecated=false&offset=0&limit=10',
+      apiPrefix + '_ui/v1/repo/published/?deprecated=false&offset=0&limit=10',
     );
 
     //unable to log in with test credentials

--- a/test/cypress/e2e/groups_and_users/user_detail.js
+++ b/test/cypress/e2e/groups_and_users/user_detail.js
@@ -1,4 +1,5 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('user detail tests all fields, editing, and deleting', () => {
   const num = (~~(Math.random() * 1000000)).toString();
@@ -29,7 +30,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
     //  { group: 'users', permissions: ['View user'] },
     //]);
 
-    cy.visit('/ui/users');
+    cy.visit(uiPrefix + 'users');
     cy.contains('testUser').click();
     cy.contains('Edit').click();
     selectInput('first_name').type('first_name');
@@ -37,7 +38,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
     selectInput('email').type('example@example.com');
     cy.get('button[type=submit]').click();
 
-    cy.visit('/ui/users');
+    cy.visit(uiPrefix + 'users');
     cy.intercept('GET', apiPrefix + '_ui/v1/users/*/').as('testUser');
     cy.contains('testUser').click();
     cy.wait('@testUser');
@@ -55,7 +56,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
   });
 
   it('edits user', () => {
-    cy.visit('/ui/users');
+    cy.visit(uiPrefix + 'users');
     cy.contains('testUser').click();
     //edits some fields
     cy.contains('Edit').click();
@@ -65,7 +66,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
     cy.get('button[type=submit]').click();
     cy.reload();
     //checks those fields
-    cy.visit('/ui/users');
+    cy.visit(uiPrefix + 'users');
     cy.intercept('GET', apiPrefix + '_ui/v1/users/*/').as('user');
     cy.contains('testUser').click();
     cy.wait('@user');
@@ -77,7 +78,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
   });
 
   it('deletes user', () => {
-    cy.visit('/ui/users');
+    cy.visit(uiPrefix + 'users');
     cy.contains('testUser').click();
     cy.contains('Delete').click();
     cy.get('[data-cy="delete-button"]').click();
@@ -99,7 +100,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
 
     //unable to log in with test credentials
 
-    cy.get('a[href*="/ui/users/"]').click();
+    cy.get(`a[href*="${uiPrefix}users/"]`).click();
     cy.contains('User detail');
     cy.contains('Edit').should('not.exist');
     cy.contains('Delete').should('not.exist');

--- a/test/cypress/e2e/groups_and_users/user_detail.js
+++ b/test/cypress/e2e/groups_and_users/user_detail.js
@@ -30,7 +30,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
     //  { group: 'users', permissions: ['View user'] },
     //]);
 
-    cy.visit(uiPrefix + 'users');
+    cy.visit(`${uiPrefix}users`);
     cy.contains('testUser').click();
     cy.contains('Edit').click();
     selectInput('first_name').type('first_name');
@@ -38,8 +38,8 @@ describe('user detail tests all fields, editing, and deleting', () => {
     selectInput('email').type('example@example.com');
     cy.get('button[type=submit]').click();
 
-    cy.visit(uiPrefix + 'users');
-    cy.intercept('GET', apiPrefix + '_ui/v1/users/*/').as('testUser');
+    cy.visit(`${uiPrefix}users`);
+    cy.intercept('GET', `${apiPrefix}_ui/v1/users/*/`).as('testUser');
     cy.contains('testUser').click();
     cy.wait('@testUser');
 
@@ -56,7 +56,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
   });
 
   it('edits user', () => {
-    cy.visit(uiPrefix + 'users');
+    cy.visit(`${uiPrefix}users`);
     cy.contains('testUser').click();
     //edits some fields
     cy.contains('Edit').click();
@@ -66,8 +66,8 @@ describe('user detail tests all fields, editing, and deleting', () => {
     cy.get('button[type=submit]').click();
     cy.reload();
     //checks those fields
-    cy.visit(uiPrefix + 'users');
-    cy.intercept('GET', apiPrefix + '_ui/v1/users/*/').as('user');
+    cy.visit(`${uiPrefix}users`);
+    cy.intercept('GET', `${apiPrefix}_ui/v1/users/*/`).as('user');
     cy.contains('testUser').click();
     cy.wait('@user');
     cy.get('[data-cy="DataForm-field-first_name"]').contains('new_first_name');
@@ -78,7 +78,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
   });
 
   it('deletes user', () => {
-    cy.visit(uiPrefix + 'users');
+    cy.visit(`${uiPrefix}users`);
     cy.contains('testUser').click();
     cy.contains('Delete').click();
     cy.get('[data-cy="delete-button"]').click();
@@ -95,7 +95,7 @@ describe('user detail tests all fields, editing, and deleting', () => {
     cy.get('button[type="submit"]').click();
     cy.intercept(
       'GET',
-      apiPrefix + '_ui/v1/repo/published/?deprecated=false&offset=0&limit=10',
+      `${apiPrefix}_ui/v1/repo/published/?deprecated=false&offset=0&limit=10`,
     );
 
     //unable to log in with test credentials

--- a/test/cypress/e2e/groups_and_users/user_list.js
+++ b/test/cypress/e2e/groups_and_users/user_list.js
@@ -24,7 +24,7 @@ describe('User list tests for sorting, paging and filtering', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit(uiPrefix + 'users');
+    cy.visit(`${uiPrefix}users`);
   });
 
   it('table contains all columns', () => {

--- a/test/cypress/e2e/groups_and_users/user_list.js
+++ b/test/cypress/e2e/groups_and_users/user_list.js
@@ -1,5 +1,7 @@
 import { range, sortBy } from 'lodash';
 
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('User list tests for sorting, paging and filtering', () => {
   let items = [];
 
@@ -22,7 +24,7 @@ describe('User list tests for sorting, paging and filtering', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit('/ui/users');
+    cy.visit(uiPrefix + 'users');
   });
 
   it('table contains all columns', () => {

--- a/test/cypress/e2e/imports/imports_filter.js
+++ b/test/cypress/e2e/imports/imports_filter.js
@@ -1,4 +1,5 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Imports filter test', () => {
   const testCollection = `test_collection_${Math.random()
@@ -25,11 +26,11 @@ describe('Imports filter test', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit('/ui/my-imports?namespace=filter_test_namespace');
+    cy.visit(uiPrefix + 'my-imports?namespace=filter_test_namespace');
   });
 
   it('should display success info after importing collection', () => {
-    cy.visit('/ui/my-imports?namespace=test_namespace');
+    cy.visit(uiPrefix + 'my-imports?namespace=test_namespace');
 
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).click();
     cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]').contains(
@@ -45,7 +46,7 @@ describe('Imports filter test', () => {
 
   it('should fail on importing existing collection', () => {
     cy.galaxykit('-i collection upload', 'test_namespace', testCollection);
-    cy.visit('/ui/my-imports?namespace=test_namespace');
+    cy.visit(uiPrefix + 'my-imports?namespace=test_namespace');
 
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).first().click();
     cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]').contains(

--- a/test/cypress/e2e/imports/imports_filter.js
+++ b/test/cypress/e2e/imports/imports_filter.js
@@ -26,11 +26,11 @@ describe('Imports filter test', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit(uiPrefix + 'my-imports?namespace=filter_test_namespace');
+    cy.visit(`${uiPrefix}my-imports?namespace=filter_test_namespace`);
   });
 
   it('should display success info after importing collection', () => {
-    cy.visit(uiPrefix + 'my-imports?namespace=test_namespace');
+    cy.visit(`${uiPrefix}my-imports?namespace=test_namespace`);
 
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).click();
     cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]').contains(
@@ -46,7 +46,7 @@ describe('Imports filter test', () => {
 
   it('should fail on importing existing collection', () => {
     cy.galaxykit('-i collection upload', 'test_namespace', testCollection);
-    cy.visit(uiPrefix + 'my-imports?namespace=test_namespace');
+    cy.visit(`${uiPrefix}my-imports?namespace=test_namespace`);
 
     cy.get(`[data-cy="ImportList-row-${testCollection}"]`).first().click();
     cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]').contains(
@@ -71,14 +71,14 @@ describe('Imports filter test', () => {
 
     cy.intercept(
       'GET',
-      apiPrefix + '_ui/v1/imports/collections/?namespace=test_namespace&*',
+      `${apiPrefix}_ui/v1/imports/collections/?namespace=test_namespace&*`,
     ).as('collectionsInNamespace');
-    cy.intercept('GET', apiPrefix + '_ui/v1/imports/collections/*').as(
+    cy.intercept('GET', `${apiPrefix}_ui/v1/imports/collections/*`).as(
       'collectionDetail',
     );
     cy.intercept(
       'GET',
-      apiPrefix + '_ui/v1/collection-versions/?namespace=test_namespace&name=*',
+      `${apiPrefix}_ui/v1/collection-versions/?namespace=test_namespace&name=*`,
     ).as('collectionVersions');
 
     cy.get('[placeholder="Select namespace"]').clear();
@@ -93,16 +93,14 @@ describe('Imports filter test', () => {
 
     cy.intercept(
       'GET',
-      apiPrefix +
-        '_ui/v1/imports/collections/?namespace=filter_test_namespace&*',
+      `${apiPrefix}_ui/v1/imports/collections/?namespace=filter_test_namespace&*`,
     ).as('collectionsInNamespace2');
-    cy.intercept('GET', apiPrefix + '_ui/v1/imports/collections/*').as(
+    cy.intercept('GET', `${apiPrefix}_ui/v1/imports/collections/*`).as(
       'collectionDetail2',
     );
     cy.intercept(
       'GET',
-      apiPrefix +
-        '_ui/v1/collection-versions/?namespace=filter_test_namespace&name=*',
+      `${apiPrefix}_ui/v1/collection-versions/?namespace=filter_test_namespace&name=*`,
     ).as('collectionVersions2');
 
     cy.get('[placeholder="Select namespace"]').click();

--- a/test/cypress/e2e/imports/imports_filter.js
+++ b/test/cypress/e2e/imports/imports_filter.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Imports filter test', () => {
   const testCollection = `test_collection_${Math.random()
     .toString(36)
@@ -68,17 +70,14 @@ describe('Imports filter test', () => {
 
     cy.intercept(
       'GET',
-      Cypress.env('prefix') +
-        '_ui/v1/imports/collections/?namespace=test_namespace&*',
+      apiPrefix + '_ui/v1/imports/collections/?namespace=test_namespace&*',
     ).as('collectionsInNamespace');
+    cy.intercept('GET', apiPrefix + '_ui/v1/imports/collections/*').as(
+      'collectionDetail',
+    );
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/imports/collections/*',
-    ).as('collectionDetail');
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') +
-        '_ui/v1/collection-versions/?namespace=test_namespace&name=*',
+      apiPrefix + '_ui/v1/collection-versions/?namespace=test_namespace&name=*',
     ).as('collectionVersions');
 
     cy.get('[placeholder="Select namespace"]').clear();
@@ -93,16 +92,15 @@ describe('Imports filter test', () => {
 
     cy.intercept(
       'GET',
-      Cypress.env('prefix') +
+      apiPrefix +
         '_ui/v1/imports/collections/?namespace=filter_test_namespace&*',
     ).as('collectionsInNamespace2');
+    cy.intercept('GET', apiPrefix + '_ui/v1/imports/collections/*').as(
+      'collectionDetail2',
+    );
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/imports/collections/*',
-    ).as('collectionDetail2');
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') +
+      apiPrefix +
         '_ui/v1/collection-versions/?namespace=filter_test_namespace&name=*',
     ).as('collectionVersions2');
 

--- a/test/cypress/e2e/imports/imports_filter_search.js
+++ b/test/cypress/e2e/imports/imports_filter_search.js
@@ -26,11 +26,11 @@ describe('Imports filter test', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit(uiPrefix + 'my-imports?namespace=filter_test_namespace');
+    cy.visit(`${uiPrefix}my-imports?namespace=filter_test_namespace`);
   });
 
   it('partial filter for name is working.', () => {
-    cy.intercept('GET', apiPrefix + '_ui/v1/collection-versions/?*').as('wait');
+    cy.intercept('GET', `${apiPrefix}_ui/v1/collection-versions/?*`).as('wait');
 
     cy.get('input[aria-label="keywords"').type('my_collection{enter}');
     cy.wait('@wait');
@@ -43,7 +43,7 @@ describe('Imports filter test', () => {
   });
 
   it('exact filter for name is working.', () => {
-    cy.intercept('GET', apiPrefix + '_ui/v1/collection-versions/?*').as('wait');
+    cy.intercept('GET', `${apiPrefix}_ui/v1/collection-versions/?*`).as('wait');
 
     cy.get('input[aria-label="keywords"').type('my_collection1{enter}');
     cy.wait('@wait');
@@ -66,7 +66,7 @@ describe('Imports filter test', () => {
     // waiting to another query, otherwise sporadic failuers
     cy.intercept(
       'GET',
-      apiPrefix + '_ui/v1/collection-versions/?namespace=*',
+      `${apiPrefix}_ui/v1/collection-versions/?namespace=*`,
     ).as('wait');
     cy.contains('[data-cy="compound_filter"] a', 'Completed').click();
 
@@ -98,7 +98,7 @@ describe('Imports filter test', () => {
     // waiting to another query, otherwise sporadic failuers
     cy.intercept(
       'GET',
-      apiPrefix + '_ui/v1/collection-versions/?namespace=*',
+      `${apiPrefix}_ui/v1/collection-versions/?namespace=*`,
     ).as('wait');
     cy.contains('a', 'Completed').click();
 
@@ -122,7 +122,7 @@ describe('Imports filter test', () => {
     // waiting to another query, otherwise sporadic failuers
     cy.intercept(
       'GET',
-      apiPrefix + '_ui/v1/collection-versions/?namespace=*',
+      `${apiPrefix}_ui/v1/collection-versions/?namespace=*`,
     ).as('wait');
     cy.contains('a', 'Completed').click();
     cy.wait('@wait');

--- a/test/cypress/e2e/imports/imports_filter_search.js
+++ b/test/cypress/e2e/imports/imports_filter_search.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Imports filter test', () => {
   const testCollection = `test_collection_${Math.random()
     .toString(36)
@@ -27,10 +29,7 @@ describe('Imports filter test', () => {
   });
 
   it('partial filter for name is working.', () => {
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') + '_ui/v1/collection-versions/?*',
-    ).as('wait');
+    cy.intercept('GET', apiPrefix + '_ui/v1/collection-versions/?*').as('wait');
 
     cy.get('input[aria-label="keywords"').type('my_collection{enter}');
     cy.wait('@wait');
@@ -43,10 +42,7 @@ describe('Imports filter test', () => {
   });
 
   it('exact filter for name is working.', () => {
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') + '_ui/v1/collection-versions/?*',
-    ).as('wait');
+    cy.intercept('GET', apiPrefix + '_ui/v1/collection-versions/?*').as('wait');
 
     cy.get('input[aria-label="keywords"').type('my_collection1{enter}');
     cy.wait('@wait');
@@ -69,7 +65,7 @@ describe('Imports filter test', () => {
     // waiting to another query, otherwise sporadic failuers
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
+      apiPrefix + '_ui/v1/collection-versions/?namespace=*',
     ).as('wait');
     cy.contains('[data-cy="compound_filter"] a', 'Completed').click();
 
@@ -101,7 +97,7 @@ describe('Imports filter test', () => {
     // waiting to another query, otherwise sporadic failuers
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
+      apiPrefix + '_ui/v1/collection-versions/?namespace=*',
     ).as('wait');
     cy.contains('a', 'Completed').click();
 
@@ -125,7 +121,7 @@ describe('Imports filter test', () => {
     // waiting to another query, otherwise sporadic failuers
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/collection-versions/?namespace=*',
+      apiPrefix + '_ui/v1/collection-versions/?namespace=*',
     ).as('wait');
     cy.contains('a', 'Completed').click();
     cy.wait('@wait');

--- a/test/cypress/e2e/imports/imports_filter_search.js
+++ b/test/cypress/e2e/imports/imports_filter_search.js
@@ -1,4 +1,5 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Imports filter test', () => {
   const testCollection = `test_collection_${Math.random()
@@ -25,7 +26,7 @@ describe('Imports filter test', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit('/ui/my-imports?namespace=filter_test_namespace');
+    cy.visit(uiPrefix + 'my-imports?namespace=filter_test_namespace');
   });
 
   it('partial filter for name is working.', () => {

--- a/test/cypress/e2e/misc/l10n.js
+++ b/test/cypress/e2e/misc/l10n.js
@@ -16,7 +16,7 @@ const languageCheckHelper = (url, selector) => (language, message) => {
 };
 
 describe('Localization tests with the t`String` format', () => {
-  const helper = languageCheckHelper(uiPrefix + 'repositories', 'h1');
+  const helper = languageCheckHelper(`${uiPrefix}repositories`, 'h1');
 
   beforeEach(() => {
     cy.login();
@@ -38,7 +38,7 @@ describe('Localization tests with the t`String` format', () => {
 
 describe('Localization tests with the <Trans> format', () => {
   const helper = languageCheckHelper(
-    uiPrefix + 'containers',
+    `${uiPrefix}containers`,
     '[data-cy="push-images-button"]',
   );
 

--- a/test/cypress/e2e/misc/l10n.js
+++ b/test/cypress/e2e/misc/l10n.js
@@ -1,3 +1,5 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 // Note up to date there is no translation for any string in 'es' and 'nl'.
 const languageCheckHelper = (url, selector) => (language, message) => {
   cy.visit(url, {
@@ -14,7 +16,7 @@ const languageCheckHelper = (url, selector) => (language, message) => {
 };
 
 describe('Localization tests with the t`String` format', () => {
-  const helper = languageCheckHelper('/ui/repositories', 'h1');
+  const helper = languageCheckHelper(uiPrefix + 'repositories', 'h1');
 
   beforeEach(() => {
     cy.login();
@@ -36,7 +38,7 @@ describe('Localization tests with the t`String` format', () => {
 
 describe('Localization tests with the <Trans> format', () => {
   const helper = languageCheckHelper(
-    '/ui/containers',
+    uiPrefix + 'containers',
     '[data-cy="push-images-button"]',
   );
 

--- a/test/cypress/e2e/misc/profile.js
+++ b/test/cypress/e2e/misc/profile.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('My Profile Tests', () => {
   const username = 'nopermission';
   const password = 'n0permissi0n';
@@ -104,7 +106,7 @@ describe('My Profile Tests', () => {
   });
 
   it('user can save form', () => {
-    cy.intercept('PUT', Cypress.env('prefix') + '_ui/v1/me/').as('saveForm');
+    cy.intercept('PUT', apiPrefix + '_ui/v1/me/').as('saveForm');
 
     cy.contains('Save').click();
     cy.get('[aria-label="Success Alert"]').contains(

--- a/test/cypress/e2e/misc/profile.js
+++ b/test/cypress/e2e/misc/profile.js
@@ -106,7 +106,7 @@ describe('My Profile Tests', () => {
   });
 
   it('user can save form', () => {
-    cy.intercept('PUT', apiPrefix + '_ui/v1/me/').as('saveForm');
+    cy.intercept('PUT', `${apiPrefix}_ui/v1/me/`).as('saveForm');
 
     cy.contains('Save').click();
     cy.get('[aria-label="Success Alert"]').contains(

--- a/test/cypress/e2e/misc/rbac.js
+++ b/test/cypress/e2e/misc/rbac.js
@@ -1,3 +1,5 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 const adminUsername = Cypress.env('username');
 const adminPassword = Cypress.env('password');
 
@@ -49,13 +51,13 @@ describe('RBAC test for user without permissions', () => {
   });
 
   it("shouldn't display create, edit and delete buttons in namespace when user doesn't have permission", () => {
-    cy.visit('/ui/namespaces');
+    cy.visit(uiPrefix + 'namespaces');
 
     // cannot Add namespace
     cy.contains('Create').should('not.exist');
 
     cy.galaxykit('-i namespace create', 'testspace');
-    cy.visit('/ui/repo/published/testspace');
+    cy.visit(uiPrefix + 'repo/published/testspace');
 
     // cannot Change namespace and Delete namespace
     cy.get('[data-cy=kebab-toggle]').should('not.exist');
@@ -65,7 +67,7 @@ describe('RBAC test for user without permissions', () => {
   });
 
   it("shouldn't let delete collection and modify ansible repo content when user doesn't have permission", () => {
-    cy.visit('/ui/repo/published/testspace/testcollection');
+    cy.visit(uiPrefix + 'repo/published/testspace/testcollection');
 
     // cannot Delete collection
     cy.get('[data-cy=kebab-toggle]').should('not.exist');
@@ -74,16 +76,16 @@ describe('RBAC test for user without permissions', () => {
   it("shouldn't let view, add, change and delete users when user doesn't have permission", () => {
     // cannot View user
     cy.menuMissing('User Access > Users');
-    cy.visit('/ui/users');
+    cy.visit(uiPrefix + 'users');
     cy.contains('You do not have access to Automation Hub');
 
     // cannot Add user
     cy.contains('Create').should('not.exist');
-    cy.visit('/ui/users/create');
+    cy.visit(uiPrefix + 'users/create');
     cy.contains('You do not have access to Automation Hub');
 
     // cannot Change and Delete user
-    cy.visit('/ui/users');
+    cy.visit(uiPrefix + 'users');
     cy.get('[data-cy="UserList-row-testUser"] [data-cy=kebab-toggle]').should(
       'not.exist',
     );
@@ -92,7 +94,7 @@ describe('RBAC test for user without permissions', () => {
   it("shouldn't let view, add, change and delete groups when user doesn't have permission", () => {
     // cannot View group
     cy.menuMissing('User Access > Groups');
-    cy.visit('/ui/group-list');
+    cy.visit(uiPrefix + 'group-list');
     cy.contains('You do not have access to Automation Hub');
 
     // cannot Add group
@@ -103,7 +105,7 @@ describe('RBAC test for user without permissions', () => {
   });
 
   it("shouldn't let create, edit or delete container when user doesn't have permission", () => {
-    cy.visit('/ui/containers');
+    cy.visit(uiPrefix + 'containers');
 
     // cannot Create new containers
     cy.contains('Add execution environment').should('not.exist');
@@ -115,7 +117,7 @@ describe('RBAC test for user without permissions', () => {
     cy.contains('Edit').should('not.exist');
     cy.contains('Delete').should('not.exist');
 
-    cy.visit('/ui/containers/testcontainer');
+    cy.visit(uiPrefix + 'containers/testcontainer');
     cy.contains('Edit').should('not.exist');
     cy.get('[aria-label="Actions"]').click();
     cy.contains('Delete').should('not.exist');
@@ -127,7 +129,7 @@ describe('RBAC test for user without permissions', () => {
   it("shouldn't let add, delete and sync remote registries when user doesn't have permission", () => {
     // can Add remote registry
     // in here we hide the button (correct), but in containers we dont (wrong)
-    cy.visit('/ui/registries');
+    cy.visit(uiPrefix + 'registries');
     cy.contains('Add remote registry').should('not.exist');
 
     // can Change and Delete remote registry
@@ -142,7 +144,7 @@ describe('RBAC test for user without permissions', () => {
   });
 
   it("shouldn't let view all tasks, change and delete task when user doesn't have permission", () => {
-    cy.visit('/ui/tasks');
+    cy.visit(uiPrefix + 'tasks');
 
     cy.get('[aria-label="Task list"] tr td a').first().click();
 
@@ -270,13 +272,13 @@ describe('RBAC test for user with permissions', () => {
     cy.login(userName, userPassword);
 
     cy.galaxykit('-i namespace create', 'testspace');
-    cy.visit('/ui/namespaces');
+    cy.visit(uiPrefix + 'namespaces');
 
     // can Add namespace
     cy.contains('Create').should('exist');
     cy.galaxykit('-i namespace create', 'testspace');
 
-    cy.visit('/ui/repo/published/testspace');
+    cy.visit(uiPrefix + 'repo/published/testspace');
     cy.get('[data-cy="ns-kebab-toggle"]').should('exist').click();
     cy.contains('Edit namespace');
     cy.contains('Delete namespace');
@@ -290,7 +292,7 @@ describe('RBAC test for user with permissions', () => {
     cy.login(userName, userPassword);
 
     cy.galaxykit('-i collection upload testspace testcollection');
-    cy.visit('/ui/repo/published/testspace/testcollection');
+    cy.visit(uiPrefix + 'repo/published/testspace/testcollection');
 
     // can Delete collection
     cy.get('[data-cy=kebab-toggle]').should('exist').click();
@@ -303,16 +305,16 @@ describe('RBAC test for user with permissions', () => {
 
     // can View user
     cy.menuPresent('User Access > Users');
-    cy.visit('/ui/users');
+    cy.visit(uiPrefix + 'users');
     cy.contains('Users');
 
     // can Add user
     cy.contains('Create');
-    cy.visit('/ui/users/create');
+    cy.visit(uiPrefix + 'users/create');
     cy.contains('Create new user');
 
     // can Change and Delete user
-    cy.visit('/ui/users');
+    cy.visit(uiPrefix + 'users');
     cy.get(
       '[data-cy="UserList-row-testUser"] [data-cy=kebab-toggle] > .pf-c-dropdown',
     ).click();
@@ -326,7 +328,7 @@ describe('RBAC test for user with permissions', () => {
 
     // can View group
     cy.menuPresent('User Access > Groups');
-    cy.visit('/ui/group-list');
+    cy.visit(uiPrefix + 'group-list');
     cy.contains('Groups');
 
     // can Add group
@@ -343,7 +345,7 @@ describe('RBAC test for user with permissions', () => {
     cy.galaxykit('-i group role add', groupName, 'galaxy.test_containers');
     cy.login(userName, userPassword);
 
-    cy.visit('/ui/containers');
+    cy.visit(uiPrefix + 'containers');
 
     // can Create new containers
     cy.contains('Add execution environment').should('exist');
@@ -355,7 +357,7 @@ describe('RBAC test for user with permissions', () => {
     cy.contains('Edit').should('exist');
     cy.contains('Delete').should('exist');
 
-    cy.visit('/ui/containers/testcontainer');
+    cy.visit(uiPrefix + 'containers/testcontainer');
     cy.contains('Edit').should('exist');
     cy.get('[aria-label="Actions"]').click();
     cy.contains('Delete').should('exist');
@@ -370,7 +372,7 @@ describe('RBAC test for user with permissions', () => {
     cy.login(userName, userPassword);
 
     // can Add remote registry
-    cy.visit('/ui/registries');
+    cy.visit(uiPrefix + 'registries');
     cy.contains('Add remote registry').should('exist');
 
     // can Change and Delete remote registry
@@ -389,7 +391,7 @@ describe('RBAC test for user with permissions', () => {
     cy.galaxykit('-i group role add', groupName, 'galaxy.test_task_management');
     cy.login(userName, userPassword);
 
-    cy.visit('/ui/tasks');
+    cy.visit(uiPrefix + 'tasks');
     cy.get('[aria-label="Task list"] tr td a').first().click();
     cy.contains('Task detail');
   });

--- a/test/cypress/e2e/misc/rbac.js
+++ b/test/cypress/e2e/misc/rbac.js
@@ -51,13 +51,13 @@ describe('RBAC test for user without permissions', () => {
   });
 
   it("shouldn't display create, edit and delete buttons in namespace when user doesn't have permission", () => {
-    cy.visit(uiPrefix + 'namespaces');
+    cy.visit(`${uiPrefix}namespaces`);
 
     // cannot Add namespace
     cy.contains('Create').should('not.exist');
 
     cy.galaxykit('-i namespace create', 'testspace');
-    cy.visit(uiPrefix + 'repo/published/testspace');
+    cy.visit(`${uiPrefix}repo/published/testspace`);
 
     // cannot Change namespace and Delete namespace
     cy.get('[data-cy=kebab-toggle]').should('not.exist');
@@ -67,7 +67,7 @@ describe('RBAC test for user without permissions', () => {
   });
 
   it("shouldn't let delete collection and modify ansible repo content when user doesn't have permission", () => {
-    cy.visit(uiPrefix + 'repo/published/testspace/testcollection');
+    cy.visit(`${uiPrefix}repo/published/testspace/testcollection`);
 
     // cannot Delete collection
     cy.get('[data-cy=kebab-toggle]').should('not.exist');
@@ -76,16 +76,16 @@ describe('RBAC test for user without permissions', () => {
   it("shouldn't let view, add, change and delete users when user doesn't have permission", () => {
     // cannot View user
     cy.menuMissing('User Access > Users');
-    cy.visit(uiPrefix + 'users');
+    cy.visit(`${uiPrefix}users`);
     cy.contains('You do not have access to Automation Hub');
 
     // cannot Add user
     cy.contains('Create').should('not.exist');
-    cy.visit(uiPrefix + 'users/create');
+    cy.visit(`${uiPrefix}users/create`);
     cy.contains('You do not have access to Automation Hub');
 
     // cannot Change and Delete user
-    cy.visit(uiPrefix + 'users');
+    cy.visit(`${uiPrefix}users`);
     cy.get('[data-cy="UserList-row-testUser"] [data-cy=kebab-toggle]').should(
       'not.exist',
     );
@@ -94,7 +94,7 @@ describe('RBAC test for user without permissions', () => {
   it("shouldn't let view, add, change and delete groups when user doesn't have permission", () => {
     // cannot View group
     cy.menuMissing('User Access > Groups');
-    cy.visit(uiPrefix + 'group-list');
+    cy.visit(`${uiPrefix}group-list`);
     cy.contains('You do not have access to Automation Hub');
 
     // cannot Add group
@@ -105,7 +105,7 @@ describe('RBAC test for user without permissions', () => {
   });
 
   it("shouldn't let create, edit or delete container when user doesn't have permission", () => {
-    cy.visit(uiPrefix + 'containers');
+    cy.visit(`${uiPrefix}containers`);
 
     // cannot Create new containers
     cy.contains('Add execution environment').should('not.exist');
@@ -117,7 +117,7 @@ describe('RBAC test for user without permissions', () => {
     cy.contains('Edit').should('not.exist');
     cy.contains('Delete').should('not.exist');
 
-    cy.visit(uiPrefix + 'containers/testcontainer');
+    cy.visit(`${uiPrefix}containers/testcontainer`);
     cy.contains('Edit').should('not.exist');
     cy.get('[aria-label="Actions"]').click();
     cy.contains('Delete').should('not.exist');
@@ -129,7 +129,7 @@ describe('RBAC test for user without permissions', () => {
   it("shouldn't let add, delete and sync remote registries when user doesn't have permission", () => {
     // can Add remote registry
     // in here we hide the button (correct), but in containers we dont (wrong)
-    cy.visit(uiPrefix + 'registries');
+    cy.visit(`${uiPrefix}registries`);
     cy.contains('Add remote registry').should('not.exist');
 
     // can Change and Delete remote registry
@@ -144,7 +144,7 @@ describe('RBAC test for user without permissions', () => {
   });
 
   it("shouldn't let view all tasks, change and delete task when user doesn't have permission", () => {
-    cy.visit(uiPrefix + 'tasks');
+    cy.visit(`${uiPrefix}tasks`);
 
     cy.get('[aria-label="Task list"] tr td a').first().click();
 
@@ -272,13 +272,13 @@ describe('RBAC test for user with permissions', () => {
     cy.login(userName, userPassword);
 
     cy.galaxykit('-i namespace create', 'testspace');
-    cy.visit(uiPrefix + 'namespaces');
+    cy.visit(`${uiPrefix}namespaces`);
 
     // can Add namespace
     cy.contains('Create').should('exist');
     cy.galaxykit('-i namespace create', 'testspace');
 
-    cy.visit(uiPrefix + 'repo/published/testspace');
+    cy.visit(`${uiPrefix}repo/published/testspace`);
     cy.get('[data-cy="ns-kebab-toggle"]').should('exist').click();
     cy.contains('Edit namespace');
     cy.contains('Delete namespace');
@@ -292,7 +292,7 @@ describe('RBAC test for user with permissions', () => {
     cy.login(userName, userPassword);
 
     cy.galaxykit('-i collection upload testspace testcollection');
-    cy.visit(uiPrefix + 'repo/published/testspace/testcollection');
+    cy.visit(`${uiPrefix}repo/published/testspace/testcollection`);
 
     // can Delete collection
     cy.get('[data-cy=kebab-toggle]').should('exist').click();
@@ -305,16 +305,16 @@ describe('RBAC test for user with permissions', () => {
 
     // can View user
     cy.menuPresent('User Access > Users');
-    cy.visit(uiPrefix + 'users');
+    cy.visit(`${uiPrefix}users`);
     cy.contains('Users');
 
     // can Add user
     cy.contains('Create');
-    cy.visit(uiPrefix + 'users/create');
+    cy.visit(`${uiPrefix}users/create`);
     cy.contains('Create new user');
 
     // can Change and Delete user
-    cy.visit(uiPrefix + 'users');
+    cy.visit(`${uiPrefix}users`);
     cy.get(
       '[data-cy="UserList-row-testUser"] [data-cy=kebab-toggle] > .pf-c-dropdown',
     ).click();
@@ -328,7 +328,7 @@ describe('RBAC test for user with permissions', () => {
 
     // can View group
     cy.menuPresent('User Access > Groups');
-    cy.visit(uiPrefix + 'group-list');
+    cy.visit(`${uiPrefix}group-list`);
     cy.contains('Groups');
 
     // can Add group
@@ -345,7 +345,7 @@ describe('RBAC test for user with permissions', () => {
     cy.galaxykit('-i group role add', groupName, 'galaxy.test_containers');
     cy.login(userName, userPassword);
 
-    cy.visit(uiPrefix + 'containers');
+    cy.visit(`${uiPrefix}containers`);
 
     // can Create new containers
     cy.contains('Add execution environment').should('exist');
@@ -357,7 +357,7 @@ describe('RBAC test for user with permissions', () => {
     cy.contains('Edit').should('exist');
     cy.contains('Delete').should('exist');
 
-    cy.visit(uiPrefix + 'containers/testcontainer');
+    cy.visit(`${uiPrefix}containers/testcontainer`);
     cy.contains('Edit').should('exist');
     cy.get('[aria-label="Actions"]').click();
     cy.contains('Delete').should('exist');
@@ -372,7 +372,7 @@ describe('RBAC test for user with permissions', () => {
     cy.login(userName, userPassword);
 
     // can Add remote registry
-    cy.visit(uiPrefix + 'registries');
+    cy.visit(`${uiPrefix}registries`);
     cy.contains('Add remote registry').should('exist');
 
     // can Change and Delete remote registry
@@ -391,7 +391,7 @@ describe('RBAC test for user with permissions', () => {
     cy.galaxykit('-i group role add', groupName, 'galaxy.test_task_management');
     cy.login(userName, userPassword);
 
-    cy.visit(uiPrefix + 'tasks');
+    cy.visit(`${uiPrefix}tasks`);
     cy.get('[aria-label="Task list"] tr td a').first().click();
     cy.contains('Task detail');
   });

--- a/test/cypress/e2e/misc/rbac_list.js
+++ b/test/cypress/e2e/misc/rbac_list.js
@@ -1,12 +1,14 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('RBAC table contains correct headers and filter', () => {
   before(() => {
     cy.login();
-    cy.visit('/ui/roles');
+    cy.visit(uiPrefix + 'roles');
   });
 
   it('table contains all columns and filter', () => {
     cy.login();
-    cy.visit('/ui/roles');
+    cy.visit(uiPrefix + 'roles');
     cy.contains('Roles');
 
     // ensure role names begin with 'galaxy.'

--- a/test/cypress/e2e/misc/rbac_list.js
+++ b/test/cypress/e2e/misc/rbac_list.js
@@ -3,12 +3,12 @@ const uiPrefix = Cypress.env('uiPrefix');
 describe('RBAC table contains correct headers and filter', () => {
   before(() => {
     cy.login();
-    cy.visit(uiPrefix + 'roles');
+    cy.visit(`${uiPrefix}roles`);
   });
 
   it('table contains all columns and filter', () => {
     cy.login();
-    cy.visit(uiPrefix + 'roles');
+    cy.visit(`${uiPrefix}roles`);
     cy.contains('Roles');
 
     // ensure role names begin with 'galaxy.'

--- a/test/cypress/e2e/misc/rbac_owners.js
+++ b/test/cypress/e2e/misc/rbac_owners.js
@@ -1,3 +1,5 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('Namespace owners tab', () => {
   const num = (~~(Math.random() * 1000000)).toString();
 
@@ -11,7 +13,7 @@ describe('Namespace owners tab', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit(`/ui/repo/published/rbac_owners_${num}`);
+    cy.visit(`${uiPrefix}repo/published/rbac_owners_${num}`);
     cy.get('.pf-c-tabs__item-text').contains('Namespace owners').click();
   });
 
@@ -52,7 +54,7 @@ describe('Execution Environment Owners tab', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit(`/ui/containers/rbac_owners_${num}`);
+    cy.visit(`${uiPrefix}containers/rbac_owners_${num}`);
     cy.get('.pf-c-tabs__item-text').contains('Owners').click();
   });
 

--- a/test/cypress/e2e/misc/signing.js
+++ b/test/cypress/e2e/misc/signing.js
@@ -27,7 +27,7 @@ describe('signing versions', () => {
     });
 
     it('has the switch to sync only certified repos', () => {
-      cy.visit(uiPrefix + 'repositories?tab=remote');
+      cy.visit(`${uiPrefix}repositories?tab=remote`);
       cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
       cy.contains('Edit').click();
       cy.contains('Show advanced options').click();
@@ -35,7 +35,7 @@ describe('signing versions', () => {
     });
 
     it('signs when the Sign and Approve button is pressed', () => {
-      cy.visit(uiPrefix + 'approval-dashboard');
+      cy.visit(`${uiPrefix}approval-dashboard`);
 
       // Check if the button is correctly worded
       cy.get('[data-cy="approve-button"]').should(
@@ -50,7 +50,7 @@ describe('signing versions', () => {
       cy.wait(10000);
 
       // Go and check if it is signed in the collections
-      cy.visit(uiPrefix + 'repo/published');
+      cy.visit(`${uiPrefix}repo/published`);
       cy.get('[data-cy="signature-badge"]', { timeout: 20000 }).should(
         'have.length',
         1,
@@ -58,7 +58,7 @@ describe('signing versions', () => {
       cy.get('[data-cy="signature-badge"]').first().should('contain', 'Signed');
 
       // Optimization: check the signature button too here
-      cy.visit(uiPrefix + 'repo/published/autosign_test/test_collection');
+      cy.visit(`${uiPrefix}repo/published/autosign_test/test_collection`);
       cy.get('[data-cy="signature-badge"]').first().should('contain', 'Signed');
       cy.get('[data-cy="toggle-signature-button"]').should('be.visible');
     });
@@ -101,7 +101,7 @@ describe('signing versions', () => {
     });
 
     it('can sign all collections and versions from the namespace screen', () => {
-      cy.visit(uiPrefix + 'repo/published/namespace_signing_test');
+      cy.visit(`${uiPrefix}repo/published/namespace_signing_test`);
 
       // Make sure it is unsigned at first
       cy.get('[data-cy="signature-badge"]')
@@ -127,7 +127,7 @@ describe('signing versions', () => {
     });
 
     it('can sign a single version in the collection from collection details', () => {
-      cy.visit(uiPrefix + 'repo/published/collection_signing_test/collection1');
+      cy.visit(`${uiPrefix}repo/published/collection_signing_test/collection1`);
 
       // Make sure it is unsigned at first
       cy.get('[data-cy="signature-badge"]')
@@ -151,7 +151,7 @@ describe('signing versions', () => {
     });
 
     it('can sign all version in the collection from collection details', () => {
-      cy.visit(uiPrefix + 'repo/published/collection_signing_test/collection2');
+      cy.visit(`${uiPrefix}repo/published/collection_signing_test/collection2`);
 
       // Make sure it is unsigned at first
       cy.get('[data-cy="signature-badge"]')

--- a/test/cypress/e2e/misc/signing.js
+++ b/test/cypress/e2e/misc/signing.js
@@ -1,3 +1,5 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('signing versions', () => {
   before(() => {
     cy.deleteNamespacesAndCollections();
@@ -25,7 +27,7 @@ describe('signing versions', () => {
     });
 
     it('has the switch to sync only certified repos', () => {
-      cy.visit('/ui/repositories?tab=remote');
+      cy.visit(uiPrefix + 'repositories?tab=remote');
       cy.get('[aria-label="Actions"]:first').click(); // click the kebab menu on the 'community' repo
       cy.contains('Edit').click();
       cy.contains('Show advanced options').click();
@@ -33,7 +35,7 @@ describe('signing versions', () => {
     });
 
     it('signs when the Sign and Approve button is pressed', () => {
-      cy.visit('/ui/approval-dashboard');
+      cy.visit(uiPrefix + 'approval-dashboard');
 
       // Check if the button is correctly worded
       cy.get('[data-cy="approve-button"]').should(
@@ -48,7 +50,7 @@ describe('signing versions', () => {
       cy.wait(10000);
 
       // Go and check if it is signed in the collections
-      cy.visit('/ui/repo/published');
+      cy.visit(uiPrefix + 'repo/published');
       cy.get('[data-cy="signature-badge"]', { timeout: 20000 }).should(
         'have.length',
         1,
@@ -56,7 +58,7 @@ describe('signing versions', () => {
       cy.get('[data-cy="signature-badge"]').first().should('contain', 'Signed');
 
       // Optimization: check the signature button too here
-      cy.visit('/ui/repo/published/autosign_test/test_collection');
+      cy.visit(uiPrefix + 'repo/published/autosign_test/test_collection');
       cy.get('[data-cy="signature-badge"]').first().should('contain', 'Signed');
       cy.get('[data-cy="toggle-signature-button"]').should('be.visible');
     });
@@ -99,7 +101,7 @@ describe('signing versions', () => {
     });
 
     it('can sign all collections and versions from the namespace screen', () => {
-      cy.visit('/ui/repo/published/namespace_signing_test');
+      cy.visit(uiPrefix + 'repo/published/namespace_signing_test');
 
       // Make sure it is unsigned at first
       cy.get('[data-cy="signature-badge"]')
@@ -125,7 +127,7 @@ describe('signing versions', () => {
     });
 
     it('can sign a single version in the collection from collection details', () => {
-      cy.visit('/ui/repo/published/collection_signing_test/collection1');
+      cy.visit(uiPrefix + 'repo/published/collection_signing_test/collection1');
 
       // Make sure it is unsigned at first
       cy.get('[data-cy="signature-badge"]')
@@ -149,7 +151,7 @@ describe('signing versions', () => {
     });
 
     it('can sign all version in the collection from collection details', () => {
-      cy.visit('/ui/repo/published/collection_signing_test/collection2');
+      cy.visit(uiPrefix + 'repo/published/collection_signing_test/collection2');
 
       // Make sure it is unsigned at first
       cy.get('[data-cy="signature-badge"]')

--- a/test/cypress/e2e/misc/task_list.js
+++ b/test/cypress/e2e/misc/task_list.js
@@ -4,16 +4,16 @@ const uiPrefix = Cypress.env('uiPrefix');
 describe('Task table contains correct headers and filter', () => {
   before(() => {
     cy.login();
-    cy.visit(uiPrefix + 'repositories?tab=remote');
+    cy.visit(`${uiPrefix}repositories?tab=remote`);
 
     cy.contains('Repo Management');
     cy.contains('Sync');
 
-    cy.intercept('POST', apiPrefix + 'content/rh-certified/v3/sync/').as(
+    cy.intercept('POST', `${apiPrefix}content/rh-certified/v3/sync/`).as(
       'sync',
     );
 
-    cy.intercept('GET', apiPrefix + '_ui/v1/remotes/?*').as('remotes');
+    cy.intercept('GET', `${apiPrefix}_ui/v1/remotes/?*`).as('remotes');
 
     cy.get('tr').eq(2).contains('Sync').click();
 
@@ -23,7 +23,7 @@ describe('Task table contains correct headers and filter', () => {
 
   it('table contains all columns and filter', () => {
     cy.login();
-    cy.visit(uiPrefix + 'tasks');
+    cy.visit(`${uiPrefix}tasks`);
     cy.contains('Task Management');
     cy.get('[aria-label="name__contains"]');
     ['Task name', 'Created on', 'Started at', 'Finished at', 'Status'].forEach(

--- a/test/cypress/e2e/misc/task_list.js
+++ b/test/cypress/e2e/misc/task_list.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Task table contains correct headers and filter', () => {
   before(() => {
     cy.login();
@@ -6,14 +8,11 @@ describe('Task table contains correct headers and filter', () => {
     cy.contains('Repo Management');
     cy.contains('Sync');
 
-    cy.intercept(
-      'POST',
-      Cypress.env('prefix') + 'content/rh-certified/v3/sync/',
-    ).as('sync');
-
-    cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/remotes/?*').as(
-      'remotes',
+    cy.intercept('POST', apiPrefix + 'content/rh-certified/v3/sync/').as(
+      'sync',
     );
+
+    cy.intercept('GET', apiPrefix + '_ui/v1/remotes/?*').as('remotes');
 
     cy.get('tr').eq(2).contains('Sync').click();
 

--- a/test/cypress/e2e/misc/task_list.js
+++ b/test/cypress/e2e/misc/task_list.js
@@ -1,9 +1,10 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Task table contains correct headers and filter', () => {
   before(() => {
     cy.login();
-    cy.visit('/ui/repositories?tab=remote');
+    cy.visit(uiPrefix + 'repositories?tab=remote');
 
     cy.contains('Repo Management');
     cy.contains('Sync');
@@ -22,7 +23,7 @@ describe('Task table contains correct headers and filter', () => {
 
   it('table contains all columns and filter', () => {
     cy.login();
-    cy.visit('/ui/tasks');
+    cy.visit(uiPrefix + 'tasks');
     cy.contains('Task Management');
     cy.get('[aria-label="name__contains"]');
     ['Task name', 'Created on', 'Started at', 'Finished at', 'Status'].forEach(

--- a/test/cypress/e2e/misc/task_management_detail.js
+++ b/test/cypress/e2e/misc/task_management_detail.js
@@ -1,9 +1,10 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Task detail', () => {
   before(() => {
     cy.login();
-    cy.visit('/ui/repositories?tab=remote');
+    cy.visit(uiPrefix + 'repositories?tab=remote');
 
     cy.contains('Repo Management');
     cy.contains('Sync');
@@ -22,7 +23,7 @@ describe('Task detail', () => {
 
   it('contains correct headers and field names.', () => {
     cy.login();
-    cy.visit('/ui/tasks');
+    cy.visit(uiPrefix + 'tasks');
     cy.contains('pulp_ansible.app.tasks.collections.sync').click();
 
     cy.contains('h1', 'Pulp Ansible: Collections sync');

--- a/test/cypress/e2e/misc/task_management_detail.js
+++ b/test/cypress/e2e/misc/task_management_detail.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Task detail', () => {
   before(() => {
     cy.login();
@@ -6,14 +8,11 @@ describe('Task detail', () => {
     cy.contains('Repo Management');
     cy.contains('Sync');
 
-    cy.intercept(
-      'POST',
-      Cypress.env('prefix') + 'content/rh-certified/v3/sync/',
-    ).as('sync');
-
-    cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/remotes/?*').as(
-      'remotes',
+    cy.intercept('POST', apiPrefix + 'content/rh-certified/v3/sync/').as(
+      'sync',
     );
+
+    cy.intercept('GET', apiPrefix + '_ui/v1/remotes/?*').as('remotes');
 
     cy.get('tr').eq(2).contains('Sync').click();
 

--- a/test/cypress/e2e/misc/task_management_detail.js
+++ b/test/cypress/e2e/misc/task_management_detail.js
@@ -4,16 +4,16 @@ const uiPrefix = Cypress.env('uiPrefix');
 describe('Task detail', () => {
   before(() => {
     cy.login();
-    cy.visit(uiPrefix + 'repositories?tab=remote');
+    cy.visit(`${uiPrefix}repositories?tab=remote`);
 
     cy.contains('Repo Management');
     cy.contains('Sync');
 
-    cy.intercept('POST', apiPrefix + 'content/rh-certified/v3/sync/').as(
+    cy.intercept('POST', `${apiPrefix}content/rh-certified/v3/sync/`).as(
       'sync',
     );
 
-    cy.intercept('GET', apiPrefix + '_ui/v1/remotes/?*').as('remotes');
+    cy.intercept('GET', `${apiPrefix}_ui/v1/remotes/?*`).as('remotes');
 
     cy.get('tr').eq(2).contains('Sync').click();
 
@@ -23,7 +23,7 @@ describe('Task detail', () => {
 
   it('contains correct headers and field names.', () => {
     cy.login();
-    cy.visit(uiPrefix + 'tasks');
+    cy.visit(`${uiPrefix}tasks`);
     cy.contains('pulp_ansible.app.tasks.collections.sync').click();
 
     cy.contains('h1', 'Pulp Ansible: Collections sync');

--- a/test/cypress/e2e/misc/task_status.js
+++ b/test/cypress/e2e/misc/task_status.js
@@ -1,7 +1,9 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('test status filter label on list view', () => {
   before(() => {
     cy.login();
-    cy.visit('/ui/tasks');
+    cy.visit(uiPrefix + 'tasks');
     cy.intercept(
       'GET',
       Cypress.env('pulpPrefix') +

--- a/test/cypress/e2e/misc/task_status.js
+++ b/test/cypress/e2e/misc/task_status.js
@@ -4,10 +4,10 @@ const uiPrefix = Cypress.env('uiPrefix');
 describe('test status filter label on list view', () => {
   before(() => {
     cy.login();
-    cy.visit(uiPrefix + 'tasks');
+    cy.visit(`${uiPrefix}tasks`);
     cy.intercept(
       'GET',
-      pulpPrefix + 'tasks/?ordering=-pulp_created&offset=0&limit=10',
+      `${pulpPrefix}tasks/?ordering=-pulp_created&offset=0&limit=10`,
     ).as('tasks');
 
     cy.wait('@tasks');

--- a/test/cypress/e2e/misc/task_status.js
+++ b/test/cypress/e2e/misc/task_status.js
@@ -1,3 +1,4 @@
+const pulpPrefix = Cypress.env('pulpPrefix');
 const uiPrefix = Cypress.env('uiPrefix');
 
 describe('test status filter label on list view', () => {
@@ -6,8 +7,7 @@ describe('test status filter label on list view', () => {
     cy.visit(uiPrefix + 'tasks');
     cy.intercept(
       'GET',
-      Cypress.env('pulpPrefix') +
-        'tasks/?ordering=-pulp_created&offset=0&limit=10',
+      pulpPrefix + 'tasks/?ordering=-pulp_created&offset=0&limit=10',
     ).as('tasks');
 
     cy.wait('@tasks');

--- a/test/cypress/e2e/misc/token_management.js
+++ b/test/cypress/e2e/misc/token_management.js
@@ -12,8 +12,8 @@ describe('Token Management Tests', () => {
   });
 
   it('user can load token', () => {
-    cy.visit(uiPrefix + 'token');
-    cy.intercept('POST', apiPrefix + 'v3/auth/token/').as('tokenPost');
+    cy.visit(`${uiPrefix}token`);
+    cy.intercept('POST', `${apiPrefix}v3/auth/token/`).as('tokenPost');
 
     cy.contains('Load token').click();
     cy.get('.pf-c-clipboard-copy').should('exist');

--- a/test/cypress/e2e/misc/token_management.js
+++ b/test/cypress/e2e/misc/token_management.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Token Management Tests', () => {
   before(() => {
     cy.deleteTestUsers();
@@ -10,9 +12,7 @@ describe('Token Management Tests', () => {
 
   it('user can load token', () => {
     cy.visit('/ui/token');
-    cy.intercept('POST', Cypress.env('prefix') + 'v3/auth/token/').as(
-      'tokenPost',
-    );
+    cy.intercept('POST', apiPrefix + 'v3/auth/token/').as('tokenPost');
 
     cy.contains('Load token').click();
     cy.get('.pf-c-clipboard-copy').should('exist');

--- a/test/cypress/e2e/misc/token_management.js
+++ b/test/cypress/e2e/misc/token_management.js
@@ -1,4 +1,5 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Token Management Tests', () => {
   before(() => {
@@ -11,7 +12,7 @@ describe('Token Management Tests', () => {
   });
 
   it('user can load token', () => {
-    cy.visit('/ui/token');
+    cy.visit(uiPrefix + 'token');
     cy.intercept('POST', apiPrefix + 'v3/auth/token/').as('tokenPost');
 
     cy.contains('Load token').click();

--- a/test/cypress/e2e/misc/view-only.js
+++ b/test/cypress/e2e/misc/view-only.js
@@ -48,7 +48,7 @@ describe('view-only mode', () => {
     });
 
     it('can load Namespaces', () => {
-      cy.visit(uiPrefix + 'namespaces');
+      cy.visit(`${uiPrefix}namespaces`);
       cy.contains('.pf-c-title', 'Namespaces');
 
       cy.contains('button', 'Create').should('not.exist');
@@ -63,7 +63,7 @@ describe('view-only mode', () => {
     });
 
     it('gets Unauthorized elsewhere', () => {
-      cy.visit(uiPrefix + 'repositories');
+      cy.visit(`${uiPrefix}repositories`);
       cy.contains('You do not have access to Automation Hub');
       cy.contains('.pf-c-button', 'Login');
     });

--- a/test/cypress/e2e/misc/view-only.js
+++ b/test/cypress/e2e/misc/view-only.js
@@ -1,3 +1,5 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('view-only mode', () => {
   before(() => {
     cy.galaxykit('collection upload');
@@ -46,7 +48,7 @@ describe('view-only mode', () => {
     });
 
     it('can load Namespaces', () => {
-      cy.visit('/ui/namespaces');
+      cy.visit(uiPrefix + 'namespaces');
       cy.contains('.pf-c-title', 'Namespaces');
 
       cy.contains('button', 'Create').should('not.exist');
@@ -61,7 +63,7 @@ describe('view-only mode', () => {
     });
 
     it('gets Unauthorized elsewhere', () => {
-      cy.visit('/ui/repositories');
+      cy.visit(uiPrefix + 'repositories');
       cy.contains('You do not have access to Automation Hub');
       cy.contains('.pf-c-button', 'Login');
     });

--- a/test/cypress/e2e/namespaces/namespace_delete.js
+++ b/test/cypress/e2e/namespaces/namespace_delete.js
@@ -1,4 +1,5 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Delete a namespace', () => {
   beforeEach(() => {
@@ -12,7 +13,7 @@ describe('Delete a namespace', () => {
     cy.intercept('GET', apiPrefix + '_ui/v1/namespaces/?sort=name*').as(
       'reload',
     );
-    cy.get('a[href*="ui/repo/published/testns1"]').click();
+    cy.get(`a[href*="${uiPrefix}repo/published/testns1"]`).click();
     cy.get('[data-cy="ns-kebab-toggle"]').click();
     cy.contains('Delete namespace').click();
     cy.get('input[id=delete_confirm]').click();
@@ -33,7 +34,7 @@ describe('Delete a namespace', () => {
     cy.menuGo('Collections > Namespaces');
     cy.wait('@reload');
 
-    cy.get('a[href*="ui/repo/published/ansible"]').click();
+    cy.get(`a[href*="${uiPrefix}repo/published/ansible"]`).click();
 
     //upload a collection
 

--- a/test/cypress/e2e/namespaces/namespace_delete.js
+++ b/test/cypress/e2e/namespaces/namespace_delete.js
@@ -10,7 +10,7 @@ describe('Delete a namespace', () => {
   it('deletes a namespace', () => {
     cy.galaxykit('-i namespace create', 'testns1');
     cy.menuGo('Collections > Namespaces');
-    cy.intercept('GET', apiPrefix + '_ui/v1/namespaces/?sort=name*').as(
+    cy.intercept('GET', `${apiPrefix}_ui/v1/namespaces/?sort=name*`).as(
       'reload',
     );
     cy.get(`a[href*="${uiPrefix}repo/published/testns1"]`).click();
@@ -27,7 +27,7 @@ describe('Delete a namespace', () => {
 
   it('cannot delete a non-empty namespace', () => {
     //create namespace
-    cy.intercept('GET', apiPrefix + '_ui/v1/namespaces/?sort=name*').as(
+    cy.intercept('GET', `${apiPrefix}_ui/v1/namespaces/?sort=name*`).as(
       'reload',
     );
     cy.galaxykit('-i namespace create', 'ansible');
@@ -47,7 +47,7 @@ describe('Delete a namespace', () => {
     // attempt deletion
     cy.intercept(
       'GET',
-      apiPrefix + '_ui/v1/namespaces/?sort=name&offset=0&limit=20',
+      `${apiPrefix}_ui/v1/namespaces/?sort=name&offset=0&limit=20`,
     ).as('namespaces');
     cy.menuGo('Collections > Namespaces');
     cy.wait('@namespaces');

--- a/test/cypress/e2e/namespaces/namespace_delete.js
+++ b/test/cypress/e2e/namespaces/namespace_delete.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Delete a namespace', () => {
   beforeEach(() => {
     cy.login();
@@ -7,10 +9,9 @@ describe('Delete a namespace', () => {
   it('deletes a namespace', () => {
     cy.galaxykit('-i namespace create', 'testns1');
     cy.menuGo('Collections > Namespaces');
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') + '_ui/v1/namespaces/?sort=name*',
-    ).as('reload');
+    cy.intercept('GET', apiPrefix + '_ui/v1/namespaces/?sort=name*').as(
+      'reload',
+    );
     cy.get('a[href*="ui/repo/published/testns1"]').click();
     cy.get('[data-cy="ns-kebab-toggle"]').click();
     cy.contains('Delete namespace').click();
@@ -25,10 +26,9 @@ describe('Delete a namespace', () => {
 
   it('cannot delete a non-empty namespace', () => {
     //create namespace
-    cy.intercept(
-      'GET',
-      Cypress.env('prefix') + '_ui/v1/namespaces/?sort=name*',
-    ).as('reload');
+    cy.intercept('GET', apiPrefix + '_ui/v1/namespaces/?sort=name*').as(
+      'reload',
+    );
     cy.galaxykit('-i namespace create', 'ansible');
     cy.menuGo('Collections > Namespaces');
     cy.wait('@reload');
@@ -46,7 +46,7 @@ describe('Delete a namespace', () => {
     // attempt deletion
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/namespaces/?sort=name&offset=0&limit=20',
+      apiPrefix + '_ui/v1/namespaces/?sort=name&offset=0&limit=20',
     ).as('namespaces');
     cy.menuGo('Collections > Namespaces');
     cy.wait('@namespaces');

--- a/test/cypress/e2e/namespaces/namespace_detail.js
+++ b/test/cypress/e2e/namespaces/namespace_detail.js
@@ -1,3 +1,5 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('Namespace detail screen', () => {
   before(() => {
     cy.deleteNamespacesAndCollections();
@@ -13,7 +15,7 @@ describe('Namespace detail screen', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit('/ui/repo/published/namespace_detail_test');
+    cy.visit(uiPrefix + 'repo/published/namespace_detail_test');
   });
 
   it('should display the collections belonging to the namespace', () => {
@@ -29,7 +31,7 @@ describe('Namespace detail screen', () => {
     cy.contains('.body ul a', 'Deprecate').click();
 
     // Reload the page
-    cy.visit('/ui/repo/published/namespace_detail_test');
+    cy.visit(uiPrefix + 'repo/published/namespace_detail_test');
 
     cy.get('[data-cy="CollectionListItem"]:first').contains('DEPRECATED');
   });
@@ -78,7 +80,7 @@ describe('Namespace detail screen', () => {
   it('should filter by repositories', () => {
     const namespace = 'coolestnamespace';
     cy.galaxykit('-i namespace create', namespace);
-    cy.visit(`/ui/repo/published/${namespace}`);
+    cy.visit(`${uiPrefix}repo/published/${namespace}`);
 
     cy.get('.nav-select').contains('Published').click();
     cy.contains('Red Hat Certified').click();
@@ -86,7 +88,7 @@ describe('Namespace detail screen', () => {
     cy.get('.nav-select').contains('Red Hat Certified');
     cy.url().should('include', `/repo/rh-certified/${namespace}`);
 
-    cy.visit(`/ui/repo/community/${namespace}`);
+    cy.visit(`${uiPrefix}repo/community/${namespace}`);
     cy.get('.nav-select').contains('Community');
   });
 
@@ -96,7 +98,7 @@ describe('Namespace detail screen', () => {
     cy.galaxykit('-i namespace create', namespace);
     cy.galaxykit('collection upload', namespace, collection);
 
-    cy.visit(`/ui/repo/published/${namespace}/${collection}`);
+    cy.visit(`${uiPrefix}repo/published/${namespace}/${collection}`);
     cy.get('.nav-select').contains('Published').should('be.disabled');
   });
 });

--- a/test/cypress/e2e/namespaces/namespace_detail.js
+++ b/test/cypress/e2e/namespaces/namespace_detail.js
@@ -15,7 +15,7 @@ describe('Namespace detail screen', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit(uiPrefix + 'repo/published/namespace_detail_test');
+    cy.visit(`${uiPrefix}repo/published/namespace_detail_test`);
   });
 
   it('should display the collections belonging to the namespace', () => {
@@ -31,7 +31,7 @@ describe('Namespace detail screen', () => {
     cy.contains('.body ul a', 'Deprecate').click();
 
     // Reload the page
-    cy.visit(uiPrefix + 'repo/published/namespace_detail_test');
+    cy.visit(`${uiPrefix}repo/published/namespace_detail_test`);
 
     cy.get('[data-cy="CollectionListItem"]:first').contains('DEPRECATED');
   });

--- a/test/cypress/e2e/namespaces/namespace_edit.js
+++ b/test/cypress/e2e/namespaces/namespace_edit.js
@@ -1,3 +1,5 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('Edit a namespace', () => {
   let kebabToggle = () => {
     return cy.get('button[id^=pf-dropdown-toggle-id-] > svg').parent().click();
@@ -44,7 +46,7 @@ describe('Edit a namespace', () => {
     cy.login();
     cy.galaxykit('-i namespace create', 'testns1');
     cy.menuGo('Collections > Namespaces');
-    cy.get('a[href*="ui/repo/published/testns1"]').click();
+    cy.get(`a[href*="${uiPrefix}repo/published/testns1"]`).click();
     kebabToggle();
     cy.contains('Edit namespace').click();
   });
@@ -70,7 +72,7 @@ describe('Edit a namespace', () => {
   it('saves a new company name', () => {
     cy.get('#company').clear().type('Company name');
     saveButton().click();
-    cy.url().should('match', /\/ui\/repo\/published\/testns1/);
+    cy.url().should('match', new RegExp(`${uiPrefix}repo/published/testns1`));
     cy.get('.pf-c-title').should('contain', 'Company name');
   });
 

--- a/test/cypress/e2e/namespaces/namespace_form.js
+++ b/test/cypress/e2e/namespaces/namespace_form.js
@@ -19,9 +19,6 @@ describe('A namespace form', () => {
   let createNamespace = () => {
     return cy.galaxykit('-i namespace create', 'testns1');
   };
-  let getUrl = () => {
-    return cy.url();
-  };
 
   beforeEach(() => {
     cy.login();

--- a/test/cypress/e2e/namespaces/namespace_form.js
+++ b/test/cypress/e2e/namespaces/namespace_form.js
@@ -1,3 +1,5 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('A namespace form', () => {
   let getCreateNamespace = () => {
     return cy.get('.pf-c-button.pf-m-primary');
@@ -84,6 +86,6 @@ describe('A namespace form', () => {
     let id = parseInt(Math.random() * 1000000);
     getInputBox().type(`testns_${id}`);
     getCreateButton().click();
-    getUrl().should('match', /\/ui\/repo\/published\/testns_/);
+    cy.url().should('match', new RegExp(`${uiPrefix}repo/published/testns_`));
   });
 });

--- a/test/cypress/e2e/repo/container-signing.js
+++ b/test/cypress/e2e/repo/container-signing.js
@@ -1,3 +1,5 @@
+const uiPrefix = Cypress.env('uiPrefix');
+
 describe('Container Signing', () => {
   const user = 'EESignTestUser';
   const password = 'MyPassword123';
@@ -48,7 +50,7 @@ describe('Container Signing', () => {
 
   it('can sign remote1', () => {
     cy.login();
-    cy.visit('/ui/containers/remote1');
+    cy.visit(uiPrefix + 'containers/remote1');
     cy.contains('.column-section', 'remote1');
     cy.contains('.header-bottom', 'Unsigned', {
       timeout: 10000,
@@ -66,7 +68,7 @@ describe('Container Signing', () => {
 
   it('can not sign remote2', () => {
     cy.login();
-    cy.visit('/ui/containers/remote2');
+    cy.visit(uiPrefix + 'containers/remote2');
     cy.contains('.column-section', 'remote2');
     cy.contains('.header-bottom', 'Unsigned', {
       timeout: 10000,
@@ -79,7 +81,7 @@ describe('Container Signing', () => {
 
   it('can sign local', () => {
     cy.login();
-    cy.visit('/ui/containers/local1');
+    cy.visit(uiPrefix + 'containers/local1');
     cy.contains('.column-section', 'local1');
     cy.contains('.header-bottom', 'Unsigned', {
       timeout: 10000,
@@ -95,7 +97,7 @@ describe('Container Signing', () => {
 
   it('cant see sign button when user has no rights', () => {
     cy.login(user, password);
-    cy.visit('/ui/containers/local1');
+    cy.visit(uiPrefix + 'containers/local1');
     // this is now covered by alert that should not be here in the future
     cy.get('button[aria-label="Actions"]').click({ force: true });
     cy.contains('[role="menuitem"]', 'Use in Controller');

--- a/test/cypress/e2e/repo/container-signing.js
+++ b/test/cypress/e2e/repo/container-signing.js
@@ -50,7 +50,7 @@ describe('Container Signing', () => {
 
   it('can sign remote1', () => {
     cy.login();
-    cy.visit(uiPrefix + 'containers/remote1');
+    cy.visit(`${uiPrefix}containers/remote1`);
     cy.contains('.column-section', 'remote1');
     cy.contains('.header-bottom', 'Unsigned', {
       timeout: 10000,
@@ -68,7 +68,7 @@ describe('Container Signing', () => {
 
   it('can not sign remote2', () => {
     cy.login();
-    cy.visit(uiPrefix + 'containers/remote2');
+    cy.visit(`${uiPrefix}containers/remote2`);
     cy.contains('.column-section', 'remote2');
     cy.contains('.header-bottom', 'Unsigned', {
       timeout: 10000,
@@ -81,7 +81,7 @@ describe('Container Signing', () => {
 
   it('can sign local', () => {
     cy.login();
-    cy.visit(uiPrefix + 'containers/local1');
+    cy.visit(`${uiPrefix}containers/local1`);
     cy.contains('.column-section', 'local1');
     cy.contains('.header-bottom', 'Unsigned', {
       timeout: 10000,
@@ -97,7 +97,7 @@ describe('Container Signing', () => {
 
   it('cant see sign button when user has no rights', () => {
     cy.login(user, password);
-    cy.visit(uiPrefix + 'containers/local1');
+    cy.visit(`${uiPrefix}containers/local1`);
     // this is now covered by alert that should not be here in the future
     cy.get('button[aria-label="Actions"]').click({ force: true });
     cy.contains('[role="menuitem"]', 'Use in Controller');

--- a/test/cypress/e2e/repo/remote_registry.js
+++ b/test/cypress/e2e/repo/remote_registry.js
@@ -41,7 +41,7 @@ describe('Remote Registry Tests', () => {
   });
 
   it('admin can view data', () => {
-    cy.visit(uiPrefix + 'registries');
+    cy.visit(`${uiPrefix}registries`);
 
     // table headers
     cy.contains('Remote Registries');
@@ -62,11 +62,11 @@ describe('Remote Registry Tests', () => {
   });
 
   it('user can sync succesfully remote registry', () => {
-    cy.visit(uiPrefix + 'registries');
+    cy.visit(`${uiPrefix}registries`);
 
     cy.intercept(
       'POST',
-      apiPrefix + '_ui/v1/execution-environments/registries/*/sync',
+      `${apiPrefix}_ui/v1/execution-environments/registries/*/sync`,
     ).as('sync');
 
     cy.get(
@@ -108,14 +108,14 @@ describe('Remote Registry Tests', () => {
 
     cy.intercept(
       'GET',
-      apiPrefix + '_ui/v1/execution-environments/registries/?*',
+      `${apiPrefix}_ui/v1/execution-environments/registries/?*`,
     ).as('registriesGet');
 
     cy.contains('button', 'Save').click();
     cy.wait('@registriesGet');
 
     // verify url change in list view
-    cy.visit(uiPrefix + 'registries');
+    cy.visit(`${uiPrefix}registries`);
     cy.contains('table tr', 'https://some new url2');
 
     // verify advanced option values have been saved properly.

--- a/test/cypress/e2e/repo/remote_registry.js
+++ b/test/cypress/e2e/repo/remote_registry.js
@@ -1,4 +1,5 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Remote Registry Tests', () => {
   before(() => {
@@ -40,7 +41,7 @@ describe('Remote Registry Tests', () => {
   });
 
   it('admin can view data', () => {
-    cy.visit('/ui/registries');
+    cy.visit(uiPrefix + 'registries');
 
     // table headers
     cy.contains('Remote Registries');
@@ -61,7 +62,7 @@ describe('Remote Registry Tests', () => {
   });
 
   it('user can sync succesfully remote registry', () => {
-    cy.visit('/ui/registries');
+    cy.visit(uiPrefix + 'registries');
 
     cy.intercept(
       'POST',
@@ -114,7 +115,7 @@ describe('Remote Registry Tests', () => {
     cy.wait('@registriesGet');
 
     // verify url change in list view
-    cy.visit('/ui/registries');
+    cy.visit(uiPrefix + 'registries');
     cy.contains('table tr', 'https://some new url2');
 
     // verify advanced option values have been saved properly.

--- a/test/cypress/e2e/repo/remote_registry.js
+++ b/test/cypress/e2e/repo/remote_registry.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Remote Registry Tests', () => {
   before(() => {
     cy.visit('/');
@@ -63,7 +65,7 @@ describe('Remote Registry Tests', () => {
 
     cy.intercept(
       'POST',
-      Cypress.env('prefix') + '_ui/v1/execution-environments/registries/*/sync',
+      apiPrefix + '_ui/v1/execution-environments/registries/*/sync',
     ).as('sync');
 
     cy.get(
@@ -105,7 +107,7 @@ describe('Remote Registry Tests', () => {
 
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/execution-environments/registries/?*',
+      apiPrefix + '_ui/v1/execution-environments/registries/?*',
     ).as('registriesGet');
 
     cy.contains('button', 'Save').click();

--- a/test/cypress/e2e/repo/remote_repo_edit.js
+++ b/test/cypress/e2e/repo/remote_repo_edit.js
@@ -1,7 +1,8 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('edit a remote repository', () => {
-  let remoteRepoUrl = '/ui/repositories?tab=remote';
+  let remoteRepoUrl = uiPrefix + 'repositories?tab=remote';
 
   beforeEach(() => {
     cy.login();

--- a/test/cypress/e2e/repo/remote_repo_edit.js
+++ b/test/cypress/e2e/repo/remote_repo_edit.js
@@ -2,7 +2,7 @@ const apiPrefix = Cypress.env('apiPrefix');
 const uiPrefix = Cypress.env('uiPrefix');
 
 describe('edit a remote repository', () => {
-  let remoteRepoUrl = uiPrefix + 'repositories?tab=remote';
+  let remoteRepoUrl = `${uiPrefix}repositories?tab=remote`;
 
   beforeEach(() => {
     cy.login();
@@ -37,7 +37,7 @@ describe('edit a remote repository', () => {
           fileName: 'test.yaml',
         });
       });
-    cy.intercept('PUT', apiPrefix + 'content/community/v3/sync/config/').as(
+    cy.intercept('PUT', `${apiPrefix}content/community/v3/sync/config/`).as(
       'editCommunityRemote',
     );
     cy.contains('Save').click();
@@ -102,7 +102,7 @@ describe('edit a remote repository', () => {
     cy.get('input[id="proxy_url"]').type('https://example.org');
     cy.get('input[id="proxy_username"]').type('test');
     cy.get('input[id="proxy_password"]').type('test');
-    cy.intercept('PUT', apiPrefix + 'content/rh-certified/v3/sync/config/').as(
+    cy.intercept('PUT', `${apiPrefix}content/rh-certified/v3/sync/config/`).as(
       'editRemote',
     );
     cy.contains('Save').click();
@@ -116,7 +116,7 @@ describe('edit a remote repository', () => {
     cy.get('input[id="username"]').should('have.value', 'test');
     cy.get('input[id="proxy_url"]').should('have.value', 'https://example.org');
     cy.get('input[id="proxy_username"]').should('have.value', 'test');
-    cy.intercept('PUT', apiPrefix + 'content/community/v3/sync/config/').as(
+    cy.intercept('PUT', `${apiPrefix}content/community/v3/sync/config/`).as(
       'editRemote',
     );
     cy.contains('Save').click();

--- a/test/cypress/e2e/repo/remote_repo_edit.js
+++ b/test/cypress/e2e/repo/remote_repo_edit.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('edit a remote repository', () => {
   let remoteRepoUrl = '/ui/repositories?tab=remote';
 
@@ -34,10 +36,9 @@ describe('edit a remote repository', () => {
           fileName: 'test.yaml',
         });
       });
-    cy.intercept(
-      'PUT',
-      Cypress.env('prefix') + 'content/community/v3/sync/config/',
-    ).as('editCommunityRemote');
+    cy.intercept('PUT', apiPrefix + 'content/community/v3/sync/config/').as(
+      'editCommunityRemote',
+    );
     cy.contains('Save').click();
     cy.wait('@editCommunityRemote');
 
@@ -100,10 +101,9 @@ describe('edit a remote repository', () => {
     cy.get('input[id="proxy_url"]').type('https://example.org');
     cy.get('input[id="proxy_username"]').type('test');
     cy.get('input[id="proxy_password"]').type('test');
-    cy.intercept(
-      'PUT',
-      Cypress.env('prefix') + 'content/rh-certified/v3/sync/config/',
-    ).as('editRemote');
+    cy.intercept('PUT', apiPrefix + 'content/rh-certified/v3/sync/config/').as(
+      'editRemote',
+    );
     cy.contains('Save').click();
     cy.wait('@editRemote');
 
@@ -115,10 +115,9 @@ describe('edit a remote repository', () => {
     cy.get('input[id="username"]').should('have.value', 'test');
     cy.get('input[id="proxy_url"]').should('have.value', 'https://example.org');
     cy.get('input[id="proxy_username"]').should('have.value', 'test');
-    cy.intercept(
-      'PUT',
-      Cypress.env('prefix') + 'content/community/v3/sync/config/',
-    ).as('editRemote');
+    cy.intercept('PUT', apiPrefix + 'content/community/v3/sync/config/').as(
+      'editRemote',
+    );
     cy.contains('Save').click();
     cy.wait('@editRemote');
 

--- a/test/cypress/e2e/repo/repo_management.js
+++ b/test/cypress/e2e/repo/repo_management.js
@@ -2,8 +2,8 @@ const apiPrefix = Cypress.env('apiPrefix');
 const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Repo Management tests', () => {
-  let remoteRepoUrl = uiPrefix + 'repositories?tab=remote';
-  let localRepoUrl = uiPrefix + 'repositories';
+  let remoteRepoUrl = `${uiPrefix}repositories?tab=remote`;
+  let localRepoUrl = `${uiPrefix}repositories`;
 
   let noPrivilegesUser0 = 'noPrivilegesUser0';
 
@@ -57,7 +57,7 @@ describe('Repo Management tests', () => {
     cy.visit(localRepoUrl);
     cy.intercept(
       'GET',
-      apiPrefix + '_ui/v1/distributions/?offset=0&limit=10',
+      `${apiPrefix}_ui/v1/distributions/?offset=0&limit=10`,
     ).as('loadRepos');
     cy.wait('@loadRepos');
     cy.get('button').contains('Get token').click();
@@ -76,7 +76,7 @@ describe('Repo Management tests', () => {
     ).click(); //show expandable content
     cy.get(
       '.pf-c-clipboard-copy > .pf-c-clipboard-copy__expandable-content > pre:first',
-    ).contains(apiPrefix + 'content/community/'); // check content of input
+    ).contains(`${apiPrefix}content/community/`); // check content of input
 
     cy.get('button[aria-label="Copy to clipboard"]').eq(1).should('be.enabled');
   });
@@ -111,7 +111,7 @@ describe('Repo Management tests', () => {
     cy.visit(remoteRepoUrl);
 
     //checks sync status === 'Running' after sync post request
-    cy.intercept('POST', apiPrefix + 'content/rh-certified/v3/sync/').as(
+    cy.intercept('POST', `${apiPrefix}content/rh-certified/v3/sync/`).as(
       'startSync',
     );
     cy.get('td')
@@ -144,7 +144,7 @@ describe('Repo Management tests', () => {
     cy.get('input[id="proxy_url"]').type('https://example.org');
     cy.get('input[id="proxy_username"]').type('test');
     cy.get('input[id="proxy_password"]').type('test');
-    cy.intercept('PUT', apiPrefix + 'content/community/v3/sync/config/').as(
+    cy.intercept('PUT', `${apiPrefix}content/community/v3/sync/config/`).as(
       'saveConfig',
     );
     cy.contains('Save').click();

--- a/test/cypress/e2e/repo/repo_management.js
+++ b/test/cypress/e2e/repo/repo_management.js
@@ -1,3 +1,5 @@
+const apiPrefix = Cypress.env('apiPrefix');
+
 describe('Repo Management tests', () => {
   let remoteRepoUrl = '/ui/repositories?tab=remote';
   let localRepoUrl = '/ui/repositories';
@@ -54,7 +56,7 @@ describe('Repo Management tests', () => {
     cy.visit(localRepoUrl);
     cy.intercept(
       'GET',
-      Cypress.env('prefix') + '_ui/v1/distributions/?offset=0&limit=10',
+      apiPrefix + '_ui/v1/distributions/?offset=0&limit=10',
     ).as('loadRepos');
     cy.wait('@loadRepos');
     cy.get('button').contains('Get token').click();
@@ -73,7 +75,7 @@ describe('Repo Management tests', () => {
     ).click(); //show expandable content
     cy.get(
       '.pf-c-clipboard-copy > .pf-c-clipboard-copy__expandable-content > pre:first',
-    ).contains(Cypress.env('prefix') + 'content/community/'); // check content of input
+    ).contains(apiPrefix + 'content/community/'); // check content of input
 
     cy.get('button[aria-label="Copy to clipboard"]').eq(1).should('be.enabled');
   });
@@ -108,10 +110,9 @@ describe('Repo Management tests', () => {
     cy.visit(remoteRepoUrl);
 
     //checks sync status === 'Running' after sync post request
-    cy.intercept(
-      'POST',
-      Cypress.env('prefix') + 'content/rh-certified/v3/sync/',
-    ).as('startSync');
+    cy.intercept('POST', apiPrefix + 'content/rh-certified/v3/sync/').as(
+      'startSync',
+    );
     cy.get('td')
       .contains('rh-certified')
       .parent()
@@ -142,10 +143,9 @@ describe('Repo Management tests', () => {
     cy.get('input[id="proxy_url"]').type('https://example.org');
     cy.get('input[id="proxy_username"]').type('test');
     cy.get('input[id="proxy_password"]').type('test');
-    cy.intercept(
-      'PUT',
-      Cypress.env('prefix') + 'content/community/v3/sync/config/',
-    ).as('saveConfig');
+    cy.intercept('PUT', apiPrefix + 'content/community/v3/sync/config/').as(
+      'saveConfig',
+    );
     cy.contains('Save').click();
     cy.wait('@saveConfig').its('status').should('eq', 200);
 

--- a/test/cypress/e2e/repo/repo_management.js
+++ b/test/cypress/e2e/repo/repo_management.js
@@ -1,8 +1,9 @@
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Repo Management tests', () => {
-  let remoteRepoUrl = '/ui/repositories?tab=remote';
-  let localRepoUrl = '/ui/repositories';
+  let remoteRepoUrl = uiPrefix + 'repositories?tab=remote';
+  let localRepoUrl = uiPrefix + 'repositories';
 
   let noPrivilegesUser0 = 'noPrivilegesUser0';
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -35,7 +35,7 @@ Cypress.Commands.add('menuGo', {}, (name) => {
 });
 
 Cypress.Commands.add('apiLogin', {}, (username, password) => {
-  let loginUrl = apiPrefix + '_ui/v1/auth/login/';
+  let loginUrl = `${apiPrefix}_ui/v1/auth/login/`;
   cy.request('GET', loginUrl).then(() => {
     cy.getCookie('csrftoken').then((csrftoken) => {
       cy.request({
@@ -50,9 +50,9 @@ Cypress.Commands.add('apiLogin', {}, (username, password) => {
 });
 
 Cypress.Commands.add('manualLogin', {}, (username, password) => {
-  cy.intercept('POST', apiPrefix + '_ui/v1/auth/login/').as('login');
-  cy.intercept('GET', apiPrefix + '_ui/v1/feature-flags/').as('feature-flags');
-  cy.visit(uiPrefix + 'login');
+  cy.intercept('POST', `${apiPrefix}_ui/v1/auth/login/`).as('login');
+  cy.intercept('GET', `${apiPrefix}_ui/v1/feature-flags/`).as('feature-flags');
+  cy.visit(`${uiPrefix}login`);
   cy.get('#pf-login-username-id').type(username);
   cy.get('#pf-login-password-id').type(`${password}{enter}`);
   cy.wait('@login');
@@ -100,7 +100,7 @@ Cypress.Commands.add('cookieLogin', {}, (username, password) => {
 });
 
 Cypress.Commands.add('logout', {}, () => {
-  cy.intercept('GET', apiPrefix + '_ui/v1/feature-flags/').as('feature-flags');
+  cy.intercept('GET', `${apiPrefix}_ui/v1/feature-flags/`).as('feature-flags');
   cy.get('[aria-label="user-dropdown"] button').click();
   cy.get('[aria-label="logout"]').click();
   cy.wait('@feature-flags');
@@ -143,7 +143,7 @@ Cypress.Commands.add(
     cy.get('#password').type(user.password);
     cy.get('#password-confirm').type(user.password);
 
-    cy.intercept('POST', apiPrefix + '_ui/v1/users/').as('createUser');
+    cy.intercept('POST', `${apiPrefix}_ui/v1/users/`).as('createUser');
 
     cy.contains('Save').click();
     cy.wait('@createUser');
@@ -154,13 +154,13 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('createGroupManually', {}, (name) => {
-  cy.intercept('GET', apiPrefix + '_ui/v1/groups/?*').as('loadGroups');
+  cy.intercept('GET', `${apiPrefix}_ui/v1/groups/?*`).as('loadGroups');
   cy.menuGo('User Access > Groups');
   cy.wait('@loadGroups');
 
   cy.contains('Create').click();
 
-  cy.intercept('POST', apiPrefix + '_ui/v1/groups/').as('submitGroup');
+  cy.intercept('POST', `${apiPrefix}_ui/v1/groups/`).as('submitGroup');
   cy.contains('div', 'Name *').findnear('input').first().type(`${name}{enter}`);
   cy.wait('@submitGroup');
 
@@ -214,14 +214,14 @@ Cypress.Commands.add(
 
 Cypress.Commands.add('deleteUser', {}, (username) => {
   cy.menuGo('User Access > Users');
-  cy.intercept('DELETE', apiPrefix + '_ui/v1/users/*').as('deleteUser');
+  cy.intercept('DELETE', `${apiPrefix}_ui/v1/users/*`).as('deleteUser');
   cy.get(`[data-cy="UserList-row-${username}"] [aria-label="Actions"]`).click();
   cy.containsnear(
     `[data-cy="UserList-row-${username}"] [aria-label="Actions"]`,
     'Delete',
   ).click();
 
-  cy.intercept('GET', apiPrefix + '_ui/v1/users/?*').as('userList');
+  cy.intercept('GET', `${apiPrefix}_ui/v1/users/?*`).as('userList');
 
   cy.contains('[role=dialog] button', 'Delete').click();
   cy.wait('@deleteUser').then(({ response }) => {
@@ -238,8 +238,8 @@ Cypress.Commands.add('deleteUser', {}, (username) => {
 
 Cypress.Commands.add('deleteGroupManually', {}, (name) => {
   cy.menuGo('User Access > Groups');
-  cy.intercept('DELETE', apiPrefix + '_ui/v1/groups/*').as('deleteGroup');
-  cy.intercept('GET', apiPrefix + '_ui/v1/groups/?*').as('listGroups');
+  cy.intercept('DELETE', `${apiPrefix}_ui/v1/groups/*`).as('deleteGroup');
+  cy.intercept('GET', `${apiPrefix}_ui/v1/groups/?*`).as('listGroups');
   cy.get(`[data-cy="GroupList-row-${name}"] [aria-label="Actions"]`).click();
   cy.get('[aria-label=Delete]').click();
   cy.contains('[role=dialog] button', 'Delete').click();
@@ -343,7 +343,7 @@ Cypress.Commands.add('settings', {}, (newSettings) => {
       // wait for server to respond with a good status (502 means server didn't restart yet)
       // ..after waiting to make sure we're not faster than the restart
       cy.request({
-        url: apiPrefix + '_ui/v1/feature-flags/',
+        url: `${apiPrefix}_ui/v1/feature-flags/`,
         retryOnStatusCodeFailure: true,
       }).then((response) => {
         console.log(
@@ -389,12 +389,12 @@ Cypress.Commands.add('addRemoteRegistry', {}, (name, url, extra = null) => {
 
   cy.intercept(
     'POST',
-    apiPrefix + '_ui/v1/execution-environments/registries/',
+    `${apiPrefix}_ui/v1/execution-environments/registries/`,
   ).as('registries');
 
   cy.intercept(
     'GET',
-    apiPrefix + '_ui/v1/execution-environments/registries/?*',
+    `${apiPrefix}_ui/v1/execution-environments/registries/?*`,
   ).as('registriesGet');
 
   cy.contains('button', 'Save').click();
@@ -439,12 +439,12 @@ Cypress.Commands.add(
 
     cy.intercept(
       'POST',
-      apiPrefix + '_ui/v1/execution-environments/remotes/',
+      `${apiPrefix}_ui/v1/execution-environments/remotes/`,
     ).as('saved');
 
     cy.intercept(
       'GET',
-      apiPrefix + 'v3/plugin/execution-environments/repositories/?*',
+      `${apiPrefix}v3/plugin/execution-environments/repositories/?*`,
     ).as('listLoad');
 
     cy.contains('button', 'Save').click();
@@ -512,10 +512,10 @@ Cypress.Commands.add('syncRemoteContainer', {}, (name) => {
 Cypress.Commands.add('deleteRegistriesManual', {}, () => {
   cy.intercept(
     'GET',
-    apiPrefix + '_ui/v1/execution-environments/registries/?*',
+    `${apiPrefix}_ui/v1/execution-environments/registries/?*`,
   ).as('registries');
 
-  cy.visit(uiPrefix + 'registries');
+  cy.visit(`${uiPrefix}registries`);
 
   cy.wait('@registries').then((result) => {
     var data = result.response.body.data;
@@ -533,10 +533,10 @@ Cypress.Commands.add('deleteRegistriesManual', {}, () => {
 Cypress.Commands.add('deleteRegistries', {}, () => {
   cy.intercept(
     'GET',
-    apiPrefix + '_ui/v1/execution-environments/registries/?*',
+    `${apiPrefix}_ui/v1/execution-environments/registries/?*`,
   ).as('registries');
 
-  cy.visit(uiPrefix + 'registries?page_size=100');
+  cy.visit(`${uiPrefix}registries?page_size=100`);
 
   cy.wait('@registries').then((result) => {
     var data = result.response.body.data;
@@ -549,10 +549,10 @@ Cypress.Commands.add('deleteRegistries', {}, () => {
 Cypress.Commands.add('deleteContainers', {}, () => {
   cy.intercept(
     'GET',
-    apiPrefix + 'v3/plugin/execution-environments/repositories/?*',
+    `${apiPrefix}v3/plugin/execution-environments/repositories/?*`,
   ).as('listLoad');
 
-  cy.visit(uiPrefix + 'containers?page_size=100');
+  cy.visit(`${uiPrefix}containers?page_size=100`);
 
   cy.wait('@listLoad').then((result) => {
     var data = result.response.body.data;
@@ -565,10 +565,10 @@ Cypress.Commands.add('deleteContainers', {}, () => {
 Cypress.Commands.add('deleteContainersManual', {}, () => {
   cy.intercept(
     'GET',
-    apiPrefix + 'v3/plugin/execution-environments/repositories/?*',
+    `${apiPrefix}v3/plugin/execution-environments/repositories/?*`,
   ).as('listLoad');
 
-  cy.visit(uiPrefix + 'containers');
+  cy.visit(`${uiPrefix}containers`);
 
   cy.wait('@listLoad').then((result) => {
     var data = result.response.body.data;
@@ -647,7 +647,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('deleteRole', {}, (role) => {
-  cy.visit(uiPrefix + 'roles/');
+  cy.visit(`${uiPrefix}roles/`);
 
   cy.get(
     `[data-cy="RoleListTable-ExpandableRow-row-${role}"] [data-cy=kebab-toggle]`,

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -4,6 +4,7 @@ import shell from 'shell-escape-tag';
 import { range } from 'lodash';
 
 const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
 
 Cypress.Commands.add('findnear', { prevSubject: true }, (subject, selector) => {
   return subject.closest(`*:has(${selector})`).find(selector);
@@ -51,7 +52,7 @@ Cypress.Commands.add('apiLogin', {}, (username, password) => {
 Cypress.Commands.add('manualLogin', {}, (username, password) => {
   cy.intercept('POST', apiPrefix + '_ui/v1/auth/login/').as('login');
   cy.intercept('GET', apiPrefix + '_ui/v1/feature-flags/').as('feature-flags');
-  cy.visit('/ui/login');
+  cy.visit(uiPrefix + 'login');
   cy.get('#pf-login-username-id').type(username);
   cy.get('#pf-login-password-id').type(`${password}{enter}`);
   cy.wait('@login');
@@ -514,7 +515,7 @@ Cypress.Commands.add('deleteRegistriesManual', {}, () => {
     apiPrefix + '_ui/v1/execution-environments/registries/?*',
   ).as('registries');
 
-  cy.visit('/ui/registries');
+  cy.visit(uiPrefix + 'registries');
 
   cy.wait('@registries').then((result) => {
     var data = result.response.body.data;
@@ -535,7 +536,7 @@ Cypress.Commands.add('deleteRegistries', {}, () => {
     apiPrefix + '_ui/v1/execution-environments/registries/?*',
   ).as('registries');
 
-  cy.visit('/ui/registries?page_size=100');
+  cy.visit(uiPrefix + 'registries?page_size=100');
 
   cy.wait('@registries').then((result) => {
     var data = result.response.body.data;
@@ -551,7 +552,7 @@ Cypress.Commands.add('deleteContainers', {}, () => {
     apiPrefix + 'v3/plugin/execution-environments/repositories/?*',
   ).as('listLoad');
 
-  cy.visit('/ui/containers?page_size=100');
+  cy.visit(uiPrefix + 'containers?page_size=100');
 
   cy.wait('@listLoad').then((result) => {
     var data = result.response.body.data;
@@ -567,7 +568,7 @@ Cypress.Commands.add('deleteContainersManual', {}, () => {
     apiPrefix + 'v3/plugin/execution-environments/repositories/?*',
   ).as('listLoad');
 
-  cy.visit('/ui/containers');
+  cy.visit(uiPrefix + 'containers');
 
   cy.wait('@listLoad').then((result) => {
     var data = result.response.body.data;
@@ -646,7 +647,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('deleteRole', {}, (role) => {
-  cy.visit('/ui/roles/');
+  cy.visit(uiPrefix + 'roles/');
 
   cy.get(
     `[data-cy="RoleListTable-ExpandableRow-row-${role}"] [data-cy=kebab-toggle]`,

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -3,6 +3,8 @@
 import shell from 'shell-escape-tag';
 import { range } from 'lodash';
 
+const apiPrefix = Cypress.env('apiPrefix');
+
 Cypress.Commands.add('findnear', { prevSubject: true }, (subject, selector) => {
   return subject.closest(`*:has(${selector})`).find(selector);
 });
@@ -32,7 +34,7 @@ Cypress.Commands.add('menuGo', {}, (name) => {
 });
 
 Cypress.Commands.add('apiLogin', {}, (username, password) => {
-  let loginUrl = Cypress.env('prefix') + '_ui/v1/auth/login/';
+  let loginUrl = apiPrefix + '_ui/v1/auth/login/';
   cy.request('GET', loginUrl).then(() => {
     cy.getCookie('csrftoken').then((csrftoken) => {
       cy.request({
@@ -47,12 +49,8 @@ Cypress.Commands.add('apiLogin', {}, (username, password) => {
 });
 
 Cypress.Commands.add('manualLogin', {}, (username, password) => {
-  cy.intercept('POST', Cypress.env('prefix') + '_ui/v1/auth/login/').as(
-    'login',
-  );
-  cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/feature-flags/').as(
-    'feature-flags',
-  );
+  cy.intercept('POST', apiPrefix + '_ui/v1/auth/login/').as('login');
+  cy.intercept('GET', apiPrefix + '_ui/v1/feature-flags/').as('feature-flags');
   cy.visit('/ui/login');
   cy.get('#pf-login-username-id').type(username);
   cy.get('#pf-login-password-id').type(`${password}{enter}`);
@@ -101,9 +99,7 @@ Cypress.Commands.add('cookieLogin', {}, (username, password) => {
 });
 
 Cypress.Commands.add('logout', {}, () => {
-  cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/feature-flags/').as(
-    'feature-flags',
-  );
+  cy.intercept('GET', apiPrefix + '_ui/v1/feature-flags/').as('feature-flags');
   cy.get('[aria-label="user-dropdown"] button').click();
   cy.get('[aria-label="logout"]').click();
   cy.wait('@feature-flags');
@@ -146,9 +142,7 @@ Cypress.Commands.add(
     cy.get('#password').type(user.password);
     cy.get('#password-confirm').type(user.password);
 
-    cy.intercept('POST', Cypress.env('prefix') + '_ui/v1/users/').as(
-      'createUser',
-    );
+    cy.intercept('POST', apiPrefix + '_ui/v1/users/').as('createUser');
 
     cy.contains('Save').click();
     cy.wait('@createUser');
@@ -159,17 +153,13 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('createGroupManually', {}, (name) => {
-  cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/groups/?*').as(
-    'loadGroups',
-  );
+  cy.intercept('GET', apiPrefix + '_ui/v1/groups/?*').as('loadGroups');
   cy.menuGo('User Access > Groups');
   cy.wait('@loadGroups');
 
   cy.contains('Create').click();
 
-  cy.intercept('POST', Cypress.env('prefix') + '_ui/v1/groups/').as(
-    'submitGroup',
-  );
+  cy.intercept('POST', apiPrefix + '_ui/v1/groups/').as('submitGroup');
   cy.contains('div', 'Name *').findnear('input').first().type(`${name}{enter}`);
   cy.wait('@submitGroup');
 
@@ -223,16 +213,14 @@ Cypress.Commands.add(
 
 Cypress.Commands.add('deleteUser', {}, (username) => {
   cy.menuGo('User Access > Users');
-  cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/users/*').as(
-    'deleteUser',
-  );
+  cy.intercept('DELETE', apiPrefix + '_ui/v1/users/*').as('deleteUser');
   cy.get(`[data-cy="UserList-row-${username}"] [aria-label="Actions"]`).click();
   cy.containsnear(
     `[data-cy="UserList-row-${username}"] [aria-label="Actions"]`,
     'Delete',
   ).click();
 
-  cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/users/?*').as('userList');
+  cy.intercept('GET', apiPrefix + '_ui/v1/users/?*').as('userList');
 
   cy.contains('[role=dialog] button', 'Delete').click();
   cy.wait('@deleteUser').then(({ response }) => {
@@ -249,12 +237,8 @@ Cypress.Commands.add('deleteUser', {}, (username) => {
 
 Cypress.Commands.add('deleteGroupManually', {}, (name) => {
   cy.menuGo('User Access > Groups');
-  cy.intercept('DELETE', Cypress.env('prefix') + '_ui/v1/groups/*').as(
-    'deleteGroup',
-  );
-  cy.intercept('GET', Cypress.env('prefix') + '_ui/v1/groups/?*').as(
-    'listGroups',
-  );
+  cy.intercept('DELETE', apiPrefix + '_ui/v1/groups/*').as('deleteGroup');
+  cy.intercept('GET', apiPrefix + '_ui/v1/groups/?*').as('listGroups');
   cy.get(`[data-cy="GroupList-row-${name}"] [aria-label="Actions"]`).click();
   cy.get('[aria-label=Delete]').click();
   cy.contains('[role=dialog] button', 'Delete').click();
@@ -273,7 +257,7 @@ Cypress.Commands.add('galaxykit', {}, (operation, ...args) => {
   const adminUsername = Cypress.env('username');
   const adminPassword = Cypress.env('password');
   const galaxykitCommand = Cypress.env('galaxykit') || 'galaxykit';
-  const server = Cypress.config().baseUrl + Cypress.env('prefix');
+  const server = Cypress.config().baseUrl + apiPrefix;
   const options = (args.length >= 1 &&
     typeof args[args.length - 1] == 'object' &&
     args.splice(args.length - 1, 1)[0]) || { failOnNonZeroExit: false };
@@ -358,7 +342,7 @@ Cypress.Commands.add('settings', {}, (newSettings) => {
       // wait for server to respond with a good status (502 means server didn't restart yet)
       // ..after waiting to make sure we're not faster than the restart
       cy.request({
-        url: Cypress.env('prefix') + '_ui/v1/feature-flags/',
+        url: apiPrefix + '_ui/v1/feature-flags/',
         retryOnStatusCodeFailure: true,
       }).then((response) => {
         console.log(
@@ -404,12 +388,12 @@ Cypress.Commands.add('addRemoteRegistry', {}, (name, url, extra = null) => {
 
   cy.intercept(
     'POST',
-    Cypress.env('prefix') + '_ui/v1/execution-environments/registries/',
+    apiPrefix + '_ui/v1/execution-environments/registries/',
   ).as('registries');
 
   cy.intercept(
     'GET',
-    Cypress.env('prefix') + '_ui/v1/execution-environments/registries/?*',
+    apiPrefix + '_ui/v1/execution-environments/registries/?*',
   ).as('registriesGet');
 
   cy.contains('button', 'Save').click();
@@ -454,13 +438,12 @@ Cypress.Commands.add(
 
     cy.intercept(
       'POST',
-      Cypress.env('prefix') + '_ui/v1/execution-environments/remotes/',
+      apiPrefix + '_ui/v1/execution-environments/remotes/',
     ).as('saved');
 
     cy.intercept(
       'GET',
-      Cypress.env('prefix') +
-        'v3/plugin/execution-environments/repositories/?*',
+      apiPrefix + 'v3/plugin/execution-environments/repositories/?*',
     ).as('listLoad');
 
     cy.contains('button', 'Save').click();
@@ -528,7 +511,7 @@ Cypress.Commands.add('syncRemoteContainer', {}, (name) => {
 Cypress.Commands.add('deleteRegistriesManual', {}, () => {
   cy.intercept(
     'GET',
-    Cypress.env('prefix') + '_ui/v1/execution-environments/registries/?*',
+    apiPrefix + '_ui/v1/execution-environments/registries/?*',
   ).as('registries');
 
   cy.visit('/ui/registries');
@@ -549,7 +532,7 @@ Cypress.Commands.add('deleteRegistriesManual', {}, () => {
 Cypress.Commands.add('deleteRegistries', {}, () => {
   cy.intercept(
     'GET',
-    Cypress.env('prefix') + '_ui/v1/execution-environments/registries/?*',
+    apiPrefix + '_ui/v1/execution-environments/registries/?*',
   ).as('registries');
 
   cy.visit('/ui/registries?page_size=100');
@@ -565,7 +548,7 @@ Cypress.Commands.add('deleteRegistries', {}, () => {
 Cypress.Commands.add('deleteContainers', {}, () => {
   cy.intercept(
     'GET',
-    Cypress.env('prefix') + 'v3/plugin/execution-environments/repositories/?*',
+    apiPrefix + 'v3/plugin/execution-environments/repositories/?*',
   ).as('listLoad');
 
   cy.visit('/ui/containers?page_size=100');
@@ -581,7 +564,7 @@ Cypress.Commands.add('deleteContainers', {}, () => {
 Cypress.Commands.add('deleteContainersManual', {}, () => {
   cy.intercept(
     'GET',
-    Cypress.env('prefix') + 'v3/plugin/execution-environments/repositories/?*',
+    apiPrefix + 'v3/plugin/execution-environments/repositories/?*',
   ).as('listLoad');
 
   cy.visit('/ui/containers');


### PR DESCRIPTION
Continues AAH-1271 from #2740 

Before:

cypress `baseUrl` *config* is set to `http://localhost:8002` - a common prefix for cypress visit and request calls
cypress `prefix` *env* is set to `/api/automation-hub/` or `/api/galaxy/` (or `/api/` for community)
(cypress `pulpPrefix` *env* is set to prefix+`pulp/api/v3/`)

After:

`baseUrl`, `pulpPrefix` remain unchanged
`prefix` renamed to `apiPrefix`
added new `uiPrefix` *env*, set to `/ui/` in standalone, `/beta/ansible/automation-hub/` in insights
