### PR TITLE
automerge workflow: skip on non-dependabot PRs, fail on bad args, and patternfly

### DIFF
--- a/.github/workflows/automerge.js
+++ b/.github/workflows/automerge.js
@@ -1,56 +1,37 @@
-let { exec } = require('node:child_process');
-console.log(exec);
+const { exec } = require('node:child_process');
+const [ _node, _automerge, branch, prTitle, actor ] = process.argv;
 
-let branch = '';
-let actor = '';
-let prName = '';
-
-if (process.argv.length >= 3) {
-  branch = process.argv[2];
-}
-if (process.argv.length >= 4) {
-  prName = process.argv[3];
-}
-if (process.argv.length >= 5) {
-  actor = process.argv[4];
-}
-
-console.log('--------------------------------------------------------');
+console.log({ branch, prTitle, actor });
 
 if (!branch) {
   console.log('Branch name argument (first) was not specified');
-  return;
+  process.exit(1);
 }
 
-if (!prName) {
-  console.log('prName argument (second) was not specified');
-  return;
+if (!prTitle) {
+  console.log('PR title argument (second) was not specified');
+  process.exit(1);
 }
 
 if (!actor) {
   console.log('Actor argument (third) was not specified');
-  return;
+  process.exit(1);
 }
-
-console.log(branch);
-console.log(prName);
-console.log(actor);
 
 if (actor != 'dependabot[bot]') {
   console.log('Automerge works only for PRs created by dependabot.');
-  return;
+  process.exit(0);
 }
 
-if (prName.includes('patternfly')) {
-  console.log('Automerge cant merge patternfly Prs.');
-  return;
+if (prTitle.includes('patternfly')) {
+  console.log('Automerge can\'t merge patternfly PRs.');
+  process.exit(1);
 }
 
-if (prName.includes('types/node')) {
-  console.log('Checking for types node version.');
-  let pattern = /from 16[.]\d\d[.]\d\d to 16[.]\d\d[.]\d\d/;
-  let res = pattern.test(prName);
-  if (res) {
+if (prTitle.includes('@types/node')) {
+  console.log('Checking for @types/node version.');
+  const pattern = /from 16[.]\d+[.]\d+ to 16[.]\d+[.]\d+/;
+  if (pattern.test(prTitle)) {
     console.log('Version does match the pattern ' + pattern);
   } else {
     console.log('Version does not match the pattern ' + pattern);

--- a/.github/workflows/automerge.js
+++ b/.github/workflows/automerge.js
@@ -20,7 +20,7 @@ if (!actor) {
 
 if (actor != 'dependabot[bot]') {
   console.log('Automerge works only for PRs created by dependabot.');
-  process.exit(0);
+  process.exit(1);
 }
 
 if (prTitle.includes('patternfly')) {
@@ -35,7 +35,7 @@ if (prTitle.includes('@types/node')) {
     console.log('Version does match the pattern ' + pattern);
   } else {
     console.log('Version does not match the pattern ' + pattern);
-    return;
+    process.exit(1);
   }
 }
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,33 +1,26 @@
 name: Automerge
 
 on:
-  # allow running manually
-  workflow_dispatch:
   pull_request:
     branches: [ 'master', 'stable-*', 'feature/*' ]
 
 jobs:
-  Automerge:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     steps:
 
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v3
-      with:
-        path: 'ansible-hub-ui'
 
     - name: "Install node 16"
       uses: actions/setup-node@v3
       with:
         node-version: '16'
 
-    - name: "run the automerge.js"
+    - name: "Run automerge.js"
+      working-directory: ".github/workflows"
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        echo "branch: ${{ github.head_ref }}"
-        echo "PR name:  ${{ github.event.pull_request.title }}"
-        echo "Actor:  ${{ github.actor }}"
-        cd ./ansible-hub-ui/.github/workflows
         node automerge.js "${{ github.head_ref }}" "${{ github.event.pull_request.title }}" "${{ github.actor }}"


### PR DESCRIPTION
The automerge workflow is surprising on PRs not created by dependabot  => adding a step-level condition, as per https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution

And making sure the script fails on missing/empty args, skips patternfly PRs with a failure, and handles single-digit node versions.