### PR TITLE
[stable-4.4] Pin pulp-ci-centos to 66dc18a - fix CI container build

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -63,7 +63,6 @@ jobs:
           FROM ghcr.io/pulp/pulp-ci-centos:3.15
 
           RUN pip3 install --upgrade \
-            requests \
             git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
 
           RUN mkdir -p /etc/nginx/pulp/


### PR DESCRIPTION
trying if this fixes 4.4 failure to build container

from ansible/galaxy_ng#1545

test failure https://github.com/ansible/ansible-hub-ui/actions/runs/3536976022/jobs/5936534257