### PR TITLE
Quick fix of screenshot tests - disable pages with variable time info

### DIFF
--- a/test/cypress/e2e/screenshots/screenshots.js
+++ b/test/cypress/e2e/screenshots/screenshots.js
@@ -31,14 +31,14 @@ describe('screenshots', () => {
     screenshot('/repo/published');
     screenshot('/namespaces');
     // TODO - problems - repositories are showing minutes, so text may quickly change and generate diff
-    screenshot('/repositories');
+    //screenshot('/repositories');
     screenshot('/token');
     screenshot('/approval-dashboard');
     screenshot('/containers');
     screenshot('/registries');
     // screenshot('/tasks'); // TODO fake empty API response
     // screenshot('/signature-keys'); // TODO fake empty API response
-    screenshot('/users');
+    //screenshot('/users');
     screenshot('/group-list');
 
     // screenshot('/roles');  // TODO fake empty API response


### PR DESCRIPTION
No-Issue

Those pages are falling even without any changes in code - it depends on workflow planner, it will sometimes display different text (few seconds ago etc) and fails the tests. In future, it will be better to solve this, but for now, lets skip those tests.
