### PR TITLE
Cypress: add community/ test dir, enable on CI

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -29,6 +29,7 @@ jobs:
         - 'screenshots'
         - 'approval'
         - 'collections'
+        - 'community'
         - 'ee_controller'
         - 'execution_environments'
         - 'groups_and_users'
@@ -50,7 +51,18 @@ jobs:
     - name: "Set env.SHORT_BRANCH, COMPOSE_PROFILE"
       run: |
         SHORT_BRANCH=`sed 's/^refs\/heads\///' <<< $BRANCH`
-        COMPOSE_PROFILE=`[ "${{ matrix.test }}" = 'insights' ] && echo 'insights' || echo 'standalone'`
+        case "${{ matrix.test }}" in
+          community*)
+            COMPOSE_PROFILE='community'
+            ;;
+          insights*)
+            COMPOSE_PROFILE='insights'
+            ;;
+          *)
+            COMPOSE_PROFILE='standalone'
+            ;;
+        esac
+        [ -n "$COMPOSE_PROFILE" ]
 
         echo "SHORT_BRANCH=${SHORT_BRANCH}" >> $GITHUB_ENV
         echo "COMPOSE_PROFILE=${COMPOSE_PROFILE}" >> $GITHUB_ENV
@@ -119,6 +131,7 @@ jobs:
           npm-${{ env.SHORT_BRANCH }}-
           npm-
 
+
     - name: "Build standalone UI"
       if: ${{ env.COMPOSE_PROFILE == 'standalone' }}
       working-directory: 'ansible-hub-ui'
@@ -149,6 +162,18 @@ jobs:
           --rewrite '/v2/(.*) -> http://localhost:5001/v2/$1' \
           --rewrite '/extensions/v2/(.*) -> http://localhost:5001/extensions/v2/$1' &
 
+    - name: "Run community UI"
+      if: ${{ env.COMPOSE_PROFILE == 'community' }}
+      working-directory: 'ansible-hub-ui'
+      run: |
+        npm install
+
+        # production displays unknown translations literally, make sure it's up to date
+        npm run gettext:extract
+        npm run gettext:compile
+
+        npm run start-community &
+
     - name: "Run insights UI"
       if: ${{ env.COMPOSE_PROFILE == 'insights' }}
       working-directory: 'ansible-hub-ui'
@@ -172,6 +197,7 @@ jobs:
 
         npm run start &
 
+
     - name: "Install Cypress & test dependencies"
       working-directory: 'ansible-hub-ui/test'
       run: |
@@ -187,11 +213,17 @@ jobs:
       run: |
         cp -aiv ../.github/workflows/cypress/cypress.env.json."$COMPOSE_PROFILE" cypress.env.json
 
+
     - name: "Ensure index.html uses the new js"
       if: ${{ env.COMPOSE_PROFILE == 'standalone' }}
       run: |
         echo 'expecting /static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
         curl http://localhost:8002/static/galaxy_ng/index.html | tee /dev/stderr | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
+
+    - name: "Ensure community is served"
+      if: ${{ env.COMPOSE_PROFILE == 'community' }}
+      run: |
+        curl http://localhost:8002/beta/ansible/automation-hub/ | tee /dev/stderr | grep '/static/galaxy_ng/js/App'
 
     - name: "Ensure insights is served"
       if: ${{ env.COMPOSE_PROFILE == 'insights' }}
@@ -201,10 +233,16 @@ jobs:
         curl http://localhost:8002/beta/ansible/automation-hub/ | tee /dev/stderr | grep '/beta/apps/chrome/js/'
         sleep 30
 
+
     - name: "Ensure galaxykit can connect to API (standalone)"
       if: ${{ env.COMPOSE_PROFILE == 'standalone' }}
       run: |
         galaxykit -s http://localhost:8002/api/galaxy/ -u admin -p admin collection list
+
+    - name: "Ensure galaxykit can connect to API (community)"
+      if: ${{ env.COMPOSE_PROFILE == 'community' }}
+      run: |
+        galaxykit -s http://localhost:8002/api/ -u admin -p admin collection list
 
     - name: "Ensure galaxykit can connect to API (insights)"
       if: ${{ env.COMPOSE_PROFILE == 'insights' }}
@@ -214,15 +252,22 @@ jobs:
           --auth-url http://localhost:8002/auth/realms/redhat-external/protocol/openid-connect/token \
           collection list
 
+
     - name: "Check initial feature flags (standalone)"
       if: ${{ env.COMPOSE_PROFILE == 'standalone' }}
       run: |
         curl -s http://localhost:5001/api/galaxy/_ui/v1/feature-flags/ | jq
 
+    - name: "Check initial feature flags (community)"
+      if: ${{ env.COMPOSE_PROFILE == 'community' }}
+      run: |
+        curl -s http://localhost:5001/api/_ui/v1/feature-flags/ | jq
+
     - name: "Check initial feature flags (insights)"
       if: ${{ env.COMPOSE_PROFILE == 'insights' }}
       run: |
         curl -s http://localhost:5001/api/automation-hub/_ui/v1/feature-flags/ | jq
+
 
     - name: "Check component versions & settings (standalone)"
       if: ${{ env.COMPOSE_PROFILE == 'standalone' }}
@@ -230,6 +275,13 @@ jobs:
         HUB_TOKEN=`curl -s -u admin:admin -d '' http://localhost:5001/api/galaxy/v3/auth/token/ | jq -r .token`
         curl -s -H "Authorization: Token $HUB_TOKEN" http://localhost:5001/api/galaxy/ | jq
         curl -s -H "Authorization: Token $HUB_TOKEN" http://localhost:5001/api/galaxy/_ui/v1/settings/ | jq
+
+    - name: "Check component versions & settings (community)"
+      if: ${{ env.COMPOSE_PROFILE == 'community' }}
+      run: |
+        HUB_TOKEN=`curl -s -u admin:admin -d '' http://localhost:5001/api/v3/auth/token/ | jq -r .token`
+        curl -s -H "Authorization: Token $HUB_TOKEN" http://localhost:5001/api/ | jq
+        curl -s -H "Authorization: Token $HUB_TOKEN" http://localhost:5001/api/_ui/v1/settings/ | jq
 
     - name: "Check component versions & settings (insights)"
       if: ${{ env.COMPOSE_PROFILE == 'insights' }}
@@ -239,6 +291,7 @@ jobs:
           http://localhost:8002/auth/realms/redhat-external/protocol/openid-connect/token | jq -r .access_token`
         curl -s -H "Authorization: Bearer $BEARER" http://localhost:8002/api/automation-hub/ | jq
         curl -s -H "Authorization: Bearer $BEARER" http://localhost:8002/api/automation-hub/_ui/v1/settings/ | jq
+
 
     - name: "Check if e2e contains only dirs in matrix test array"
       working-directory: 'ansible-hub-ui'

--- a/.github/workflows/cypress/compose.env.community
+++ b/.github/workflows/cypress/compose.env.community
@@ -1,0 +1,1 @@
+COMPOSE_PROFILE=galaxy_ng/base:galaxy_ng/community

--- a/.github/workflows/cypress/cypress.env.json.community
+++ b/.github/workflows/cypress/cypress.env.json.community
@@ -1,10 +1,10 @@
 {
-  "apiPrefix": "/api/galaxy/",
-  "pulpPrefix": "/api/galaxy/pulp/api/v3/",
+  "apiPrefix": "/api/",
+  "pulpPrefix": "/api/pulp/api/v3/",
   "uiPrefix": "/ui/",
   "username": "admin",
   "password": "admin",
-  "containers": "localhost:8002",
+  "containers": "localhost:5001",
   "galaxykit": "galaxykit --ignore-certs",
   "insightsLogin": false,
   "disableRepoSwitch" : false

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,6 +9,6 @@ Dockerfile
 *.png
 *.mp4
 *.po
-test/cypress.env.json.template
+test/cypress.env.json.template.*
 test/cypress/fixtures/
 test/cypress/e2e/*/compose.env

--- a/test/README.md
+++ b/test/README.md
@@ -34,7 +34,8 @@ These are separate from the project's own dependencies. Run the following from t
 
 ### Prepare your `cypress.env.json`
 
-The tests need to know details about the instance of Automation Hub that it's running against. Create a file named `cypress.env.json` in the test/ directory, and use the below example as a template or start by copying `cypress.env.json.template`.
+The tests need to know details about the instance of Automation Hub that it's running against. Create a file named `cypress.env.json` in the test/ directory, and use the below example as a template or start by copying `cypress.env.json.template.standalone`.
+Templates for insights and community modes also exist.
 
     {
         "apiPrefix": "<api root>",
@@ -44,7 +45,8 @@ The tests need to know details about the instance of Automation Hub that it's ru
         "password": "<your password here>",
         "containers": "<container push target>",
         "galaxykit": "<galaxykit command>",
-        "insightsLogin": true|false
+        "insightsLogin": true|false,
+        "disableRepoSwitch": true|false,
     }
 
 *note*: the api root for the docker development environment of ansible/galaxy\_ng is `/api/automation-hub/`, while pulp-oci-images uses `/api/galaxy/`.

--- a/test/cypress.env.json.template.community
+++ b/test/cypress.env.json.template.community
@@ -1,10 +1,10 @@
 {
-  "apiPrefix": "/api/galaxy/",
-  "pulpPrefix": "/api/galaxy/pulp/api/v3/",
+  "apiPrefix": "/api/",
+  "pulpPrefix": "/api/pulp/api/v3/",
   "uiPrefix": "/ui/",
   "username": "admin",
   "password": "admin",
-  "containers": "localhost:8002",
+  "containers": "localhost:5001",
   "galaxykit": "galaxykit --ignore-certs",
   "insightsLogin": false,
   "disableRepoSwitch" : false

--- a/test/cypress.env.json.template.insights
+++ b/test/cypress.env.json.template.insights
@@ -1,17 +1,3 @@
-// Standalone
-{
-  "apiPrefix": "/api/automation-hub/",
-  "pulpPrefix": "/api/automation-hub/pulp/api/v3/",
-  "uiPrefix": "/ui/",
-  "username": "admin",
-  "password": "admin",
-  "containers": "localhost:5001",
-  "galaxykit": "galaxykit --ignore-certs",
-  "insightsLogin": false
-}
-
-
-// Insights
 {
   "apiPrefix": "/api/automation-hub/",
   "pulpPrefix": "/api/automation-hub/pulp/api/v3/",
@@ -19,5 +5,6 @@
   "username": "admin",
   "password": "admin",
   "galaxykit": "galaxykit --ignore-certs --auth-url 'http://localhost:8002/auth/realms/redhat-external/protocol/openid-connect/token'",
-  "insightsLogin" : true
+  "insightsLogin": true,
+  "disableRepoSwitch" : true
 }

--- a/test/cypress.env.json.template.standalone
+++ b/test/cypress.env.json.template.standalone
@@ -1,10 +1,10 @@
 {
-  "apiPrefix": "/api/galaxy/",
-  "pulpPrefix": "/api/galaxy/pulp/api/v3/",
+  "apiPrefix": "/api/automation-hub/",
+  "pulpPrefix": "/api/automation-hub/pulp/api/v3/",
   "uiPrefix": "/ui/",
   "username": "admin",
   "password": "admin",
-  "containers": "localhost:8002",
+  "containers": "localhost:5001",
   "galaxykit": "galaxykit --ignore-certs",
   "insightsLogin": false,
   "disableRepoSwitch" : false

--- a/test/cypress/e2e/community/legacy.js
+++ b/test/cypress/e2e/community/legacy.js
@@ -1,0 +1,2 @@
+// TODO test legacy features
+// also link view-only tests


### PR DESCRIPTION
Test also the community mode screens and workings.
Enables a community mode CI test ... TODO but missing community profile for oci_env
=> more of a reminder at this point,
Also TODO actual tests, a smoke test for standalone features, link view-only tests, write legacy roles/legacy namespaces tests.