### PR TITLE
Use version range when comparing dependencies.

### DIFF
--- a/CHANGES/2018.bugfix
+++ b/CHANGES/2018.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where the UI was falsely reporting that collection dependencies don't exist.

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -12,7 +12,9 @@ import 'src/containers/collection-detail/collection-dependencies.scss';
 
 interface IProps {
   collection: CollectionDetailType;
-  dependencies_repos: (CollectionVersion & { path?: string })[];
+  dependencies_repos: (CollectionVersion & {
+    path?: string;
+  })[];
 }
 
 export class CollectionDependenciesList extends React.Component<IProps> {
@@ -31,26 +33,32 @@ export class CollectionDependenciesList extends React.Component<IProps> {
 
     return (
       <List variant={ListVariant.inline} className='hub-c-list-dependencies'>
-        {dependencies_repos.map((dependency, i) => (
-          <>
-            {dependency.path && (
-              <ListItem key={i} style={{ marginRight: '70px' }}>
-                <Link to={dependency.path}>
-                  {dependency.namespace + '.' + dependency.name}
-                </Link>
-              </ListItem>
-            )}
-            {!dependency.path && (
-              <ListItem key={i} style={{ marginRight: '70px' }}>
-                {dependency.namespace + '.' + dependency.name}
-                <HelperText
-                  content={t`Collection version ${dependency.version} was not found in the system. You must upload it.`}
-                />
-              </ListItem>
-            )}
-          </>
-        ))}
+        {dependencies_repos.map((dependency, i) =>
+          this.listDep(dependency, i, dependencies),
+        )}
       </List>
     );
+  }
+
+  private listDep(dependency, i, dependencies) {
+    const fqn = dependency.namespace + '.' + dependency.name;
+    const version_range = dependencies[fqn];
+
+    if (dependency.path) {
+      return (
+        <ListItem key={i} style={{ marginRight: '70px' }}>
+          <Link to={dependency.path}>{fqn}</Link>: {version_range}
+        </ListItem>
+      );
+    } else {
+      return (
+        <ListItem key={i} style={{ marginRight: '70px' }}>
+          {fqn}: {version_range}
+          <HelperText
+            content={t`No version of ${fqn} exists that matches ${version_range}.`}
+          />
+        </ListItem>
+      );
+    }
   }
 }

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -197,13 +197,12 @@ class CollectionDependencies extends React.Component<
 
     Object.keys(dependencies).forEach((dependency) => {
       const [namespace, collection] = dependency.split('.');
-      let version = dependencies[dependency];
-      version = this.separateVersion(version).version;
+      const version_range = dependencies[dependency];
 
       const dependency_repo = {
         name: collection,
         namespace: namespace,
-        version: version,
+        version_range: version_range,
         repo: '',
         path: '',
       };
@@ -222,19 +221,16 @@ class CollectionDependencies extends React.Component<
     return CollectionVersionAPI.list({
       namespace: dependency_repo.namespace,
       name: dependency_repo.name,
-      version: dependency_repo.version,
+      version_range: dependency_repo.version_range,
+      page_size: 1,
     })
       .then((result) => {
         dependency_repo.repo = result.data.data[0].repository_list[0];
-        dependency_repo.path = formatPath(
-          Paths.collectionByRepo,
-          {
-            collection: dependency_repo.name,
-            namespace: dependency_repo.namespace,
-            repo: dependency_repo.repo,
-          },
-          dependency_repo.version,
-        );
+        dependency_repo.path = formatPath(Paths.collectionByRepo, {
+          collection: dependency_repo.name,
+          namespace: dependency_repo.namespace,
+          repo: dependency_repo.repo,
+        });
       })
       .catch(() => {
         // do nothing, dependency_repo.path and repo stays empty


### PR DESCRIPTION
Use version range when looking up if a dependency exists on the collection dependencies tab.

Issue: AAH-2018

Requires: https://github.com/ansible/galaxy_ng/pull/1571