### PR TITLE
Make collections list test faster

### DIFF
--- a/test/cypress.env.json.template
+++ b/test/cypress.env.json.template
@@ -1,3 +1,4 @@
+// Standalone
 {
   "apiPrefix": "/api/automation-hub/",
   "pulpPrefix": "/api/automation-hub/pulp/api/v3/",
@@ -7,4 +8,16 @@
   "containers": "localhost:5001",
   "galaxykit": "galaxykit --ignore-certs",
   "insightsLogin": false
+}
+
+
+// Insights
+{
+  "apiPrefix": "/api/automation-hub/",
+  "pulpPrefix": "/api/automation-hub/pulp/api/v3/",
+  "uiPrefix": "/beta/ansible/automation-hub/",
+  "username": "admin",
+  "password": "admin",
+  "galaxykit": "galaxykit --ignore-certs --auth-url 'http://localhost:8002/auth/realms/redhat-external/protocol/openid-connect/token'",
+  "insightsLogin" : true
 }

--- a/test/cypress/e2e/collections/collections_list.js
+++ b/test/cypress/e2e/collections/collections_list.js
@@ -47,7 +47,7 @@ describe('Collections list Tests', () => {
 
     cy.galaxykit('namespace create my_namespace');
     // insert test data
-    range(21).forEach((i) => {
+    range(11).forEach((i) => {
       cy.galaxykit('-i collection upload my_namespace my_collection' + i);
     });
   });
@@ -87,10 +87,7 @@ describe('Collections list Tests', () => {
   });
 
   it('paging is working', () => {
-    // this page cant sort items, so we can only count them, there should be at least 21 items that we inserted
-    cy.get('.collection-container').get('article').should('have.length', 10);
-
-    cy.get('.hub-cards').get('[aria-label="Go to next page"]:first').click();
+    // this page cant sort items, so we can only count them, there should be 11 items that we inserted
     cy.get('.collection-container').get('article').should('have.length', 10);
 
     cy.get('.hub-cards').get('[aria-label="Go to next page"]:first').click();
@@ -111,7 +108,7 @@ describe('Collections list Tests', () => {
       .click();
     cy.get('.hub-cards').get('[data-action="per-page-20"]').click();
 
-    cy.get('.collection-container').get('article').should('have.length', 20);
+    cy.get('.collection-container').get('article').should('have.length', 11);
   });
 
   it('Cards/List switch is working', () => {


### PR DESCRIPTION
No-Issue

Instead of 21 items, this PR now creates only 11 items. This is enough for the test, only paging is affected and the test is still covering most functionality.

Additionaly - settings for both standalone and insights were added in cypress settings template.
