### PR TITLE
pr-checks - webpack: ignore different counts of "Waiting for rbac_postgres"

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -128,6 +128,7 @@ jobs:
                 -e 's/"UI_COMMIT_HASH": ".*"/"UI_COMMIT_HASH": "HASH"/' |
               perl -ne 'print unless /^[0-9a-f]{64,64}$/d' |
               grep -v '^Current branch:' |
+              grep -v '^Waiting for ' |
               grep -v '^Root folder:' > ~/webpack-config/"$version"/"$file".json
           done
 


### PR DESCRIPTION
Example:
https://github.com/ansible/ansible-hub-ui/actions/runs/3819788623/jobs/6497617694#step:5:283

```diff
diff -Naur /home/runner/webpack-config/base/insights.dev.webpack.config.js.json /home/runner/webpack-config/pr/insights.dev.webpack.config.js.json
--- /home/runner/webpack-config/base/insights.dev.webpack.config.js.json	2023-01-02 02:16:42.919163436 +0000
+++ /home/runner/webpack-config/pr/insights.dev.webpack.config.js.json	2023-01-02 02:17:37.519457512 +0000
@@ -465,3 +465,4 @@
   ]
 }
 Waiting for rbac_postgres
+Waiting for rbac_postgres
Error: Process completed with exit code 1.
```

webpack-config check failed because the rbac container took a while to start .. ignoring these lines now.