### PR TITLE
standalone dev: proxy /static/rest_framework to pulp

### DIFF
--- a/config/standalone.dev.webpack.config.js
+++ b/config/standalone.dev.webpack.config.js
@@ -45,5 +45,6 @@ module.exports = webpackBase({
     '/pulp/api/': `http://${proxyHost}:${proxyPort}`,
     '/v2/': `http://${proxyHost}:${proxyPort}`,
     '/extensions/v2/': `http://${proxyHost}:${proxyPort}`,
+    '/static/rest_framework/': `http://${proxyHost}:${proxyPort}`,
   },
 });


### PR DESCRIPTION
provides the API web view css & js on http://localhost:8002/api/automation-hub/_ui/v1/me/, instead of localhost:5001-only

|Before|After|
|-|-|
|![20221205131855](https://user-images.githubusercontent.com/289743/205646957-3af203ca-8353-40c8-bd4b-982dc89960be.png)|![20221205131745](https://user-images.githubusercontent.com/289743/205646954-8b78c847-4480-41a8-9b20-a516847b88d4.png)|

(affects only standalone dev)