### PR TITLE
EE tests - switch to quay as source, drop unique suffix

### DIFF
--- a/test/cypress/e2e/ee_controller/execution_environments_use_in_controller.js
+++ b/test/cypress/e2e/ee_controller/execution_environments_use_in_controller.js
@@ -75,7 +75,6 @@ describe('Execution Environments - Use in Controller', () => {
       it(`Use in Controller - ${type} ${opener.name}`, () => {
         opener(type);
 
-        // sporadic failure
         // shows links
         cy.contains('a', 'https://www.example.com')
           .should('have.attr', 'href')
@@ -105,12 +104,12 @@ describe('Execution Environments - Use in Controller', () => {
 
         // search tag
         cy.get('input.pf-c-select__toggle-typeahead').click();
-        cy.contains('.pf-c-select__menu', 'latest').click();
+        cy.contains('.pf-c-select__menu', 'hello-world').click();
         cy.contains('a', 'https://another.example.com')
           .should('have.attr', 'href')
           .and(
             'match',
-            /^https:\/\/another\.example\.com\/#\/execution_environments\/add\?image=.*latest$/,
+            /^https:\/\/another\.example\.com\/#\/execution_environments\/add\?image=.*hello-world$/,
           );
 
         // unfilter controllers

--- a/test/cypress/e2e/ee_controller/execution_environments_use_in_controller.js
+++ b/test/cypress/e2e/ee_controller/execution_environments_use_in_controller.js
@@ -1,26 +1,24 @@
 const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Execution Environments - Use in Controller', () => {
-  let num = (~~(Math.random() * 1000000)).toString(); // FIXME: maybe drop everywhere once AAH-1095 is fixed
-
   before(() => {
     cy.login();
     cy.deleteRegistries();
     cy.deleteContainers();
-    cy.addRemoteRegistry(`docker${num}`, 'https://registry.hub.docker.com/');
+    cy.addRemoteRegistry(`registry`, 'https://quay.io/');
 
     cy.addRemoteContainer({
-      name: `remotepine${num}`,
-      upstream_name: 'library/alpine',
-      registry: `docker${num}`,
-      include_tags: 'latest',
+      name: `remotepine`,
+      upstream_name: 'ansible/docker-test-containers',
+      registry: `registry`,
+      include_tags: 'hello-world',
     });
 
     cy.visit(`${uiPrefix}containers/`);
-    cy.contains('.body', `remotepine${num}`, { timeout: 10000 });
+    cy.contains('.body', `remotepine`, { timeout: 10000 });
 
-    cy.syncRemoteContainer(`remotepine${num}`);
-    cy.addLocalContainer(`localpine${num}`, 'alpine');
+    cy.syncRemoteContainer(`remotepine`);
+    cy.addLocalContainer(`localpine`, 'alpine');
   });
 
   beforeEach(() => {

--- a/test/cypress/e2e/execution_environments/execution_environments.js
+++ b/test/cypress/e2e/execution_environments/execution_environments.js
@@ -1,22 +1,16 @@
 describe('execution environments', () => {
-  let num = (~~(Math.random() * 1000000)).toString();
-
   before(() => {
     cy.login();
 
     cy.deleteRegistries();
     cy.deleteContainers();
 
-    cy.galaxykit(
-      'registry create',
-      `docker${num}`,
-      'https://registry.hub.docker.com/',
-    );
+    cy.galaxykit('registry create', `registry`, 'https://quay.io/');
     cy.galaxykit(
       'container create',
-      `remotepine${num}`,
-      'library/alpine',
-      `docker${num}`,
+      `remotepine`,
+      'ansible/docker-test-containers',
+      `registry`,
     );
   });
 
@@ -26,7 +20,7 @@ describe('execution environments', () => {
   });
 
   it('checks the EE list view', () => {
-    cy.contains('a', `remotepine${num}`);
+    cy.contains('a', `remotepine`);
     cy.contains('button', 'Add execution environment');
     cy.contains('button', 'Push container images');
     cy.contains('table th', 'Container repository name');
@@ -37,16 +31,16 @@ describe('execution environments', () => {
   });
 
   it('checks the EE detail view', () => {
-    cy.contains('a', `remotepine${num}`).click();
-    cy.get('.title-box').should('have.text', `remotepine${num}`);
+    cy.contains('a', `remotepine`).click();
+    cy.get('.title-box').should('have.text', `remotepine`);
     cy.get('.pf-c-form-control').should(
       'have.value',
-      `podman pull localhost:8002/remotepine${num}`,
+      `podman pull localhost:8002/remotepine`,
     );
   });
 
   it('adds a Readme', () => {
-    cy.contains('a', `remotepine${num}`).click();
+    cy.contains('a', `remotepine`).click();
     cy.get('[data-cy=add-readme]').click();
     cy.get('textarea').type('This is the readme file.');
     cy.get('[data-cy=save-readme]').click();

--- a/test/cypress/e2e/execution_environments/execution_environments_edit.js
+++ b/test/cypress/e2e/execution_environments/execution_environments_edit.js
@@ -1,24 +1,18 @@
 describe('execution environments', () => {
-  let num = (~~(Math.random() * 1000000)).toString();
-
   before(() => {
     cy.login();
 
     cy.deleteRegistriesManual();
     cy.deleteContainersManual();
 
-    cy.galaxykit(
-      'registry create',
-      `docker${num}`,
-      'https://registry.hub.docker.com/',
-    );
+    cy.galaxykit('registry create', `registry`, 'https://quay.io/');
     cy.galaxykit(
       'container create',
-      `remotepine${num}`,
-      'library/alpine',
-      `docker${num}`,
+      `remotepine`,
+      'ansible/docker-test-containers',
+      `registry`,
     );
-    cy.addLocalContainer(`localpine${num}`, 'alpine');
+    cy.addLocalContainer(`localpine`, 'alpine');
   });
 
   beforeEach(() => {
@@ -27,7 +21,7 @@ describe('execution environments', () => {
   });
 
   it('edits a remote container', () => {
-    cy.contains('a', `remotepine${num}`).click();
+    cy.contains('a', `remotepine`).click();
     cy.get('.pf-c-button.pf-m-secondary').contains('Edit').click();
     cy.get('#description').type('This is the description.');
     cy.contains('button', 'Save').click();
@@ -39,7 +33,7 @@ describe('execution environments', () => {
   });
 
   it('edits a local container', () => {
-    cy.contains('a', `localpine${num}`).click();
+    cy.contains('a', `localpine`).click();
     cy.get('.pf-c-button.pf-m-secondary').contains('Edit').click();
     cy.get('#description').type('This is the description.');
     cy.contains('button', 'Save').click();

--- a/test/cypress/e2e/misc/rbac.js
+++ b/test/cypress/e2e/misc/rbac.js
@@ -9,17 +9,13 @@ describe('RBAC test for user without permissions', () => {
   before(() => {
     cy.login();
 
-    cy.galaxykit(
-      '-i registry create',
-      'docker',
-      'https://registry.hub.docker.com/',
-    );
+    cy.galaxykit('-i registry create', 'registry', 'https://quay.io/');
 
     cy.galaxykit(
       '-i container create',
       `testcontainer`,
-      'library/alpine',
-      `docker`,
+      'ansible/docker-test-containers',
+      `registry`,
     );
 
     cy.galaxykit('-i user create', userName, userPassword);
@@ -128,7 +124,7 @@ describe('RBAC test for user without permissions', () => {
 
     // can Change and Delete remote registry
     cy.get(
-      '[data-cy="ExecutionEnvironmentRegistryList-row-docker"] [data-cy="kebab-toggle"]',
+      '[data-cy="ExecutionEnvironmentRegistryList-row-registry"] [data-cy="kebab-toggle"]',
     ).click();
     cy.contains('Edit').should('not.exist');
     cy.contains('Delete').should('not.exist');
@@ -217,16 +213,12 @@ describe('RBAC test for user with permissions', () => {
   before(() => {
     cy.login();
 
-    cy.galaxykit(
-      '-i registry create',
-      'docker',
-      'https://registry.hub.docker.com/',
-    );
+    cy.galaxykit('-i registry create', 'registry', 'https://quay.io/');
     cy.addRemoteContainer({
       name: `testcontainer`,
-      upstream_name: 'library/alpine',
-      registry: `docker`,
-      include_tags: 'latest',
+      upstream_name: 'ansible/docker-test-containers',
+      registry: `registry`,
+      include_tags: 'hello-world',
     });
 
     cy.galaxykit('-i user create', userName, userPassword);
@@ -373,7 +365,7 @@ describe('RBAC test for user with permissions', () => {
     // can sync remote registry
     cy.contains('Sync from registry').click();
     cy.get('[data-cy="AlertList"] .pf-c-alert__title').contains(
-      'Sync started for remote registry "docker".',
+      'Sync started for remote registry "registry".',
     );
   });
 

--- a/test/cypress/e2e/misc/rbac_create.js
+++ b/test/cypress/e2e/misc/rbac_create.js
@@ -1,5 +1,6 @@
 describe('add and delete roles', () => {
-  let num = (~~(Math.random() * 1000000)).toString();
+  const num = (~~(Math.random() * 1000000)).toString();
+
   before(() => {
     cy.login();
     cy.menuGo('User Access > Roles');

--- a/test/cypress/e2e/misc/rbac_owners.js
+++ b/test/cypress/e2e/misc/rbac_owners.js
@@ -1,25 +1,22 @@
 const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Namespace owners tab', () => {
-  const num = (~~(Math.random() * 1000000)).toString();
-
   before(() => {
     cy.deleteNamespacesAndCollections();
     cy.deleteTestGroups();
 
-    cy.galaxykit(`-i namespace create rbac_owners_${num}`);
+    cy.galaxykit(`-i namespace create rbac_owners`);
     cy.galaxykit('-i group create', `owners_group`);
   });
 
   beforeEach(() => {
     cy.login();
-    cy.visit(`${uiPrefix}repo/published/rbac_owners_${num}`);
+    cy.visit(`${uiPrefix}repo/published/rbac_owners`);
     cy.get('.pf-c-tabs__item-text').contains('Namespace owners').click();
   });
 
   it('add and remove group and roles', () => {
     testOwnersTab({
-      num,
       permission: 'change_namespace',
       permissionGroup: 'Galaxy',
       permissionLabel: 'Change namespace',
@@ -30,37 +27,30 @@ describe('Namespace owners tab', () => {
 });
 
 describe('Execution Environment Owners tab', () => {
-  const num = (~~(Math.random() * 1000000)).toString();
-
   before(() => {
     cy.login();
     cy.deleteRegistries();
     cy.deleteContainers();
     cy.deleteTestGroups();
 
-    cy.galaxykit(
-      'registry create',
-      `rbac_owners_${num}_registry`,
-      'https://registry.hub.docker.com/',
-    );
+    cy.galaxykit('registry create', `rbac_owners_registry`, 'https://quay.io/');
     cy.galaxykit(
       'container create',
-      `rbac_owners_${num}`,
-      'library/alpine',
-      `rbac_owners_${num}_registry`,
+      `rbac_owners`,
+      'ansible/docker-test-containers',
+      `rbac_owners_registry`,
     );
     cy.galaxykit('-i group create', `owners_group`);
   });
 
   beforeEach(() => {
     cy.login();
-    cy.visit(`${uiPrefix}containers/rbac_owners_${num}`);
+    cy.visit(`${uiPrefix}containers/rbac_owners`);
     cy.get('.pf-c-tabs__item-text').contains('Owners').click();
   });
 
   it('add and remove group and roles', () => {
     testOwnersTab({
-      num,
       permission: 'change_containernamespace',
       permissionGroup: 'Container',
       permissionLabel: 'Change container namespace permissions',
@@ -71,7 +61,6 @@ describe('Execution Environment Owners tab', () => {
 });
 
 function testOwnersTab({
-  num,
   permission,
   permissionGroup,
   permissionLabel,
@@ -119,7 +108,7 @@ function testOwnersTab({
   cy.get('footer button').contains('Add').click();
   cy.get('.pf-c-alert__title')
     .contains(
-      `Group "owners_group" has been successfully added to "rbac_owners_${num}".`,
+      `Group "owners_group" has been successfully added to "rbac_owners".`,
     )
     .parent('.pf-c-alert')
     .find('button')
@@ -143,7 +132,7 @@ function testOwnersTab({
   cy.get('footer button').contains('Add').click();
   cy.get('.pf-c-alert__title')
     .contains(
-      `Group "owners_group" roles successfully updated in "rbac_owners_${num}".`,
+      `Group "owners_group" roles successfully updated in "rbac_owners".`,
     )
     .parent('.pf-c-alert')
     .find('button')
@@ -163,11 +152,11 @@ function testOwnersTab({
   cy.get('.pf-c-dropdown__menu-item').contains('Remove role').click();
   cy.get('.pf-c-modal-box__body b').contains('owners_group');
   cy.get('.pf-c-modal-box__body b').contains(role);
-  cy.get('.pf-c-modal-box__body b').contains(`rbac_owners_${num}`);
+  cy.get('.pf-c-modal-box__body b').contains(`rbac_owners`);
   cy.get('[data-cy=delete-button]').click();
   cy.get('.pf-c-alert__title')
     .contains(
-      `Group "owners_group" roles successfully updated in "rbac_owners_${num}".`,
+      `Group "owners_group" roles successfully updated in "rbac_owners".`,
     )
     .parent('.pf-c-alert')
     .find('button')
@@ -182,11 +171,11 @@ function testOwnersTab({
   ).click();
   cy.get('.pf-c-dropdown__menu-item').contains('Remove group').click();
   cy.get('.pf-c-modal-box__body b').contains('owners_group');
-  cy.get('.pf-c-modal-box__body b').contains(`rbac_owners_${num}`);
+  cy.get('.pf-c-modal-box__body b').contains(`rbac_owners`);
   cy.get('[data-cy=delete-button]').click();
   cy.get('.pf-c-alert__title')
     .contains(
-      `Group "owners_group" has been successfully removed from "rbac_owners_${num}".`,
+      `Group "owners_group" has been successfully removed from "rbac_owners".`,
     )
     .parent('.pf-c-alert')
     .find('button')

--- a/test/cypress/e2e/repo/container-signing.js
+++ b/test/cypress/e2e/repo/container-signing.js
@@ -17,23 +17,21 @@ describe('Container Signing', () => {
     // user without sign privilleges
     cy.galaxykit('-i user create', user, password);
 
-    cy.galaxykit(
-      'registry create',
-      `docker`,
-      'https://registry.hub.docker.com/',
-    );
+    cy.galaxykit('registry create', 'registry', 'https://quay.io/');
 
     cy.addRemoteContainer({
       name: 'remote1',
-      upstream_name: 'pulp/test-fixture-1',
-      registry: 'docker',
+      upstream_name: 'ansible/docker-test-containers',
+      registry: 'registry',
+      include_tags: 'hello-world',
       exclude_tags: '*-source',
     });
 
     cy.addRemoteContainer({
       name: 'remote2',
-      upstream_name: 'pulp/test-fixture-1',
-      registry: 'docker',
+      upstream_name: 'ansible/docker-test-containers',
+      registry: 'registry',
+      include_tags: 'busybox',
       exclude_tags: '*-source',
     });
 


### PR DESCRIPTION
Closes #1986 

We may not need to run a separate docker api server to test sync, we're already using quay to pull containers during CI, so we can find testable containers there.

This should fix EE use in controller tests failing when many tests run at the same time.

The smallest container I've found on quay is `quay.io/ansible/docker-test-containers:busybox` (and 
 `:hello-world`) (https://quay.io/repository/ansible/docker-test-containers?tab=tags), using that.

---

Also dropping unique `num` suffix from EE/RR tests - no longer needed with working EE cleanup (AAH-1095)