### PR TITLE
Configurable legacy prefix

### DIFF
--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,6 +1,5 @@
 import { t, defineMessage } from '@lingui/macro';
 
-
 export class Constants {
   static readonly SEARCH_VIEW_TYPE_LOCAL_KEY = 'search_view_type';
   static readonly DEFAULT_PAGE_SIZE = 10;

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,5 +1,6 @@
 import { t, defineMessage } from '@lingui/macro';
 
+
 export class Constants {
   static readonly SEARCH_VIEW_TYPE_LOCAL_KEY = 'search_view_type';
   static readonly DEFAULT_PAGE_SIZE = 10;
@@ -9,6 +10,9 @@ export class Constants {
   static readonly CARD_DEFAULT_PAGINATION_OPTIONS = [10, 20, 50, 100];
   static readonly INSIGHTS_DEPLOYMENT_MODE = 'insights';
   static readonly STANDALONE_DEPLOYMENT_MODE = 'standalone';
+
+  static readonly LEGACY_ROLE_PREFIX = 'legacy';
+  static readonly LEGACY_ROLE_PREFIX_TITLE = 'Legacy';
 
   static readonly ADMIN_GROUP = 'system:partner-engineers';
   static PUBLISHED = 'published';

--- a/src/containers/legacy-namespaces/legacy-namespace.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespace.tsx
@@ -140,7 +140,9 @@ class LegacyNamespaceRoles extends React.Component<
             />
           ) : (
             <div>
-              <DataList aria-label={t`List of ${Constants.LEGACY_ROLE_PREFIX_TITLE} Roles`}>
+              <DataList
+                aria-label={t`List of ${Constants.LEGACY_ROLE_PREFIX_TITLE} Roles`}
+              >
                 {this.state.roles.map((lrole, ix) => (
                   <LegacyRoleListItem
                     key={ix}

--- a/src/containers/legacy-namespaces/legacy-namespace.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespace.tsx
@@ -25,6 +25,7 @@ import { LegacyRoleAPI } from 'src/api/legacyrole';
 import { LegacyNamespaceAPI } from 'src/api/legacynamespace';
 import { LegacyNamespaceListType, LegacyRoleListType } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
+import { Constants } from 'src/constants';
 
 interface LegacyNamespaceRolesProps {
   namespace: LegacyNamespaceListType;
@@ -139,7 +140,7 @@ class LegacyNamespaceRoles extends React.Component<
             />
           ) : (
             <div>
-              <DataList aria-label={t`List of Legacy Roles`}>
+              <DataList aria-label={t`List of ${Constants.LEGACY_ROLE_PREFIX_TITLE} Roles`}>
                 {this.state.roles.map((lrole, ix) => (
                   <LegacyRoleListItem
                     key={ix}

--- a/src/containers/legacy-namespaces/legacy-namespaces.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespaces.tsx
@@ -133,7 +133,9 @@ class LegacyNamespaces extends React.Component<
 
     return (
       <div>
-        <BaseHeader title={t`${Constants.LEGACY_ROLE_PREFIX_TITLE} Namespaces`}></BaseHeader>
+        <BaseHeader
+          title={t`${Constants.LEGACY_ROLE_PREFIX_TITLE} Namespaces`}
+        ></BaseHeader>
         <React.Fragment>
           {loading ? (
             <LoadingPageSpinner />
@@ -156,7 +158,9 @@ class LegacyNamespaces extends React.Component<
                 count={this.state.count}
               />
 
-              <DataList aria-label={t`List of ${Constants.LEGACY_ROLE_PREFIX_TITLE} Namespaces`}>
+              <DataList
+                aria-label={t`List of ${Constants.LEGACY_ROLE_PREFIX_TITLE} Namespaces`}
+              >
                 {this.state.legacynamespaces &&
                   this.state.legacynamespaces.map((lnamespace) => (
                     <LegacyNamespaceListItem

--- a/src/containers/legacy-namespaces/legacy-namespaces.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespaces.tsx
@@ -15,6 +15,7 @@ import {
 import { LegacyNamespaceAPI } from 'src/api/legacynamespace';
 import { LegacyNamespaceListType } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
+import { Constants } from 'src/constants';
 
 interface LegacyNamespacesProps {
   legacynamespaces: LegacyNamespaceListType[];
@@ -132,7 +133,7 @@ class LegacyNamespaces extends React.Component<
 
     return (
       <div>
-        <BaseHeader title={t`Legacy Namespaces`}></BaseHeader>
+        <BaseHeader title={t`${Constants.LEGACY_ROLE_PREFIX_TITLE} Namespaces`}></BaseHeader>
         <React.Fragment>
           {loading ? (
             <LoadingPageSpinner />
@@ -155,7 +156,7 @@ class LegacyNamespaces extends React.Component<
                 count={this.state.count}
               />
 
-              <DataList aria-label={t`List of Legacy Namespaces`}>
+              <DataList aria-label={t`List of ${Constants.LEGACY_ROLE_PREFIX_TITLE} Namespaces`}>
                 {this.state.legacynamespaces &&
                   this.state.legacynamespaces.map((lnamespace) => (
                     <LegacyNamespaceListItem

--- a/src/containers/legacy-roles/legacy-role.tsx
+++ b/src/containers/legacy-roles/legacy-role.tsx
@@ -37,6 +37,7 @@ import { LegacyRoleAPI } from 'src/api/legacyrole';
 import { AppContext } from 'src/loaders/app-context';
 import { LegacyRoleDetailType } from 'src/api/response-types/legacy-role';
 import { LegacyRoleVersionDetailType } from 'src/api/response-types/legacy-role';
+import { Constants } from 'src/constants';
 
 interface RoleMeta {
   role: LegacyRoleDetailType;
@@ -351,7 +352,7 @@ class LegacyRole extends React.Component<RouteComponentProps, IProps> {
 
     const breadcrumbs = [
       {
-        name: 'Legacy Roles',
+        name: `${Constants.LEGACY_ROLE_PREFIX_TITLE} Roles`,
         url: formatPath(Paths.legacyRoles, {}),
       },
       {

--- a/src/containers/legacy-roles/legacy-roles.tsx
+++ b/src/containers/legacy-roles/legacy-roles.tsx
@@ -15,6 +15,7 @@ import {
 import { LegacyRoleAPI } from 'src/api/legacyrole';
 import { LegacyRoleListType } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
+import { Constants } from 'src/constants';
 
 interface IProps {
   legacyroles: LegacyRoleListType[];
@@ -143,7 +144,7 @@ class LegacyRoles extends React.Component<RouteComponentProps, IProps> {
 
     return (
       <div>
-        <BaseHeader title={t`Legacy Roles`}></BaseHeader>
+        <BaseHeader title={t`${Constants.LEGACY_ROLE_PREFIX_TITLE} Roles`}></BaseHeader>
         <React.Fragment>
           {loading ? (
             <LoadingPageSpinner />

--- a/src/containers/legacy-roles/legacy-roles.tsx
+++ b/src/containers/legacy-roles/legacy-roles.tsx
@@ -144,7 +144,9 @@ class LegacyRoles extends React.Component<RouteComponentProps, IProps> {
 
     return (
       <div>
-        <BaseHeader title={t`${Constants.LEGACY_ROLE_PREFIX_TITLE} Roles`}></BaseHeader>
+        <BaseHeader
+          title={t`${Constants.LEGACY_ROLE_PREFIX_TITLE} Roles`}
+        ></BaseHeader>
         <React.Fragment>
           {loading ? (
             <LoadingPageSpinner />

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -47,6 +47,7 @@ import {
 import { hasPermission } from 'src/utilities';
 import { AppContext } from '../app-context';
 import Logo from 'src/../static/images/logo_large.svg';
+import { Constants } from 'src/constants';
 
 interface IState {
   user: UserType;
@@ -385,15 +386,15 @@ class App extends React.Component<RouteComponentProps, IState> {
         ],
       ),
       menuSection(
-        t`Legacy`,
+        t`${Constants.LEGACY_ROLE_PREFIX_TITLE}`,
         {
           condition: ({ featureFlags }) => featureFlags.legacy_roles,
         },
         [
-          menuItem(t`Legacy Roles`, {
+          menuItem(t`${Constants.LEGACY_ROLE_PREFIX_TITLE} Roles`, {
             url: Paths.legacyRoles,
           }),
-          menuItem(t`Legacy Namespaces`, {
+          menuItem(t`${Constants.LEGACY_ROLE_PREFIX_TITLE} Namespaces`, {
             url: Paths.legacyNamespaces,
           }),
         ],


### PR DESCRIPTION
The community has raised various complaints over using the term "legacy" to refer to roles. This PR makes that term configurable in the display so that the community can debate amongst themselves and change it to whatever they want when they reach a consensus.

Due to the lack of support for computed values in enums, the configurable term can't influence the paths in paths.tx, at least not until https://github.com/microsoft/TypeScript/pull/50528 is extended for strings.

![image](https://user-images.githubusercontent.com/1869705/207464775-791867da-43cb-4fe2-b863-9e618073d838.png)

NOTE: The "standalone" prefix doesn't really make sense in the context of the left nav menu. It would be better if the standalone roles and standalone namespaces fell under the "Collections" NAV and that was renamed.