### PR TITLE
Test ansible/galaxykit#81 fix

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -41,7 +41,9 @@ jobs:
     - name: "Install galaxykit dependency"
       run: |
         # pip install git+https://github.com/ansible/galaxykit.git@branch_name
-        pip install git+https://github.com/ansible/galaxykit.git
+        # pip install git+https://github.com/ansible/galaxykit.git
+        # ansible/galaxykit#81
+        pip install git+https://github.com/himdel/galaxykit.git@fix80
 
     - name: "Set env.SHORT_BRANCH, GALAXY_NG_COMMIT, COMPOSE_PROFILE, API_BASE"
       run: |


### PR DESCRIPTION
ansible/galaxykit#80 causes `galaxykit container create ...` to error with `Cannot parse expected JSON response (http://localhost:8002/api/galaxy/v3/plugin/execution-environments/remotes/)` (bad url)
https://github.com/ansible/galaxykit/pull/81 should fix that, testing.