### PR TITLE
Fix undefined `id` in `Index execution environments`

### DIFF
--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -516,8 +516,8 @@ class ExecutionEnvironmentRegistryList extends React.Component<
       });
   }
 
-  private indexRegistry({ pk, name }) {
-    ExecutionEnvironmentRegistryAPI.index(pk)
+  private indexRegistry({ id, name }) {
+    ExecutionEnvironmentRegistryAPI.index(id)
       .then((result) => {
         const task_id = parsePulpIDFromURL(result.data.task);
         this.addAlert(

--- a/test/cypress/e2e/repo/remote_registry.js
+++ b/test/cypress/e2e/repo/remote_registry.js
@@ -86,6 +86,29 @@ describe('Remote Registry Tests', () => {
     ).contains('Completed', { timeout: 10000 });
   });
 
+  it('users can index only redhat.registry.io', () => {
+    cy.addRemoteRegistry('registry.test.io', 'https://registry.test.io');
+
+    cy.get(
+      'tr[data-cy="ExecutionEnvironmentRegistryList-row-registry.test.io"] button[aria-label="Actions"]',
+    ).click();
+    cy.contains('Index execution environments').should(
+      'have.class',
+      'pf-m-disabled',
+    );
+
+    cy.addRemoteRegistry('registry.redhat.io', 'https://registry.redhat.io');
+
+    cy.get(
+      'tr[data-cy="ExecutionEnvironmentRegistryList-row-registry.redhat.io"] button[aria-label="Actions"]',
+    ).click();
+
+    cy.contains('Index execution environments').click();
+    cy.get('[data-cy="AlertList"]').contains(
+      'Indexing started for execution environment "registry.redhat.io',
+    );
+  });
+
   it('admin can edit new remote registry', () => {
     cy.menuGo('Execution Environments > Remote Registries');
 


### PR DESCRIPTION
No-Issue

Indexing remote registry `redhat.registry.io` fails with error 500

Reproduce:
1. Go to Remote Registries
2.  Add remote registry with URL `https://registry.redhat.io` and Save
3. click kebap menu and `Index execution environments`
4. `http://localhost:8002/api/automation-hub/_ui/v1/execution-environments/registries/undefined/index/`

I think this the bug comes from my PR https://github.com/ansible/galaxy_ng/pull/1397. Added a small test to verify this functionality
