### PR TITLE
[stable-4.5] The ui for dependencies doesn't show collection namespace (#2686)

### DIFF
--- a/CHANGES/1807.bug
+++ b/CHANGES/1807.bug
@@ -1,0 +1,1 @@
+Repair list of collection dependencies - add namespace to the link caption. 

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -46,6 +46,7 @@ export class CollectionDependenciesList extends React.Component<IProps> {
                 this.separateVersion(dependencies[dependency]),
               )}
             >
+              {this.splitDependencyName(dependency).namespace}.
               {this.splitDependencyName(dependency).collection}
             </Link>
           </ListItem>

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -134,7 +134,7 @@ export class CollectionUsedbyDependenciesList extends React.Component<IProps> {
                                 ),
                               )}
                             >
-                              {name} v{version}
+                              {namespace + '.' + name} v{version}
                             </Link>
                           </td>
                         </tr>


### PR DESCRIPTION
Backports #2686 

---

https://issues.redhat.com/browse/AAH-1807

Added namespace to the link caption. Also namespace is also added to used by dependencies links captions.

![20221222193550](https://user-images.githubusercontent.com/289743/209212957-ac76a98c-32cd-4f1d-9ccf-0c9cf7f6fcb3.png)
![20221222193559](https://user-images.githubusercontent.com/289743/209212961-c35ce4d5-147d-4164-be50-93c821cc1f15.png)
