### PR TITLE
License fields on ah blank or formatted incorrectly

### DIFF
--- a/CHANGES/2048.bug
+++ b/CHANGES/2048.bug
@@ -1,0 +1,1 @@
+License fields on AH - blank or formatted incorrectly - Add comma separator between licences.

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -34,7 +34,7 @@ export class CollectionVersionDetail extends CollectionVersion {
     description: string;
     tags: string[];
     authors: string[];
-    license: string;
+    license: string[];
     homepage: string;
     documentation: string;
     issues: string;

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -62,7 +62,11 @@ export class CollectionInfo extends React.Component<IProps> {
           <GridItem>
             <Split hasGutter={true}>
               <SplitItem className='install-title'>{t`License`}</SplitItem>
-              <SplitItem isFilled>{latest_version.metadata.license ? latest_version.metadata.license.join(', ') : ''}</SplitItem>
+              <SplitItem isFilled>
+                {latest_version.metadata.license
+                  ? latest_version.metadata.license.join(', ')
+                  : ''}
+              </SplitItem>
             </Split>
           </GridItem>
           <GridItem>

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -62,7 +62,7 @@ export class CollectionInfo extends React.Component<IProps> {
           <GridItem>
             <Split hasGutter={true}>
               <SplitItem className='install-title'>{t`License`}</SplitItem>
-              <SplitItem isFilled>{latest_version.metadata.license}</SplitItem>
+              <SplitItem isFilled>{latest_version.metadata.license ? latest_version.metadata.license.join(', ') : ''}</SplitItem>
             </Split>
           </GridItem>
           <GridItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-2048

Now, only comma separator between multiple licenses is repaired.

![20221216143841](https://user-images.githubusercontent.com/289743/208122157-d609913b-ec97-44c3-83c6-5feb8d20166b.png)
