### PR TITLE
Labeler workflow: disable for 4.2 and 4.4

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,12 +2,6 @@
 # to be looked at by PR author and reviewer to keep or remove
 # called by .github/workflows/labeler.yml
 
-backport-4.2:
-- src/**/*
-
-backport-4.4:
-- src/**/*
-
 backport-4.5:
 - src/**/*
 


### PR DESCRIPTION
as per [life cycle](https://access.redhat.com/support/policy/updates/ansible-automation-platform), both 4.2 and 4.4 are past the phase where we'd want to consider backporting - we'll only backport things explicitly marked for those releases

=> removing 4.2 and 4.4 from the labeler workflow, these can still be added manually, but should no longer be the deafult