### PR TITLE
Insights: run more tests in insights mode

### DIFF
--- a/test/cypress/e2e/insights/api_token.js
+++ b/test/cypress/e2e/insights/api_token.js
@@ -1,0 +1,1 @@
+../misc/api_token.js

--- a/test/cypress/e2e/insights/approval_dashboard_list.js
+++ b/test/cypress/e2e/insights/approval_dashboard_list.js
@@ -1,0 +1,1 @@
+../approval/approval_dashboard_list.js

--- a/test/cypress/e2e/insights/approval_process.js
+++ b/test/cypress/e2e/insights/approval_process.js
@@ -1,0 +1,1 @@
+../approval/approval_process.js

--- a/test/cypress/e2e/insights/collection.js
+++ b/test/cypress/e2e/insights/collection.js
@@ -1,0 +1,1 @@
+../collections/collection.js

--- a/test/cypress/e2e/insights/collection_approval.js
+++ b/test/cypress/e2e/insights/collection_approval.js
@@ -1,0 +1,1 @@
+../approval/collection_approval.js

--- a/test/cypress/e2e/insights/collection_detail.js
+++ b/test/cypress/e2e/insights/collection_detail.js
@@ -1,0 +1,1 @@
+../collections/collection_detail.js

--- a/test/cypress/e2e/insights/collection_upload.js
+++ b/test/cypress/e2e/insights/collection_upload.js
@@ -1,0 +1,1 @@
+../collections/collection_upload.js

--- a/test/cypress/e2e/insights/collections_list.js
+++ b/test/cypress/e2e/insights/collections_list.js
@@ -1,0 +1,1 @@
+../collections/collections_list.js

--- a/test/cypress/e2e/insights/imports_filter.js
+++ b/test/cypress/e2e/insights/imports_filter.js
@@ -1,0 +1,1 @@
+../imports/imports_filter.js

--- a/test/cypress/e2e/insights/imports_filter_search.js
+++ b/test/cypress/e2e/insights/imports_filter_search.js
@@ -1,0 +1,1 @@
+../imports/imports_filter_search.js

--- a/test/cypress/e2e/insights/namespace_delete.js
+++ b/test/cypress/e2e/insights/namespace_delete.js
@@ -1,0 +1,1 @@
+../namespaces/namespace_delete.js

--- a/test/cypress/e2e/insights/namespace_detail.js
+++ b/test/cypress/e2e/insights/namespace_detail.js
@@ -1,0 +1,1 @@
+../namespaces/namespace_detail.js

--- a/test/cypress/e2e/insights/namespace_edit.js
+++ b/test/cypress/e2e/insights/namespace_edit.js
@@ -1,0 +1,1 @@
+../namespaces/namespace_edit.js

--- a/test/cypress/e2e/insights/namespace_form.js
+++ b/test/cypress/e2e/insights/namespace_form.js
@@ -1,0 +1,1 @@
+../namespaces/namespace_form.js

--- a/test/cypress/e2e/insights/namespace_list.js
+++ b/test/cypress/e2e/insights/namespace_list.js
@@ -1,0 +1,1 @@
+../namespaces/namespace_list.js

--- a/test/cypress/e2e/insights/signing.js
+++ b/test/cypress/e2e/insights/signing.js
@@ -1,0 +1,1 @@
+../approval/signing.js

--- a/test/cypress/e2e/insights/task_list.js
+++ b/test/cypress/e2e/insights/task_list.js
@@ -1,0 +1,1 @@
+../misc/task_list.js

--- a/test/cypress/e2e/insights/task_management_detail.js
+++ b/test/cypress/e2e/insights/task_management_detail.js
@@ -1,0 +1,1 @@
+../misc/task_management_detail.js

--- a/test/cypress/e2e/insights/task_status.js
+++ b/test/cypress/e2e/insights/task_status.js
@@ -1,0 +1,1 @@
+../misc/task_status.js

--- a/test/cypress/e2e/insights/token_management.js
+++ b/test/cypress/e2e/insights/token_management.js
@@ -1,0 +1,1 @@
+../misc/token_management.js

--- a/test/cypress/e2e/namespaces/namespace_edit.js
+++ b/test/cypress/e2e/namespaces/namespace_edit.js
@@ -1,39 +1,35 @@
 const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Edit a namespace', () => {
-  let kebabToggle = () => {
+  const kebabToggle = () => {
     return cy.get('button[id^=pf-dropdown-toggle-id-] > svg').parent().click();
   };
 
-  let saveButton = () => {
+  const saveButton = () => {
     return cy.contains('Save');
   };
 
-  let getLinkTextField = () => {
+  const getLinkTextField = () => {
     return cy
       .get('div.useful-links > div.link-name input')
       .invoke('attr', 'placeholder', 'Link text')
+      .first()
       .click();
   };
 
-  let getUrlField = () => {
-    return cy.get('div.useful-links div.link-url #url').click();
+  const getUrlField = () => {
+    return cy.get('div.useful-links div.link-url #url').first().click();
   };
 
-  let linksHelper = () => {
-    return cy.get('#links-helper');
-  };
-
-  let getEditTab = () => {
+  const getEditTab = () => {
     return cy
       .get(
         'ul.pf-c-tabs__list > li.pf-c-tabs__item > button > span.pf-c-tabs__item-text',
       )
-      .contains('Edit resources')
-      .click();
+      .contains('Edit resources');
   };
 
-  let getTextField = () => {
+  const getTextField = () => {
     return cy.get('div.pf-c-form__group-control > textarea.pf-c-form-control');
   };
 
@@ -62,8 +58,7 @@ describe('Edit a namespace', () => {
         'This name is too long vaðlaheiðarvegavinnuverkfærageymsluskúraútidyralyklakippuhringur',
       );
     saveButton().click();
-    let helperText = cy.get('#company-helper');
-    helperText.should(
+    cy.get('#company-helper').should(
       'have.text',
       'Ensure this field has no more than 64 characters.',
     );
@@ -100,24 +95,24 @@ describe('Edit a namespace', () => {
   });
 
   it('tests the Links field', () => {
-    getLinkTextField().first().type('Too long ^TrR>dG(F55:5(P:!sdafd#ZWCf2');
-    getUrlField().first().type('https://example.com');
+    getLinkTextField().type('Too long ^TrR>dG(F55:5(P:!sdafd#ZWCf2');
+    getUrlField().type('https://example.com');
     saveButton().click();
-    linksHelper().should(
+    cy.get('#links-helper').should(
       'contain',
       'Text: Ensure this field has no more than 32 characters.',
     );
-    getLinkTextField().first().clear();
+    getLinkTextField().clear();
     cy.contains('.useful-links', 'Name must not be empty.');
 
-    getLinkTextField().first().type('Link to example website');
-    getUrlField().first().clear();
+    getLinkTextField().type('Link to example website');
+    getUrlField().clear();
     cy.contains('.useful-links', 'URL must not be empty.');
 
-    getUrlField().first().type('example.com');
+    getUrlField().type('example.com');
     cy.contains('.useful-links', 'The URL needs to be in');
 
-    getUrlField().first().clear().type('https://example.com/');
+    getUrlField().clear().type('https://example.com/');
     saveButton().click();
     cy.get('div.link a')
       .should('contain', 'Link to example website')
@@ -134,7 +129,7 @@ describe('Edit a namespace', () => {
   });
 
   it('edits namespace resources', () => {
-    getEditTab();
+    getEditTab().click();
     getTextField()
       .invoke('attr', 'placeholder')
       .should(
@@ -145,7 +140,7 @@ describe('Edit a namespace', () => {
     saveButton().click();
     kebabToggle();
     cy.contains('Edit namespace').click();
-    getEditTab();
+    getEditTab().click();
     getTextField().should('contain', 'Editing the readme file');
   });
 });

--- a/test/cypress/e2e/namespaces/namespace_form.js
+++ b/test/cypress/e2e/namespaces/namespace_form.js
@@ -1,28 +1,15 @@
 const uiPrefix = Cypress.env('uiPrefix');
 
 describe('A namespace form', () => {
-  let getCreateNamespace = () => {
-    return cy.get('.pf-c-button.pf-m-primary');
-  };
-  let getMessage = () => {
-    return cy.get('.pf-c-form__helper-text');
-  };
-  let getCreateButton = () => {
-    return cy.get('.pf-c-modal-box__footer .pf-m-primary');
-  };
-  let getInputBox = () => {
-    return cy.get('#pf-modal-part-2 #newNamespaceName');
-  };
-  let clearInput = () => {
-    return cy.get('#pf-modal-part-2 #newNamespaceName').clear();
-  };
-  let createNamespace = () => {
-    return cy.galaxykit('-i namespace create', 'testns1');
-  };
+  const getCreateNamespace = () => cy.get('.pf-c-button.pf-m-primary');
+  const getMessage = () => cy.get('.pf-c-form__helper-text');
+  const getCreateButton = () => cy.get('.pf-c-modal-box__footer .pf-m-primary');
+  const getInputBox = () => cy.get('#pf-modal-part-2 #newNamespaceName');
+  const clearInput = () => getInputBox().clear();
 
   beforeEach(() => {
     cy.login();
-    createNamespace();
+    cy.galaxykit('-i namespace create', 'testns1');
     cy.menuGo('Collections > Namespaces');
     getCreateNamespace().click();
   });
@@ -80,7 +67,7 @@ describe('A namespace form', () => {
   });
 
   it('creates a new namespace with no error messages', () => {
-    let id = parseInt(Math.random() * 1000000);
+    const id = parseInt(Math.random() * 1000000);
     getInputBox().type(`testns_${id}`);
     getCreateButton().click();
     cy.url().should('match', new RegExp(`${uiPrefix}repo/published/testns_`));


### PR DESCRIPTION
Based on #2898 & #2897
Issue: AAH-1271
Depends on: https://github.com/ansible/galaxy_ng/pull/1564 (takes collection upload back from 30s -> 2s .. without this it runs for almost 2 hours; merged)

Run a subset of standalone tests in insights mode, specifically:

* Namespace create/edit/list/search/delete
* Namespace group management
* Collection list and search
* Collection detail and documentation
* Import records and logs, search
* Approval dashboard

---

link tests to insights mode tests dir,
fix any issues...

* namespace\* simplify helpers a bit
* ...