### PR TITLE
[stable-4.4] ci: override GALAXY_NG_COMMIT to use a cached container that works

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -37,6 +37,9 @@ jobs:
         # blow up without galaxy_ng commit info
         [ -n "$GALAXY_NG_COMMIT" ]
 
+        # temporary, use cached container that still works
+        GALAXY_NG_COMMIT="f621cf8f21d7a32c64c3daf46706825c53bdada5"
+
         echo "SHORT_BRANCH=${SHORT_BRANCH}" >> $GITHUB_ENV
         echo "GALAXY_NG_COMMIT=${GALAXY_NG_COMMIT}" >> $GITHUB_ENV
 


### PR DESCRIPTION
temporary fix pending a real one or the oci-env switch

(failing in https://github.com/ansible/ansible-hub-ui/pull/2926)