### PR TITLE
cypress: Retry wait for index.html, try longer settings restart interval

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -197,7 +197,10 @@ jobs:
       if: ${{ env.COMPOSE_PROFILE == 'standalone' }}
       run: |
         echo 'expecting /static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
-        curl http://localhost:8002/static/galaxy_ng/index.html | tee /dev/stderr | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
+        if ! curl http://localhost:8002/static/galaxy_ng/index.html | tee /dev/stderr | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'; then
+          sleep 20
+          curl http://localhost:8002/static/galaxy_ng/index.html | tee /dev/stderr | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
+        fi
 
     - name: "Ensure insights is served"
       if: ${{ env.COMPOSE_PROFILE == 'insights' }}

--- a/.github/workflows/cypress/cypress.env.json.standalone
+++ b/.github/workflows/cypress/cypress.env.json.standalone
@@ -5,7 +5,7 @@
   "username": "admin",
   "password": "admin",
   "settings": "../../pulp_galaxy_ng/settings/settings.py",
-  "restart": "podman exec pulp bash -c \"s6-svc -r /var/run/s6-rc/servicedirs/pulpcore-api\"; sleep 10",
+  "restart": "podman exec pulp bash -c \"s6-svc -r /var/run/s6-rc/servicedirs/pulpcore-api\"; sleep 20",
   "containers": "localhost:8002",
   "galaxykit": "galaxykit --ignore-certs"
 }


### PR DESCRIPTION
There seems to be a `cy.settings`-related test issue after some recent container changes .. approval_process, view-only, ee_use_in_controller are all failing, somehow ending up on the login screen, and the thing they have in common is cy.settings.

Also, groups_and_users is failing on the curl check, adding a retry.
(https://github.com/ansible/ansible-hub-ui/actions/runs/3571333989/jobs/6003112593)