### PR TITLE
workflows - use rh-galaxy-droid key to allow pushing to protected branches

### DIFF
--- a/.github/workflows/cloud-stage-disable.yml
+++ b/.github/workflows/cloud-stage-disable.yml
@@ -18,8 +18,16 @@ jobs:
         git config --global user.name 'GH Actions'
         git config --global user.email 'gh_actions@users.noreply.github.com'
 
+        # decrypt deploy key and use
+        gpg --quiet --batch --yes --decrypt --passphrase="${{ secrets.MANIFEST_PASSPHRASE }}" --output .travis/deploy_manifest .travis/deploy_manifest.gpg
+
+        chmod 600 .travis/deploy_manifest
+        eval `ssh-agent -s`
+        ssh-add .travis/deploy_manifest
+
+        git remote set-url origin git@github.com:ansible/ansible-hub-ui.git
+
         git rm -f .cloud-stage-cron.enabled
 
         git commit -m 'Disable cloud stage cron deploy '`date --iso=d`
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/ansible/ansible-hub-ui.git
         git push origin HEAD:master

--- a/.github/workflows/cloud-stage-enable.yml
+++ b/.github/workflows/cloud-stage-enable.yml
@@ -18,9 +18,17 @@ jobs:
         git config --global user.name 'GH Actions'
         git config --global user.email 'gh_actions@users.noreply.github.com'
 
+        # decrypt deploy key and use
+        gpg --quiet --batch --yes --decrypt --passphrase="${{ secrets.MANIFEST_PASSPHRASE }}" --output .travis/deploy_manifest .travis/deploy_manifest.gpg
+
+        chmod 600 .travis/deploy_manifest
+        eval `ssh-agent -s`
+        ssh-add .travis/deploy_manifest
+
+        git remote set-url origin git@github.com:ansible/ansible-hub-ui.git
+
         touch .cloud-stage-cron.enabled
         git add .cloud-stage-cron.enabled
 
         git commit -m 'Enable cloud stage cron deploy '`date --iso=d`
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/ansible/ansible-hub-ui.git
         git push origin HEAD:master

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -37,7 +37,16 @@ jobs:
       run: |
         git config --global user.name 'GH Actions'
         git config --global user.email 'gh_actions@users.noreply.github.com'
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/ansible/ansible-hub-ui.git
+
+        # decrypt deploy key and use
+        gpg --quiet --batch --yes --decrypt --passphrase="${{ secrets.MANIFEST_PASSPHRASE }}" --output .travis/deploy_manifest .travis/deploy_manifest.gpg
+
+        chmod 600 .travis/deploy_manifest
+        eval `ssh-agent -s`
+        ssh-add .travis/deploy_manifest
+
+        git remote set-url origin git@github.com:ansible/ansible-hub-ui.git
+
         git add locale/
         if git commit -m "Automated updated of i18n strings on $(date +'%Y-%m-%d')"; then
           git push --set-upstream origin


### PR DESCRIPTION
Enabling the branch push protection stops i18n, and cloud-stage-* workflows from being able to push to stable-*/master

there's no way to use GITHUB_TOKEN together with push protection, but we can use a different user
=> going with @rh-galaxy-droid, used for manifests

wip.. need to check that's the right key, and the right account

fixes https://github.com/ansible/ansible-hub-ui/actions/runs/3667585193/jobs/6200136062#step:5:16