### PR TITLE
CRC Hub has broken link to SSO offline token page

### DIFF
--- a/CHANGES/2069.bugfix
+++ b/CHANGES/2069.bugfix
@@ -1,0 +1,1 @@
+CRC Hub has broken link to SSO offline token page. Fixed URL from: https://sso.redhat.com/auth/realms/redhat-external/account/applications to: https://sso.redhat.com/auth/realms/redhat-external/account.

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -168,7 +168,7 @@ class TokenPage extends React.Component<RouteComponentProps, IState> {
             <Trans>
               To revoke a token or see all of your tokens, visit the{' '}
               <a
-                href='https://sso.redhat.com/auth/realms/redhat-external/account/applications'
+                href='https://sso.redhat.com/auth/realms/redhat-external/account'
                 target='_blank'
                 rel='noreferrer'
               >


### PR DESCRIPTION
Issue: AAH-2069

https://issues.redhat.com/browse/AAH-2069