### PR TITLE
[stable-4.5] Pin pulp-ci-centos to 66dc18a - fix CI container build

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -62,7 +62,7 @@ jobs:
 
         echo '# Containerfile'
         echo '\
-          FROM ghcr.io/pulp/pulp-ci-centos:3.18
+          FROM ghcr.io/pulp/pulp-ci-centos@sha256:66dc18a2f201ae9359629b2bcbe0ea67d05fbc8efb9151fab5c6ca0c711eea34
 
           # fix pip install failing to build python-ldap on missing lber.h
           RUN yum -y install openldap-devel

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -73,6 +73,7 @@ jobs:
 
           RUN pip3 install --upgrade \
             requests \
+            distutils==65.5.1 \
             git+https://github.com/ansible/galaxy_ng.git@${{ env.SHORT_BRANCH }}
 
           RUN mkdir -p /etc/nginx/pulp/


### PR DESCRIPTION
trying if this fixes 4.5 failure to build container

from ansible/galaxy_ng#1525

test failure https://github.com/ansible/ansible-hub-ui/actions/runs/3536978652/jobs/5936539038