### PR TITLE
Container signing feature flag fix

### DIFF
--- a/CHANGES/2013.bug
+++ b/CHANGES/2013.bug
@@ -1,0 +1,1 @@
+Show container signing button based only on container_signing, not collection_signing

--- a/CHANGES/2015.bug
+++ b/CHANGES/2015.bug
@@ -1,0 +1,1 @@
+Show container signature badge based only on container_signing, not collection_signing

--- a/src/api/response-types/feature-flags.ts
+++ b/src/api/response-types/feature-flags.ts
@@ -5,6 +5,9 @@ export class FeatureFlagsType {
   // keycloak login screen
   external_authentication: boolean;
 
+  // community version
+  legacy_roles: boolean;
+
   // collection signing
   can_create_signatures: boolean;
   can_upload_signatures: boolean;

--- a/src/api/response-types/feature-flags.ts
+++ b/src/api/response-types/feature-flags.ts
@@ -1,8 +1,11 @@
 export class FeatureFlagsType {
+  // execution environments menu section
   execution_environments: boolean;
+
+  // keycloak login screen
   external_authentication: boolean;
 
-  // signing
+  // collection signing
   can_create_signatures: boolean;
   can_upload_signatures: boolean;
   collection_auto_sign: boolean;
@@ -10,5 +13,10 @@ export class FeatureFlagsType {
   display_signatures: boolean;
   require_upload_signatures: boolean;
   signatures_enabled: boolean;
+
+  // container signing (EE)
+  container_signing: boolean;
+
+  // errors
   _messages: string[];
 }

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -23,6 +23,7 @@ import { Constants } from 'src/constants';
 
 interface IProps extends CollectionListType {
   className?: string;
+  displaySignatures: boolean;
   footer?: React.ReactNode;
   repo?: string;
   menu?: React.ReactNode;
@@ -37,6 +38,7 @@ export class CollectionCard extends React.Component<IProps> {
       latest_version,
       namespace,
       className,
+      displaySignatures,
       footer,
       repo,
       sign_state,
@@ -58,7 +60,9 @@ export class CollectionCard extends React.Component<IProps> {
             flexGrow
           />
           <TextContent>{this.getCertification(repo)}</TextContent>
-          <SignatureBadge isCompact signState={sign_state} />
+          {displaySignatures ? (
+            <SignatureBadge isCompact signState={sign_state} />
+          ) : null}
           {menu}
         </CardHeader>
         <CardHeader>

--- a/src/components/collection-detail/download-signature-grid-item.tsx
+++ b/src/components/collection-detail/download-signature-grid-item.tsx
@@ -18,7 +18,7 @@ interface Props {
 }
 
 export const DownloadSignatureGridItem: FC<Props> = ({ version }) => {
-  const { display_signatures } = useContext()?.featureFlags || {};
+  const { display_signatures } = useContext().featureFlags;
   const [show, setShow] = useState(false);
 
   // No signature object or the signatures is empty

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -47,7 +47,7 @@ export class CollectionFilter extends React.Component<IProps, IState> {
 
   render() {
     const { ignoredParams, params, updateParams } = this.props;
-    const { display_signatures } = this.context?.featureFlags || {};
+    const { display_signatures } = this.context.featureFlags;
     const display_tags = ignoredParams.includes('tags') === false;
 
     const filterConfig = [

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -30,6 +30,7 @@ import { SignatureBadge } from '../signing';
 interface IProps extends CollectionListType {
   showNamespace?: boolean;
   controls?: React.ReactNode;
+  displaySignatures: boolean;
   repo?: string;
 }
 
@@ -42,6 +43,7 @@ export class CollectionListItem extends React.Component<IProps> {
       showNamespace,
       controls,
       deprecated,
+      displaySignatures,
       repo,
       sign_state,
     } = this.props;
@@ -119,7 +121,9 @@ export class CollectionListItem extends React.Component<IProps> {
           </Trans>
         </div>
         <div className='hub-entry'>v{latest_version.version}</div>
-        <SignatureBadge className='hub-entry' signState={sign_state} />
+        {displaySignatures ? (
+          <SignatureBadge className='hub-entry' signState={sign_state} />
+        ) : null}
       </DataListCell>,
     );
 

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -14,6 +14,7 @@ import { ParamHelper } from 'src/utilities/param-helper';
 
 interface IProps {
   collections: CollectionListType[];
+  displaySignatures: boolean;
   params: {
     sort?: string;
     page?: number;
@@ -32,6 +33,7 @@ export class CollectionList extends React.Component<IProps> {
   render() {
     const {
       collections,
+      displaySignatures,
       params,
       updateParams,
       ignoredParams,
@@ -52,6 +54,7 @@ export class CollectionList extends React.Component<IProps> {
                 key={c.id}
                 {...c}
                 repo={repo}
+                displaySignatures={displaySignatures}
               />
             ))
           ) : (

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -55,7 +55,7 @@ import {
 import { Paths, formatPath } from 'src/paths';
 import {
   waitForTask,
-  canSign as canSignNS,
+  canSignNamespace,
   parsePulpIDFromURL,
 } from 'src/utilities';
 import { ParamHelper } from 'src/utilities/param-helper';
@@ -208,7 +208,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       return <Navigate to={redirect} />;
     }
 
-    const canSign = canSignNS(this.context, namespace);
+    const canSign = canSignNamespace(this.context, namespace);
 
     const { hasPermission } = this.context;
 

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -187,7 +187,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
     const latestVersion = collection.latest_version.created_at;
 
     const { display_signatures, can_upload_signatures } =
-      this.context?.featureFlags || {};
+      this.context.featureFlags;
 
     const signedString = (v) => {
       if (display_signatures && 'sign_state' in v) {

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -478,10 +478,12 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                   </Trans>
                 </span>
               ) : null}
-              <SignatureBadge
-                isCompact
-                signState={collection.latest_version.sign_state}
-              />
+              {display_signatures ? (
+                <SignatureBadge
+                  isCompact
+                  signState={collection.latest_version.sign_state}
+                />
+              ) : null}
             </div>
           }
           pageControls={

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -158,7 +158,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
   private renderForm(requiredFields, disabledFields) {
     const { remote, errorMessages } = this.props;
     const { filenames } = this.state;
-    const { signatures_enabled } = this.context.featureFlags;
+    const { collection_signing } = this.context.featureFlags;
 
     const docsAnsibleLink = (
       <a
@@ -231,7 +231,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
           />
         </FormGroup>
 
-        {!disabledFields.includes('signed_only') && signatures_enabled ? (
+        {!disabledFields.includes('signed_only') && collection_signing ? (
           <FormGroup
             fieldId={'signed_only'}
             name={t`Signed only`}

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -158,7 +158,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
   private renderForm(requiredFields, disabledFields) {
     const { remote, errorMessages } = this.props;
     const { filenames } = this.state;
-    const { signatures_enabled } = this.context?.featureFlags || {};
+    const { signatures_enabled } = this.context.featureFlags;
 
     const docsAnsibleLink = (
       <a

--- a/src/components/signing/signature-badge.tsx
+++ b/src/components/signing/signature-badge.tsx
@@ -16,7 +16,7 @@ export const SignatureBadge: FC<Props> = ({
   isCompact = false,
   ...props
 }) => {
-  const { display_signatures } = useContext()?.featureFlags || {};
+  const { display_signatures } = useContext().featureFlags;
 
   if (!display_signatures) {
     return null;

--- a/src/components/signing/signature-badge.tsx
+++ b/src/components/signing/signature-badge.tsx
@@ -5,7 +5,6 @@ import {
   CheckCircleIcon,
   ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
-import { useContext } from 'src/loaders/app-context';
 
 interface Props extends LabelProps {
   signState: 'signed' | 'unsigned';
@@ -16,12 +15,6 @@ export const SignatureBadge: FC<Props> = ({
   isCompact = false,
   ...props
 }) => {
-  const { display_signatures } = useContext().featureFlags;
-
-  if (!display_signatures) {
-    return null;
-  }
-
   const text = () => {
     switch (signState) {
       case 'signed':

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -319,7 +319,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
       return <span className='fa fa-lg fa-spin fa-spinner' />;
     }
     if (version.repository_list.includes(Constants.PUBLISHED)) {
-      const { display_signatures } = this.context?.featureFlags || {};
+      const { display_signatures } = this.context.featureFlags;
       return (
         <Label variant='outline' color='green' icon={<CheckCircleIcon />}>
           {display_signatures && version.sign_state === 'signed'
@@ -337,7 +337,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
     }
     if (version.repository_list.includes(Constants.NEEDSREVIEW)) {
       const { can_upload_signatures, require_upload_signatures } =
-        this.context?.featureFlags || {};
+        this.context.featureFlags;
       return (
         <Label
           variant='outline'
@@ -399,7 +399,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
       can_upload_signatures,
       collection_auto_sign,
       require_upload_signatures,
-    } = this.context?.featureFlags || {};
+    } = this.context.featureFlags;
     if (this.state.updatingVersions.includes(version)) {
       return <ListItemActions />; // empty td;
     }

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -223,7 +223,7 @@ export function withContainerRepo(WrappedComponent) {
             tab={this.getTab()}
             groupId={groupId}
             container={this.state.repo}
-            displaySignatures={this.context.featureFlags.display_signatures}
+            displaySignatures={this.context.featureFlags.container_signing}
             pageControls={
               <>
                 {showEdit ? (

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -487,10 +487,7 @@ class GroupDetail extends React.Component<RouteProps, IState> {
         'email',
         'role__icontains',
       ]);
-    let isUserMgmtDisabled = false;
-    if (featureFlags) {
-      isUserMgmtDisabled = featureFlags.external_authentication;
-    }
+    const isUserMgmtDisabled = featureFlags.external_authentication;
 
     if (noData) {
       return (
@@ -659,7 +656,7 @@ class GroupDetail extends React.Component<RouteProps, IState> {
   private renderTableRow(user: UserType, index: number) {
     const currentUser = this.context.user;
     const { featureFlags, hasPermission } = this.context;
-    const isUserMgmtDisabled = featureFlags?.external_authentication;
+    const isUserMgmtDisabled = featureFlags.external_authentication;
     const dropdownItems = [
       !!currentUser &&
         hasPermission('galaxy.change_group') &&

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -436,6 +436,9 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                   renderCollectionControls={(collection) =>
                     this.renderCollectionControls(collection)
                   }
+                  displaySignatures={
+                    this.context.featureFlags.display_signatures
+                  }
                 />
               </section>
             )

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -779,7 +779,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
   private renderPageControls() {
     const { canSign, collections } = this.state;
-    const { can_upload_signatures } = this.context?.featureFlags || {};
+    const { can_upload_signatures } = this.context.featureFlags;
     const { hasPermission } = this.context;
 
     const dropdownItems = [

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -57,7 +57,7 @@ import {
   filterIsSet,
   errorMessage,
   waitForTask,
-  canSign as canSignNS,
+  canSignNamespace,
   DeleteCollectionUtils,
 } from 'src/utilities';
 
@@ -724,7 +724,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           itemCount: val[0].data.meta.count,
           namespace: val[1].data,
           showControls: !!val[2],
-          canSign: canSignNS(this.context, val[2]?.data),
+          canSign: canSignNamespace(this.context, val[2]?.data),
           group: this.filterGroup(
             this.state.params['group'],
             val[1].data['groups'],

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -317,6 +317,7 @@ class Search extends React.Component<RouteProps, IState> {
               footer={this.renderSyncToogle(c.name, c.namespace.name)}
               repo={this.context.selectedRepo}
               menu={this.renderMenu(false, c)}
+              displaySignatures={this.context.featureFlags.display_signatures}
             />
           );
         })}
@@ -517,6 +518,7 @@ class Search extends React.Component<RouteProps, IState> {
                   </>
                 }
                 repo={this.context.selectedRepo}
+                displaySignatures={this.context.featureFlags.display_signatures}
               />
             ))}
           </DataList>

--- a/src/containers/settings/user-profile.tsx
+++ b/src/containers/settings/user-profile.tsx
@@ -56,10 +56,7 @@ class UserProfile extends React.Component<RouteProps, IState> {
 
     const { user, errorMessages, inEditMode, alerts } = this.state;
     const { featureFlags } = this.context;
-    let isUserMgmtDisabled = false;
-    if (featureFlags) {
-      isUserMgmtDisabled = featureFlags.external_authentication;
-    }
+    const isUserMgmtDisabled = featureFlags.external_authentication;
 
     if (!user) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;

--- a/src/loaders/load-context.ts
+++ b/src/loaders/load-context.ts
@@ -18,7 +18,7 @@ type ContextFragment = {
 export function loadContext(): Promise<ContextFragment> {
   const getFeatureFlags = FeatureFlagsAPI.get().then(
     ({ data: featureFlags }) => ({
-      alerts: (featureFlags?._messages || []).map((msg) => ({
+      alerts: (featureFlags._messages || []).map((msg) => ({
         variant: 'warning',
         title: msg.split(':')[1],
       })),

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -98,7 +98,8 @@ function standaloneMenu({ repository }) {
     menuItem(t`Signature Keys`, {
       url: formatPath(Paths.signatureKeys),
       condition: ({ featureFlags, user }) =>
-        featureFlags.display_signatures && !user.is_anonymous,
+        (featureFlags.collection_signing || featureFlags.container_signing) &&
+        !user.is_anonymous,
     }),
     menuItem(t`Documentation`, {
       url: 'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',

--- a/src/utilities/can-sign.tsx
+++ b/src/utilities/can-sign.tsx
@@ -4,8 +4,9 @@ export const canSignNamespace = (
   { featureFlags }: { featureFlags: FeatureFlagsType },
   namespace,
 ) => {
-  const { can_create_signatures } = featureFlags || {};
+  const { can_create_signatures } = featureFlags;
   const permissions = namespace?.related_fields?.my_permissions || [];
+
   return (
     // (can_create_signatures also implies signatures_enabled and collection_signing)
     can_create_signatures &&
@@ -18,12 +19,11 @@ export const canSignEE = (
   { featureFlags }: { featureFlags: FeatureFlagsType },
   container,
 ) => {
-  const { container_signing } = featureFlags || {};
+  const { container_signing } = featureFlags;
+  const permissions = container.namespace.my_permissions;
 
   return (
     container_signing &&
-    container.namespace.my_permissions.includes(
-      'container.change_containernamespace',
-    )
+    permissions.includes('container.change_containernamespace')
   );
 };

--- a/src/utilities/can-sign.tsx
+++ b/src/utilities/can-sign.tsx
@@ -1,7 +1,6 @@
-// TODO - canSign can be renamed to canSignNS
 import { FeatureFlagsType } from 'src/api';
 
-export const canSign = (
+export const canSignNamespace = (
   { featureFlags }: { featureFlags: FeatureFlagsType },
   namespace,
 ) => {

--- a/src/utilities/can-sign.tsx
+++ b/src/utilities/can-sign.tsx
@@ -1,21 +1,27 @@
 // TODO - canSign can be renamed to canSignNS
-export const canSign = ({ featureFlags }, namespace) => {
+import { FeatureFlagsType } from 'src/api';
+
+export const canSign = (
+  { featureFlags }: { featureFlags: FeatureFlagsType },
+  namespace,
+) => {
   const { can_create_signatures } = featureFlags || {};
   const permissions = namespace?.related_fields?.my_permissions || [];
   return (
+    // (can_create_signatures also implies signatures_enabled and collection_signing)
     can_create_signatures &&
     permissions.includes('galaxy.change_namespace') &&
     permissions.includes('galaxy.upload_to_namespace')
   );
 };
 
-export const canSignEE = ({ featureFlags }, container) => {
-  const { can_create_signatures, signatures_enabled, container_signing } =
-    featureFlags || {};
+export const canSignEE = (
+  { featureFlags }: { featureFlags: FeatureFlagsType },
+  container,
+) => {
+  const { container_signing } = featureFlags || {};
 
   return (
-    can_create_signatures &&
-    signatures_enabled &&
     container_signing &&
     container.namespace.my_permissions.includes(
       'container.change_containernamespace',

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -23,7 +23,7 @@ export { lastSynced, lastSyncStatus } from './last-sync-task';
 export { waitForTask, waitForTaskUrl } from './wait-for-task';
 export { errorMessage } from './fail-alerts';
 export { validateURLHelper } from './validateURLHelper';
-export { canSign, canSignEE } from './can-sign';
+export { canSignNamespace, canSignEE } from './can-sign';
 export { DeleteCollectionUtils } from './delete-collection';
 export { RepoSigningUtils } from './repo-signing';
 export { translateLockedRolesDescription } from './translate-locked-roles-desc';


### PR DESCRIPTION
Fixes AAH-2013, AAH-2015
(AAH-1989 will come as a separate PR)

Before:
used the `can_create_signatures`, `can_upload_signatures`, `display_signatures`, `require_upload_signatures`, `signatures_enabled` feature flags for both container(EE) and collection signatures, and only treated the `container_signing` / `collection_signing`, `collection_auto_sign` flags as model specific

After:
* collection/namespace/approvals signing uses `can_create_signatures`, `can_upload_signatures`, `collection_auto_sign`, `collection_signing`, `display_signatures`, `require_upload_signatures` (as documented in https://galaxyng.netlify.app/config/collection_signing/#feature-flags)
* EE signing uses `container_signing` only
* `SignatureKeys` use `collection_signing || container_signing`
* (nothing uses `signatures_enabled` since it doesn't mean what it says, as it's an alias for `collection_signing` only)

AAH-2013: `canSignEE` no longer checks `can_create_signatures`, or `signatures_enabled`, only `container_signatures`
AAH-2015: `SignatureBadge` now gets a `displaySignatures` check using either `display_signatures` or `container_signing`, depending on where we are.

(And cleaned up some obsolete defensive programming around feature flags availability.)

Cc @hendersonreed @rochacbruno 