### PR TITLE
insights-loader: switch to useChrome

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@patternfly/patternfly": "^4.222.4",
                 "@patternfly/react-core": "^4.231.8",
                 "@patternfly/react-table": "^4.112.6",
+                "@redhat-cloud-services/frontend-components": "^3.9.27",
                 "@redhat-cloud-services/frontend-components-utilities": "^3.3.11",
                 "@types/node": "^16.18.11",
                 "@types/react": "^17.0.2",
@@ -2764,6 +2765,31 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/@redhat-cloud-services/frontend-components": {
+            "version": "3.9.27",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.27.tgz",
+            "integrity": "sha512-3d2cnFiWbMsBQM92tXujoXvH45YKMROB1/IVQjgNG1c1hZZTJJwEjsqG/zKAuXVrjMmF1VQ0znHRsxJsCXAncQ==",
+            "dependencies": {
+                "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
+                "@redhat-cloud-services/types": "^0.0.17",
+                "@scalprum/core": "^0.2.3",
+                "@scalprum/react-core": "^0.2.4",
+                "sanitize-html": "^2.7.2"
+            },
+            "peerDependencies": {
+                "@patternfly/react-core": "^4.18.5",
+                "@patternfly/react-icons": "^4.53.16",
+                "@patternfly/react-table": "^4.5.7",
+                "classnames": "^2.2.5",
+                "lodash": "^4.17.15",
+                "prop-types": "^15.6.2",
+                "react": "^16.14.0 || ^17.0.0",
+                "react-content-loader": "^6.2.0",
+                "react-dom": "^16.14.0 || ^17.0.0",
+                "react-redux": ">=7.0.0",
+                "react-router-dom": "^5.0.0 || ^6.0.0"
+            }
+        },
         "node_modules/@redhat-cloud-services/frontend-components-config": {
             "version": "4.6.34",
             "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.34.tgz",
@@ -3201,9 +3227,9 @@
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "node_modules/@redhat-cloud-services/rbac-client": {
-            "version": "1.0.109",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.0.109.tgz",
-            "integrity": "sha512-bzuSxKDd9ZLCPtdrHVFjJqGD67C1/CsG+Mkxr+hT3ajHCLlyfg43ag/raTAfAL6dtj3zEDgjvszdkZV5FeXaaQ==",
+            "version": "1.0.118",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.0.118.tgz",
+            "integrity": "sha512-clwnpSDbteeOJsvvZuOG6hr62/wiTEqp4PPMctFwov2aqC5Bi5sJ4hlWOUxhEarvS9pLfhJRIygT218hUoSqJg==",
             "peer": true,
             "dependencies": {
                 "axios": "^0.21.1"
@@ -3223,9 +3249,28 @@
             "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.17.tgz",
             "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg=="
         },
+        "node_modules/@scalprum/core": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.2.6.tgz",
+            "integrity": "sha512-EXaQkQ0T6nsk4rEpYJjDchrINSQfDEK6sAhxICr2tr927FPWDo7nGNpxhPYr5/6Vpw+pcc7YAEGyjzdQUzmfqg=="
+        },
+        "node_modules/@scalprum/react-core": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.2.11.tgz",
+            "integrity": "sha512-Cy1nJq1Im8kVf3hKjcV65PN6BEbu6TnfEHL3ecAyYAN4tlj+l02NAP6skTwkkzvrDesCVtAMUcdMO1tfoXnxOw==",
+            "dependencies": {
+                "@scalprum/core": "^0.2.6",
+                "lodash": "^4.17.0"
+            },
+            "peerDependencies": {
+                "react": ">=16.8.0 || >=17.0.0",
+                "react-dom": ">=16.8.0 || >=17.0.0"
+            }
+        },
         "node_modules/@sentry/browser": {
             "version": "5.30.0",
-            "license": "BSD-3-Clause",
+            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.30.0.tgz",
+            "integrity": "sha512-rOb58ZNVJWh1VuMuBG1mL9r54nZqKeaIlwSlvzJfc89vyfd7n6tQ1UXMN383QBz/MS5H5z44Hy5eE+7pCrYAfw==",
             "dependencies": {
                 "@sentry/core": "5.30.0",
                 "@sentry/types": "5.30.0",
@@ -3238,7 +3283,8 @@
         },
         "node_modules/@sentry/core": {
             "version": "5.30.0",
-            "license": "BSD-3-Clause",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
+            "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
             "dependencies": {
                 "@sentry/hub": "5.30.0",
                 "@sentry/minimal": "5.30.0",
@@ -3252,7 +3298,8 @@
         },
         "node_modules/@sentry/hub": {
             "version": "5.30.0",
-            "license": "BSD-3-Clause",
+            "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
+            "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
             "dependencies": {
                 "@sentry/types": "5.30.0",
                 "@sentry/utils": "5.30.0",
@@ -3264,7 +3311,8 @@
         },
         "node_modules/@sentry/minimal": {
             "version": "5.30.0",
-            "license": "BSD-3-Clause",
+            "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
+            "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
             "dependencies": {
                 "@sentry/hub": "5.30.0",
                 "@sentry/types": "5.30.0",
@@ -3276,14 +3324,16 @@
         },
         "node_modules/@sentry/types": {
             "version": "5.30.0",
-            "license": "BSD-3-Clause",
+            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
+            "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==",
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/@sentry/utils": {
             "version": "5.30.0",
-            "license": "BSD-3-Clause",
+            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
+            "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
             "dependencies": {
                 "@sentry/types": "5.30.0",
                 "tslib": "^1.9.3"
@@ -3355,8 +3405,9 @@
             }
         },
         "node_modules/@types/debounce-promise": {
-            "version": "3.1.4",
-            "license": "MIT"
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.6.tgz",
+            "integrity": "sha512-DowqK95aku+OxMCeG2EQSeXeGeE8OCwLpMsUfIbP7hMF8Otj8eQXnzpwdtIKV+UqQBtkMcF6vbi4Otbh8P/wmg=="
         },
         "node_modules/@types/debug": {
             "version": "4.1.7",
@@ -4585,7 +4636,8 @@
         },
         "node_modules/awesome-debounce-promise": {
             "version": "2.1.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/awesome-debounce-promise/-/awesome-debounce-promise-2.1.0.tgz",
+            "integrity": "sha512-0Dv4j2wKk5BrNZh4jgV2HUdznaeVgEK/WTvcHhZWUElhmQ1RR+iURRoLEwICFyR0S/5VtxfcvY6gR+qSe95jNg==",
             "dependencies": {
                 "@types/debounce-promise": "^3.1.1",
                 "awesome-imperative-promise": "^1.0.1",
@@ -4599,7 +4651,8 @@
         },
         "node_modules/awesome-imperative-promise": {
             "version": "1.0.1",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/awesome-imperative-promise/-/awesome-imperative-promise-1.0.1.tgz",
+            "integrity": "sha512-EmPr3FqbQGqlNh+WxMNcF9pO9uDQJnOC4/3rLBQNH9m4E9qI+8lbfHCmHpVAsmGqPJPKhCjJLHUQzQW/RBHRdQ==",
             "engines": {
                 "node": ">=8",
                 "npm": ">=5"
@@ -4607,7 +4660,8 @@
         },
         "node_modules/awesome-only-resolves-last-promise": {
             "version": "1.0.3",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/awesome-only-resolves-last-promise/-/awesome-only-resolves-last-promise-1.0.3.tgz",
+            "integrity": "sha512-7q4WPsYiD8Omvi/yHL314DkvsD/lM//Z2/KcU1vWk0xJotiV0GMJTgHTpWl3n90HJqpXKg7qX+VVNs5YbQyPRQ==",
             "dependencies": {
                 "awesome-imperative-promise": "^1.0.1"
             },
@@ -5932,9 +5986,9 @@
             "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
         },
         "node_modules/cypress": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.10.0.tgz",
-            "integrity": "sha512-bU8r44x1NIYAUNNXt3CwJpLOVth7HUv2hUhYCxZmgZ1IugowDvuHNpevnoZRQx1KKOEisLvIJW+Xen5Pjn41pg==",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
+            "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
             "hasInstallScript": true,
             "peer": true,
             "dependencies": {
@@ -5989,9 +6043,9 @@
             }
         },
         "node_modules/cypress/node_modules/@types/node": {
-            "version": "14.18.32",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.32.tgz",
-            "integrity": "sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow==",
+            "version": "14.18.36",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
+            "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
             "peer": true
         },
         "node_modules/cypress/node_modules/ansi-styles": {
@@ -6227,14 +6281,15 @@
             }
         },
         "node_modules/dayjs": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
-            "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==",
+            "version": "1.11.7",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+            "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
             "peer": true
         },
         "node_modules/debounce-promise": {
             "version": "3.1.2",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/debounce-promise/-/debounce-promise-3.1.2.tgz",
+            "integrity": "sha512-rZHcgBkbYavBeD9ej6sP56XfG53d51CD4dnaw989YX/nZ/ZJfgRx/9ePKmTNiUiyQvh4mtrMoS3OAWW+yoYtpg=="
         },
         "node_modules/debug": {
             "version": "4.3.4",
@@ -6302,7 +6357,6 @@
         },
         "node_modules/deepmerge": {
             "version": "4.2.2",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -6486,7 +6540,6 @@
         },
         "node_modules/domelementtype": {
             "version": "2.3.0",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -8084,9 +8137,9 @@
             "dev": true
         },
         "node_modules/global-dirs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-            "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+            "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
             "peer": true,
             "dependencies": {
                 "ini": "2.0.0"
@@ -9195,10 +9248,13 @@
             }
         },
         "node_modules/is-ci/node_modules/ci-info": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-            "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
-            "peer": true
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+            "integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/is-core-module": {
             "version": "2.5.0",
@@ -9952,18 +10008,18 @@
             }
         },
         "node_modules/listr2/node_modules/rxjs": {
-            "version": "7.5.7",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-            "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+            "version": "7.8.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+            "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
             "peer": true,
             "dependencies": {
                 "tslib": "^2.1.0"
             }
         },
         "node_modules/listr2/node_modules/tslib": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-            "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+            "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
             "peer": true
         },
         "node_modules/load-json-file": {
@@ -11109,7 +11165,6 @@
         },
         "node_modules/nanoid": {
             "version": "3.3.4",
-            "dev": true,
             "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -11762,6 +11817,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/parse-srcset": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+            "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+        },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -11852,7 +11912,6 @@
         },
         "node_modules/picocolors": {
             "version": "1.0.0",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/picomatch": {
@@ -12031,7 +12090,6 @@
             "version": "8.4.20",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
             "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
-            "dev": true,
             "funding": [
                 {
                     "type": "opencollective",
@@ -12470,7 +12528,8 @@
         },
         "node_modules/react-content-loader": {
             "version": "6.2.0",
-            "license": "MIT",
+            "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-6.2.0.tgz",
+            "integrity": "sha512-r1dI6S+uHNLW68qraLE2njJYOuy6976PpCExuCZUcABWbfnF3FMcmuESRI8L4Bj45wnZ7n8g71hkPLzbma7/Cw==",
             "engines": {
                 "node": ">=10"
             },
@@ -13134,6 +13193,107 @@
             "version": "2.1.2",
             "license": "MIT"
         },
+        "node_modules/sanitize-html": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.8.1.tgz",
+            "integrity": "sha512-qK5neD0SaMxGwVv5txOYv05huC3o6ZAA4h5+7nJJgWMNFUNRjcjLO6FpwAtKzfKCZ0jrG6xTk6eVFskbvOGblg==",
+            "dependencies": {
+                "deepmerge": "^4.2.2",
+                "escape-string-regexp": "^4.0.0",
+                "htmlparser2": "^8.0.0",
+                "is-plain-object": "^5.0.0",
+                "parse-srcset": "^1.0.2",
+                "postcss": "^8.3.11"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/domutils": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/entities": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+            "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/escape-string-regexp": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+            "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/htmlparser2": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+            "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "entities": "^4.3.0"
+            }
+        },
+        "node_modules/sanitize-html/node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/sass": {
             "version": "1.57.1",
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.57.1.tgz",
@@ -13543,7 +13703,6 @@
         },
         "node_modules/source-map-js": {
             "version": "1.0.2",
-            "dev": true,
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -17554,6 +17713,18 @@
                 }
             }
         },
+        "@redhat-cloud-services/frontend-components": {
+            "version": "3.9.27",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-3.9.27.tgz",
+            "integrity": "sha512-3d2cnFiWbMsBQM92tXujoXvH45YKMROB1/IVQjgNG1c1hZZTJJwEjsqG/zKAuXVrjMmF1VQ0znHRsxJsCXAncQ==",
+            "requires": {
+                "@redhat-cloud-services/frontend-components-utilities": "^3.2.25",
+                "@redhat-cloud-services/types": "^0.0.17",
+                "@scalprum/core": "^0.2.3",
+                "@scalprum/react-core": "^0.2.4",
+                "sanitize-html": "^2.7.2"
+            }
+        },
         "@redhat-cloud-services/frontend-components-config": {
             "version": "4.6.34",
             "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.6.34.tgz",
@@ -17836,9 +18007,9 @@
             }
         },
         "@redhat-cloud-services/rbac-client": {
-            "version": "1.0.109",
-            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.0.109.tgz",
-            "integrity": "sha512-bzuSxKDd9ZLCPtdrHVFjJqGD67C1/CsG+Mkxr+hT3ajHCLlyfg43ag/raTAfAL6dtj3zEDgjvszdkZV5FeXaaQ==",
+            "version": "1.0.118",
+            "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.0.118.tgz",
+            "integrity": "sha512-clwnpSDbteeOJsvvZuOG6hr62/wiTEqp4PPMctFwov2aqC5Bi5sJ4hlWOUxhEarvS9pLfhJRIygT218hUoSqJg==",
             "peer": true,
             "requires": {
                 "axios": "^0.21.1"
@@ -17860,8 +18031,24 @@
             "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-0.0.17.tgz",
             "integrity": "sha512-3V9mmarS3jD5fBksMwh+XCEAMUIzqSOxDkH6OcIVu6w/gaBBOWHh34Jwn4CxKlu+WStxVV/rxm3oFGpsWqljvg=="
         },
+        "@scalprum/core": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.2.6.tgz",
+            "integrity": "sha512-EXaQkQ0T6nsk4rEpYJjDchrINSQfDEK6sAhxICr2tr927FPWDo7nGNpxhPYr5/6Vpw+pcc7YAEGyjzdQUzmfqg=="
+        },
+        "@scalprum/react-core": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.2.11.tgz",
+            "integrity": "sha512-Cy1nJq1Im8kVf3hKjcV65PN6BEbu6TnfEHL3ecAyYAN4tlj+l02NAP6skTwkkzvrDesCVtAMUcdMO1tfoXnxOw==",
+            "requires": {
+                "@scalprum/core": "^0.2.6",
+                "lodash": "^4.17.0"
+            }
+        },
         "@sentry/browser": {
             "version": "5.30.0",
+            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.30.0.tgz",
+            "integrity": "sha512-rOb58ZNVJWh1VuMuBG1mL9r54nZqKeaIlwSlvzJfc89vyfd7n6tQ1UXMN383QBz/MS5H5z44Hy5eE+7pCrYAfw==",
             "requires": {
                 "@sentry/core": "5.30.0",
                 "@sentry/types": "5.30.0",
@@ -17871,6 +18058,8 @@
         },
         "@sentry/core": {
             "version": "5.30.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
+            "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
             "requires": {
                 "@sentry/hub": "5.30.0",
                 "@sentry/minimal": "5.30.0",
@@ -17881,6 +18070,8 @@
         },
         "@sentry/hub": {
             "version": "5.30.0",
+            "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
+            "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
             "requires": {
                 "@sentry/types": "5.30.0",
                 "@sentry/utils": "5.30.0",
@@ -17889,6 +18080,8 @@
         },
         "@sentry/minimal": {
             "version": "5.30.0",
+            "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
+            "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
             "requires": {
                 "@sentry/hub": "5.30.0",
                 "@sentry/types": "5.30.0",
@@ -17896,10 +18089,14 @@
             }
         },
         "@sentry/types": {
-            "version": "5.30.0"
+            "version": "5.30.0",
+            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
+            "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw=="
         },
         "@sentry/utils": {
             "version": "5.30.0",
+            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
+            "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
             "requires": {
                 "@sentry/types": "5.30.0",
                 "tslib": "^1.9.3"
@@ -17968,7 +18165,9 @@
             }
         },
         "@types/debounce-promise": {
-            "version": "3.1.4"
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.6.tgz",
+            "integrity": "sha512-DowqK95aku+OxMCeG2EQSeXeGeE8OCwLpMsUfIbP7hMF8Otj8eQXnzpwdtIKV+UqQBtkMcF6vbi4Otbh8P/wmg=="
         },
         "@types/debug": {
             "version": "4.1.7",
@@ -18872,6 +19071,8 @@
         },
         "awesome-debounce-promise": {
             "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/awesome-debounce-promise/-/awesome-debounce-promise-2.1.0.tgz",
+            "integrity": "sha512-0Dv4j2wKk5BrNZh4jgV2HUdznaeVgEK/WTvcHhZWUElhmQ1RR+iURRoLEwICFyR0S/5VtxfcvY6gR+qSe95jNg==",
             "requires": {
                 "@types/debounce-promise": "^3.1.1",
                 "awesome-imperative-promise": "^1.0.1",
@@ -18880,10 +19081,14 @@
             }
         },
         "awesome-imperative-promise": {
-            "version": "1.0.1"
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/awesome-imperative-promise/-/awesome-imperative-promise-1.0.1.tgz",
+            "integrity": "sha512-EmPr3FqbQGqlNh+WxMNcF9pO9uDQJnOC4/3rLBQNH9m4E9qI+8lbfHCmHpVAsmGqPJPKhCjJLHUQzQW/RBHRdQ=="
         },
         "awesome-only-resolves-last-promise": {
             "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/awesome-only-resolves-last-promise/-/awesome-only-resolves-last-promise-1.0.3.tgz",
+            "integrity": "sha512-7q4WPsYiD8Omvi/yHL314DkvsD/lM//Z2/KcU1vWk0xJotiV0GMJTgHTpWl3n90HJqpXKg7qX+VVNs5YbQyPRQ==",
             "requires": {
                 "awesome-imperative-promise": "^1.0.1"
             }
@@ -19796,9 +20001,9 @@
             "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
         },
         "cypress": {
-            "version": "10.10.0",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.10.0.tgz",
-            "integrity": "sha512-bU8r44x1NIYAUNNXt3CwJpLOVth7HUv2hUhYCxZmgZ1IugowDvuHNpevnoZRQx1KKOEisLvIJW+Xen5Pjn41pg==",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
+            "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
             "peer": true,
             "requires": {
                 "@cypress/request": "^2.88.10",
@@ -19846,9 +20051,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "14.18.32",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.32.tgz",
-                    "integrity": "sha512-Y6S38pFr04yb13qqHf8uk1nHE3lXgQ30WZbv1mLliV9pt0NjvqdWttLcrOYLnXbOafknVYRHZGoMSpR9UwfYow==",
+                    "version": "14.18.36",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
+                    "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
                     "peer": true
                 },
                 "ansi-styles": {
@@ -20004,13 +20209,15 @@
             "dev": true
         },
         "dayjs": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.5.tgz",
-            "integrity": "sha512-CAdX5Q3YW3Gclyo5Vpqkgpj8fSdLQcRuzfX6mC6Phy0nfJ0eGYOeS7m4mt2plDWLAtA4TqTakvbboHvUxfe4iA==",
+            "version": "1.11.7",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+            "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==",
             "peer": true
         },
         "debounce-promise": {
-            "version": "3.1.2"
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/debounce-promise/-/debounce-promise-3.1.2.tgz",
+            "integrity": "sha512-rZHcgBkbYavBeD9ej6sP56XfG53d51CD4dnaw989YX/nZ/ZJfgRx/9ePKmTNiUiyQvh4mtrMoS3OAWW+yoYtpg=="
         },
         "debug": {
             "version": "4.3.4",
@@ -20052,8 +20259,7 @@
             "dev": true
         },
         "deepmerge": {
-            "version": "4.2.2",
-            "dev": true
+            "version": "4.2.2"
         },
         "default-gateway": {
             "version": "6.0.3",
@@ -20181,8 +20387,7 @@
             }
         },
         "domelementtype": {
-            "version": "2.3.0",
-            "dev": true
+            "version": "2.3.0"
         },
         "domhandler": {
             "version": "4.3.1",
@@ -21293,9 +21498,9 @@
             "dev": true
         },
         "global-dirs": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-            "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+            "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
             "peer": true,
             "requires": {
                 "ini": "2.0.0"
@@ -22002,9 +22207,9 @@
             },
             "dependencies": {
                 "ci-info": {
-                    "version": "3.5.0",
-                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.5.0.tgz",
-                    "integrity": "sha512-yH4RezKOGlOhxkmhbeNuC4eYZKAUsEaGtBuBzDDP1eFUKiccDWzBABxBfOx31IDwDIXMTxWuwAxUGModvkbuVw==",
+                    "version": "3.7.0",
+                    "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+                    "integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
                     "peer": true
                 }
             }
@@ -22475,18 +22680,18 @@
                     }
                 },
                 "rxjs": {
-                    "version": "7.5.7",
-                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-                    "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
+                    "version": "7.8.0",
+                    "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+                    "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
                     "peer": true,
                     "requires": {
                         "tslib": "^2.1.0"
                     }
                 },
                 "tslib": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-                    "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+                    "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
                     "peer": true
                 }
             }
@@ -23158,8 +23363,7 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.3.4",
-            "dev": true
+            "version": "3.3.4"
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -23593,6 +23797,11 @@
                 "lines-and-columns": "^1.1.6"
             }
         },
+        "parse-srcset": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+            "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+        },
         "parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -23660,8 +23869,7 @@
             "peer": true
         },
         "picocolors": {
-            "version": "1.0.0",
-            "dev": true
+            "version": "1.0.0"
         },
         "picomatch": {
             "version": "2.3.0",
@@ -23777,7 +23985,6 @@
             "version": "8.4.20",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
             "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
-            "dev": true,
             "requires": {
                 "nanoid": "^3.3.4",
                 "picocolors": "^1.0.0",
@@ -24050,6 +24257,8 @@
         },
         "react-content-loader": {
             "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-6.2.0.tgz",
+            "integrity": "sha512-r1dI6S+uHNLW68qraLE2njJYOuy6976PpCExuCZUcABWbfnF3FMcmuESRI8L4Bj45wnZ7n8g71hkPLzbma7/Cw==",
             "requires": {}
         },
         "react-dom": {
@@ -24502,6 +24711,75 @@
         "safer-buffer": {
             "version": "2.1.2"
         },
+        "sanitize-html": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.8.1.tgz",
+            "integrity": "sha512-qK5neD0SaMxGwVv5txOYv05huC3o6ZAA4h5+7nJJgWMNFUNRjcjLO6FpwAtKzfKCZ0jrG6xTk6eVFskbvOGblg==",
+            "requires": {
+                "deepmerge": "^4.2.2",
+                "escape-string-regexp": "^4.0.0",
+                "htmlparser2": "^8.0.0",
+                "is-plain-object": "^5.0.0",
+                "parse-srcset": "^1.0.2",
+                "postcss": "^8.3.11"
+            },
+            "dependencies": {
+                "dom-serializer": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+                    "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+                    "requires": {
+                        "domelementtype": "^2.3.0",
+                        "domhandler": "^5.0.2",
+                        "entities": "^4.2.0"
+                    }
+                },
+                "domhandler": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+                    "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+                    "requires": {
+                        "domelementtype": "^2.3.0"
+                    }
+                },
+                "domutils": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+                    "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+                    "requires": {
+                        "dom-serializer": "^2.0.0",
+                        "domelementtype": "^2.3.0",
+                        "domhandler": "^5.0.1"
+                    }
+                },
+                "entities": {
+                    "version": "4.4.0",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+                    "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+                },
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+                },
+                "htmlparser2": {
+                    "version": "8.0.1",
+                    "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+                    "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+                    "requires": {
+                        "domelementtype": "^2.3.0",
+                        "domhandler": "^5.0.2",
+                        "domutils": "^3.0.1",
+                        "entities": "^4.3.0"
+                    }
+                },
+                "is-plain-object": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+                    "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+                }
+            }
+        },
         "sass": {
             "version": "1.57.1",
             "resolved": "https://registry.npmjs.org/sass/-/sass-1.57.1.tgz",
@@ -24798,8 +25076,7 @@
             "dev": true
         },
         "source-map-js": {
-            "version": "1.0.2",
-            "dev": true
+            "version": "1.0.2"
         },
         "source-map-loader": {
             "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "@patternfly/patternfly": "^4.222.4",
         "@patternfly/react-core": "^4.231.8",
         "@patternfly/react-table": "^4.112.6",
+        "@redhat-cloud-services/frontend-components": "^3.9.27",
         "@redhat-cloud-services/frontend-components-utilities": "^3.3.11",
         "@types/node": "^16.18.11",
         "@types/react": "^17.0.2",

--- a/src/loaders/insights/insights-loader.tsx
+++ b/src/loaders/insights/insights-loader.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import React, { Component } from 'react';
+import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, withRouter, matchPath } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { Alert } from '@patternfly/react-core';
@@ -21,37 +21,32 @@ interface IProps {
   match: RouteComponentProps['match'];
 }
 
-interface IState {
-  alerts: AlertType[];
-  featureFlags: FeatureFlagsType;
-  selectedRepo: string;
-  settings?: SettingsType;
-  user?: UserType;
-}
+// might get called before router mount, ignore
+let appNav = () => null;
 
-class App extends Component<IProps, IState> {
-  constructor(props) {
-    super(props);
+const isRepoURL = (location) =>
+  matchPath(location, { path: Paths.collectionByRepo });
 
-    this.state = {
-      alerts: [],
-      featureFlags: null,
-      selectedRepo: DEFAULT_REPO,
-      settings: null,
-      user: null,
-    };
-  }
+const App = (props: IProps) => {
+  const match = isRepoURL(props.location.pathname);
 
-  appNav: () => void;
+  const [alerts, setAlerts] = useState<AlertType[]>([]);
+  const [featureFlags, setFeatureFlags] = useState<FeatureFlagsType>(null);
+  const [selectedRepo, setSelectedRepo] = useState<string>(DEFAULT_REPO);
+  const [settings, setSettings] = useState<SettingsType>(null);
+  const [user, setUser] = useState<UserType>(null);
+  const setRepo = (_repo: string) => {
+    throw new Error('RepoSelector & setRepo only available in standalone');
+  };
 
-  componentDidMount() {
+  // componentDidMount
+  useEffect(() => {
+    // TODO
     window.insights.chrome.init();
     window.insights.chrome.identifyApp('automation-hub', APPLICATION_NAME);
 
-    // This listens for insights navigation events, so this will fire
-    // when items in the nav are clicked or the app is loaded for the first
-    // time
-    this.appNav = window.insights.chrome.on('APP_NAVIGATION', (event) => {
+    // This listens for insights navigation events, so this will fire when items in the nav are clicked or the app is loaded for the first time
+    appNav = window.insights.chrome.on('APP_NAVIGATION', (event) => {
       // might be undefined early in the load, or may not happen at all
       if (!event?.domEvent?.href) {
         return;
@@ -59,7 +54,7 @@ class App extends Component<IProps, IState> {
 
       // basename is either `/ansible/automation-hub` or `/beta/ansible/automation-hub`, remove trailing /
       // menu events don't have the /beta, converting
-      const basename = this.props.basename
+      const basename = props.basename
         .replace(/^\/beta\//, '/')
         .replace(/\/$/, '');
 
@@ -67,111 +62,82 @@ class App extends Component<IProps, IState> {
       // go to the href, relative to our *actual* basename (basename has no trailing /, so a path will start with / unless empty
       const href = event.domEvent.href.replace(basename, '') || '/';
 
-      this.props.history.push(href);
+      props.history.push(href);
     });
 
-    loadContext().then((data) => this.setState(data));
-  }
+    loadContext().then(({ alerts, featureFlags, settings, user }) => {
+      setAlerts(alerts);
+      setFeatureFlags(featureFlags);
+      setSettings(settings);
+      setUser(user);
+    });
 
-  componentWillUnmount() {
-    this.appNav();
-  }
+    // componentWillUnmount
+    return () => appNav();
+  }, []);
 
-  componentDidUpdate() {
-    // This is sort of a dirty hack to make it so that collection details can
-    // view repositories other than "published", but all other views are locked
-    // to "published"
-    // We do this because there is not currently a way to toggle repositories
-    // in automation hub on console.redhat.com, so it's important to ensure the user
-    // always lands on the published repo
+  // componentDidUpdate
+  useEffect(() => {
+    // This is sort of a dirty hack to make it so that collection details can view repositories other than "published", but all other views are locked to "published"
+    // We do this because there is not currently a way to toggle repositories in automation hub on console.redhat.com, so it's important to ensure the user always lands on the published repo
 
     // check if the URL matches the base path for the collection detail page
-    const match = this.isRepoURL(this.props.location.pathname);
-
     if (match) {
-      // if the URL matches, allow the repo to be switched to the repo defined in
-      // the url
-      if (match.params['repo'] !== this.state.selectedRepo) {
-        this.setState({ selectedRepo: match.params['repo'] });
+      // if the URL matches, allow the repo to be switched to the repo defined in the url
+      if (match.params['repo'] !== selectedRepo) {
+        setSelectedRepo(match.params['repo']);
       }
     } else {
-      // For all other URLs, switch the global state back to the "publised" repo
-      // if the repo is set to anything else.
-      if (this.state.selectedRepo !== DEFAULT_REPO) {
-        this.setState({ selectedRepo: DEFAULT_REPO });
+      // For all other URLs, switch the global state back to the "publised" repo if the repo is set to anything else.
+      if (selectedRepo !== DEFAULT_REPO) {
+        setSelectedRepo(DEFAULT_REPO);
       }
     }
+  });
+
+  // block the page from rendering if we're on a repo route and the repo in the url doesn't match the current state
+  // This gives componentDidUpdate a chance to recognize that route has changed and update the internal state to match the route before any pages can redirect the URL to a 404 state.
+  if (match && match.params['repo'] !== selectedRepo) {
+    return null;
   }
 
-  render() {
-    // block the page from rendering if we're on a repo route and the repo in the
-    // url doesn't match the current state
-    // This gives componentDidUpdate a chance to recognize that route has chnaged
-    // and update the internal state to match the route before any pages can
-    // redirect the URL to a 404 state.
-    const match = this.isRepoURL(this.props.location.pathname);
-    if (match && match.params['repo'] !== this.state.selectedRepo) {
-      return null;
-    }
-
-    // Wait for the user data to load before any of the child components are
-    // rendered. This will prevent API calls from happening
-    // before the app can authenticate
-    if (!this.state.user) {
-      return null;
-    }
-
-    return (
-      <AppContext.Provider
-        value={{
-          alerts: this.state.alerts,
-          featureFlags: this.state.featureFlags,
-          selectedRepo: this.state.selectedRepo,
-          setAlerts: this.setAlerts,
-          setRepo: this.setRepo,
-          setUser: this.setUser,
-          settings: this.state.settings,
-          user: this.state.user,
-          hasPermission: (name) =>
-            hasPermission(
-              {
-                user: this.state.user,
-                settings: this.state.settings,
-                featureFlags: this.state.featureFlags,
-              },
-              name,
-            ),
-        }}
-      >
-        <Alert
-          isInline
-          variant='info'
-          title={t`The Automation Hub sync toggle is now only supported in AAP 2.0. Previous versions of AAP will continue automatically syncing all collections.`}
-        />
-        <Routes childProps={this.props} />
-        <UIVersion />
-      </AppContext.Provider>
-    );
+  // Wait for the user data to load before any of the child components are rendered. This will prevent API calls from happening before the app can authenticate
+  if (!user) {
+    return null;
   }
 
-  setUser = (user) => {
-    this.setState({ user });
-  };
-
-  setAlerts = (alerts) => {
-    this.setState({ alerts });
-  };
-
-  isRepoURL = (location) => {
-    return matchPath(location, {
-      path: Paths.collectionByRepo,
-    });
-  };
-
-  setRepo = (_repo: string) => {
-    throw new Error('RepoSelector & setRepo only available in standalone');
-  };
-}
+  return (
+    <AppContext.Provider
+      value={{
+        alerts,
+        featureFlags,
+        selectedRepo,
+        setAlerts,
+        setRepo,
+        setUser,
+        settings,
+        user,
+        hasPermission: (name) =>
+          hasPermission(
+            {
+              user,
+              settings,
+              featureFlags,
+            },
+            name,
+          ),
+      }}
+    >
+      <Alert
+        isInline
+        variant='info'
+        title={t`The Automation Hub sync toggle is now only supported in AAP 2.0. Previous versions of AAP will continue automatically syncing all collections.`}
+      />
+      <Routes childProps={props} />
+      <UIVersion />
+    </AppContext.Provider>
+  );
+};
 
 /**
  * withRouter: https://reacttraining.com/react-router/web/api/withRouter


### PR DESCRIPTION
Fixes a warning in insights mode:

> Calling deprecated "chrome.init function"! Please remove the function call from your code. Functions "on" and "updateDocumentTitle" are directly accessible from "useChrome" hook.

Switching insights-loader to a functional component first,
changing `window.insights.chrome.init()` to  `useChrome()`,
and calling `indentifyApp`, `updateDocumentTitle` and `on('APP_NAVIGATION', ...)` returned by `useChrome` instead of `window.insights.chrome` now.

(We're only calling `window.insights.chrome.auth` now without the hook.)