### PR TITLE
Fix imports_filter test, update console-logger

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -230,6 +230,8 @@ jobs:
 
     - name: "Run cypress"
       working-directory: 'ansible-hub-ui/test'
+      env:
+        CONSOLE_LOG_TO_TERMINAL: true
       run: |
         sed -i '/specPattern:/s/\*\*/${{matrix.test}}/' cypress.config.js
         grep specPattern cypress.config.js

--- a/test/cypress.config.js
+++ b/test/cypress.config.js
@@ -5,7 +5,9 @@ module.exports = defineConfig({
   viewportHeight: 800,
   e2e: {
     setupNodeEvents(on, _config) {
-      return require('./cypress/plugins/console-logger').install(on);
+      if (process.env.CONSOLE_LOG_TO_TERMINAL) {
+        return require('./cypress/plugins/console-logger').install(on);
+      }
     },
     baseUrl: 'http://localhost:8002',
     specPattern: 'cypress/e2e/**/*.js',

--- a/test/cypress/e2e/imports/imports_filter.js
+++ b/test/cypress/e2e/imports/imports_filter.js
@@ -44,25 +44,6 @@ describe('Imports filter test', () => {
     ).contains('Done');
   });
 
-  it('should fail on importing existing collection', () => {
-    cy.galaxykit('-i collection upload', 'test_namespace', testCollection);
-    cy.visit(`${uiPrefix}my-imports?namespace=test_namespace`);
-
-    cy.get(`[data-cy="ImportList-row-${testCollection}"]`).first().click();
-    cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]').contains(
-      `test_namespace.${testCollection}`,
-    );
-    cy.get(
-      '[data-cy="MyImports"] [data-cy="ImportConsole"] .title-bar',
-    ).contains('Failed', { timeout: 10000 });
-    cy.get('[data-cy="MyImports"] [data-cy="ImportConsole"]').contains(
-      'Error message',
-    );
-    cy.get(
-      '[data-cy="MyImports"] [data-cy="ImportConsole"] .message-list',
-    ).contains('Failed');
-  });
-
   it('should be able to switch between namespaces', () => {
     cy.get('button[aria-label="Clear all"]').click();
     cy.contains('[data-cy="import-list-data"]', 'No namespace selected.', {

--- a/test/cypress/plugins/console-logger.js
+++ b/test/cypress/plugins/console-logger.js
@@ -1,134 +1,47 @@
 const CDP = require('chrome-remote-interface');
-const chalk = require('chalk');
 
-let eventFilter;
-let recordLogs;
-
-let messageLog = [];
-
-const severityColors = {
-  verbose: (a) => a,
-  info: chalk.blue,
-  warning: chalk.yellow,
-  error: chalk.red,
-};
-
-const severityIcons = {
-  verbose: ' ',
-  info: '🛈',
-  warning: '⚠',
-  error: '⚠',
-};
-
-function debugLog(msg) {
-  // suppress with DEBUG=-cypress-log-to-output
-  if (
-    process.env.DEBUG &&
-    process.env.DEBUG.includes('-cypress-log-to-output')
-  ) {
-    return;
-  }
-
-  log(`[cypress-log-to-output] ${msg}`);
-}
-
-function log(msg) {
-  console.log(msg);
-}
-
-function logConsole(params) {
-  if (eventFilter && !eventFilter('console', params)) {
-    return;
-  }
-  if (!process.env.CONSOLE_LOG_TO_TERMINAL) {
-    return;
-  }
-
-  const { type, args, timestamp } = params;
-  const level = type === 'error' ? 'error' : 'verbose';
-  const color = severityColors[level];
-  const icon = severityIcons[level];
-
-  const prefix = `[${new Date(timestamp).toISOString()}] ${icon} `;
-
-  if (args) {
-    args.forEach((arg) => {
-      log(color(`${prefix}${arg.value}`));
-      recordLogMessage(`${prefix}${arg.value}`);
-    });
-  }
-}
-
-function install(on, filter, options = {}) {
-  eventFilter = filter;
-  recordLogs = options.recordLogs;
-  on('before:browser:launch', browserLaunchHandler);
-}
-
-function recordLogMessage(logMessage) {
-  if (recordLogs) {
-    messageLog.push(logMessage);
-  }
-}
-
-function getLogs() {
-  return messageLog;
-}
-
-function clearLogs() {
-  messageLog = [];
+function logConsole({ args }) {
+  console.log(...args.map((arg) => arg.value || arg.preview || arg));
 }
 
 function isChrome(browser) {
-  return (
-    browser.family === 'chrome' ||
-    ['chrome', 'chromium', 'canary'].includes(browser.name) ||
-    (browser.family === 'chromium' && browser.name !== 'electron')
-  );
+  return ['chrome', 'chromium'].includes(browser.family);
 }
 
 function ensureRdpPort(args) {
-  const existing = args.find(
-    (arg) => arg.slice(0, 23) === '--remote-debugging-port',
+  const existing = args.find((arg) =>
+    arg.startsWith('--remote-debugging-port'),
   );
-
   if (existing) {
     return Number(existing.split('=')[1]);
   }
 
   const port = 40000 + Math.round(Math.random() * 25000);
-
   args.push(`--remote-debugging-port=${port}`);
-
   return port;
 }
 
 function browserLaunchHandler(browser = {}, launchOptions) {
-  const args = launchOptions.args || launchOptions;
-
   if (!isChrome(browser)) {
-    return debugLog(
-      `Warning: An unsupported browser family was used, output will not be logged to console: ${browser.family}`,
-    );
+    return console.log('unsupported browser', browser);
   }
 
+  const args = launchOptions.args || launchOptions;
   const rdp = ensureRdpPort(args);
-
-  debugLog('Attempting to connect to Chrome Debugging Protocol');
 
   const tryConnect = () => {
     new CDP({
       port: rdp,
     })
       .then((cdp) => {
-        debugLog('Connected to Chrome Debugging Protocol');
+        console.log('Connected to Chrome Debugging Protocol');
 
         /** captures logs from console.X calls */
         cdp.Runtime.enable();
         cdp.Runtime.consoleAPICalled(logConsole);
 
         cdp.on('disconnect', () => {
-          debugLog('Chrome Debugging Protocol disconnected');
+          console.log('Chrome Debugging Protocol disconnected');
         });
       })
       .catch(() => {
@@ -137,14 +50,9 @@ function browserLaunchHandler(browser = {}, launchOptions) {
   };
 
   tryConnect();
-
   return launchOptions;
 }
 
 module.exports = {
-  _ensureRdpPort: ensureRdpPort,
-  install,
-  browserLaunchHandler,
-  getLogs,
-  clearLogs,
+  install: (on) => on('before:browser:launch', browserLaunchHandler),
 };

--- a/test/package-lock.json
+++ b/test/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "chrome-remote-interface": "^0.31.3",
         "cypress": "^11.2.0",
         "cypress-file-upload": "^5.0.8",
-        "cypress-log-to-output": "^1.1.2",
         "shell-escape-tag": "^2.0.2",
         "url-join": "^5.0.0"
       }
@@ -198,10 +198,6 @@
       "version": "3.2.3",
       "license": "MIT"
     },
-    "node_modules/async-limiter": {
-      "version": "1.0.1",
-      "license": "MIT"
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "license": "MIT"
@@ -309,38 +305,6 @@
       "version": "0.12.0",
       "license": "Apache-2.0"
     },
-    "node_modules/chalk": {
-      "version": "2.4.2",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chalk/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "5.5.0",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/check-more-types": {
       "version": "2.24.0",
       "license": "MIT",
@@ -349,11 +313,12 @@
       }
     },
     "node_modules/chrome-remote-interface": {
-      "version": "0.27.2",
-      "license": "MIT",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.31.3.tgz",
+      "integrity": "sha512-NTwb1YNPHXLTus1RjqsLxJmdViKwKJg/lrFEcM6pbyQy04Ow2QKWHXyPpxzwE+dFsJghWuvSAdTy4W0trluz1g==",
       "dependencies": {
         "commander": "2.11.x",
-        "ws": "^6.1.0"
+        "ws": "^7.2.0"
       },
       "bin": {
         "chrome-remote-interface": "bin/client.js"
@@ -410,17 +375,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/color-convert": {
-      "version": "1.9.3",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.3",
-      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.16",
@@ -534,14 +488,6 @@
       },
       "peerDependencies": {
         "cypress": ">3.0.0"
-      }
-    },
-    "node_modules/cypress-log-to-output": {
-      "version": "1.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "chrome-remote-interface": "^0.27.1"
       }
     },
     "node_modules/cypress/node_modules/chalk": {
@@ -834,13 +780,6 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "license": "ISC"
-    },
-    "node_modules/has-flag": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/http-signature": {
       "version": "1.3.6",
@@ -1644,10 +1583,23 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "6.2.2",
-      "license": "MIT",
-      "dependencies": {
-        "async-limiter": "~1.0.0"
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yallist": {
@@ -1779,9 +1731,6 @@
     "async": {
       "version": "3.2.3"
     },
-    "async-limiter": {
-      "version": "1.0.1"
-    },
     "asynckit": {
       "version": "0.4.0"
     },
@@ -1835,36 +1784,16 @@
     "caseless": {
       "version": "0.12.0"
     },
-    "chalk": {
-      "version": "2.4.2",
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
     "check-more-types": {
       "version": "2.24.0"
     },
     "chrome-remote-interface": {
-      "version": "0.27.2",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/chrome-remote-interface/-/chrome-remote-interface-0.31.3.tgz",
+      "integrity": "sha512-NTwb1YNPHXLTus1RjqsLxJmdViKwKJg/lrFEcM6pbyQy04Ow2QKWHXyPpxzwE+dFsJghWuvSAdTy4W0trluz1g==",
       "requires": {
         "commander": "2.11.x",
-        "ws": "^6.1.0"
+        "ws": "^7.2.0"
       },
       "dependencies": {
         "commander": {
@@ -1897,15 +1826,6 @@
         "slice-ansi": "^3.0.0",
         "string-width": "^4.2.0"
       }
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3"
     },
     "colorette": {
       "version": "2.0.16"
@@ -2008,13 +1928,6 @@
     "cypress-file-upload": {
       "version": "5.0.8",
       "requires": {}
-    },
-    "cypress-log-to-output": {
-      "version": "1.1.2",
-      "requires": {
-        "chalk": "^2.4.2",
-        "chrome-remote-interface": "^0.27.1"
-      }
     },
     "dashdash": {
       "version": "1.14.1",
@@ -2178,9 +2091,6 @@
     },
     "graceful-fs": {
       "version": "4.2.10"
-    },
-    "has-flag": {
-      "version": "3.0.0"
     },
     "http-signature": {
       "version": "1.3.6",
@@ -2634,10 +2544,10 @@
       "version": "1.0.2"
     },
     "ws": {
-      "version": "6.2.2",
-      "requires": {
-        "async-limiter": "~1.0.0"
-      }
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "requires": {}
     },
     "yallist": {
       "version": "4.0.0"

--- a/test/package.json
+++ b/test/package.json
@@ -13,9 +13,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "chrome-remote-interface": "^0.31.3",
     "cypress": "^11.2.0",
     "cypress-file-upload": "^5.0.8",
-    "cypress-log-to-output": "^1.1.2",
     "shell-escape-tag": "^2.0.2",
     "url-join": "^5.0.0"
   }


### PR DESCRIPTION
imports_filter is failing because the test expects import errors when importing a duplicate collection, but we're now getting validation errors during the upload.

Nothing to test here, removing that one - fixes https://github.com/ansible/ansible-hub-ui/actions/runs/3660912544/jobs/6189465640#step:26:51
(Not relevant in 4.6 (yet?) beacuse of the different test backend.)

Also update console-logger plugin to actually log the whole message, enabled on CI to match #2990 #2989 and #2988.