### PR TITLE
[stable-4.4] backport getContainersURL (#2852)

### DIFF
--- a/CHANGES/1988.bug
+++ b/CHANGES/1988.bug
@@ -1,0 +1,1 @@
+Fix podman pull URLs when latest tag not present, fix digest urls

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -181,8 +181,7 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
 
   renderControllers() {
     const { image, isOpen } = this.props;
-    const { controllers, controllerCount, digest, tag } = this.state;
-    const url = getContainersURL();
+    const { controllers, digest, tag } = this.state;
     const unsafeLinksSupported = !Object.keys(window).includes('chrome');
 
     if (!isOpen || !controllers) {
@@ -198,13 +197,18 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
       return t`No tag or digest selected.`;
     }
 
+    const imageUrl = encodeURIComponent(
+      getContainersURL({
+        name: image,
+        tag,
+        digest,
+      }),
+    );
+
     return (
       <List isPlain isBordered>
         {controllers.map((host) => {
-          const imageUrl = `${url}/${tag ? `${image}:${tag}` : digest}`;
-          const href = `${host}/#/execution_environments/add?image=${encodeURIComponent(
-            imageUrl,
-          )}`;
+          const href = `${host}/#/execution_environments/add?image=${imageUrl}`;
 
           return (
             <ListItem style={{ paddingTop: '8px' }}>

--- a/src/containers/execution-environment-detail/execution_environment_detail.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail.tsx
@@ -51,18 +51,16 @@ class ExecutionEnvironmentDetail extends React.Component<
   }
 
   renderDetail() {
-    const url = getContainersURL();
-    const instructions =
-      'podman pull ' +
-      url +
-      '/' +
-      this.props.containerRepository.name +
-      ':latest';
-
     const { containerRepository } = this.props;
     const canEdit = containerRepository.namespace.my_permissions.includes(
       'container.change_containernamespace',
     );
+
+    const instructions =
+      'podman pull ' +
+      getContainersURL({
+        name: containerRepository.name,
+      });
 
     return (
       <Flex direction={{ default: 'column' }}>

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -349,9 +349,10 @@ class ExecutionEnvironmentDetailImages extends React.Component<
     canEditTags: boolean,
     cols: number,
   ) {
+    const container = this.props.match.params['container'];
     const manifestLink = (digestOrTag) =>
       formatPath(Paths.executionEnvironmentManifest, {
-        container: this.props.match.params['container'],
+        container,
         digest: digestOrTag,
       });
 
@@ -366,11 +367,13 @@ class ExecutionEnvironmentDetailImages extends React.Component<
       </Link>
     );
 
-    const url = getContainersURL();
-    let instruction =
-      image.tags.length === 0
-        ? image.digest
-        : this.props.match.params['container'] + ':' + image.tags[0];
+    const instructions =
+      'podman pull ' +
+      getContainersURL({
+        name: container,
+        tag: image.tags?.[0],
+        digest: image.digest,
+      });
 
     const isRemote = !!this.props.containerRepository.pulp.repository.remote;
     const { isManifestList } = image;
@@ -458,9 +461,7 @@ class ExecutionEnvironmentDetailImages extends React.Component<
             )}
           </td>
           <td>
-            <ClipboardCopy isReadOnly>
-              {'podman pull ' + url + '/' + instruction}
-            </ClipboardCopy>
+            <ClipboardCopy isReadOnly>{instructions}</ClipboardCopy>
           </td>
 
           <td style={{ paddingRight: '0px', textAlign: 'right' }}>

--- a/src/utilities/get-repo-url.ts
+++ b/src/utilities/get-repo-url.ts
@@ -10,6 +10,19 @@ export function getRepoUrl(distributionPath: string) {
 }
 
 // returns the server name for (protocol-less) container urls
-export function getContainersURL() {
-  return window.location.href.split('://')[1].split('/ui')[0];
+// url/image, url/image:tag, url/image@digest (including sha256: prefix)
+export function getContainersURL({
+  name,
+  tag,
+  digest,
+}: {
+  name: string;
+  tag?: string;
+  digest?: string;
+}) {
+  const host = window.location.host;
+
+  return `${host}/${name}${tag ? `:${tag}` : ''}${
+    digest && !tag ? `@${digest}` : ''
+  }`;
 }

--- a/test/cypress/integration/execution_environments.js
+++ b/test/cypress/integration/execution_environments.js
@@ -39,7 +39,7 @@ describe('execution environments', () => {
     cy.get('.title-box').should('have.text', `remotepine${num}`);
     cy.get('.pf-c-form-control').should(
       'have.value',
-      `podman pull localhost:8002/remotepine${num}:latest`,
+      `podman pull localhost:8002/remotepine${num}`,
     );
   });
 


### PR DESCRIPTION
Backports #2852 - `getContainersURL`: support generating full url, reuse, fix `:latest` in detail, fix missing `name@` before digest

manual because ExecutionEnvironmentDetailImages renderTableRow has a trivial conflict because there's no hasPermission in 4.6-,
PublishToControllerModal renderControllers no longer has controllerCount in 4.5+,
ExecutionEnvironmentDetailImages changed let to const in 4.5

---

* getContainersURL: support generating full url, reuse; fix :latest in detail; fix missing name@ before digest

merge logic for generating podman image urls into getContainersURL, only add tag when passed, only add digest when passed with an empty tag, don't skip name and @ for digest mode
use host from location.host

stop assuming :latest on detail screen

before/after:

detail:

```diff
-localhost:8002/alpine:latest
+localhost:8002/alpine
```

tag:

```diff
-localhost:8002/alpine:latest
+localhost:8002/alpine:latest
```

digest:

```diff
-localhost:8002/sha256:abcdef
+localhost:8002/alpine@sha256:abcdef
```

Issue: AAH-1988

* update EE test to not expect :latest