### PR TITLE
Convert SignatureKeysList & TaskList to ListPage

### DIFF
--- a/src/actions/action.tsx
+++ b/src/actions/action.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react';
-import { DropdownItem } from '@patternfly/react-core';
+import { Button, DropdownItem } from '@patternfly/react-core';
 
 export const Action = ({ title, onClick }) => ({
   dropdownItem: (item) => (
     <DropdownItem key={title} onClick={() => onClick(item)}>
       {title}
     </DropdownItem>
+  ),
+  button: (item) => (
+    <Button key={title} onClick={() => onClick(item)}>
+      {title}
+    </Button>
   ),
 });

--- a/src/actions/action.tsx
+++ b/src/actions/action.tsx
@@ -1,0 +1,10 @@
+import * as React from 'react';
+import { DropdownItem } from '@patternfly/react-core';
+
+export const Action = ({ title, onClick }) => ({
+  dropdownItem: (item) => (
+    <DropdownItem key={title} onClick={() => onClick(item)}>
+      {title}
+    </DropdownItem>
+  ),
+});

--- a/src/actions/action.tsx
+++ b/src/actions/action.tsx
@@ -3,7 +3,8 @@ import { Button, DropdownItem } from '@patternfly/react-core';
 
 interface ActionParams {
   buttonVariant?: 'primary' | 'secondary';
-  onClick: (item) => void;
+  modal?: ({ addAlert, state, setState, query }) => React.ReactNode;
+  onClick: (item, { setState }) => void;
   title: string;
   visible?: (item) => boolean;
 }
@@ -12,18 +13,24 @@ export const Action = ({
   buttonVariant,
   title,
   onClick,
+  modal = null,
   visible = () => true,
 }: ActionParams) => ({
-  dropdownItem: (item) =>
+  dropdownItem: (item, { setState }) =>
     visible(item) ? (
-      <DropdownItem key={title} onClick={() => onClick(item)}>
+      <DropdownItem key={title} onClick={() => onClick(item, { setState })}>
         {title}
       </DropdownItem>
     ) : null,
-  button: (item) =>
+  button: (item, { setState }) =>
     visible(item) ? (
-      <Button variant={buttonVariant} key={title} onClick={() => onClick(item)}>
+      <Button
+        variant={buttonVariant}
+        key={title}
+        onClick={() => onClick(item, { setState })}
+      >
         {title}
       </Button>
     ) : null,
+  modal,
 });

--- a/src/actions/action.tsx
+++ b/src/actions/action.tsx
@@ -1,15 +1,29 @@
 import * as React from 'react';
 import { Button, DropdownItem } from '@patternfly/react-core';
 
-export const Action = ({ title, onClick }) => ({
-  dropdownItem: (item) => (
-    <DropdownItem key={title} onClick={() => onClick(item)}>
-      {title}
-    </DropdownItem>
-  ),
-  button: (item) => (
-    <Button key={title} onClick={() => onClick(item)}>
-      {title}
-    </Button>
-  ),
+interface ActionParams {
+  buttonVariant?: 'primary' | 'secondary';
+  onClick: (item) => void;
+  title: string;
+  visible?: (item) => boolean;
+}
+
+export const Action = ({
+  buttonVariant,
+  title,
+  onClick,
+  visible = () => true,
+}: ActionParams) => ({
+  dropdownItem: (item) =>
+    visible(item) ? (
+      <DropdownItem key={title} onClick={() => onClick(item)}>
+        {title}
+      </DropdownItem>
+    ) : null,
+  button: (item) =>
+    visible(item) ? (
+      <Button variant={buttonVariant} key={title} onClick={() => onClick(item)}>
+        {title}
+      </Button>
+    ) : null,
 });

--- a/src/actions/action.tsx
+++ b/src/actions/action.tsx
@@ -4,7 +4,7 @@ import { Button, DropdownItem } from '@patternfly/react-core';
 interface ActionParams {
   buttonVariant?: 'primary' | 'secondary';
   modal?: ({ addAlert, state, setState, query }) => React.ReactNode;
-  onClick: (item, { setState }) => void;
+  onClick: (item, actionContext) => void;
   title: string;
   visible?: (item) => boolean;
 }
@@ -16,18 +16,18 @@ export const Action = ({
   modal = null,
   visible = () => true,
 }: ActionParams) => ({
-  dropdownItem: (item, { setState }) =>
+  dropdownItem: (item, actionContext) =>
     visible(item) ? (
-      <DropdownItem key={title} onClick={() => onClick(item, { setState })}>
+      <DropdownItem key={title} onClick={() => onClick(item, actionContext)}>
         {title}
       </DropdownItem>
     ) : null,
-  button: (item, { setState }) =>
+  button: (item, actionContext) =>
     visible(item) ? (
       <Button
         variant={buttonVariant}
         key={title}
-        onClick={() => onClick(item, { setState })}
+        onClick={() => onClick(item, actionContext)}
       >
         {title}
       </Button>

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,1 +1,2 @@
 export { signatureKeyDownloadAction } from './signature-key-download';
+export { taskStopAction } from './task-stop';

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,1 +1,1 @@
-export { downloadSignatureKeyAction } from './signature-keys-download-key';
+export { signatureKeyDownloadAction } from './signature-key-download';

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -1,0 +1,1 @@
+export { downloadSignatureKeyAction } from './signature-keys-download-key';

--- a/src/actions/signature-key-download.tsx
+++ b/src/actions/signature-key-download.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { Action } from './action';
 
-export const downloadSignatureKeyAction = Action({
+export const signatureKeyDownloadAction = Action({
   title: t`Download key`,
   onClick: ({ public_key }) =>
     (document.location =

--- a/src/actions/signature-keys-download-key.tsx
+++ b/src/actions/signature-keys-download-key.tsx
@@ -1,0 +1,9 @@
+import { t } from '@lingui/macro';
+import { Action } from './action';
+
+export const downloadSignatureKeyAction = Action({
+  title: t`Download key`,
+  onClick: ({ public_key }) =>
+    (document.location =
+      'data:application/octet-stream,' + encodeURIComponent(public_key)),
+});

--- a/src/actions/task-stop.tsx
+++ b/src/actions/task-stop.tsx
@@ -1,0 +1,82 @@
+import { t, Trans } from '@lingui/macro';
+import * as React from 'react';
+import { TaskManagementAPI } from 'src/api';
+import { ConfirmModal } from 'src/components';
+import { Constants } from 'src/constants';
+import { errorMessage, parsePulpIDFromURL } from 'src/utilities';
+import { Action } from './action';
+
+const stopTask = (
+  {
+    addAlert,
+    state: {
+      selectedTask: { pulp_href },
+    },
+    setState,
+    query,
+  },
+  name,
+) =>
+  TaskManagementAPI.patch(parsePulpIDFromURL(pulp_href), {
+    state: 'canceled',
+  })
+    .then(() => {
+      setState({
+        loading: true,
+        selectedTask: null,
+        cancelModalVisible: false,
+      });
+      addAlert({
+        variant: 'success',
+        title: name,
+        description: (
+          <Trans>Task &quot;{name}&quot; stopped successfully.</Trans>
+        ),
+      });
+
+      query();
+    })
+    .catch((e) => {
+      const { status, statusText } = e.response;
+      setState({
+        loading: false,
+        cancelModalVisible: false,
+      });
+      addAlert({
+        variant: 'danger',
+        title: t`Task "${name}" could not be stopped.`,
+        description: errorMessage(status, statusText),
+      });
+    });
+
+export const taskStopAction = Action({
+  buttonVariant: 'secondary',
+  onClick: (selectedTask, { setState }) =>
+    setState({
+      cancelModalVisible: true,
+      selectedTask,
+    }),
+  title: t`Stop task`,
+  visible: ({ state }) => ['running', 'waiting'].includes(state),
+  modal: ({ addAlert, state, setState, query }) => {
+    if (!state.cancelModalVisible) {
+      return null;
+    }
+
+    const name =
+      Constants.TASK_NAMES[state.selectedTask.name] || state.selectedTask.name;
+
+    return (
+      <ConfirmModal
+        cancelAction={() => setState({ cancelModalVisible: false })}
+        confirmAction={() =>
+          stopTask({ addAlert, state, setState, query }, name)
+        }
+        confirmButtonTitle={t`Yes, stop`}
+        title={t`Stop task?`}
+      >
+        {t`${name} will be cancelled.`}
+      </ConfirmModal>
+    );
+  },
+});

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,7 +20,10 @@ export { CollectionListItem } from './collection-list/collection-list-item';
 export { ConfirmModal } from './confirm-modal/confirm-modal';
 export { CollectionDependenciesList } from './collection-dependencies-list/collection-dependencies-list';
 export { CollectionUsedbyDependenciesList } from './collection-dependencies-list/collection-usedby-dependencies-list';
-export { CompoundFilter } from './patternfly-wrappers/compound-filter';
+export {
+  CompoundFilter,
+  FilterOption,
+} from './patternfly-wrappers/compound-filter';
 export { DateComponent } from './date-component/date-component';
 export { DeleteExecutionEnvironmentModal } from './delete-modal/delete-execution-environment-modal';
 export { DeleteGroupModal } from './rbac/delete-group-modal';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -38,6 +38,7 @@ export { HelperText } from './helper-text/helper-text';
 export { ImportConsole } from './my-imports/import-console';
 export { ImportList } from './my-imports/import-list';
 export { ImportModal } from './import-modal/import-modal';
+export { ListPage } from './page/list-page';
 export { LinkTabs } from './patternfly-wrappers/link-tabs';
 export { LoadingPageSpinner } from './loading/loading-page-spinner';
 export { LoadingPageWithHeader } from './loading/loading-with-header';

--- a/src/components/list-item-actions/list-item-actions.tsx
+++ b/src/components/list-item-actions/list-item-actions.tsx
@@ -10,22 +10,24 @@ export class ListItemActions extends React.Component<IProps> {
   render() {
     const buttons = this.props.buttons?.filter(Boolean);
     const kebabItems = this.props.kebabItems?.filter(Boolean);
+    const anyButtons = buttons?.length;
+    const anyKebab = kebabItems?.length;
 
     return (
       <td
         style={{
-          paddingRight: '0px',
+          paddingRight: anyKebab ? '0px' : '16px',
           textAlign: 'right',
           display: 'flex',
           justifyContent: 'flex-end',
         }}
       >
-        {buttons?.length ? (
+        {anyButtons ? (
           <>
             <List>{buttons}</List>{' '}
           </>
         ) : null}
-        {kebabItems?.length ? (
+        {anyKebab ? (
           <div data-cy='kebab-toggle'>
             <StatefulDropdown items={kebabItems} />{' '}
           </div>

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -1,0 +1,282 @@
+import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import {
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import {
+  AlertList,
+  AlertType,
+  AppliedFilters,
+  BaseHeader,
+  CompoundFilter,
+  EmptyStateFilter,
+  EmptyStateNoData,
+  EmptyStateUnauthorized,
+  LoadingPageSpinner,
+  Main,
+  Pagination,
+  SortTable,
+  closeAlertMixin,
+} from 'src/components';
+import { AppContext } from 'src/loaders/app-context';
+import { ParamHelper, errorMessage, filterIsSet } from 'src/utilities';
+
+interface IState<T> {
+  params: {
+    page?: number;
+    page_size?: number;
+  };
+  loading: boolean;
+  items: T[];
+  itemCount: number;
+  alerts: AlertType[];
+  unauthorised: boolean;
+  inputText: string;
+}
+
+// states:
+// loading - initial state, only Main + spinner, header and alerts
+// unauthorised - only EmptyStateUnauthorized, header and alerts
+// noData - no data at all, EmptyStateNoData with possible buttons
+// !items.length - no visible data but a filter is on, EmptyStateFilter with a clear filters button, CompoundFilter + AppliedFilters
+// (data) - also renders SortTable
+
+type CanPermission = (o: { featureFlags; settings; user }) => boolean;
+type FilterConfig = { id: string; title: string }[];
+type ParamsType = { page?: number; page_size?: number };
+type Query<T> = (o: {
+  params?: ParamsType;
+}) => Promise<{ data: { count: number; results: T[] } }>;
+type RenderTableRow<T> = (item: T, index: number) => React.ReactNode;
+type SortHeaders = {
+  title: string;
+  type: string;
+  id: string;
+  className?: string;
+}[];
+
+interface ListPageParams<T> {
+  condition: CanPermission;
+  defaultPageSize: number;
+  displayName: string;
+  errorTitle: string;
+  filterConfig: FilterConfig;
+  noDataDescription: string;
+  noDataTitle: string;
+  query: Query<T>;
+  renderTableRow: RenderTableRow<T>;
+  sortHeaders: SortHeaders;
+  title: string;
+}
+
+export const ListPage = function <T>({
+  // { featureFlags, settings, user } => bool
+  condition,
+  // component name for debugging
+  displayName,
+  // initial page size
+  defaultPageSize,
+  // alert on query failure
+  errorTitle,
+  // filters
+  filterConfig,
+  // EmptyStateNoData
+  noDataDescription,
+  noDataTitle,
+  // ({ params }) => Promise<{ data: { count, results[] } }>
+  query,
+  // (item, index) => <tr>...</tr>
+  renderTableRow,
+  // table headers
+  sortHeaders,
+  // container title
+  title,
+}: ListPageParams<T>) {
+  const klass = class extends React.Component<RouteComponentProps, IState<T>> {
+    static displayName = displayName;
+    static contextType = AppContext;
+
+    constructor(props) {
+      super(props);
+
+      const params = ParamHelper.parseParamString(props.location.search, [
+        'page',
+        'page_size',
+      ]);
+
+      if (!params['page_size']) {
+        params['page_size'] = defaultPageSize;
+      }
+
+      this.state = {
+        alerts: [],
+        inputText: '',
+        itemCount: 0,
+        items: [],
+        loading: true,
+        params,
+        unauthorised: false,
+      };
+    }
+
+    componentDidMount() {
+      if (!condition(this.context)) {
+        this.setState({ loading: false, unauthorised: true });
+      } else {
+        this.query();
+      }
+    }
+
+    render() {
+      const { params, itemCount, loading, items, alerts, unauthorised } =
+        this.state;
+
+      const knownFilters = (filterConfig || []).map(({ id }) => id);
+      const noData = items.length === 0 && !filterIsSet(params, knownFilters);
+
+      const updateParams = (p) => this.updateParams(p, () => this.query());
+
+      const niceNames = Object.fromEntries(
+        (filterConfig || []).map(({ id, title }) => [id, title]),
+      );
+
+      return (
+        <React.Fragment>
+          <AlertList
+            alerts={alerts}
+            closeAlert={(i) => this.closeAlert(i)}
+          ></AlertList>
+          <BaseHeader title={title} />
+          {unauthorised ? (
+            <EmptyStateUnauthorized />
+          ) : noData && !loading ? (
+            <EmptyStateNoData
+              title={noDataTitle}
+              description={noDataDescription}
+            />
+          ) : (
+            <Main>
+              {loading ? (
+                <LoadingPageSpinner />
+              ) : (
+                <section className='body'>
+                  <div className='hub-list-toolbar'>
+                    <Toolbar>
+                      <ToolbarContent>
+                        <ToolbarGroup>
+                          <ToolbarItem>
+                            <CompoundFilter
+                              inputText={this.state.inputText}
+                              onChange={(text) =>
+                                this.setState({ inputText: text })
+                              }
+                              updateParams={updateParams}
+                              params={params}
+                              filterConfig={filterConfig}
+                            />
+                          </ToolbarItem>
+                        </ToolbarGroup>
+                      </ToolbarContent>
+                    </Toolbar>
+                    <Pagination
+                      params={params}
+                      updateParams={updateParams}
+                      count={itemCount}
+                      isTop
+                    />
+                  </div>
+                  <div>
+                    <AppliedFilters
+                      updateParams={(p) => {
+                        updateParams(p);
+                        this.setState({ inputText: '' });
+                      }}
+                      params={params}
+                      ignoredParams={['page_size', 'page', 'sort', 'ordering']}
+                      niceNames={niceNames}
+                    />
+                  </div>
+                  {loading ? (
+                    <LoadingPageSpinner />
+                  ) : (
+                    this.renderTable(params, updateParams)
+                  )}
+
+                  <Pagination
+                    params={params}
+                    updateParams={updateParams}
+                    count={itemCount}
+                  />
+                </section>
+              )}
+            </Main>
+          )}
+        </React.Fragment>
+      );
+    }
+
+    private renderTable(params, updateParams) {
+      const { items } = this.state;
+
+      if (!items.length) {
+        return <EmptyStateFilter />;
+      }
+
+      return (
+        <table aria-label={title} className='hub-c-table-content pf-c-table'>
+          <SortTable
+            options={{ headers: sortHeaders }}
+            params={params}
+            updateParams={updateParams}
+          />
+          <tbody>{items.map((item, i) => renderTableRow(item, i))}</tbody>
+        </table>
+      );
+    }
+
+    private get closeAlert() {
+      return closeAlertMixin('alerts');
+    }
+
+    private query() {
+      this.setState({ loading: true }, () => {
+        query({ params: this.state.params })
+          .then((result) => {
+            this.setState({
+              items: result.data.results,
+              itemCount: result.data.count,
+              loading: false,
+            });
+          })
+          .catch((e) => {
+            const { status, statusText } = e.response;
+            this.setState({
+              loading: false,
+              items: [],
+              itemCount: 0,
+            });
+            this.addAlert({
+              title: errorTitle,
+              variant: 'danger',
+              description: errorMessage(status, statusText),
+            });
+          });
+      });
+    }
+
+    private addAlert(alert: AlertType) {
+      this.setState({
+        alerts: [...this.state.alerts, alert],
+      });
+    }
+
+    private get updateParams() {
+      return ParamHelper.updateParamsMixin();
+    }
+  };
+
+  return withRouter(klass);
+};

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -63,6 +63,7 @@ interface ListPageParams<T> {
   condition: CanContext;
   defaultPageSize: number;
   defaultSort?: string;
+  didMount?: ({ context, addAlert }) => void;
   displayName: string;
   errorTitle: string;
   filterConfig: FilterConfig;
@@ -77,6 +78,8 @@ interface ListPageParams<T> {
 export const ListPage = function <T>({
   // { featureFlags, settings, user } => bool
   condition,
+  // extra code to run on mount
+  didMount,
   // component name for debugging
   displayName,
   // initial page size
@@ -135,6 +138,13 @@ export const ListPage = function <T>({
         this.setState({ loading: false, unauthorised: true });
       } else {
         this.query();
+      }
+
+      if (didMount) {
+        didMount({
+          context: this.context,
+          addAlert: (alert) => this.addAlert(alert),
+        });
       }
     }
 

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -15,6 +15,7 @@ import {
   EmptyStateFilter,
   EmptyStateNoData,
   EmptyStateUnauthorized,
+  FilterOption,
   LoadingPageSpinner,
   Main,
   Pagination,
@@ -45,7 +46,7 @@ interface IState<T> {
 // !items.length - no visible data but a filter is on, EmptyStateFilter with a clear filters button, CompoundFilter + AppliedFilters
 // (data) - also renders SortTable
 
-type FilterConfig = { id: string; title: string }[];
+type FilterConfig = FilterOption[];
 type ParamsType = { page?: number; page_size?: number };
 type Query<T> = (o: {
   params?: ParamsType;

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -62,6 +62,7 @@ type SortHeaders = {
 interface ListPageParams<T> {
   condition: CanContext;
   defaultPageSize: number;
+  defaultSort?: string;
   displayName: string;
   errorTitle: string;
   filterConfig: FilterConfig;
@@ -80,6 +81,8 @@ export const ListPage = function <T>({
   displayName,
   // initial page size
   defaultPageSize,
+  // initial sort ordering
+  defaultSort,
   // alert on query failure
   errorTitle,
   // filters
@@ -110,6 +113,10 @@ export const ListPage = function <T>({
 
       if (!params['page_size']) {
         params['page_size'] = defaultPageSize;
+      }
+
+      if (!params['sort'] && defaultSort) {
+        params['sort'] = defaultSort;
       }
 
       this.state = {

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -180,7 +180,7 @@ export const ListPage = function <T>({
               {loading ? (
                 <LoadingPageSpinner />
               ) : (
-                <section className='body'>
+                <section className='body' data-cy={`ListPage-${displayName}`}>
                   <div className='hub-list-toolbar'>
                     <Toolbar>
                       <ToolbarContent>

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -54,7 +54,7 @@ type Query<T> = (o: {
 type RenderTableRow<T> = (
   item: T,
   index: number,
-  { setState },
+  { addAlert, setState },
 ) => React.ReactNode;
 type RenderModals = ({ addAlert, state, setState, query }) => React.ReactNode;
 type SortHeaders = {
@@ -73,6 +73,7 @@ interface ListPageParams<T, ExtraState> {
   errorTitle: string;
   extraState?: ExtraState;
   filterConfig: FilterConfig;
+  headerActions?: any[];
   noDataDescription: string;
   noDataTitle: string;
   query: Query<T>;
@@ -99,6 +100,8 @@ export const ListPage = function <T, ExtraState = Record<string, never>>({
   extraState,
   // filters
   filterConfig,
+  // displayed after filters
+  headerActions,
   // EmptyStateNoData
   noDataDescription,
   noDataTitle,
@@ -216,9 +219,16 @@ export const ListPage = function <T, ExtraState = Record<string, never>>({
                               filterConfig={filterConfig}
                             />
                           </ToolbarItem>
+                          {headerActions?.length &&
+                            headerActions.map((action) => (
+                              <ToolbarItem>
+                                {action.button(null, actionContext)}
+                              </ToolbarItem>
+                            ))}
                         </ToolbarGroup>
                       </ToolbarContent>
                     </Toolbar>
+
                     <Pagination
                       params={params}
                       updateParams={updateParams}

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -22,6 +22,7 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
+import { CanContext } from 'src/permissions';
 import { ParamHelper, errorMessage, filterIsSet } from 'src/utilities';
 
 interface IState<T> {
@@ -44,7 +45,6 @@ interface IState<T> {
 // !items.length - no visible data but a filter is on, EmptyStateFilter with a clear filters button, CompoundFilter + AppliedFilters
 // (data) - also renders SortTable
 
-type CanPermission = (o: { featureFlags; settings; user }) => boolean;
 type FilterConfig = { id: string; title: string }[];
 type ParamsType = { page?: number; page_size?: number };
 type Query<T> = (o: {
@@ -59,7 +59,7 @@ type SortHeaders = {
 }[];
 
 interface ListPageParams<T> {
-  condition: CanPermission;
+  condition: CanContext;
   defaultPageSize: number;
   displayName: string;
   errorTitle: string;

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -18,7 +18,7 @@ import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import { StatefulDropdown } from 'src/components';
 import { ParamHelper } from 'src/utilities';
 
-class FilterOption {
+export class FilterOption {
   id: string;
   title: string;
   placeholder?: string;

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -37,7 +37,7 @@ export { default as ExecutionEnvironmentDetailImages } from './execution-environ
 export { default as ExecutionEnvironmentDetailOwners } from './execution-environment-detail/execution_environment_detail_owners';
 export { default as ExecutionEnvironmentManifest } from './execution-environment-manifest/execution-environment-manifest';
 export { default as TaskDetail } from './task-management/task_detail';
-export { default as TaskListView } from './task-management/task-list-view';
+export { default as TaskList } from './task-management/list';
 export { default as SignatureKeysList } from './signature-keys/list';
 
 export { default as LegacyRoles } from './legacy-roles/legacy-roles';

--- a/src/containers/signature-keys/list.tsx
+++ b/src/containers/signature-keys/list.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import { downloadSignatureKeyAction } from 'src/actions';
+import { signatureKeyDownloadAction } from 'src/actions';
 import { SigningServiceAPI, SigningServiceType } from 'src/api';
 import {
   ClipboardCopy,
@@ -28,7 +28,7 @@ export const SignatureKeysList = ListPage<SigningServiceType>({
     const { name, pubkey_fingerprint, public_key, pulp_created } = item;
 
     const dropdownItems = [
-      downloadSignatureKeyAction.dropdownItem({ public_key }),
+      signatureKeyDownloadAction.dropdownItem({ public_key }),
     ];
 
     return (

--- a/src/containers/signature-keys/list.tsx
+++ b/src/containers/signature-keys/list.tsx
@@ -1,227 +1,29 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import { withRouter, RouteComponentProps } from 'react-router-dom';
-import {
-  DropdownItem,
-  Toolbar,
-  ToolbarContent,
-  ToolbarGroup,
-  ToolbarItem,
-} from '@patternfly/react-core';
-import { ParamHelper, filterIsSet, errorMessage } from '../../utilities';
-import {
-  AlertList,
-  AlertType,
-  AppliedFilters,
-  BaseHeader,
-  ClipboardCopy,
-  CompoundFilter,
-  DateComponent,
-  EmptyStateFilter,
-  EmptyStateNoData,
-  EmptyStateUnauthorized,
-  ListItemActions,
-  LoadingPageSpinner,
-  Main,
-  Pagination,
-  SortTable,
-  closeAlertMixin,
-} from 'src/components';
+import { DropdownItem } from '@patternfly/react-core';
 import { SigningServiceAPI, SigningServiceType } from 'src/api';
-import { AppContext } from 'src/loaders/app-context';
+import {
+  ClipboardCopy,
+  DateComponent,
+  ListItemActions,
+  ListPage,
+} from 'src/components';
 
-interface IState {
-  params: {
-    page?: number;
-    page_size?: number;
-  };
-  loading: boolean;
-  items: SigningServiceType[];
-  itemCount: number;
-  alerts: AlertType[];
-  unauthorised: boolean;
-  inputText: string;
-}
-
-export class SignatureKeysList extends React.Component<
-  RouteComponentProps,
-  IState
-> {
-  constructor(props) {
-    super(props);
-
-    const params = ParamHelper.parseParamString(props.location.search, [
-      'page',
-      'page_size',
-    ]);
-
-    if (!params['page_size']) {
-      params['page_size'] = 100;
-    }
-
-    this.state = {
-      params: params,
-      items: [],
-      loading: true,
-      itemCount: 0,
-      alerts: [],
-      unauthorised: false,
-      inputText: '',
-    };
-  }
-
-  componentDidMount() {
-    if (!this.context.user || this.context.user.is_anonymous) {
-      this.setState({ loading: false, unauthorised: true });
-    } else {
-      this.query();
-    }
-  }
-
-  render() {
-    const { params, itemCount, loading, items, alerts, unauthorised } =
-      this.state;
-
-    const noData = items.length === 0 && !filterIsSet(params, ['name']);
-
-    return (
-      <React.Fragment>
-        <AlertList
-          alerts={alerts}
-          closeAlert={(i) => this.closeAlert(i)}
-        ></AlertList>
-        <BaseHeader title={t`Signature Keys`} />
-        {unauthorised ? (
-          <EmptyStateUnauthorized />
-        ) : noData && !loading ? (
-          <EmptyStateNoData
-            title={t`No signature keys yet`}
-            description={t`Signature keys will appear once created.`}
-          />
-        ) : (
-          <Main>
-            {loading ? (
-              <LoadingPageSpinner />
-            ) : (
-              <section className='body'>
-                <div className='hub-list-toolbar'>
-                  <Toolbar>
-                    <ToolbarContent>
-                      <ToolbarGroup>
-                        <ToolbarItem>
-                          <CompoundFilter
-                            inputText={this.state.inputText}
-                            onChange={(text) =>
-                              this.setState({ inputText: text })
-                            }
-                            updateParams={(p) => {
-                              p['page'] = 1;
-                              this.updateParams(p, () => this.query());
-                            }}
-                            params={params}
-                            filterConfig={[
-                              {
-                                id: 'name',
-                                title: t`Name`,
-                              },
-                            ]}
-                          />
-                        </ToolbarItem>
-                      </ToolbarGroup>
-                    </ToolbarContent>
-                  </Toolbar>
-                  <Pagination
-                    params={params}
-                    updateParams={(p) =>
-                      this.updateParams(p, () => this.query())
-                    }
-                    count={itemCount}
-                    isTop
-                  />
-                </div>
-                <div>
-                  <AppliedFilters
-                    updateParams={(p) => {
-                      this.updateParams(p, () => this.query());
-                      this.setState({ inputText: '' });
-                    }}
-                    params={params}
-                    ignoredParams={['page_size', 'page', 'sort', 'ordering']}
-                    niceNames={{
-                      name: t`Name`,
-                    }}
-                  />
-                </div>
-                {loading ? <LoadingPageSpinner /> : this.renderTable(params)}
-
-                <Pagination
-                  params={params}
-                  updateParams={(p) => this.updateParams(p, () => this.query())}
-                  count={itemCount}
-                />
-              </section>
-            )}
-          </Main>
-        )}
-      </React.Fragment>
-    );
-  }
-
-  private renderTable(params) {
-    const { items } = this.state;
-    if (!items.length) {
-      return <EmptyStateFilter />;
-    }
-
-    const sortTableOptions = {
-      headers: [
-        {
-          title: t`Name`,
-          type: 'none',
-          id: 'name',
-        },
-        {
-          title: t`Key fingerprint`,
-          type: 'none',
-          id: 'pubkey_fingerprint',
-        },
-        {
-          title: t`Created on`,
-          type: 'none',
-          id: 'pulp_created',
-        },
-        {
-          title: t`Public key`,
-          type: 'none',
-          id: 'public_key',
-        },
-        {
-          title: '',
-          type: 'none',
-          id: 'kebab',
-        },
-      ],
-    };
-
-    return (
-      <table
-        aria-label={t`Signature keys`}
-        className='hub-c-table-content pf-c-table'
-      >
-        <SortTable
-          options={sortTableOptions}
-          params={params}
-          updateParams={(p) => {
-            p['page'] = 1;
-            this.updateParams(p, () => this.query());
-          }}
-        />
-        <tbody>{items.map((item, i) => this.renderTableRow(item, i))}</tbody>
-      </table>
-    );
-  }
-
-  private renderTableRow(item, index: number) {
+export const SignatureKeysList = ListPage<SigningServiceType>({
+  condition: ({ user }) => user && !user.is_anonymous,
+  defaultPageSize: 100,
+  displayName: 'SignatureKeysList',
+  errorTitle: t`Signature keys could not be displayed.`,
+  filterConfig: [
+    {
+      id: 'name',
+      title: t`Name`,
+    },
+  ],
+  noDataDescription: t`Signature keys will appear once created.`,
+  noDataTitle: t`No signature keys yet`,
+  query: ({ params }) => SigningServiceAPI.list(params),
+  renderTableRow(item: SigningServiceType, index: number) {
     const { name, pubkey_fingerprint, public_key, pulp_created } = item;
 
     const dropdownItems = [
@@ -251,49 +53,35 @@ export class SignatureKeysList extends React.Component<
         <ListItemActions kebabItems={dropdownItems} />
       </tr>
     );
-  }
+  },
+  sortHeaders: [
+    {
+      title: t`Name`,
+      type: 'none',
+      id: 'name',
+    },
+    {
+      title: t`Key fingerprint`,
+      type: 'none',
+      id: 'pubkey_fingerprint',
+    },
+    {
+      title: t`Created on`,
+      type: 'none',
+      id: 'pulp_created',
+    },
+    {
+      title: t`Public key`,
+      type: 'none',
+      id: 'public_key',
+    },
+    {
+      title: '',
+      type: 'none',
+      id: 'kebab',
+    },
+  ],
+  title: t`Signature keys`,
+});
 
-  private get closeAlert() {
-    return closeAlertMixin('alerts');
-  }
-
-  private query() {
-    this.setState({ loading: true }, () => {
-      SigningServiceAPI.list(this.state.params)
-        .then((result) => {
-          this.setState({
-            items: result.data.results,
-            itemCount: result.data.count,
-            loading: false,
-          });
-        })
-        .catch((e) => {
-          const { status, statusText } = e.response;
-          this.setState({
-            loading: false,
-            items: [],
-            itemCount: 0,
-          });
-          this.addAlert({
-            title: t`Signature keys could not be displayed.`,
-            variant: 'danger',
-            description: errorMessage(status, statusText),
-          });
-        });
-    });
-  }
-
-  private addAlert(alert: AlertType) {
-    this.setState({
-      alerts: [...this.state.alerts, alert],
-    });
-  }
-
-  private get updateParams() {
-    return ParamHelper.updateParamsMixin();
-  }
-}
-
-export default withRouter(SignatureKeysList);
-
-SignatureKeysList.contextType = AppContext;
+export default SignatureKeysList;

--- a/src/containers/signature-keys/list.tsx
+++ b/src/containers/signature-keys/list.tsx
@@ -24,11 +24,11 @@ export const SignatureKeysList = ListPage<SigningServiceType>({
   noDataDescription: t`Signature keys will appear once created.`,
   noDataTitle: t`No signature keys yet`,
   query: ({ params }) => SigningServiceAPI.list(params),
-  renderTableRow(item: SigningServiceType, index: number) {
+  renderTableRow(item: SigningServiceType, index: number, actionContext) {
     const { name, pubkey_fingerprint, public_key, pulp_created } = item;
 
     const dropdownItems = [
-      signatureKeyDownloadAction.dropdownItem({ public_key }),
+      signatureKeyDownloadAction.dropdownItem({ public_key }, actionContext),
     ];
 
     return (

--- a/src/containers/signature-keys/list.tsx
+++ b/src/containers/signature-keys/list.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import { DropdownItem } from '@patternfly/react-core';
+import { downloadSignatureKeyAction } from 'src/actions';
 import { SigningServiceAPI, SigningServiceType } from 'src/api';
 import {
   ClipboardCopy,
@@ -28,15 +28,7 @@ export const SignatureKeysList = ListPage<SigningServiceType>({
     const { name, pubkey_fingerprint, public_key, pulp_created } = item;
 
     const dropdownItems = [
-      <DropdownItem
-        key='download-key'
-        onClick={() => {
-          document.location =
-            'data:application/octet-stream,' + encodeURIComponent(public_key);
-        }}
-      >
-        {t`Download key`}
-      </DropdownItem>,
+      downloadSignatureKeyAction.dropdownItem({ public_key }),
     ];
 
     return (

--- a/src/containers/signature-keys/list.tsx
+++ b/src/containers/signature-keys/list.tsx
@@ -8,9 +8,10 @@ import {
   ListItemActions,
   ListPage,
 } from 'src/components';
+import { isLoggedIn } from 'src/permissions';
 
 export const SignatureKeysList = ListPage<SigningServiceType>({
-  condition: ({ user }) => user && !user.is_anonymous,
+  condition: isLoggedIn,
   defaultPageSize: 100,
   displayName: 'SignatureKeysList',
   errorTitle: t`Signature keys could not be displayed.`,

--- a/src/containers/task-management/list.tsx
+++ b/src/containers/task-management/list.tsx
@@ -1,281 +1,87 @@
-import { t, Trans } from '@lingui/macro';
+import { t } from '@lingui/macro';
 import { i18n } from '@lingui/core';
-
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import './task.scss';
-import { Constants } from 'src/constants';
-import { withRouter, RouteComponentProps, Link } from 'react-router-dom';
-import {
-  Button,
-  Toolbar,
-  ToolbarGroup,
-  ToolbarItem,
-  ToolbarContent,
-} from '@patternfly/react-core';
-import { ParamHelper, filterIsSet, errorMessage } from '../../utilities';
-import { parsePulpIDFromURL } from 'src/utilities/parse-pulp-id';
-import {
-  AlertList,
-  AlertType,
-  AppliedFilters,
-  BaseHeader,
-  closeAlertMixin,
-  ConfirmModal,
-  CompoundFilter,
-  DateComponent,
-  EmptyStateFilter,
-  EmptyStateNoData,
-  EmptyStateUnauthorized,
-  LoadingPageSpinner,
-  Main,
-  Pagination,
-  SortTable,
-  Tooltip,
-  StatusIndicator,
-} from 'src/components';
+import { taskStopAction } from 'src/actions';
 import { TaskManagementAPI } from 'src/api';
 import { TaskType } from 'src/api/response-types/task';
+import { Constants } from 'src/constants';
+import {
+  DateComponent,
+  ListItemActions,
+  ListPage,
+  StatusIndicator,
+  Tooltip,
+} from 'src/components';
 import { formatPath, Paths } from 'src/paths';
-import { AppContext } from 'src/loaders/app-context';
+import { canViewAllTasks, isLoggedIn } from 'src/permissions';
+import { parsePulpIDFromURL } from 'src/utilities';
 
 interface IState {
-  params: {
-    page?: number;
-    page_size?: number;
-  };
-  loading: boolean;
-  items: Array<TaskType>;
-  itemCount: number;
-  alerts: AlertType[];
   cancelModalVisible: boolean;
   selectedTask: TaskType;
-  unauthorised: boolean;
-  inputText: string;
 }
 
-export class TaskList extends React.Component<RouteComponentProps, IState> {
-  constructor(props) {
-    super(props);
-
-    const params = ParamHelper.parseParamString(props.location.search, [
-      'page',
-      'page_size',
-    ]);
-
-    if (!params['page_size']) {
-      params['page_size'] = 10;
+export const TaskList = ListPage<TaskType, IState>({
+  condition: isLoggedIn,
+  defaultPageSize: 10,
+  defaultSort: '-pulp_created',
+  displayName: 'TaskList',
+  didMount: ({ context, addAlert }) => {
+    if (!canViewAllTasks(context)) {
+      addAlert({
+        title: t`You do not have permission to view all tasks. Only tasks created by you are visible.`,
+        variant: 'info',
+      });
     }
-
-    if (!params['sort']) {
-      params['sort'] = '-pulp_created';
-    }
-
-    this.state = {
-      params: params,
-      items: [],
-      loading: true,
-      itemCount: 0,
-      alerts: [],
-      cancelModalVisible: false,
-      selectedTask: null,
-      unauthorised: false,
-      inputText: '',
-    };
-  }
-
-  componentDidMount() {
-    const { user, hasPermission } = this.context;
-    if (!user || user.is_anonymous) {
-      this.setState({ loading: false, unauthorised: true });
-    } else {
-      this.queryTasks();
-    }
-
-    if (!hasPermission('core.view_task')) {
-      this.addAlert(
-        t`You do not have permission to view all tasks. Only tasks created by you are visible.`,
-        'info',
-      );
-    }
-  }
-
-  render() {
-    const {
-      params,
-      itemCount,
-      loading,
-      items,
-      alerts,
-      cancelModalVisible,
-      unauthorised,
-    } = this.state;
-
-    const noData =
-      items.length === 0 && !filterIsSet(params, ['name__contains', 'state']);
-
-    return (
-      <React.Fragment>
-        <AlertList
-          alerts={alerts}
-          closeAlert={(i) => this.closeAlert(i)}
-        ></AlertList>
-        {cancelModalVisible ? this.renderCancelModal() : null}
-        <BaseHeader title={t`Task Management`} />
-        {unauthorised ? (
-          <EmptyStateUnauthorized />
-        ) : noData && !loading ? (
-          <EmptyStateNoData
-            title={t`No tasks yet`}
-            description={t`Tasks will appear once created.`}
-          />
-        ) : (
-          <Main>
-            {loading ? (
-              <LoadingPageSpinner />
-            ) : (
-              <section className='body'>
-                <div className='hub-list-toolbar'>
-                  <Toolbar>
-                    <ToolbarContent>
-                      <ToolbarGroup>
-                        <ToolbarItem>
-                          <CompoundFilter
-                            inputText={this.state.inputText}
-                            onChange={(text) =>
-                              this.setState({ inputText: text })
-                            }
-                            updateParams={(p) =>
-                              this.updateParams(p, () => this.queryTasks())
-                            }
-                            params={params}
-                            filterConfig={[
-                              {
-                                id: 'name__contains',
-                                title: t`Task name`,
-                              },
-                              {
-                                id: 'state',
-                                title: t`Status`,
-                                inputType: 'select',
-                                options: [
-                                  {
-                                    id: 'completed',
-                                    title: t`Completed`,
-                                  },
-                                  {
-                                    id: 'failed',
-                                    title: t`Failed`,
-                                  },
-                                  {
-                                    id: 'running',
-                                    title: t`Running`,
-                                  },
-                                  {
-                                    id: 'waiting',
-                                    title: t`Waiting`,
-                                  },
-                                ],
-                              },
-                            ]}
-                          />
-                        </ToolbarItem>
-                      </ToolbarGroup>
-                    </ToolbarContent>
-                  </Toolbar>
-                  <Pagination
-                    params={params}
-                    updateParams={(p) =>
-                      this.updateParams(p, () => this.queryTasks())
-                    }
-                    count={itemCount}
-                    isTop
-                  />
-                </div>
-                <div>
-                  <AppliedFilters
-                    updateParams={(p) => {
-                      this.updateParams(p, () => this.queryTasks());
-                      this.setState({ inputText: '' });
-                    }}
-                    params={params}
-                    ignoredParams={['page_size', 'page', 'sort', 'ordering']}
-                    niceNames={{
-                      name__contains: t`Task name`,
-                      state: t`Status`,
-                    }}
-                  />
-                </div>
-                {loading ? <LoadingPageSpinner /> : this.renderTable(params)}
-
-                <Pagination
-                  params={params}
-                  updateParams={(p) =>
-                    this.updateParams(p, () => this.queryTasks())
-                  }
-                  count={itemCount}
-                />
-              </section>
-            )}
-          </Main>
-        )}
-      </React.Fragment>
-    );
-  }
-
-  private renderTable(params) {
-    const { items } = this.state;
-    if (items.length === 0) {
-      return <EmptyStateFilter />;
-    }
-    const sortTableOptions = {
-      headers: [
+  },
+  errorTitle: t`Tasks list could not be displayed.`,
+  extraState: {
+    cancelModalVisible: false,
+    selectedTask: null,
+  },
+  filterConfig: [
+    {
+      id: 'name__contains',
+      title: t`Task name`,
+    },
+    {
+      id: 'state',
+      title: t`Status`,
+      inputType: 'select',
+      options: [
         {
-          title: t`Task name`,
-          type: 'alpha',
-          id: 'name',
+          id: 'completed',
+          title: t`Completed`,
         },
         {
-          title: t`Created on`,
-          type: 'numeric',
-          id: 'pulp_created',
+          id: 'failed',
+          title: t`Failed`,
         },
         {
-          title: t`Started at`,
-          type: 'numeric',
-          id: 'started_at',
+          id: 'running',
+          title: t`Running`,
         },
         {
-          title: t`Finished at`,
-          type: 'numeric',
-          id: 'finished_at',
-        },
-        {
-          title: t`Status`,
-          type: 'alpha',
-          id: 'state',
+          id: 'waiting',
+          title: t`Waiting`,
         },
       ],
-    };
-
-    return (
-      <table
-        aria-label={t`Task list`}
-        className='hub-c-table-content pf-c-table'
-      >
-        <SortTable
-          options={sortTableOptions}
-          params={params}
-          updateParams={(p) => this.updateParams(p, () => this.queryTasks())}
-        />
-        <tbody>{items.map((item, i) => this.renderTableRow(item, i))}</tbody>
-      </table>
-    );
-  }
-
-  private renderTableRow(item, index: number) {
+    },
+  ],
+  noDataDescription: t`Tasks will appear once created.`,
+  noDataTitle: t`No tasks yet`,
+  query: ({ params }) => TaskManagementAPI.list(params),
+  renderModals: ({ addAlert, setState, state, query }) =>
+    taskStopAction.modal({ addAlert, setState, state, query }),
+  renderTableRow(item: TaskType, index: number, { setState }) {
     const { name, state, pulp_created, started_at, finished_at, pulp_href } =
       item;
     const taskId = parsePulpIDFromURL(pulp_href);
+
+    const buttons = [taskStopAction.button(item, { setState })];
+
     return (
       <tr key={index}>
         <td>
@@ -303,152 +109,38 @@ export class TaskList extends React.Component<RouteComponentProps, IState> {
         <td>
           <StatusIndicator status={state} />
         </td>
-        <td>{this.cancelButton(state, item)}</td>
+        <ListItemActions buttons={buttons} />
       </tr>
     );
-  }
+  },
+  sortHeaders: [
+    {
+      title: t`Task name`,
+      type: 'alpha',
+      id: 'name',
+    },
+    {
+      title: t`Created on`,
+      type: 'numeric',
+      id: 'pulp_created',
+    },
+    {
+      title: t`Started at`,
+      type: 'numeric',
+      id: 'started_at',
+    },
+    {
+      title: t`Finished at`,
+      type: 'numeric',
+      id: 'finished_at',
+    },
+    {
+      title: t`Status`,
+      type: 'alpha',
+      id: 'state',
+    },
+  ],
+  title: t`Task Management`,
+});
 
-  private cancelButton(state, selectedTask) {
-    switch (state) {
-      case 'running':
-        return (
-          <Button
-            variant='secondary'
-            aria-label={t`Delete`}
-            key='delete'
-            onClick={() =>
-              this.setState({
-                cancelModalVisible: true,
-                selectedTask: selectedTask,
-              })
-            }
-          >
-            {t`Stop task`}
-          </Button>
-        );
-      case 'waiting':
-        return (
-          <Button
-            variant='secondary'
-            aria-label={t`Delete`}
-            key='delete'
-            onClick={() =>
-              this.setState({
-                cancelModalVisible: true,
-                selectedTask: selectedTask,
-              })
-            }
-          >
-            {t`Stop task`}
-          </Button>
-        );
-    }
-  }
-
-  private renderCancelModal() {
-    const name =
-      Constants.TASK_NAMES[this.state.selectedTask.name] ||
-      this.state.selectedTask.name;
-    return (
-      <ConfirmModal
-        cancelAction={() => this.setState({ cancelModalVisible: false })}
-        title={t`Stop task?`}
-        confirmAction={() => this.selectedTask(this.state.selectedTask, name)}
-        confirmButtonTitle={t`Yes, stop`}
-      >{t`${name} will be cancelled.`}</ConfirmModal>
-    );
-  }
-
-  private selectedTask(task, name) {
-    TaskManagementAPI.patch(parsePulpIDFromURL(task.pulp_href), {
-      state: 'canceled',
-    })
-      .then(() => {
-        this.setState({
-          loading: true,
-          selectedTask: null,
-          cancelModalVisible: false,
-          alerts: [
-            ...this.state.alerts,
-            {
-              variant: 'success',
-              title: name,
-              description: (
-                <Trans>Task &quot;{name}&quot; stopped successfully.</Trans>
-              ),
-            },
-          ],
-        });
-        this.queryTasks();
-      })
-      .catch((e) => {
-        const { status, statusText } = e.response;
-        this.setState({
-          loading: true,
-          cancelModalVisible: false,
-          alerts: [
-            ...this.state.alerts,
-            {
-              variant: 'danger',
-              title: t`Task "${name}" could not be stopped.`,
-              description: errorMessage(status, statusText),
-            },
-          ],
-        });
-      });
-  }
-
-  private get closeAlert() {
-    return closeAlertMixin('alerts');
-  }
-
-  private queryTasks() {
-    this.setState({ loading: true }, () => {
-      TaskManagementAPI.list(this.state.params)
-        .then((result) => {
-          this.setState({
-            items: result.data.results,
-            itemCount: result.data.count,
-            loading: false,
-          });
-        })
-        .catch((e) => {
-          const { status, statusText } = e.response;
-          this.setState({
-            loading: false,
-            items: [],
-            itemCount: 0,
-            alerts: [
-              ...this.state.alerts,
-              {
-                variant: 'danger',
-                title: t`Tasks list could not be displayed.`,
-                description: errorMessage(status, statusText),
-              },
-            ],
-          });
-        });
-    });
-  }
-
-  private addAlert(title, variant, description?) {
-    this.setState({
-      alerts: [
-        ...this.state.alerts,
-        {
-          description,
-          title,
-          variant,
-        },
-      ],
-    });
-  }
-
-  private get updateParams() {
-    return ParamHelper.updateParamsMixin();
-  }
-}
-
-export default withRouter(TaskList);
-
-TaskList.contextType = AppContext;
+export default TaskList;

--- a/src/containers/task-management/list.tsx
+++ b/src/containers/task-management/list.tsx
@@ -53,7 +53,7 @@ interface IState {
   inputText: string;
 }
 
-export class TaskListView extends React.Component<RouteComponentProps, IState> {
+export class TaskList extends React.Component<RouteComponentProps, IState> {
   constructor(props) {
     super(props);
 
@@ -449,6 +449,6 @@ export class TaskListView extends React.Component<RouteComponentProps, IState> {
   }
 }
 
-export default withRouter(TaskListView);
+export default withRouter(TaskList);
 
-TaskListView.contextType = AppContext;
+TaskList.contextType = AppContext;

--- a/src/containers/task-management/list.tsx
+++ b/src/containers/task-management/list.tsx
@@ -75,12 +75,12 @@ export const TaskList = ListPage<TaskType, IState>({
   query: ({ params }) => TaskManagementAPI.list(params),
   renderModals: ({ addAlert, setState, state, query }) =>
     taskStopAction.modal({ addAlert, setState, state, query }),
-  renderTableRow(item: TaskType, index: number, { setState }) {
+  renderTableRow(item: TaskType, index: number, actionContext) {
     const { name, state, pulp_created, started_at, finished_at, pulp_href } =
       item;
     const taskId = parsePulpIDFromURL(pulp_href);
 
-    const buttons = [taskStopAction.button(item, { setState })];
+    const buttons = [taskStopAction.button(item, actionContext)];
 
     return (
       <tr key={index}>

--- a/src/loaders/insights/Routes.tsx
+++ b/src/loaders/insights/Routes.tsx
@@ -116,11 +116,11 @@ const TokenPage = lazy(
     ),
 );
 
-const TaskListView = lazy(
+const TaskList = lazy(
   () =>
     import(
       /* webpackChunkName: "settings" */
-      '../../containers/task-management/task-list-view'
+      '../../containers/task-management/list'
     ),
 );
 
@@ -181,7 +181,7 @@ export const Routes = () => {
         <Route path={Paths.myCollectionsByRepo} component={ManageNamespace} />
         <Route path={Paths.myNamespaces} component={MyNamespaces} />
         <Route path={Paths.signatureKeys} component={SignatureKeysList} />
-        <Route path={Paths.taskList} component={TaskListView} />
+        <Route path={Paths.taskList} component={TaskList} />
         <Route path={Paths.taskDetail} component={TaskDetail} />
         <Route
           path={Paths.collectionDocsPageByRepo}

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -40,7 +40,7 @@ import {
   ExecutionEnvironmentDetailImages,
   ExecutionEnvironmentDetailOwners,
   ExecutionEnvironmentManifest,
-  TaskListView,
+  TaskList,
   TaskDetail,
 } from 'src/containers';
 import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
@@ -203,7 +203,7 @@ export class Routes extends React.Component<IRoutesProps> {
       { comp: LegacyRoles, path: Paths.legacyRoles },
 
       {
-        comp: TaskListView,
+        comp: TaskList,
         path: Paths.taskList,
       },
       { comp: GroupList, path: Paths.groupList },

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -8,3 +8,6 @@ export type CanContext = (o: {
 }) => boolean;
 
 export const isLoggedIn: CanContext = ({ user }) => user && !user.is_anonymous;
+
+export const canViewAllTasks: CanContext = ({ hasPermission }) =>
+  hasPermission('core.view_task');

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,0 +1,9 @@
+import { UserType, FeatureFlagsType, SettingsType } from 'src/api';
+
+export type CanContext = (o: {
+  featureFlags: FeatureFlagsType;
+  settings: SettingsType;
+  user: UserType;
+}) => boolean;
+
+export const isLoggedIn: CanContext = ({ user }) => user && !user.is_anonymous;

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -4,6 +4,7 @@ export type CanContext = (o: {
   featureFlags: FeatureFlagsType;
   settings: SettingsType;
   user: UserType;
+  hasPermission: (string) => boolean;
 }) => boolean;
 
 export const isLoggedIn: CanContext = ({ user }) => user && !user.is_anonymous;


### PR DESCRIPTION
The idea here is to convert list pages to an intermediate representation between current state and ansible-ui-framework by moving the page layout and common logic out to a shared ListPage component factory, separate the page-specific logic from the common one, while not changing how it works nor how it renders for testability.
(Any visual changes, or conversion filter and field definitions to framework style will be a separate step as well, in or after #3147.)

Converted `SignatureKeysList` and `TaskList` to use it.

---

`ListPage` params - returns a router-aware container

* `condition` - rbac, a permission checker function - from `src/permissions` (`{ featureFlags, settings, user } => bool`)
* `didMount` (optional) - extra code to run on mount
* `displayName` - component name for debugging, should be the same as the export name
* `defaultPageSize` - initial page size
* `defaultSort` (optional) - initial sort ordering
* `errorTitle` - alert on query failure
* `extraState` (optional) - extra initial state
* `filterConfig` - filters
* `headerActions` - buttons to show after filter
* `noDataDescription`, `noDataTitle` - `EmptyStateNoData` props
* `query` - `({ params }) => Promise<{ data: { count, results[] } }>`
* `renderModals` (optional) - `({ addAlert, state, setState, query }) => <ConfirmationModal... />`
* `renderTableRow` - `(item, index) => <tr>...</tr>`
* `sortHeaders` - table headers
* `title` - container title

`Action` params:
* `button` and `dropdownItem` render the right thing for `ListActionItems`, respecting a `visible(item)` check for both rbac and item-specific logic, and doing `onClick`
* `modal` renders a modal

`src/permissions`:
* trying to change all permision checks into a `canViewWhatever` call - action and model specific checks defined in one place