### PR TITLE
remote_repo_edit test - Clear before expecting empty inputs

### DIFF
--- a/test/cypress/e2e/repo/remote_repo_edit.js
+++ b/test/cypress/e2e/repo/remote_repo_edit.js
@@ -22,6 +22,12 @@ describe('edit a remote repository', () => {
 
     cy.contains('Show advanced options').click();
 
+    // clear if already set
+    cy.contains('.pf-c-modal-box__body button', 'Clear').click({
+      force: true,
+      multiple: true,
+    });
+
     // enter new values
     cy.get('input[id="url"]').type('https://galaxy.ansible.com/api/');
     cy.get('input[id="username"]').type('test');


### PR DESCRIPTION
Failure: https://github.com/ansible/ansible-hub-ui/actions/runs/3674755219/jobs/6213368249

It looks like the community remote password fields are already set (not sure if initial data or previous tests),
adding a click to the modal Clear buttons.
