### PR TITLE
CI - add flag to prevent oci-env exec from blowing up on ci

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -53,6 +53,7 @@ jobs:
 
         echo "SHORT_BRANCH=${SHORT_BRANCH}" >> $GITHUB_ENV
         echo "COMPOSE_PROFILE=${COMPOSE_PROFILE}" >> $GITHUB_ENV
+        echo "COMPOSE_INTERACTIVE_NO_CLI=1" >> $GITHUB_ENV
 
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v3


### PR DESCRIPTION
Copying from https://github.com/ansible/galaxy_ng/blob/master/.github/workflows/ci_standalone.yml#L31,
should fix failing tests in https://github.com/ansible/ansible-hub-ui/pull/3017:

    Run oci-env exec bash -c "pip3 list && pip3 install pipdeptree && pipdeptree"
    the input device is not a TTY
    Error: Process completed with exit code 1.

(https://github.com/ansible/ansible-hub-ui/actions/runs/3686488463/jobs/6238788160#step:28:13)