### PR TITLE
Prettier: sort imports, bump to 2.8

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -5,3 +5,7 @@ tabWidth: 2
 jsxSingleQuote: true
 jsxBracketSameLine: false
 bracketSpacing: true
+importOrder:
+  - "^src/"
+  - "^[./]"
+importOrderSortSpecifiers: true

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -3,6 +3,8 @@ jsxSingleQuote: true
 trailingComma: 'all'
 bracketSameLine: false
 importOrder:
+  - '^[.][.]/app.scss'
+  - '<THIRD_PARTY_MODULES>'
   - "^src/"
   - "^[./]"
 importOrderSortSpecifiers: true

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,10 +1,7 @@
-printWidth: 80
 singleQuote: true
-trailingComma: 'all'
-tabWidth: 2
 jsxSingleQuote: true
-jsxBracketSameLine: false
-bracketSpacing: true
+trailingComma: 'all'
+bracketSameLine: false
 importOrder:
   - "^src/"
   - "^[./]"

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
                 "husky": "^4.3.0",
                 "npm-run-all": "^4.1.5",
                 "postcss": "^8.4.20",
-                "prettier": "^2.3.2",
+                "prettier": "^2.8.3",
                 "sass": "^1.57.1",
                 "sass-loader": "^13.2.0",
                 "source-map-loader": "^4.0.1",
@@ -12673,14 +12673,18 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.3.2",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+            "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
             "dev": true,
-            "license": "MIT",
             "bin": {
                 "prettier": "bin-prettier.js"
             },
             "engines": {
                 "node": ">=10.13.0"
+            },
+            "funding": {
+                "url": "https://github.com/prettier/prettier?sponsor=1"
             }
         },
         "node_modules/pretty-bytes": {
@@ -24795,7 +24799,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.3.2",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+            "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
             "dev": true
         },
         "pretty-bytes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
                 "@ls-lint/ls-lint": "^1.11.2",
                 "@redhat-cloud-services/frontend-components-config": "^4.6.34",
                 "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.26",
+                "@trivago/prettier-plugin-sort-imports": "^4.0.0",
                 "@typescript-eslint/eslint-plugin": "^5.48.1",
                 "@typescript-eslint/parser": "^5.47.1",
                 "babel-core": "^7.0.0-bridge.0",
@@ -3343,6 +3344,124 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@trivago/prettier-plugin-sort-imports": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.0.0.tgz",
+            "integrity": "sha512-Tyuk5ZY4a0e2MNFLdluQO9F6d1awFQYXVVujEPFfvKPPXz8DADNHzz73NMhwCSXGSuGGZcA/rKOyZBrxVNMxaA==",
+            "dev": true,
+            "dependencies": {
+                "@babel/core": "7.17.8",
+                "@babel/generator": "7.17.7",
+                "@babel/parser": "7.18.9",
+                "@babel/traverse": "7.17.3",
+                "@babel/types": "7.17.0",
+                "javascript-natural-sort": "0.7.1",
+                "lodash": "4.17.21"
+            },
+            "peerDependencies": {
+                "@vue/compiler-sfc": "3.x",
+                "prettier": "2.x"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/core": {
+            "version": "7.17.8",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+            "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+            "dev": true,
+            "dependencies": {
+                "@ampproject/remapping": "^2.1.0",
+                "@babel/code-frame": "^7.16.7",
+                "@babel/generator": "^7.17.7",
+                "@babel/helper-compilation-targets": "^7.17.7",
+                "@babel/helper-module-transforms": "^7.17.7",
+                "@babel/helpers": "^7.17.8",
+                "@babel/parser": "^7.17.8",
+                "@babel/template": "^7.16.7",
+                "@babel/traverse": "^7.17.3",
+                "@babel/types": "^7.17.0",
+                "convert-source-map": "^1.7.0",
+                "debug": "^4.1.0",
+                "gensync": "^1.0.0-beta.2",
+                "json5": "^2.1.2",
+                "semver": "^6.3.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/babel"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator": {
+            "version": "7.17.7",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+            "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+            "dev": true,
+            "dependencies": {
+                "@babel/types": "^7.17.0",
+                "jsesc": "^2.5.1",
+                "source-map": "^0.5.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/parser": {
+            "version": "7.18.9",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+            "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
+            "dev": true,
+            "bin": {
+                "parser": "bin/babel-parser.js"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse": {
+            "version": "7.17.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+            "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.16.7",
+                "@babel/generator": "^7.17.3",
+                "@babel/helper-environment-visitor": "^7.16.7",
+                "@babel/helper-function-name": "^7.16.7",
+                "@babel/helper-hoist-variables": "^7.16.7",
+                "@babel/helper-split-export-declaration": "^7.16.7",
+                "@babel/parser": "^7.17.3",
+                "@babel/types": "^7.17.0",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/types": {
+            "version": "7.17.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+            "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/helper-validator-identifier": "^7.16.7",
+                "to-fast-properties": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -4272,6 +4391,101 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
+        },
+        "node_modules/@vue/compiler-core": {
+            "version": "3.2.45",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+            "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.16.4",
+                "@vue/shared": "3.2.45",
+                "estree-walker": "^2.0.2",
+                "source-map": "^0.6.1"
+            }
+        },
+        "node_modules/@vue/compiler-core/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.2.45",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+            "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.2.45",
+                "@vue/shared": "3.2.45"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.2.45",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+            "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.16.4",
+                "@vue/compiler-core": "3.2.45",
+                "@vue/compiler-dom": "3.2.45",
+                "@vue/compiler-ssr": "3.2.45",
+                "@vue/reactivity-transform": "3.2.45",
+                "@vue/shared": "3.2.45",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.25.7",
+                "postcss": "^8.1.10",
+                "source-map": "^0.6.1"
+            }
+        },
+        "node_modules/@vue/compiler-sfc/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.2.45",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+            "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.2.45",
+                "@vue/shared": "3.2.45"
+            }
+        },
+        "node_modules/@vue/reactivity-transform": {
+            "version": "3.2.45",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+            "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "@babel/parser": "^7.16.4",
+                "@vue/compiler-core": "3.2.45",
+                "@vue/shared": "3.2.45",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.25.7"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.2.45",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+            "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
+            "dev": true,
+            "peer": true
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.11.1",
@@ -7485,6 +7699,13 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "peer": true
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "dev": true,
@@ -9828,6 +10049,12 @@
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
             "peer": true
         },
+        "node_modules/javascript-natural-sort": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+            "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+            "dev": true
+        },
         "node_modules/jest-get-type": {
             "version": "26.3.0",
             "dev": true,
@@ -10493,6 +10720,16 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/magic-string": {
+            "version": "0.25.9",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+            "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "sourcemap-codec": "^1.4.8"
             }
         },
         "node_modules/make-dir": {
@@ -13903,6 +14140,14 @@
             "peerDependencies": {
                 "webpack": "^5.72.1"
             }
+        },
+        "node_modules/sourcemap-codec": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+            "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+            "dev": true,
+            "peer": true
         },
         "node_modules/space-separated-tokens": {
             "version": "2.0.1",
@@ -18280,6 +18525,97 @@
                 "tslib": "^1.9.3"
             }
         },
+        "@trivago/prettier-plugin-sort-imports": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.0.0.tgz",
+            "integrity": "sha512-Tyuk5ZY4a0e2MNFLdluQO9F6d1awFQYXVVujEPFfvKPPXz8DADNHzz73NMhwCSXGSuGGZcA/rKOyZBrxVNMxaA==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "7.17.8",
+                "@babel/generator": "7.17.7",
+                "@babel/parser": "7.18.9",
+                "@babel/traverse": "7.17.3",
+                "@babel/types": "7.17.0",
+                "javascript-natural-sort": "0.7.1",
+                "lodash": "4.17.21"
+            },
+            "dependencies": {
+                "@babel/core": {
+                    "version": "7.17.8",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+                    "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+                    "dev": true,
+                    "requires": {
+                        "@ampproject/remapping": "^2.1.0",
+                        "@babel/code-frame": "^7.16.7",
+                        "@babel/generator": "^7.17.7",
+                        "@babel/helper-compilation-targets": "^7.17.7",
+                        "@babel/helper-module-transforms": "^7.17.7",
+                        "@babel/helpers": "^7.17.8",
+                        "@babel/parser": "^7.17.8",
+                        "@babel/template": "^7.16.7",
+                        "@babel/traverse": "^7.17.3",
+                        "@babel/types": "^7.17.0",
+                        "convert-source-map": "^1.7.0",
+                        "debug": "^4.1.0",
+                        "gensync": "^1.0.0-beta.2",
+                        "json5": "^2.1.2",
+                        "semver": "^6.3.0"
+                    }
+                },
+                "@babel/generator": {
+                    "version": "7.17.7",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+                    "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.17.0",
+                        "jsesc": "^2.5.1",
+                        "source-map": "^0.5.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.18.9",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+                    "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
+                    "dev": true
+                },
+                "@babel/traverse": {
+                    "version": "7.17.3",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+                    "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.16.7",
+                        "@babel/generator": "^7.17.3",
+                        "@babel/helper-environment-visitor": "^7.16.7",
+                        "@babel/helper-function-name": "^7.16.7",
+                        "@babel/helper-hoist-variables": "^7.16.7",
+                        "@babel/helper-split-export-declaration": "^7.16.7",
+                        "@babel/parser": "^7.17.3",
+                        "@babel/types": "^7.17.0",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.17.0",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+                    "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.16.7",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+                    "dev": true
+                }
+            }
+        },
         "@tsconfig/node10": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -18962,6 +19298,99 @@
                 "@typescript-eslint/types": "5.47.1",
                 "eslint-visitor-keys": "^3.3.0"
             }
+        },
+        "@vue/compiler-core": {
+            "version": "3.2.45",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+            "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@babel/parser": "^7.16.4",
+                "@vue/shared": "3.2.45",
+                "estree-walker": "^2.0.2",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "peer": true
+                }
+            }
+        },
+        "@vue/compiler-dom": {
+            "version": "3.2.45",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+            "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@vue/compiler-core": "3.2.45",
+                "@vue/shared": "3.2.45"
+            }
+        },
+        "@vue/compiler-sfc": {
+            "version": "3.2.45",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+            "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@babel/parser": "^7.16.4",
+                "@vue/compiler-core": "3.2.45",
+                "@vue/compiler-dom": "3.2.45",
+                "@vue/compiler-ssr": "3.2.45",
+                "@vue/reactivity-transform": "3.2.45",
+                "@vue/shared": "3.2.45",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.25.7",
+                "postcss": "^8.1.10",
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true,
+                    "peer": true
+                }
+            }
+        },
+        "@vue/compiler-ssr": {
+            "version": "3.2.45",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+            "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@vue/compiler-dom": "3.2.45",
+                "@vue/shared": "3.2.45"
+            }
+        },
+        "@vue/reactivity-transform": {
+            "version": "3.2.45",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+            "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "@babel/parser": "^7.16.4",
+                "@vue/compiler-core": "3.2.45",
+                "@vue/shared": "3.2.45",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.25.7"
+            }
+        },
+        "@vue/shared": {
+            "version": "3.2.45",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+            "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
+            "dev": true,
+            "peer": true
         },
         "@webassemblyjs/ast": {
             "version": "1.11.1",
@@ -21189,6 +21618,13 @@
             "version": "4.3.0",
             "dev": true
         },
+        "estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "peer": true
+        },
         "esutils": {
             "version": "2.0.3",
             "dev": true
@@ -22718,6 +23154,12 @@
             "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
             "peer": true
         },
+        "javascript-natural-sort": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+            "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+            "dev": true
+        },
         "jest-get-type": {
             "version": "26.3.0",
             "dev": true
@@ -23172,6 +23614,16 @@
             "version": "6.0.0",
             "requires": {
                 "yallist": "^4.0.0"
+            }
+        },
+        "magic-string": {
+            "version": "0.25.9",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+            "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "sourcemap-codec": "^1.4.8"
             }
         },
         "make-dir": {
@@ -25345,6 +25797,13 @@
                 "iconv-lite": "^0.6.3",
                 "source-map-js": "^1.0.2"
             }
+        },
+        "sourcemap-codec": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+            "dev": true,
+            "peer": true
         },
         "space-separated-tokens": {
             "version": "2.0.1"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "husky": "^4.3.0",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.20",
-        "prettier": "^2.3.2",
+        "prettier": "^2.8.3",
         "sass": "^1.57.1",
         "sass-loader": "^13.2.0",
         "source-map-loader": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "@ls-lint/ls-lint": "^1.11.2",
         "@redhat-cloud-services/frontend-components-config": "^4.6.34",
         "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.26",
+        "@trivago/prettier-plugin-sort-imports": "^4.0.0",
         "@typescript-eslint/eslint-plugin": "^5.48.1",
         "@typescript-eslint/parser": "^5.47.1",
         "babel-core": "^7.0.0-bridge.0",

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
+import Cookies from 'js-cookie';
 import { Constants } from 'src/constants';
 import { ParamHelper } from 'src/utilities';
-import Cookies from 'js-cookie';
 
 export class BaseAPI {
   apiPath: string;

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -1,10 +1,10 @@
-import { HubAPI } from './hub';
+import axios from 'axios';
 import {
   CollectionDetailType,
   CollectionListType,
   CollectionUploadType,
 } from 'src/api';
-import axios from 'axios';
+import { HubAPI } from './hub';
 
 function filterContents(contents) {
   if (contents) {

--- a/src/api/execution-environment-registry.ts
+++ b/src/api/execution-environment-registry.ts
@@ -1,5 +1,5 @@
-import { HubAPI } from './hub';
 import { RemoteType } from '.';
+import { HubAPI } from './hub';
 import { smartUpdate } from './remotes';
 
 class API extends HubAPI {

--- a/src/api/legacy.ts
+++ b/src/api/legacy.ts
@@ -1,5 +1,5 @@
-import { BaseAPI } from './base';
 import { LegacyRoleDetailType } from 'src/api';
+import { BaseAPI } from './base';
 
 export class LegacyAPI extends BaseAPI {
   API_VERSION = 'v1';

--- a/src/api/legacynamespace.ts
+++ b/src/api/legacynamespace.ts
@@ -1,5 +1,5 @@
-import { LegacyAPI } from './legacy';
 import axios from 'axios';
+import { LegacyAPI } from './legacy';
 
 export class API extends LegacyAPI {
   apiPath = this.getApiPath('');

--- a/src/api/legacyrole.ts
+++ b/src/api/legacyrole.ts
@@ -1,5 +1,5 @@
-import { LegacyAPI } from './legacy';
 import axios from 'axios';
+import { LegacyAPI } from './legacy';
 
 export class API extends LegacyAPI {
   apiPath = this.getApiPath('');

--- a/src/api/remotes.ts
+++ b/src/api/remotes.ts
@@ -1,6 +1,6 @@
-import { HubAPI } from './hub';
-import { RemoteType } from '.';
 import { clearSetFieldsFromRequest } from 'src/utilities';
+import { RemoteType } from '.';
+import { HubAPI } from './hub';
 
 // removes unchanged values and write only fields before updating
 export function smartUpdate(remote: RemoteType, unmodifiedRemote: RemoteType) {

--- a/src/components/about-modal/about-modal.tsx
+++ b/src/components/about-modal/about-modal.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
 import {
   AboutModal,
   TextContent,
@@ -8,9 +7,10 @@ import {
   TextListItemVariants,
   TextListVariants,
 } from '@patternfly/react-core';
+import { detect } from 'detect-browser';
+import * as React from 'react';
 import Logo from 'src/../static/images/logo_large.svg';
 import { ApplicationInfoAPI, UserType } from 'src/api';
-import { detect } from 'detect-browser';
 
 const Label = ({ children }: { children: React.ReactNode }) => (
   <TextListItem component={TextListItemVariants.dt}>{children}</TextListItem>

--- a/src/components/card-list-switcher/card-list-switcher.tsx
+++ b/src/components/card-list-switcher/card-list-switcher.tsx
@@ -1,10 +1,8 @@
-import * as React from 'react';
-import cx from 'classnames';
-import './switcher.scss';
-
 import { ListIcon, ThLargeIcon } from '@patternfly/react-icons';
-
+import cx from 'classnames';
+import * as React from 'react';
 import { ParamHelper } from 'src/utilities/param-helper';
+import './switcher.scss';
 
 interface IProps {
   params: {

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -1,25 +1,23 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
-import cx from 'classnames';
+import { Trans, t } from '@lingui/macro';
 import {
+  Badge,
   Card,
-  CardHeader,
   CardBody,
   CardFooter,
-  TextContent,
+  CardHeader,
   Text,
+  TextContent,
   TextVariants,
-  Badge,
   Tooltip,
 } from '@patternfly/react-core';
-
+import cx from 'classnames';
+import * as React from 'react';
 import { Link } from 'react-router-dom';
-
-import { CollectionNumericLabel, Logo, SignatureBadge } from 'src/components';
 import { CollectionListType } from 'src/api';
-import { formatPath, Paths } from 'src/paths';
-import { convertContentSummaryCounts } from 'src/utilities';
+import { CollectionNumericLabel, Logo, SignatureBadge } from 'src/components';
 import { Constants } from 'src/constants';
+import { Paths, formatPath } from 'src/paths';
+import { convertContentSummaryCounts } from 'src/utilities';
 
 interface IProps extends CollectionListType {
   className?: string;

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -1,7 +1,4 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import './cards.scss';
-
 import {
   Card,
   CardBody,
@@ -11,10 +8,11 @@ import {
   CardTitle,
   Tooltip,
 } from '@patternfly/react-core';
-
+import * as React from 'react';
 import { Link } from 'react-router-dom';
-
 import { Logo } from 'src/components';
+import './cards.scss';
+
 // Use snake case to match field types provided py python API so that the
 // spread operator can be used.
 interface IProps {

--- a/src/components/collection-count/collection-count.tsx
+++ b/src/components/collection-count/collection-count.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
 import { t } from '@lingui/macro';
-import { CollectionAPI, CollectionExcludesType } from 'src/api';
 import { Spinner } from '@patternfly/react-core';
+import * as React from 'react';
+import { CollectionAPI, CollectionExcludesType } from 'src/api';
 import { AlertType } from 'src/components';
 import { errorMessage } from 'src/utilities';
 

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -1,13 +1,9 @@
 import { t } from '@lingui/macro';
+import { List, ListItem, ListVariant } from '@patternfly/react-core';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-
-import { List, ListItem, ListVariant } from '@patternfly/react-core';
-
-import { EmptyStateNoData, HelperText } from 'src/components';
-
 import { CollectionDetailType, CollectionVersion } from 'src/api';
-
+import { EmptyStateNoData, HelperText } from 'src/components';
 import 'src/containers/collection-detail/collection-dependencies.scss';
 
 interface IProps {

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -1,28 +1,23 @@
 import { t } from '@lingui/macro';
+import {
+  SearchInput,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-
 import { CollectionUsedByDependencies } from 'src/api';
-
 import {
-  Toolbar,
-  ToolbarItem,
-  ToolbarGroup,
-  SearchInput,
-} from '@patternfly/react-core';
-
-import {
-  Pagination,
-  EmptyStateNoData,
   EmptyStateFilter,
-  Sort,
+  EmptyStateNoData,
   LoadingPageSpinner,
+  Pagination,
+  Sort,
 } from 'src/components';
-
-import { ParamHelper, filterIsSet } from 'src/utilities';
-import { formatPath, Paths } from 'src/paths';
-
 import 'src/containers/collection-detail/collection-dependencies.scss';
+import { Paths, formatPath } from 'src/paths';
+import { ParamHelper, filterIsSet } from 'src/utilities';
 
 interface IProps {
   usedByDependencies: CollectionUsedByDependencies[];

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -1,24 +1,20 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import cx from 'classnames';
-import './collection-content-list.scss';
-
-import { Link } from 'react-router-dom';
 import {
   SearchInput,
   Toolbar,
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
-
-import { EmptyStateCustom } from 'src/components';
-
+import cx from 'classnames';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { ContentSummaryType } from 'src/api';
+import { EmptyStateCustom } from 'src/components';
+import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import { ParamHelper } from 'src/utilities/param-helper';
-import { AppContext } from 'src/loaders/app-context';
+import './collection-content-list.scss';
 
 interface IProps {
   contents: ContentSummaryType[];

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -1,26 +1,22 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
-import './collection-info.scss';
-import { errorMessage } from 'src/utilities';
-
-import { Link } from 'react-router-dom';
-
+import { Trans, t } from '@lingui/macro';
 import {
-  Split,
-  SplitItem,
+  Alert,
+  Button,
   Grid,
   GridItem,
-  Button,
-  Alert,
+  Split,
+  SplitItem,
 } from '@patternfly/react-core';
-
 import { DownloadIcon } from '@patternfly/react-icons';
-import { DownloadSignatureGridItem } from './download-signature-grid-item';
-
-import { CollectionDetailType, CollectionAPI } from 'src/api';
-import { Tag, ClipboardCopy, LoginLink } from 'src/components';
-import { Paths, formatPath } from 'src/paths';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { CollectionAPI, CollectionDetailType } from 'src/api';
+import { ClipboardCopy, LoginLink, Tag } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
+import { errorMessage } from 'src/utilities';
+import './collection-info.scss';
+import { DownloadSignatureGridItem } from './download-signature-grid-item';
 
 interface IProps extends CollectionDetailType {
   params: {

--- a/src/components/collection-detail/download-signature-grid-item.tsx
+++ b/src/components/collection-detail/download-signature-grid-item.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import { t } from '@lingui/macro';
 import {
   Button,
   ButtonVariant,
@@ -9,8 +9,8 @@ import {
   SplitItem,
 } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
+import React, { FC, useState } from 'react';
 import { CollectionVersionDetail } from 'src/api/response-types/collection';
-import { t } from '@lingui/macro';
 import { useContext } from 'src/loaders/app-context';
 
 interface Props {

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -1,9 +1,4 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-
-import { capitalize } from 'lodash';
-import { Link } from 'react-router-dom';
-
 import {
   Nav,
   NavExpandable,
@@ -14,11 +9,13 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-
+import { capitalize } from 'lodash';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { DocsBlobType } from 'src/api';
+import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import { ParamHelper, sanitizeDocsUrls } from 'src/utilities';
-import { AppContext } from 'src/loaders/app-context';
 
 class DocsEntry {
   display: string;

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -1,16 +1,15 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import './collection-filter.scss';
 import {
   Toolbar,
   ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-
+import * as React from 'react';
 import { AppliedFilters, CompoundFilter } from 'src/components';
 import { Constants } from 'src/constants';
 import { AppContext } from 'src/loaders/app-context';
+import './collection-filter.scss';
 
 interface IProps {
   ignoredParams: string[];

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -1,31 +1,28 @@
-import * as React from 'react';
-import { t, Trans } from '@lingui/macro';
-import './list-item.scss';
-
+import { Trans, t } from '@lingui/macro';
 import {
-  DataListItem,
-  DataListItemRow,
-  DataListItemCells,
   DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
   LabelGroup,
-  TextContent,
   Text,
+  TextContent,
   TextVariants,
 } from '@patternfly/react-core';
-
+import * as React from 'react';
 import { Link } from 'react-router-dom';
-
-import { Paths, formatPath } from 'src/paths';
+import { CollectionListType } from 'src/api';
 import {
   CollectionNumericLabel,
-  Tag,
-  Logo,
-  DeprecatedTag,
   DateComponent,
+  DeprecatedTag,
+  Logo,
+  Tag,
 } from 'src/components';
-import { CollectionListType } from 'src/api';
+import { Paths, formatPath } from 'src/paths';
 import { convertContentSummaryCounts } from 'src/utilities';
 import { SignatureBadge } from '../signing';
+import './list-item.scss';
 
 interface IProps extends CollectionListType {
   showNamespace?: boolean;

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -1,16 +1,14 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import './list.scss';
-
 import { DataList } from '@patternfly/react-core';
+import * as React from 'react';
 import { CollectionListType } from 'src/api';
-
 import {
   CollectionListItem,
-  Pagination,
   EmptyStateFilter,
+  Pagination,
 } from 'src/components';
 import { ParamHelper } from 'src/utilities/param-helper';
+import './list.scss';
 
 interface IProps {
   collections: CollectionListType[];

--- a/src/components/confirm-modal/confirm-modal.tsx
+++ b/src/components/confirm-modal/confirm-modal.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
-import { Button, Modal, Spinner } from '@patternfly/react-core';
 import { t } from '@lingui/macro';
+import { Button, Modal, Spinner } from '@patternfly/react-core';
+import * as React from 'react';
 
 interface IProps {
   cancelAction: () => void;

--- a/src/components/date-component/date-component.tsx
+++ b/src/components/date-component/date-component.tsx
@@ -1,6 +1,6 @@
+import * as moment from 'moment';
 import * as React from 'react';
 import { Tooltip } from 'src/components';
-import * as moment from 'moment';
 
 interface IProps {
   date: string;

--- a/src/components/delete-modal/delete-collection-modal.tsx
+++ b/src/components/delete-modal/delete-collection-modal.tsx
@@ -1,8 +1,8 @@
+import { Trans, t } from '@lingui/macro';
+import { Checkbox, Text } from '@patternfly/react-core';
 import React from 'react';
-import { t, Trans } from '@lingui/macro';
-import { Text, Checkbox } from '@patternfly/react-core';
-import { DeleteModal } from 'src/components';
 import { CollectionDetailType, CollectionListType } from 'src/api';
+import { DeleteModal } from 'src/components';
 
 interface IProps {
   deleteCollection: CollectionDetailType | CollectionListType;

--- a/src/components/delete-modal/delete-execution-environment-modal.tsx
+++ b/src/components/delete-modal/delete-execution-environment-modal.tsx
@@ -1,11 +1,10 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
+import { Checkbox, Text } from '@patternfly/react-core';
 import * as React from 'react';
 import { ExecutionEnvironmentAPI } from 'src/api';
-import { waitForTask } from 'src/utilities';
 import { DeleteModal } from 'src/components/delete-modal/delete-modal';
+import { waitForTask } from 'src/utilities';
 import { errorMessage } from 'src/utilities';
-
-import { Checkbox, Text } from '@patternfly/react-core';
 
 interface IState {
   confirmDelete: boolean;

--- a/src/components/delete-modal/delete-modal.tsx
+++ b/src/components/delete-modal/delete-modal.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
 import { Button, Modal, ModalProps, Spinner } from '@patternfly/react-core';
+import * as React from 'react';
 
 export interface IProps {
   cancelAction: () => void;

--- a/src/components/empty-state/empty-state-custom.tsx
+++ b/src/components/empty-state/empty-state-custom.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import {
   EmptyState,
   EmptyStateBody,
@@ -7,6 +6,7 @@ import {
   EmptyStateVariant,
   Title,
 } from '@patternfly/react-core';
+import * as React from 'react';
 import { ComponentClass } from 'react';
 import { ReactElement, ReactNode } from 'react';
 

--- a/src/components/empty-state/empty-state-filter.tsx
+++ b/src/components/empty-state/empty-state-filter.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
 import { Button } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 import { EmptyStateCustom } from './empty-state-custom';
 
 interface IProps {

--- a/src/components/empty-state/empty-state-no-data.tsx
+++ b/src/components/empty-state/empty-state-no-data.tsx
@@ -1,5 +1,5 @@
+import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { PlusCircleIcon, CubesIcon } from '@patternfly/react-icons';
 import { ReactElement, ReactNode } from 'react';
 import { EmptyStateCustom } from './empty-state-custom';
 

--- a/src/components/empty-state/empty-state-unauthorized.tsx
+++ b/src/components/empty-state/empty-state-unauthorized.tsx
@@ -1,8 +1,8 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import { EmptyStateCustom } from './empty-state-custom';
 import { LockIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 import { LoginLink } from 'src/components';
+import { EmptyStateCustom } from './empty-state-custom';
 
 export class EmptyStateUnauthorized extends React.Component {
   render() {

--- a/src/components/execution-environment-header/execution-environment-header.tsx
+++ b/src/components/execution-environment-header/execution-environment-header.tsx
@@ -1,9 +1,9 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
+import { Trans, t } from '@lingui/macro';
 import { Tooltip } from '@patternfly/react-core';
-import { Paths, formatEEPath, formatPath } from 'src/paths';
-import { BaseHeader, Breadcrumbs, Tabs, SignatureBadge } from 'src/components';
+import * as React from 'react';
 import { ContainerRepositoryType } from 'src/api';
+import { BaseHeader, Breadcrumbs, SignatureBadge, Tabs } from 'src/components';
+import { Paths, formatEEPath, formatPath } from 'src/paths';
 import { lastSyncStatus, lastSynced } from 'src/utilities';
 
 interface IProps {

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import {
   Button,
   ClipboardCopyButton,
@@ -14,6 +13,7 @@ import {
   Modal,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, TagIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 import { ControllerAPI, ExecutionEnvironmentAPI } from 'src/api';
 import {
   APISearchTypeAhead,

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -1,5 +1,4 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
+import { Trans, t } from '@lingui/macro';
 import {
   Alert,
   Button,
@@ -14,27 +13,28 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, TagIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 import { Link } from 'react-router-dom';
-import {
-  AlertType,
-  APISearchTypeAhead,
-  HelperText,
-  AlertList,
-  closeAlertMixin,
-} from 'src/components';
 import {
   ContainerDistributionAPI,
   ExecutionEnvironmentRegistryAPI,
   ExecutionEnvironmentRemoteAPI,
 } from 'src/api';
+import {
+  APISearchTypeAhead,
+  AlertList,
+  AlertType,
+  HelperText,
+  closeAlertMixin,
+} from 'src/components';
 import { Paths, formatEEPath } from 'src/paths';
 import {
-  errorMessage,
   ErrorMessagesType,
+  alertErrorsWithoutFields,
+  errorMessage,
   isFieldValid,
   isFormValid,
   mapErrorMessages,
-  alertErrorsWithoutFields,
 } from 'src/utilities';
 
 interface IProps {

--- a/src/components/execution-environment/tag-manifest-modal.tsx
+++ b/src/components/execution-environment/tag-manifest-modal.tsx
@@ -1,33 +1,28 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
-
-import { AlertType } from 'src/components';
-
+import { Trans, t } from '@lingui/macro';
 import {
-  Button,
-  Modal,
-  Spinner,
-  Label,
-  LabelGroup,
-  Form,
-  FormGroup,
-  TextInput,
-  InputGroup,
   Alert,
   AlertActionLink,
+  Button,
+  Form,
+  FormGroup,
+  InputGroup,
+  Label,
+  LabelGroup,
+  Modal,
+  Spinner,
+  TextInput,
 } from '@patternfly/react-core';
-
 import { TagIcon } from '@patternfly/react-icons';
-
+import * as React from 'react';
 import {
   ContainerManifestType,
-  ExecutionEnvironmentAPI,
-  ContainerTagAPI,
   ContainerRepositoryType,
-  TaskAPI,
+  ContainerTagAPI,
+  ExecutionEnvironmentAPI,
   PulpStatus,
+  TaskAPI,
 } from 'src/api';
-
+import { AlertType } from 'src/components';
 import { parsePulpIDFromURL } from 'src/utilities';
 
 interface IState {

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -1,9 +1,8 @@
-import * as React from 'react';
-import cx from 'classnames';
-import './header.scss';
-
 import { Title } from '@patternfly/react-core';
+import cx from 'classnames';
+import * as React from 'react';
 import { Constants } from 'src/constants';
+import './header.scss';
 
 interface IProps {
   title: string;

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -1,12 +1,4 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
-import { errorMessage, DeleteCollectionUtils } from 'src/utilities';
-import './header.scss';
-
-import { Navigate } from 'react-router-dom';
-
-import * as moment from 'moment';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { Trans, t } from '@lingui/macro';
 import {
   Alert,
   Button,
@@ -21,47 +13,51 @@ import {
   SelectVariant,
   Text,
 } from '@patternfly/react-core';
-import { AppContext } from 'src/loaders/app-context';
-
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import * as moment from 'moment';
+import * as React from 'react';
+import { Navigate } from 'react-router-dom';
 import {
-  BaseHeader,
-  Breadcrumbs,
-  BreadcrumbType,
-  LinkTabs,
-  Logo,
-  RepoSelector,
-  Pagination,
-  AlertList,
-  AlertType,
-  closeAlertMixin,
-  StatefulDropdown,
-  SignSingleCertificateModal,
-  SignAllCertificatesModal,
-  UploadSingCertificateModal,
-  ImportModal,
-  DeleteCollectionModal,
-} from 'src/components';
-
-import {
+  CertificateUploadAPI,
   CollectionAPI,
   CollectionDetailType,
-  SignCollectionAPI,
   CollectionListType,
-  MyNamespaceAPI,
   CollectionVersion,
+  MyNamespaceAPI,
   Repositories,
-  CertificateUploadAPI,
+  SignCollectionAPI,
 } from 'src/api';
-import { Paths, formatPath } from 'src/paths';
 import {
-  waitForTask,
+  AlertList,
+  AlertType,
+  BaseHeader,
+  BreadcrumbType,
+  Breadcrumbs,
+  DeleteCollectionModal,
+  ImportModal,
+  LinkTabs,
+  Logo,
+  Pagination,
+  RepoSelector,
+  SignAllCertificatesModal,
+  SignSingleCertificateModal,
+  StatefulDropdown,
+  UploadSingCertificateModal,
+  closeAlertMixin,
+} from 'src/components';
+import { Constants } from 'src/constants';
+import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
+import { DeleteCollectionUtils, errorMessage } from 'src/utilities';
+import {
   canSignNamespace,
   parsePulpIDFromURL,
+  waitForTask,
 } from 'src/utilities';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { DateComponent } from '../date-component/date-component';
-import { Constants } from 'src/constants';
 import { SignatureBadge } from '../signing';
+import './header.scss';
 
 interface IProps {
   collection: CollectionDetailType;

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -1,18 +1,16 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import './header.scss';
-
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-
+import * as React from 'react';
+import { NamespaceType } from 'src/api';
 import {
   BaseHeader,
+  BreadcrumbType,
+  Breadcrumbs,
   Logo,
   Tabs,
   TabsType,
-  Breadcrumbs,
-  BreadcrumbType,
 } from 'src/components';
-import { NamespaceType } from 'src/api';
+import './header.scss';
 
 interface IProps {
   namespace: NamespaceType;

--- a/src/components/helper-text/helper-text.tsx
+++ b/src/components/helper-text/helper-text.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
 import { t } from '@lingui/macro';
-import { Popover, PopoverPosition, Button } from '@patternfly/react-core';
+import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 import './helper-text.scss';
 
 interface IProps {

--- a/src/components/import-modal/import-modal.tsx
+++ b/src/components/import-modal/import-modal.tsx
@@ -1,16 +1,14 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import './import-modal.scss';
-import axios from 'axios';
-
-import { Modal, Button } from '@patternfly/react-core';
+import { Button, Modal } from '@patternfly/react-core';
 import { FolderOpenIcon, SpinnerIcon } from '@patternfly/react-icons';
-
+import axios from 'axios';
+import * as React from 'react';
 import {
-  CollectionListType,
   CollectionAPI,
+  CollectionListType,
   CollectionUploadType,
 } from 'src/api';
+import './import-modal.scss';
 
 enum Status {
   uploading = 'uploading',

--- a/src/components/legacy-namespace-list/legacy-namespace-item.tsx
+++ b/src/components/legacy-namespace-list/legacy-namespace-item.tsx
@@ -1,19 +1,15 @@
-import * as React from 'react';
-import './legacy-namespace-item.scss';
-
 import {
-  DataListItem,
-  DataListItemRow,
-  DataListItemCells,
   DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
 } from '@patternfly/react-core';
-
+import * as React from 'react';
 import { Link } from 'react-router-dom';
-
-import { Paths, formatPath } from 'src/paths';
-import { Logo } from 'src/components';
-
 import { LegacyNamespaceDetailType } from 'src/api';
+import { Logo } from 'src/components';
+import { Paths, formatPath } from 'src/paths';
+import './legacy-namespace-item.scss';
 
 interface LegacyNamespaceProps {
   namespace: LegacyNamespaceDetailType;

--- a/src/components/legacy-role-list/legacy-role-item.tsx
+++ b/src/components/legacy-role-list/legacy-role-item.tsx
@@ -1,24 +1,20 @@
-import * as React from 'react';
-import { t, Trans } from '@lingui/macro';
-import './legacy-role-item.scss';
-
+import { Trans, t } from '@lingui/macro';
 import {
-  DataListItem,
-  DataListItemRow,
-  DataListItemCells,
   DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
   LabelGroup,
-  TextContent,
   Text,
+  TextContent,
   TextVariants,
 } from '@patternfly/react-core';
-
+import * as React from 'react';
 import { Link } from 'react-router-dom';
-
-import { Paths, formatPath } from 'src/paths';
-import { Tag, Logo, DateComponent } from 'src/components';
-
 import { LegacyRoleDetailType } from 'src/api/response-types/legacy-role';
+import { DateComponent, Logo, Tag } from 'src/components';
+import { Paths, formatPath } from 'src/paths';
+import './legacy-role-item.scss';
 
 interface LegacyRoleProps {
   role: LegacyRoleDetailType;

--- a/src/components/loading/loading-page-spinner.tsx
+++ b/src/components/loading/loading-page-spinner.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { Bullseye, Spinner } from '@patternfly/react-core';
+import * as React from 'react';
 
 export class LoadingPageSpinner extends React.Component {
   render() {

--- a/src/components/loading/loading-with-header.tsx
+++ b/src/components/loading/loading-with-header.tsx
@@ -1,8 +1,6 @@
-import * as React from 'react';
-
 import { Skeleton, Title } from '@patternfly/react-core';
-
-import { Main, LoadingPageSpinner } from 'src/components';
+import * as React from 'react';
+import { LoadingPageSpinner, Main } from 'src/components';
 
 export class LoadingPageWithHeader extends React.Component {
   render() {

--- a/src/components/markdown-editor/markdown-editor.tsx
+++ b/src/components/markdown-editor/markdown-editor.tsx
@@ -1,9 +1,8 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import './markdown-editor.scss';
-
 import { Form, FormGroup, TextArea } from '@patternfly/react-core';
+import * as React from 'react';
 import ReactMarkdown from 'react-markdown';
+import './markdown-editor.scss';
 
 interface IProps {
   text: string;

--- a/src/components/my-imports/import-console.tsx
+++ b/src/components/my-imports/import-console.tsx
@@ -1,22 +1,18 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
+import { Spinner, Tooltip } from '@patternfly/react-core';
 import cx from 'classnames';
-import './my-imports.scss';
-
-import { Tooltip, Spinner } from '@patternfly/react-core';
+import * as React from 'react';
 import { Link } from 'react-router-dom';
-
-import { formatPath, Paths } from 'src/paths';
 import {
-  ImportListType,
-  ImportDetailType,
-  PulpStatus,
   CollectionVersion,
+  ImportDetailType,
+  ImportListType,
+  PulpStatus,
 } from 'src/api';
-
 import { StatusIndicator } from 'src/components';
-
 import { Constants } from 'src/constants';
+import { Paths, formatPath } from 'src/paths';
+import './my-imports.scss';
 
 interface IProps {
   empty: boolean;

--- a/src/components/my-imports/import-list.tsx
+++ b/src/components/my-imports/import-list.tsx
@@ -1,24 +1,24 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import cx from 'classnames';
-import './my-imports.scss';
 import { Pagination, Toolbar } from '@patternfly/react-core';
+import cx from 'classnames';
+import * as React from 'react';
 import {
+  ImportListType,
+  MyNamespaceAPI,
+  NamespaceType,
+  PulpStatus,
+} from 'src/api';
+import {
+  APISearchTypeAhead,
   AppliedFilters,
   CompoundFilter,
   LoadingPageSpinner,
-  APISearchTypeAhead,
 } from 'src/components';
-import {
-  PulpStatus,
-  NamespaceType,
-  ImportListType,
-  MyNamespaceAPI,
-} from 'src/api';
-import { ParamHelper } from 'src/utilities/param-helper';
-import { filterIsSet, errorMessage } from 'src/utilities';
 import { Constants } from 'src/constants';
-import { DateComponent, EmptyStateNoData, EmptyStateFilter } from '..';
+import { errorMessage, filterIsSet } from 'src/utilities';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { DateComponent, EmptyStateFilter, EmptyStateNoData } from '..';
+import './my-imports.scss';
 
 interface IProps {
   importList: ImportListType[];

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -1,7 +1,4 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
-import './namespace-form.scss';
-
+import { Trans, t } from '@lingui/macro';
 import {
   Alert,
   Form,
@@ -14,13 +11,14 @@ import {
   PlusCircleIcon,
   TrashIcon,
 } from '@patternfly/react-icons';
+import * as React from 'react';
 import { Link } from 'react-router-dom';
-
 import { NamespaceType } from 'src/api';
 import { NamespaceCard } from 'src/components';
+import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import { ErrorMessagesType, validateURLHelper } from 'src/utilities';
-import { AppContext } from 'src/loaders/app-context';
+import './namespace-form.scss';
 
 interface IProps {
   namespace: NamespaceType;

--- a/src/components/namespace-form/resources-form.tsx
+++ b/src/components/namespace-form/resources-form.tsx
@@ -1,8 +1,8 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import './namespace-form.scss';
 import { NamespaceType } from 'src/api';
 import { MarkdownEditor } from '..';
+import './namespace-form.scss';
 
 const placeholder = `## Custom resources
 

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
 import {
   Button,
   Form,
@@ -9,7 +8,7 @@ import {
   ModalVariant,
   TextInput,
 } from '@patternfly/react-core';
-
+import * as React from 'react';
 import { NamespaceAPI } from 'src/api';
 import { HelperText } from 'src/components';
 import { ErrorMessagesType } from 'src/utilities';

--- a/src/components/numeric-label/numeric-label.tsx
+++ b/src/components/numeric-label/numeric-label.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { plural } from '@lingui/macro';
+import * as React from 'react';
 
 interface IProps {
   number: number;

--- a/src/components/patternfly-wrappers/alert-list.tsx
+++ b/src/components/patternfly-wrappers/alert-list.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
 import {
   Alert,
   AlertActionCloseButton,
   AlertProps,
 } from '@patternfly/react-core';
+import * as React from 'react';
 
 interface IProps {
   /** List of alerts to display */

--- a/src/components/patternfly-wrappers/applied-filters.tsx
+++ b/src/components/patternfly-wrappers/applied-filters.tsx
@@ -1,8 +1,6 @@
 import { t } from '@lingui/macro';
+import { Button, Chip, ChipGroup } from '@patternfly/react-core';
 import * as React from 'react';
-
-import { Chip, ChipGroup, Button } from '@patternfly/react-core';
-
 import { ParamHelper } from 'src/utilities';
 
 interface IProps {

--- a/src/components/patternfly-wrappers/breadcrumbs.tsx
+++ b/src/components/patternfly-wrappers/breadcrumbs.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
+import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 export class BreadcrumbType {

--- a/src/components/patternfly-wrappers/clipboard-copy.tsx
+++ b/src/components/patternfly-wrappers/clipboard-copy.tsx
@@ -1,7 +1,6 @@
-import * as React from 'react';
 import { t } from '@lingui/macro';
-
 import { ClipboardCopy as PFClipboardCopy } from '@patternfly/react-core';
+import * as React from 'react';
 
 interface IProps {
   children: string;

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -1,20 +1,17 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-
 import {
-  TextInput,
-  InputGroup,
   Button,
   ButtonVariant,
   DropdownItem,
+  InputGroup,
   Select,
   SelectGroup,
   SelectOption,
   SelectVariant,
+  TextInput,
 } from '@patternfly/react-core';
-
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
-
+import * as React from 'react';
 import { StatefulDropdown } from 'src/components';
 import { ParamHelper } from 'src/utilities';
 

--- a/src/components/patternfly-wrappers/fileupload.tsx
+++ b/src/components/patternfly-wrappers/fileupload.tsx
@@ -1,10 +1,9 @@
-import * as React from 'react';
 import { t } from '@lingui/macro';
-
 import {
-  FileUpload as PFFileUpload,
   FileUploadProps,
+  FileUpload as PFFileUpload,
 } from '@patternfly/react-core';
+import * as React from 'react';
 
 export class FileUpload extends React.Component<FileUploadProps> {
   render() {

--- a/src/components/patternfly-wrappers/link-tabs.tsx
+++ b/src/components/patternfly-wrappers/link-tabs.tsx
@@ -1,6 +1,5 @@
-import * as React from 'react';
 import cx from 'classnames';
-
+import * as React from 'react';
 import { Link } from 'react-router-dom';
 
 export interface IProps {

--- a/src/components/patternfly-wrappers/main.tsx
+++ b/src/components/patternfly-wrappers/main.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import cx from 'classnames';
+import * as React from 'react';
 
 interface IProps extends React.HTMLProps<HTMLElement> {
   children: React.ReactNode;

--- a/src/components/patternfly-wrappers/pagination.tsx
+++ b/src/components/patternfly-wrappers/pagination.tsx
@@ -1,12 +1,10 @@
-import * as React from 'react';
 import { t } from '@lingui/macro';
-
 import {
   Pagination as PaginationPF,
   PaginationVariant,
   ToggleTemplate,
 } from '@patternfly/react-core';
-
+import * as React from 'react';
 import { Constants } from 'src/constants';
 import { ParamHelper } from 'src/utilities/param-helper';
 

--- a/src/components/patternfly-wrappers/sort.tsx
+++ b/src/components/patternfly-wrappers/sort.tsx
@@ -1,16 +1,14 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import './sort.scss';
-
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import {
-  SortAmountDownIcon,
-  SortAmountUpIcon,
   SortAlphaDownIcon,
   SortAlphaUpIcon,
+  SortAmountDownIcon,
+  SortAmountUpIcon,
 } from '@patternfly/react-icons';
-
+import * as React from 'react';
 import { ParamHelper } from 'src/utilities/param-helper';
+import './sort.scss';
 
 class SortFieldType {
   id: string;

--- a/src/components/patternfly-wrappers/stateful-dropdown.tsx
+++ b/src/components/patternfly-wrappers/stateful-dropdown.tsx
@@ -1,12 +1,11 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-
 import {
   Dropdown,
   DropdownPosition,
-  KebabToggle,
   DropdownToggle,
+  KebabToggle,
 } from '@patternfly/react-core';
+import * as React from 'react';
 
 interface IProps {
   /** List of patternfly DropdownItem components */

--- a/src/components/patternfly-wrappers/tabs.tsx
+++ b/src/components/patternfly-wrappers/tabs.tsx
@@ -1,7 +1,5 @@
+import { Tabs as PFTabs, Tab, TabTitleText } from '@patternfly/react-core';
 import * as React from 'react';
-
-import { Tab, Tabs as PFTabs, TabTitleText } from '@patternfly/react-core';
-
 import { ParamHelper } from 'src/utilities/param-helper';
 
 export class TabsType {

--- a/src/components/patternfly-wrappers/tooltip.tsx
+++ b/src/components/patternfly-wrappers/tooltip.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { Tooltip as PFTooltip } from '@patternfly/react-core';
+import * as React from 'react';
 
 interface IProps {
   children: React.ReactNode;

--- a/src/components/patternfly-wrappers/wizard-modal.tsx
+++ b/src/components/patternfly-wrappers/wizard-modal.tsx
@@ -1,11 +1,11 @@
 import { t } from '@lingui/macro';
-import React from 'react';
 import {
   Modal,
   ModalVariant,
   Wizard as PFWizard,
   WizardStep,
 } from '@patternfly/react-core';
+import React from 'react';
 
 interface Props {
   steps: WizardStep[];

--- a/src/components/patternfly-wrappers/write-only-field.tsx
+++ b/src/components/patternfly-wrappers/write-only-field.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
 import { Button, InputGroup, TextInput } from '@patternfly/react-core';
+import * as React from 'react';
 
 interface IProps {
   /** Specify if the value is set on the backend already */

--- a/src/components/rbac/delete-group-modal.tsx
+++ b/src/components/rbac/delete-group-modal.tsx
@@ -1,8 +1,8 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
+import { Alert, List, ListItem, Spinner } from '@patternfly/react-core';
 import * as React from 'react';
-import { List, ListItem, Spinner, Alert } from '@patternfly/react-core';
-import { DeleteModal } from 'src/components/delete-modal/delete-modal';
 import { UserType } from 'src/api';
+import { DeleteModal } from 'src/components/delete-modal/delete-modal';
 
 interface IProps {
   count?: number;

--- a/src/components/rbac/delete-user-modal.tsx
+++ b/src/components/rbac/delete-user-modal.tsx
@@ -1,10 +1,11 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import * as React from 'react';
-import { UserType, UserAPI } from 'src/api';
-import { mapErrorMessages } from 'src/utilities';
-import { AppContext } from 'src/loaders/app-context';
+import { UserAPI, UserType } from 'src/api';
 import { DeleteModal } from 'src/components/delete-modal/delete-modal';
+import { AppContext } from 'src/loaders/app-context';
+import { mapErrorMessages } from 'src/utilities';
 import { errorMessage } from 'src/utilities';
+
 interface IState {
   isWaitingForResponse: boolean;
 }

--- a/src/components/rbac/group-modal.tsx
+++ b/src/components/rbac/group-modal.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
 import {
   Button,
   Form,
@@ -8,6 +7,7 @@ import {
   ModalVariant,
   TextInput,
 } from '@patternfly/react-core';
+import * as React from 'react';
 import { ErrorMessagesType } from 'src/utilities';
 
 interface IProps {

--- a/src/components/rbac/group-role-permissions.tsx
+++ b/src/components/rbac/group-role-permissions.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
-
 import { RoleAPI } from 'src/api';
-import { PermissionCategories, LoadingPageSpinner } from 'src/components';
+import { LoadingPageSpinner, PermissionCategories } from 'src/components';
 import { translateLockedRolesDescription } from 'src/utilities';
 
 interface IProps {

--- a/src/components/rbac/owners-tab.tsx
+++ b/src/components/rbac/owners-tab.tsx
@@ -1,7 +1,4 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
-import { Link } from 'react-router-dom';
-import { sortBy } from 'lodash';
+import { Trans, t } from '@lingui/macro';
 import {
   Button,
   DropdownItem,
@@ -9,7 +6,9 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
-
+import { sortBy } from 'lodash';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { GroupType, RoleType } from 'src/api';
 import {
   DeleteModal,

--- a/src/components/rbac/permission-categories.tsx
+++ b/src/components/rbac/permission-categories.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
 import { t } from '@lingui/macro';
-import { AppContext } from 'src/loaders/app-context';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import * as React from 'react';
 import { ModelPermissionsType } from 'src/api';
 import { PermissionChipSelector } from 'src/components';
 import { Constants } from 'src/constants';
-import { Flex, FlexItem } from '@patternfly/react-core';
+import { AppContext } from 'src/loaders/app-context';
 
 interface IProps {
   permissions: string[];

--- a/src/components/rbac/permission-chip-selector.tsx
+++ b/src/components/rbac/permission-chip-selector.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
 import {
   Label,
   LabelGroup,
@@ -7,6 +6,7 @@ import {
   SelectOption,
   SelectVariant,
 } from '@patternfly/react-core';
+import * as React from 'react';
 import { AppContext } from 'src/loaders/app-context';
 
 interface IProps {

--- a/src/components/rbac/preview-roles.tsx
+++ b/src/components/rbac/preview-roles.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@lingui/macro';
+import { Divider, Flex, FlexItem, Label } from '@patternfly/react-core';
 import React from 'react';
-import { Flex, FlexItem, Label, Divider } from '@patternfly/react-core';
-import { RoleType, GroupType } from 'src/api';
+import { GroupType, RoleType } from 'src/api';
 import { Tooltip } from 'src/components';
 import { useContext } from 'src/loaders/app-context';
 import { translateLockedRolesDescription } from 'src/utilities';

--- a/src/components/rbac/role-form.tsx
+++ b/src/components/rbac/role-form.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
 import {
   ActionGroup,
   Button,
@@ -11,6 +10,7 @@ import {
   TextInput,
   Title,
 } from '@patternfly/react-core';
+import * as React from 'react';
 import { PermissionCategories } from 'src/components';
 
 interface IState {

--- a/src/components/rbac/role-header.tsx
+++ b/src/components/rbac/role-header.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
 import { Trans } from '@lingui/macro';
-import { BaseHeader, Breadcrumbs, BreadcrumbType } from 'src/components';
+import * as React from 'react';
+import { BaseHeader, BreadcrumbType, Breadcrumbs } from 'src/components';
 
 interface IProps {
   title: string;

--- a/src/components/rbac/role-list-table.tsx
+++ b/src/components/rbac/role-list-table.tsx
@@ -1,16 +1,14 @@
 import { t } from '@lingui/macro';
-
-import React, { useState } from 'react';
-
-import { SortTable } from 'src/components';
-
 import {
+  ExpandableRowContent,
   TableComposable,
-  Tr,
   Tbody,
   Td,
-  ExpandableRowContent,
+  Tr,
 } from '@patternfly/react-table';
+import React, { useState } from 'react';
+import { SortTable } from 'src/components';
+
 interface Props {
   params?: object;
   updateParams?: (params) => void;

--- a/src/components/rbac/select-group.tsx
+++ b/src/components/rbac/select-group.tsx
@@ -1,16 +1,16 @@
-import { t, Trans } from '@lingui/macro';
-import React, { useEffect, useState } from 'react';
+import { Trans, t } from '@lingui/macro';
 import { Flex, FlexItem, Label } from '@patternfly/react-core';
-import { GroupType, GroupAPI } from 'src/api';
+import React, { useEffect, useState } from 'react';
+import { GroupAPI, GroupType } from 'src/api';
 import {
-  CompoundFilter,
-  RoleListTable,
-  Pagination,
   AppliedFilters,
-  LoadingPageSpinner,
-  RadioRow,
+  CompoundFilter,
   EmptyStateFilter,
   EmptyStateNoData,
+  LoadingPageSpinner,
+  Pagination,
+  RadioRow,
+  RoleListTable,
 } from 'src/components';
 import { filterIsSet } from 'src/utilities';
 

--- a/src/components/rbac/select-roles.tsx
+++ b/src/components/rbac/select-roles.tsx
@@ -1,16 +1,16 @@
-import { t, Trans } from '@lingui/macro';
-import React, { useEffect, useState } from 'react';
+import { Trans, t } from '@lingui/macro';
 import { Flex, FlexItem, Label } from '@patternfly/react-core';
-import { RoleType, RoleAPI } from 'src/api';
+import React, { useEffect, useState } from 'react';
+import { RoleAPI, RoleType } from 'src/api';
 import {
-  CompoundFilter,
-  RoleListTable,
-  Pagination,
   AppliedFilters,
-  LoadingPageSpinner,
   CheckboxRow,
+  CompoundFilter,
   EmptyStateFilter,
   EmptyStateNoData,
+  LoadingPageSpinner,
+  Pagination,
+  RoleListTable,
 } from 'src/components';
 import { filterIsSet, translateLockedRolesDescription } from 'src/utilities';
 

--- a/src/components/rbac/user-form-page.tsx
+++ b/src/components/rbac/user-form-page.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
-
+import { UserType } from 'src/api';
 import {
   BaseHeader,
-  Main,
-  Breadcrumbs,
   BreadcrumbType,
+  Breadcrumbs,
+  Main,
   UserForm,
 } from 'src/components';
-import { UserType } from 'src/api';
 import { ErrorMessagesType } from 'src/utilities';
 
 interface IProps {

--- a/src/components/rbac/user-form.tsx
+++ b/src/components/rbac/user-form.tsx
@@ -1,23 +1,21 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-
 import {
-  FormGroup,
-  TextInput,
   ActionGroup,
-  Button,
-  Label,
-  Tooltip,
-  Switch,
   Alert,
+  Button,
+  FormGroup,
+  Label,
+  Switch,
+  TextInput,
   TextInputTypes,
+  Tooltip,
 } from '@patternfly/react-core';
-
-import { AlertType, APISearchTypeAhead, HelperText } from 'src/components';
+import * as React from 'react';
+import { GroupAPI, UserType } from 'src/api';
+import { APISearchTypeAhead, AlertType, HelperText } from 'src/components';
 import { DataForm } from 'src/components/shared/data-form';
-import { UserType, GroupAPI } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
-import { errorMessage, ErrorMessagesType } from 'src/utilities';
+import { ErrorMessagesType, errorMessage } from 'src/utilities';
 
 interface IProps {
   /** User to edit */

--- a/src/components/render-plugin-doc/render-plugin-doc.tsx
+++ b/src/components/render-plugin-doc/render-plugin-doc.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import './render-plugin-doc.scss';
-
 import {
   PluginContentType,
   PluginDoc,
   PluginOption,
   ReturnedValue,
 } from 'src/api';
+import './render-plugin-doc.scss';
 
 // Documentation for module doc string spec
 // https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -1,7 +1,5 @@
-import { t } from '@lingui/macro';
 import { i18n } from '@lingui/core';
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { t } from '@lingui/macro';
 import {
   Flex,
   FlexItem,
@@ -10,9 +8,10 @@ import {
   Select,
   SelectOption,
 } from '@patternfly/react-core';
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Constants } from 'src/constants';
 import { Paths, formatPath } from 'src/paths';
-
 import './repo-selector.scss';
 
 interface IProps {

--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -1,10 +1,9 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-
-import { DateComponent, EmptyStateNoData, SortTable, ClipboardCopy } from '..';
+import { CollectionCount } from 'src/components';
 import { Constants } from 'src/constants';
 import { getRepoUrl } from 'src/utilities';
-import { CollectionCount } from 'src/components';
+import { ClipboardCopy, DateComponent, EmptyStateNoData, SortTable } from '..';
 
 interface IProps {
   repositories: {

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -1,34 +1,28 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
-import * as FileSaver from 'file-saver';
-
+import { Trans, t } from '@lingui/macro';
 import {
-  Form,
-  FormGroup,
-  TextInput,
-  Flex,
-  FlexItem,
   Button,
-  Modal,
   Checkbox,
   ExpandableSection,
+  Flex,
+  FlexItem,
+  Form,
+  FormGroup,
+  Modal,
   Switch,
+  TextInput,
 } from '@patternfly/react-core';
-
-import { WriteOnlyField, HelperText, FileUpload } from 'src/components';
-
-import { AppContext } from 'src/loaders/app-context';
-
 import {
   DownloadIcon,
-  ExclamationTriangleIcon,
   ExclamationCircleIcon,
+  ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
-
+import * as FileSaver from 'file-saver';
+import * as React from 'react';
 import { RemoteType, WriteOnlyFieldType } from 'src/api';
+import { FileUpload, HelperText, WriteOnlyField } from 'src/components';
 import { Constants } from 'src/constants';
-import { isFieldSet, isWriteOnly, ErrorMessagesType } from 'src/utilities';
-
+import { AppContext } from 'src/loaders/app-context';
+import { ErrorMessagesType, isFieldSet, isWriteOnly } from 'src/utilities';
 import { validateURLHelper } from 'src/utilities';
 
 interface IProps {

--- a/src/components/repositories/remote-repository-table.tsx
+++ b/src/components/repositories/remote-repository-table.tsx
@@ -1,14 +1,12 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-
 import { Button, DropdownItem, Tooltip } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-
-import { AppContext } from 'src/loaders/app-context';
-import { RemoteType, UserType, PulpStatus } from 'src/api';
-import { DateComponent, SortTable, ListItemActions } from 'src/components';
+import * as React from 'react';
+import { PulpStatus, RemoteType, UserType } from 'src/api';
+import { DateComponent, ListItemActions, SortTable } from 'src/components';
 import { Constants } from 'src/constants';
-import { lastSynced, lastSyncStatus } from 'src/utilities';
+import { AppContext } from 'src/loaders/app-context';
+import { lastSyncStatus, lastSynced } from 'src/utilities';
 
 interface IProps {
   remotes: RemoteType[];

--- a/src/components/sha-label/sha-label.tsx
+++ b/src/components/sha-label/sha-label.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { Label, Tooltip } from '@patternfly/react-core';
+import * as React from 'react';
 import { truncateSha } from 'src/utilities';
 
 interface IProps {

--- a/src/components/shared/data-form.tsx
+++ b/src/components/shared/data-form.tsx
@@ -1,11 +1,10 @@
-import * as React from 'react';
 import {
   Form,
   FormGroup,
   TextInput,
   TextInputTypes,
 } from '@patternfly/react-core';
-
+import * as React from 'react';
 import { ErrorMessagesType } from 'src/utilities';
 
 interface IProps {

--- a/src/components/shared/login-link.tsx
+++ b/src/components/shared/login-link.tsx
@@ -1,8 +1,8 @@
+import { t } from '@lingui/macro';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { t } from '@lingui/macro';
-import { Paths, formatPath } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
 
 interface IProps {
   button?: boolean;

--- a/src/components/signing/sign-all-certificates-modal.tsx
+++ b/src/components/signing/sign-all-certificates-modal.tsx
@@ -1,4 +1,4 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import {
   Button,
   ButtonVariant,

--- a/src/components/signing/sign-single-certificate-modal.tsx
+++ b/src/components/signing/sign-single-certificate-modal.tsx
@@ -1,4 +1,4 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import {
   Button,
   ButtonVariant,

--- a/src/components/signing/signature-badge.tsx
+++ b/src/components/signing/signature-badge.tsx
@@ -1,10 +1,10 @@
 import { t } from '@lingui/macro';
 import { Label, LabelProps } from '@patternfly/react-core';
-import React, { FC } from 'react';
 import {
   CheckCircleIcon,
   ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
+import React, { FC } from 'react';
 
 interface Props extends LabelProps {
   signState: 'signed' | 'unsigned';

--- a/src/components/sort-table/sort-table.tsx
+++ b/src/components/sort-table/sort-table.tsx
@@ -1,10 +1,9 @@
-import * as React from 'react';
-
 import {
-  LongArrowAltUpIcon,
-  LongArrowAltDownIcon,
   ArrowsAltVIcon,
+  LongArrowAltDownIcon,
+  LongArrowAltUpIcon,
 } from '@patternfly/react-icons';
+import * as React from 'react';
 import { ParamHelper } from 'src/utilities';
 import './sort-table.scss';
 

--- a/src/components/status/status-indicator.tsx
+++ b/src/components/status/status-indicator.tsx
@@ -1,15 +1,13 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-
 import { Label, LabelProps } from '@patternfly/react-core';
 import {
-  OutlinedClockIcon,
-  ExclamationIcon,
-  SyncAltIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
+  ExclamationIcon,
+  OutlinedClockIcon,
+  SyncAltIcon,
 } from '@patternfly/react-icons';
-
+import * as React from 'react';
 import { PulpStatus } from 'src/api';
 
 interface IProps {

--- a/src/components/tag-label/tag-label.tsx
+++ b/src/components/tag-label/tag-label.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
 import { Label } from '@patternfly/react-core';
 import { TagIcon } from '@patternfly/react-icons';
+import * as React from 'react';
 
 interface IProps {
   tag: string;

--- a/src/components/tags/tag.tsx
+++ b/src/components/tags/tag.tsx
@@ -1,7 +1,6 @@
+import { Label } from '@patternfly/react-core';
 import * as React from 'react';
 import './tag.scss';
-
-import { Label } from '@patternfly/react-core';
 
 interface IProps {
   /** Value to display in the tag */

--- a/src/components/typeahead/typeahead.tsx
+++ b/src/components/typeahead/typeahead.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import * as React from 'react';
 
 interface IProps {
   results: { name: string; id: number | string }[];

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -1,4 +1,4 @@
-import { t, defineMessage } from '@lingui/macro';
+import { defineMessage, t } from '@lingui/macro';
 
 export class Constants {
   static readonly SEARCH_VIEW_TYPE_LOCAL_KEY = 'search_view_type';

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -1,9 +1,28 @@
 import { t } from '@lingui/macro';
+import {
+  Button,
+  ButtonVariant,
+  DropdownItem,
+  Label,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import {
+  CheckCircleIcon,
+  DownloadIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+} from '@patternfly/react-icons';
 import * as React from 'react';
-import './certification-dashboard.scss';
-
-import { RouteProps, withRouter } from 'src/utilities';
 import { Link } from 'react-router-dom';
+import {
+  CertificateUploadAPI,
+  CollectionAPI,
+  CollectionVersion,
+  CollectionVersionAPI,
+  Repositories,
+} from 'src/api';
 import {
   BaseHeader,
   DateComponent,
@@ -14,51 +33,29 @@ import {
   Main,
 } from 'src/components';
 import {
-  Toolbar,
-  ToolbarGroup,
-  ToolbarItem,
-  Button,
-  DropdownItem,
-  Label,
-  ButtonVariant,
-} from '@patternfly/react-core';
-
+  AlertList,
+  AlertType,
+  AppliedFilters,
+  CompoundFilter,
+  LoadingPageSpinner,
+  LoadingPageWithHeader,
+  Pagination,
+  SortTable,
+  UploadSingCertificateModal,
+  closeAlertMixin,
+} from 'src/components';
+import { Constants } from 'src/constants';
+import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
 import {
-  ExclamationTriangleIcon,
-  ExclamationCircleIcon,
-  CheckCircleIcon,
-  DownloadIcon,
-} from '@patternfly/react-icons';
-
-import {
-  CollectionVersionAPI,
-  CollectionVersion,
-  CertificateUploadAPI,
-  Repositories,
-  CollectionAPI,
-} from 'src/api';
-import {
+  ParamHelper,
   errorMessage,
   filterIsSet,
-  ParamHelper,
   parsePulpIDFromURL,
   waitForTask,
 } from 'src/utilities';
-import {
-  LoadingPageWithHeader,
-  CompoundFilter,
-  LoadingPageSpinner,
-  AppliedFilters,
-  Pagination,
-  AlertList,
-  closeAlertMixin,
-  AlertType,
-  SortTable,
-  UploadSingCertificateModal,
-} from 'src/components';
-import { Paths, formatPath } from 'src/paths';
-import { Constants } from 'src/constants';
-import { AppContext } from 'src/loaders/app-context';
+import './certification-dashboard.scss';
 
 interface IState {
   params: {

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -1,4 +1,4 @@
-import { CollectionDetailType, CollectionAPI } from 'src/api';
+import { CollectionAPI, CollectionDetailType } from 'src/api';
 import { AlertType } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -1,18 +1,16 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-
-import { RouteProps, withRouter } from 'src/utilities';
-
 import {
-  CollectionHeader,
   CollectionContentList,
+  CollectionHeader,
   LoadingPageWithHeader,
   Main,
 } from 'src/components';
-import { loadCollection, IBaseCollectionState } from './base';
-import { ParamHelper } from 'src/utilities/param-helper';
-import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { IBaseCollectionState, loadCollection } from './base';
 
 // renders list of contents in a collection
 class CollectionContent extends React.Component<

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -1,31 +1,28 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import { RouteProps, withRouter } from 'src/utilities';
-
 import {
   CollectionAPI,
   CollectionDetailType,
   CollectionUsedByDependencies,
-  CollectionVersionAPI,
   CollectionVersion,
+  CollectionVersionAPI,
 } from 'src/api';
 import {
-  CollectionHeader,
-  LoadingPageWithHeader,
-  Main,
+  AlertList,
+  AlertType,
   CollectionDependenciesList,
+  CollectionHeader,
   CollectionUsedbyDependenciesList,
   EmptyStateNoData,
-  AlertType,
-  AlertList,
+  LoadingPageWithHeader,
+  Main,
   closeAlertMixin,
 } from 'src/components';
-
-import { loadCollection } from './base';
-import { errorMessage, filterIsSet, ParamHelper } from 'src/utilities';
-import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
-
+import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ParamHelper, errorMessage, filterIsSet } from 'src/utilities';
+import { loadCollection } from './base';
 import './collection-dependencies.scss';
 
 interface IState {

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -1,21 +1,18 @@
-import * as React from 'react';
-
-import { RouteProps, withRouter } from 'src/utilities';
-
 import { isEqual } from 'lodash';
-
+import * as React from 'react';
 import {
+  AlertList,
   CollectionHeader,
   CollectionInfo,
   LoadingPageWithHeader,
   Main,
-  AlertList,
   closeAlertMixin,
 } from 'src/components';
-import { loadCollection, IBaseCollectionState } from './base';
-import { ParamHelper } from 'src/utilities/param-helper';
-import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { IBaseCollectionState, loadCollection } from './base';
 
 // renders collection level information
 class CollectionDetail extends React.Component<

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -1,13 +1,12 @@
 import { t } from '@lingui/macro';
+import { Alert } from '@patternfly/react-core';
+import {
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+} from '@patternfly/react-icons';
 import * as React from 'react';
-import './collection-detail.scss';
-
-import { RouteProps, withRouter } from 'src/utilities';
 import { Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
-
-import { Alert } from '@patternfly/react-core';
-
 import {
   CollectionHeader,
   EmptyStateCustom,
@@ -16,16 +15,12 @@ import {
   RenderPluginDoc,
   TableOfContents,
 } from 'src/components';
-
-import { loadCollection, IBaseCollectionState } from './base';
-import { ParamHelper, sanitizeDocsUrls } from 'src/utilities';
-import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
-
-import {
-  ExclamationTriangleIcon,
-  ExclamationCircleIcon,
-} from '@patternfly/react-icons';
+import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ParamHelper, sanitizeDocsUrls } from 'src/utilities';
+import { IBaseCollectionState, loadCollection } from './base';
+import './collection-detail.scss';
 
 // renders markdown files in collection docs/ directory
 class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -1,20 +1,17 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-
-import { RouteProps, withRouter } from 'src/utilities';
-
 import { ImportAPI, ImportDetailType, ImportListType } from 'src/api';
 import {
   CollectionHeader,
-  LoadingPageWithHeader,
   ImportConsole,
+  LoadingPageWithHeader,
   Main,
 } from 'src/components';
-
-import { loadCollection, IBaseCollectionState } from './base';
-import { ParamHelper } from 'src/utilities/param-helper';
-import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { IBaseCollectionState, loadCollection } from './base';
 
 interface IState extends IBaseCollectionState {
   loadingImports: boolean;

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -1,28 +1,27 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
+import { ActionGroup, Button, Form, Spinner } from '@patternfly/react-core';
 import * as React from 'react';
 import { Navigate } from 'react-router-dom';
-import { RouteProps, withRouter } from 'src/utilities';
-import { Form, ActionGroup, Button, Spinner } from '@patternfly/react-core';
-
 import { MyNamespaceAPI, NamespaceLinkType, NamespaceType } from 'src/api';
 import {
-  PartnerHeader,
-  NamespaceForm,
-  ResourcesForm,
   AlertList,
-  closeAlertMixin,
   AlertType,
-  Main,
   EmptyStateUnauthorized,
   LoadingPageSpinner,
+  Main,
+  NamespaceForm,
+  PartnerHeader,
+  ResourcesForm,
+  closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
+import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
 import {
   ErrorMessagesType,
   ParamHelper,
-  mapErrorMessages,
   errorMessage,
+  mapErrorMessages,
 } from 'src/utilities';
 
 interface IState {

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -1,16 +1,12 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
+import { Button, DropdownItem } from '@patternfly/react-core';
 import * as React from 'react';
-
 import { Link, Navigate } from 'react-router-dom';
-import { RouteProps } from 'src/utilities';
-
 import {
   ContainerRepositoryType,
   ExecutionEnvironmentAPI,
   ExecutionEnvironmentRemoteAPI,
 } from 'src/api';
-import { formatPath, formatEEPath, Paths } from 'src/paths';
-import { Button, DropdownItem } from '@patternfly/react-core';
 import {
   AlertList,
   AlertType,
@@ -23,15 +19,16 @@ import {
   StatefulDropdown,
   closeAlertMixin,
 } from 'src/components';
+import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatEEPath, formatPath } from 'src/paths';
+import { RouteProps } from 'src/utilities';
 import {
   ParamHelper,
-  parsePulpIDFromURL,
-  waitForTask,
   RepoSigningUtils,
   canSignEE,
+  parsePulpIDFromURL,
+  waitForTask,
 } from 'src/utilities';
-
-import { AppContext } from 'src/loaders/app-context';
 
 interface IState {
   publishToController: { digest?: string; image: string; tag?: string };

--- a/src/containers/execution-environment-detail/execution_environment_detail.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail.tsx
@@ -90,17 +90,19 @@ class ExecutionEnvironmentDetail extends React.Component<
             <Card>
               <CardBody>
                 <Title headingLevel='h2' size='lg'>
-                  {!this.state.markdownEditing && this.state.readme && canEdit && (
-                    <Button
-                      className={'hub-c-button-edit'}
-                      variant={'primary'}
-                      onClick={() => {
-                        this.setState({ markdownEditing: true });
-                      }}
-                    >
-                      {t`Edit`}
-                    </Button>
-                  )}
+                  {!this.state.markdownEditing &&
+                    this.state.readme &&
+                    canEdit && (
+                      <Button
+                        className={'hub-c-button-edit'}
+                        variant={'primary'}
+                        onClick={() => {
+                          this.setState({ markdownEditing: true });
+                        }}
+                      >
+                        {t`Edit`}
+                      </Button>
+                    )}
                 </Title>
                 {!this.state.markdownEditing && !this.state.readme ? (
                   <EmptyStateNoData

--- a/src/containers/execution-environment-detail/execution_environment_detail.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail.tsx
@@ -1,26 +1,26 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import { withRouter } from 'src/utilities';
 import {
-  EmptyStateNoData,
-  MarkdownEditor,
-  ClipboardCopy,
-} from 'src/components';
-import {
-  FlexItem,
-  Flex,
-  Title,
   Button,
   Card,
   CardBody,
+  Flex,
+  FlexItem,
+  Title,
 } from '@patternfly/react-core';
+import * as React from 'react';
+import { ExecutionEnvironmentAPI, GroupObjectPermissionType } from 'src/api';
 import {
+  ClipboardCopy,
+  EmptyStateNoData,
+  MarkdownEditor,
+} from 'src/components';
+import { withRouter } from 'src/utilities';
+import { getContainersURL } from 'src/utilities';
+import {
+  IDetailSharedProps,
   withContainerParamFix,
   withContainerRepo,
-  IDetailSharedProps,
 } from './base';
-import { ExecutionEnvironmentAPI, GroupObjectPermissionType } from 'src/api';
-import { getContainersURL } from 'src/utilities';
 import './execution-environment-detail.scss';
 
 interface IState {

--- a/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
@@ -1,24 +1,23 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { withRouter } from 'src/utilities';
+import { ActivitiesAPI } from 'src/api';
 import {
-  SortTable,
+  DateComponent,
   EmptyStateNoData,
   ShaLabel,
+  SortTable,
   TagLabel,
-  DateComponent,
 } from 'src/components';
-import { FlexItem, Flex, Button } from '@patternfly/react-core';
-import { formatEEPath, Paths } from 'src/paths';
-import { ActivitiesAPI } from 'src/api';
-import './execution-environment-detail.scss';
-
+import { Paths, formatEEPath } from 'src/paths';
+import { withRouter } from 'src/utilities';
 import {
+  IDetailSharedProps,
   withContainerParamFix,
   withContainerRepo,
-  IDetailSharedProps,
 } from './base';
+import './execution-environment-detail.scss';
 
 interface IState {
   loading: boolean;

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -1,23 +1,4 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
-import './execution-environment-detail.scss';
-import { errorMessage } from 'src/utilities';
-
-import { sum } from 'lodash';
-import { ExecutionEnvironmentAPI, ContainerManifestType } from 'src/api';
-import { formatEEPath, Paths } from 'src/paths';
-import {
-  ParamHelper,
-  filterIsSet,
-  getContainersURL,
-  getHumanSize,
-  waitForTask,
-} from 'src/utilities';
-import { AppContext } from 'src/loaders/app-context';
-
-import { Link } from 'react-router-dom';
-import { withRouter } from 'src/utilities';
-
+import { Trans, t } from '@lingui/macro';
 import {
   Button,
   Checkbox,
@@ -30,30 +11,44 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
-
+import { sum } from 'lodash';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { ContainerManifestType, ExecutionEnvironmentAPI } from 'src/api';
 import {
   AppliedFilters,
+  ClipboardCopy,
   CompoundFilter,
-  Pagination,
-  SortTable,
-  EmptyStateNoData,
+  DateComponent,
+  DeleteModal,
   EmptyStateFilter,
+  EmptyStateNoData,
+  ListItemActions,
+  LoadingPageSpinner,
+  Pagination,
+  PublishToControllerModal,
   ShaLabel,
+  SortTable,
   TagLabel,
   TagManifestModal,
-  PublishToControllerModal,
-  DateComponent,
-  ClipboardCopy,
-  DeleteModal,
-  LoadingPageSpinner,
-  ListItemActions,
 } from 'src/components';
-
+import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatEEPath } from 'src/paths';
+import { errorMessage } from 'src/utilities';
 import {
+  ParamHelper,
+  filterIsSet,
+  getContainersURL,
+  getHumanSize,
+  waitForTask,
+} from 'src/utilities';
+import { withRouter } from 'src/utilities';
+import {
+  IDetailSharedProps,
   withContainerParamFix,
   withContainerRepo,
-  IDetailSharedProps,
 } from './base';
+import './execution-environment-detail.scss';
 import './execution-environment-detail_images.scss';
 
 interface IState {

--- a/src/containers/execution-environment-detail/execution_environment_detail_owners.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_owners.tsx
@@ -1,23 +1,22 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import { withRouter } from 'src/utilities';
 import {
   ExecutionEnvironmentNamespaceAPI,
-  GroupType,
   GroupAPI,
+  GroupType,
   RoleType,
 } from 'src/api';
 import { OwnersTab } from 'src/components';
-import { formatEEPath, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatEEPath } from 'src/paths';
+import { withRouter } from 'src/utilities';
 import { ParamHelper, errorMessage } from 'src/utilities';
-import './execution-environment-detail.scss';
-
 import {
+  IDetailSharedProps,
   withContainerParamFix,
   withContainerRepo,
-  IDetailSharedProps,
 } from './base';
+import './execution-environment-detail.scss';
 
 interface IState {
   name: string;

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -1,9 +1,4 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
-import './execution-environment.scss';
-
-import { RouteProps, withRouter } from 'src/utilities';
-import { Link } from 'react-router-dom';
+import { Trans, t } from '@lingui/macro';
 import {
   Button,
   DropdownItem,
@@ -13,12 +8,14 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
 import {
   ExecutionEnvironmentAPI,
   ExecutionEnvironmentRemoteAPI,
   ExecutionEnvironmentType,
 } from 'src/api';
-import { filterIsSet, parsePulpIDFromURL, ParamHelper } from 'src/utilities';
 import {
   AlertList,
   AlertType,
@@ -29,6 +26,8 @@ import {
   DeleteExecutionEnvironmentModal,
   EmptyStateFilter,
   EmptyStateNoData,
+  EmptyStateUnauthorized,
+  ListItemActions,
   LoadingPageSpinner,
   Main,
   Pagination,
@@ -37,12 +36,12 @@ import {
   SortTable,
   Tooltip,
   closeAlertMixin,
-  EmptyStateUnauthorized,
-  ListItemActions,
 } from 'src/components';
-import { formatPath, formatEEPath, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { Paths, formatEEPath, formatPath } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ParamHelper, filterIsSet, parsePulpIDFromURL } from 'src/utilities';
+import './execution-environment.scss';
 
 interface IState {
   alerts: AlertType[];

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -1,36 +1,36 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
+import {
+  Card,
+  CardBody,
+  CardTitle,
+  ClipboardCopyButton,
+  DataList,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+  Flex,
+  FlexItem,
+  LabelGroup,
+  Title,
+} from '@patternfly/react-core';
+import { sum } from 'lodash';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { RouteProps, withRouter } from 'src/utilities';
+import { ExecutionEnvironmentAPI } from 'src/api';
 import {
   BaseHeader,
   Breadcrumbs,
   LoadingPageWithHeader,
   Main,
-  TagLabel,
   ShaLabel,
+  TagLabel,
 } from 'src/components';
-import {
-  DataList,
-  DataListItem,
-  DataListItemRow,
-  DataListItemCells,
-  DataListCell,
-  Flex,
-  FlexItem,
-  LabelGroup,
-  Title,
-  ClipboardCopyButton,
-  Card,
-  CardBody,
-  CardTitle,
-} from '@patternfly/react-core';
-import { sum } from 'lodash';
 import { Paths, formatEEPath, formatPath } from 'src/paths';
-import { ExecutionEnvironmentAPI } from 'src/api';
+import { RouteProps, withRouter } from 'src/utilities';
 import { getHumanSize } from 'src/utilities';
-import './execution-environment-manifest.scss';
 import { withContainerParamFix } from '../execution-environment-detail/base';
+import './execution-environment-manifest.scss';
 
 interface IState {
   container: { name: string };

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -1,9 +1,4 @@
-import * as React from 'react';
-import { t, Trans } from '@lingui/macro';
-import { errorMessage } from 'src/utilities';
-
-import { RouteProps, withRouter } from 'src/utilities';
-import { Link } from 'react-router-dom';
+import { Trans, t } from '@lingui/macro';
 import {
   Button,
   DropdownItem,
@@ -13,16 +8,9 @@ import {
   ToolbarItem,
   Tooltip,
 } from '@patternfly/react-core';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
 import { ExecutionEnvironmentRegistryAPI, RemoteType } from 'src/api';
-import {
-  ParamHelper,
-  filterIsSet,
-  lastSyncStatus,
-  lastSynced,
-  mapErrorMessages,
-  parsePulpIDFromURL,
-  ErrorMessagesType,
-} from 'src/utilities';
 import {
   AlertList,
   AlertType,
@@ -33,18 +21,28 @@ import {
   DeleteModal,
   EmptyStateFilter,
   EmptyStateNoData,
+  EmptyStateUnauthorized,
+  ListItemActions,
   LoadingPageSpinner,
   Main,
   Pagination,
   RemoteForm,
   SortTable,
   closeAlertMixin,
-  EmptyStateUnauthorized,
-  ListItemActions,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-
 import { Paths, formatPath } from 'src/paths';
+import { errorMessage } from 'src/utilities';
+import { RouteProps, withRouter } from 'src/utilities';
+import {
+  ErrorMessagesType,
+  ParamHelper,
+  filterIsSet,
+  lastSyncStatus,
+  lastSynced,
+  mapErrorMessages,
+  parsePulpIDFromURL,
+} from 'src/utilities';
 
 interface IState {
   alerts: AlertType[];

--- a/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
+++ b/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
@@ -1,37 +1,4 @@
-import { t, Trans } from '@lingui/macro';
-
-import React, { useEffect, useState } from 'react';
-
-import {
-  AppliedFilters,
-  CompoundFilter,
-  DeleteModal,
-  EmptyStateNoData,
-  PermissionCategories,
-  LoadingPageWithHeader,
-  Pagination,
-  RoleListTable,
-  SelectRoles,
-  PreviewRoles,
-  ExpandableRow,
-  WizardModal,
-  EmptyStateFilter,
-  ListItemActions,
-} from 'src/components';
-import {
-  GroupRoleAPI,
-  GroupObjectPermissionType,
-  GroupRoleType,
-  RoleType,
-} from 'src/api';
-
-import {
-  errorMessage,
-  filterIsSet,
-  ParamHelper,
-  parsePulpIDFromURL,
-  translateLockedRolesDescription,
-} from 'src/utilities';
+import { Trans, t } from '@lingui/macro';
 import {
   Button,
   DropdownItem,
@@ -40,9 +7,37 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-
+import React, { useEffect, useState } from 'react';
+import {
+  GroupObjectPermissionType,
+  GroupRoleAPI,
+  GroupRoleType,
+  RoleType,
+} from 'src/api';
+import {
+  AppliedFilters,
+  CompoundFilter,
+  DeleteModal,
+  EmptyStateFilter,
+  EmptyStateNoData,
+  ExpandableRow,
+  ListItemActions,
+  LoadingPageWithHeader,
+  Pagination,
+  PermissionCategories,
+  PreviewRoles,
+  RoleListTable,
+  SelectRoles,
+  WizardModal,
+} from 'src/components';
 import { IAppContextType } from 'src/loaders/app-context';
-
+import {
+  ParamHelper,
+  errorMessage,
+  filterIsSet,
+  parsePulpIDFromURL,
+  translateLockedRolesDescription,
+} from 'src/utilities';
 import './group-detail-role-management.scss';
 
 interface Props {

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -1,19 +1,28 @@
-import { t, Trans } from '@lingui/macro';
-
-import * as React from 'react';
-import { errorMessage } from 'src/utilities';
-
-import { Link, Navigate } from 'react-router-dom';
-import { RouteProps, withRouter } from 'src/utilities';
-
+import { Trans, t } from '@lingui/macro';
 import {
+  Button,
+  DropdownItem,
+  Modal,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import * as React from 'react';
+import { Link, Navigate } from 'react-router-dom';
+import {
+  GroupAPI,
+  GroupObjectPermissionType,
+  UserAPI,
+  UserType,
+} from 'src/api';
+import {
+  APISearchTypeAhead,
   AlertList,
   AlertType,
-  APISearchTypeAhead,
   AppliedFilters,
   BaseHeader,
   Breadcrumbs,
-  closeAlertMixin,
   CompoundFilter,
   DateComponent,
   DeleteGroupModal,
@@ -27,27 +36,13 @@ import {
   Pagination,
   SortTable,
   Tabs,
+  closeAlertMixin,
 } from 'src/components';
-import {
-  GroupAPI,
-  UserAPI,
-  UserType,
-  GroupObjectPermissionType,
-} from 'src/api';
-import { filterIsSet, ParamHelper } from 'src/utilities';
-import { formatPath, Paths } from 'src/paths';
-import {
-  Button,
-  DropdownItem,
-  Modal,
-  Toolbar,
-  ToolbarContent,
-  ToolbarGroup,
-  ToolbarItem,
-} from '@patternfly/react-core';
-
 import { AppContext } from 'src/loaders/app-context';
-
+import { Paths, formatPath } from 'src/paths';
+import { errorMessage } from 'src/utilities';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ParamHelper, filterIsSet } from 'src/utilities';
 import GroupDetailRoleManagement from './group-detail-role-management/group-detail-role-management';
 
 interface IState {

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -1,27 +1,25 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
+import {
+  Button,
+  DropdownItem,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
 import * as React from 'react';
-import { errorMessage } from 'src/utilities';
-
 import { Link, Navigate } from 'react-router-dom';
-import { RouteProps, withRouter } from 'src/utilities';
 import {
   GroupAPI,
+  GroupObjectPermissionType,
   UserAPI,
   UserType,
-  GroupObjectPermissionType,
 } from 'src/api';
-import {
-  filterIsSet,
-  mapErrorMessages,
-  ParamHelper,
-  ErrorMessagesType,
-} from 'src/utilities';
 import {
   AlertList,
   AlertType,
   AppliedFilters,
   BaseHeader,
-  closeAlertMixin,
   CompoundFilter,
   DeleteGroupModal,
   EmptyStateFilter,
@@ -33,17 +31,18 @@ import {
   Main,
   Pagination,
   SortTable,
+  closeAlertMixin,
 } from 'src/components';
-import {
-  Button,
-  DropdownItem,
-  Toolbar,
-  ToolbarContent,
-  ToolbarGroup,
-  ToolbarItem,
-} from '@patternfly/react-core';
-import { formatPath, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
+import { errorMessage } from 'src/utilities';
+import { RouteProps, withRouter } from 'src/utilities';
+import {
+  ErrorMessagesType,
+  ParamHelper,
+  filterIsSet,
+  mapErrorMessages,
+} from 'src/utilities';
 
 interface IState {
   params: {

--- a/src/containers/legacy-namespaces/legacy-namespace.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespace.tsx
@@ -1,18 +1,16 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import './legacy-namespace.scss';
-
-import { Link } from 'react-router-dom';
-import { RouteProps, withRouter } from 'src/utilities';
-
 import {
   DataList,
-  DataListItem,
-  DataListItemRow,
-  DataListItemCells,
   DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
 } from '@patternfly/react-core';
-
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { LegacyNamespaceListType, LegacyRoleListType } from 'src/api';
+import { LegacyNamespaceAPI } from 'src/api/legacynamespace';
+import { LegacyRoleAPI } from 'src/api/legacyrole';
 import {
   BaseHeader,
   EmptyStateNoData,
@@ -21,11 +19,10 @@ import {
   Logo,
   Pagination,
 } from 'src/components';
-import { Paths, formatPath } from 'src/paths';
-import { LegacyRoleAPI } from 'src/api/legacyrole';
-import { LegacyNamespaceAPI } from 'src/api/legacynamespace';
-import { LegacyNamespaceListType, LegacyRoleListType } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import './legacy-namespace.scss';
 
 interface LegacyNamespaceRolesProps {
   namespace: LegacyNamespaceListType;

--- a/src/containers/legacy-namespaces/legacy-namespaces.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespaces.tsx
@@ -1,9 +1,8 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import './legacy-namespaces.scss';
-
-import { RouteProps, withRouter } from 'src/utilities';
 import { DataList } from '@patternfly/react-core';
+import * as React from 'react';
+import { LegacyNamespaceListType } from 'src/api';
+import { LegacyNamespaceAPI } from 'src/api/legacynamespace';
 import {
   BaseHeader,
   CollectionFilter,
@@ -12,9 +11,9 @@ import {
   LoadingPageSpinner,
   Pagination,
 } from 'src/components';
-import { LegacyNamespaceAPI } from 'src/api/legacynamespace';
-import { LegacyNamespaceListType } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
+import { RouteProps, withRouter } from 'src/utilities';
+import './legacy-namespaces.scss';
 
 interface LegacyNamespacesProps {
   legacynamespaces: LegacyNamespaceListType[];

--- a/src/containers/legacy-roles/legacy-role.tsx
+++ b/src/containers/legacy-roles/legacy-role.tsx
@@ -1,29 +1,26 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
-import './legacy-roles.scss';
-import { EmptyStateNoData } from 'src/components';
-
-import { Link } from 'react-router-dom';
-import { RouteProps, withRouter } from 'src/utilities';
-
+import { Trans, t } from '@lingui/macro';
 import {
   DataList,
-  DataListItem,
-  DataListItemRow,
-  DataListItemCells,
   DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
   LabelGroup,
   Nav,
   NavItem,
   NavList,
   Panel,
-  TextContent,
   Text,
+  TextContent,
   TextVariants,
 } from '@patternfly/react-core';
-
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { LegacyRoleAPI } from 'src/api/legacyrole';
+import { LegacyRoleDetailType } from 'src/api/response-types/legacy-role';
+import { LegacyRoleVersionDetailType } from 'src/api/response-types/legacy-role';
+import { EmptyStateNoData } from 'src/components';
 import {
   Breadcrumbs,
   ClipboardCopy,
@@ -33,12 +30,10 @@ import {
   Main,
   Tag,
 } from 'src/components';
-
-import { Paths, formatPath } from 'src/paths';
-import { LegacyRoleAPI } from 'src/api/legacyrole';
 import { AppContext } from 'src/loaders/app-context';
-import { LegacyRoleDetailType } from 'src/api/response-types/legacy-role';
-import { LegacyRoleVersionDetailType } from 'src/api/response-types/legacy-role';
+import { Paths, formatPath } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import './legacy-roles.scss';
 
 interface RoleMeta {
   role: LegacyRoleDetailType;

--- a/src/containers/legacy-roles/legacy-roles.tsx
+++ b/src/containers/legacy-roles/legacy-roles.tsx
@@ -1,9 +1,8 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import './legacy-roles.scss';
-
-import { RouteProps, withRouter } from 'src/utilities';
 import { DataList } from '@patternfly/react-core';
+import * as React from 'react';
+import { LegacyRoleListType } from 'src/api';
+import { LegacyRoleAPI } from 'src/api/legacyrole';
 import {
   BaseHeader,
   CollectionFilter,
@@ -12,9 +11,9 @@ import {
   LoadingPageSpinner,
   Pagination,
 } from 'src/components';
-import { LegacyRoleAPI } from 'src/api/legacyrole';
-import { LegacyRoleListType } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
+import { RouteProps, withRouter } from 'src/utilities';
+import './legacy-roles.scss';
 
 interface IProps {
   legacyroles: LegacyRoleListType[];

--- a/src/containers/login/login.tsx
+++ b/src/containers/login/login.tsx
@@ -1,15 +1,14 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import { Navigate } from 'react-router-dom';
-import { RouteProps, withRouter } from 'src/utilities';
 import { LoginForm, LoginPage as PFLoginPage } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-
+import * as React from 'react';
+import { Navigate } from 'react-router-dom';
 import Logo from 'src/../static/images/logo_large.svg';
-import { ParamHelper } from 'src/utilities/';
-import { Paths, formatPath } from 'src/paths';
 import { ActiveUserAPI } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ParamHelper } from 'src/utilities/';
 
 interface IState {
   usernameValue: string;

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -1,30 +1,26 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import './my-imports.scss';
-
-import { RouteProps, withRouter } from 'src/utilities';
 import { cloneDeep } from 'lodash';
-
+import * as React from 'react';
 import {
+  CollectionVersion,
+  CollectionVersionAPI,
+  ImportAPI,
+  ImportDetailType,
+  ImportListType,
+  PulpStatus,
+} from 'src/api';
+import {
+  AlertList,
+  AlertType,
   BaseHeader,
   ImportConsole,
   ImportList,
   Main,
   closeAlertMixin,
-  AlertType,
-  AlertList,
 } from 'src/components';
-
-import {
-  ImportAPI,
-  ImportDetailType,
-  ImportListType,
-  PulpStatus,
-  CollectionVersion,
-  CollectionVersionAPI,
-} from 'src/api';
-
+import { RouteProps, withRouter } from 'src/utilities';
 import { ParamHelper } from 'src/utilities/param-helper';
+import './my-imports.scss';
 
 interface IState {
   selectedImport: ImportListType;

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -1,69 +1,62 @@
-import { t, Trans } from '@lingui/macro';
-import * as React from 'react';
-import './namespace-detail.scss';
-
-import { parsePulpIDFromURL } from 'src/utilities/parse-pulp-id';
-
-import { Link, Navigate } from 'react-router-dom';
-import { RouteProps, withRouter } from 'src/utilities';
+import { Trans, t } from '@lingui/macro';
 import {
   Alert,
   AlertActionCloseButton,
   Button,
-  DropdownItem,
-  Tooltip,
-  Text,
   Checkbox,
+  DropdownItem,
+  Text,
+  Tooltip,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-
+import * as React from 'react';
 import ReactMarkdown from 'react-markdown';
-
+import { Link, Navigate } from 'react-router-dom';
 import {
-  CollectionListType,
   CollectionAPI,
-  NamespaceAPI,
-  MyNamespaceAPI,
-  NamespaceType,
-  SignCollectionAPI,
+  CollectionListType,
   GroupType,
+  MyNamespaceAPI,
+  NamespaceAPI,
+  NamespaceType,
   RoleType,
+  SignCollectionAPI,
 } from 'src/api';
-
 import {
+  AlertList,
+  AlertType,
+  ClipboardCopy,
   CollectionFilter,
   CollectionList,
+  DeleteCollectionModal,
+  DeleteModal,
+  EmptyStateNoData,
   ImportModal,
   LoadingPageWithHeader,
   Main,
   OwnersTab,
   Pagination,
   PartnerHeader,
-  EmptyStateNoData,
   RepoSelector,
-  StatefulDropdown,
-  ClipboardCopy,
-  AlertList,
-  closeAlertMixin,
-  DeleteModal,
-  AlertType,
   SignAllCertificatesModal,
-  DeleteCollectionModal,
+  StatefulDropdown,
+  closeAlertMixin,
 } from 'src/components';
-
-import {
-  ParamHelper,
-  getRepoUrl,
-  filterIsSet,
-  errorMessage,
-  waitForTask,
-  canSignNamespace,
-  DeleteCollectionUtils,
-} from 'src/utilities';
-
 import { Constants } from 'src/constants';
-import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import {
+  DeleteCollectionUtils,
+  ParamHelper,
+  canSignNamespace,
+  errorMessage,
+  filterIsSet,
+  getRepoUrl,
+  waitForTask,
+} from 'src/utilities';
+import { parsePulpIDFromURL } from 'src/utilities/parse-pulp-id';
+import './namespace-detail.scss';
 
 interface IState {
   canSign: boolean;

--- a/src/containers/namespace-list/my-namespaces.tsx
+++ b/src/containers/namespace-list/my-namespaces.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
-import { RouteProps, withRouter } from 'src/utilities';
-
-import { NamespaceList } from './namespace-list';
-import { Paths } from 'src/paths';
-import { AppContext } from 'src/loaders/app-context';
 import { EmptyStateUnauthorized } from 'src/components';
+import { AppContext } from 'src/loaders/app-context';
+import { Paths } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { NamespaceList } from './namespace-list';
 
 class MyNamespaces extends React.Component<RouteProps> {
   render() {

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import { i18n } from '@lingui/core';
+import { t } from '@lingui/macro';
 import {
   Button,
   Toolbar,
@@ -6,11 +7,9 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
+import * as React from 'react';
 import { Navigate } from 'react-router-dom';
-import { RouteProps } from 'src/utilities';
-import { t } from '@lingui/macro';
-
-import { ParamHelper } from 'src/utilities/param-helper';
+import { MyNamespaceAPI, NamespaceAPI, NamespaceListType } from 'src/api';
 import {
   AlertList,
   AlertType,
@@ -28,13 +27,12 @@ import {
   Sort,
   closeAlertMixin,
 } from 'src/components';
-import { NamespaceAPI, NamespaceListType, MyNamespaceAPI } from 'src/api';
-import { formatPath, namespaceBreadcrumb, Paths } from 'src/paths';
 import { Constants } from 'src/constants';
-import { errorMessage, filterIsSet } from 'src/utilities';
 import { AppContext } from 'src/loaders/app-context';
-import { i18n } from '@lingui/core';
-
+import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { RouteProps } from 'src/utilities';
+import { errorMessage, filterIsSet } from 'src/utilities';
+import { ParamHelper } from 'src/utilities/param-helper';
 import './namespace-list.scss';
 
 interface IState {

--- a/src/containers/namespace-list/partners.tsx
+++ b/src/containers/namespace-list/partners.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { RouteProps, withRouter } from 'src/utilities';
-
-import { NamespaceList } from './namespace-list';
 import { Paths } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { NamespaceList } from './namespace-list';
 
 class Partners extends React.Component<RouteProps> {
   render() {

--- a/src/containers/not-found/not-found.tsx
+++ b/src/containers/not-found/not-found.tsx
@@ -1,12 +1,10 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import './not-found.scss';
-import NotFoundImage from 'src/../static/images/not_found.svg';
-
-import { RouteProps, withRouter } from 'src/utilities';
 import { Bullseye } from '@patternfly/react-core';
-
+import * as React from 'react';
+import NotFoundImage from 'src/../static/images/not_found.svg';
 import { BaseHeader, Main } from 'src/components';
+import { RouteProps, withRouter } from 'src/utilities';
+import './not-found.scss';
 
 class NotFound extends React.Component<RouteProps> {
   render() {

--- a/src/containers/repositories/repository-list.tsx
+++ b/src/containers/repositories/repository-list.tsx
@@ -1,35 +1,34 @@
 import { t } from '@lingui/macro';
+import { Button, ToolbarItem } from '@patternfly/react-core';
 import * as React from 'react';
-import { RouteProps, withRouter } from 'src/utilities';
 import { Link } from 'react-router-dom';
-
 import {
-  BaseHeader,
-  LoadingPageSpinner,
-  Main,
-  Tabs,
-  RemoteRepositoryTable,
-  LocalRepositoryTable,
-  RemoteForm,
-  EmptyStateNoData,
-  EmptyStateUnauthorized,
-} from 'src/components';
-import {
-  ParamHelper,
-  ErrorMessagesType,
-  mapErrorMessages,
-} from 'src/utilities';
-import { Constants } from 'src/constants';
-import {
+  DistributionAPI,
+  DistributionType,
+  MyDistributionAPI,
   RemoteAPI,
   RemoteType,
-  DistributionAPI,
-  MyDistributionAPI,
-  DistributionType,
 } from 'src/api';
+import {
+  BaseHeader,
+  EmptyStateNoData,
+  EmptyStateUnauthorized,
+  LoadingPageSpinner,
+  LocalRepositoryTable,
+  Main,
+  RemoteForm,
+  RemoteRepositoryTable,
+  Tabs,
+} from 'src/components';
+import { Constants } from 'src/constants';
 import { AppContext } from 'src/loaders/app-context';
-import { Button, ToolbarItem } from '@patternfly/react-core';
 import { Paths, formatPath } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import {
+  ErrorMessagesType,
+  ParamHelper,
+  mapErrorMessages,
+} from 'src/utilities';
 
 export class Repository {
   name: string;

--- a/src/containers/role-management/role-create.tsx
+++ b/src/containers/role-management/role-create.tsx
@@ -1,14 +1,7 @@
 import { t } from '@lingui/macro';
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import {
-  RouteProps,
-  errorMessage,
-  mapNetworkErrors,
-  validateInput,
-  withRouter,
-} from 'src/utilities';
-
+import { RoleAPI } from 'src/api/role';
 import {
   AlertType,
   EmptyStateUnauthorized,
@@ -16,10 +9,15 @@ import {
   RoleForm,
   RoleHeader,
 } from 'src/components';
-
-import { Paths, formatPath } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
-import { RoleAPI } from 'src/api/role';
+import { Paths, formatPath } from 'src/paths';
+import {
+  RouteProps,
+  errorMessage,
+  mapNetworkErrors,
+  validateInput,
+  withRouter,
+} from 'src/utilities';
 
 interface IState {
   saving: boolean;

--- a/src/containers/role-management/role-edit.tsx
+++ b/src/containers/role-management/role-edit.tsx
@@ -1,6 +1,20 @@
 import { t } from '@lingui/macro';
-
 import * as React from 'react';
+import { Navigate } from 'react-router-dom';
+import { RoleType } from 'src/api/response-types/role';
+import { RoleAPI } from 'src/api/role';
+import {
+  AlertList,
+  AlertType,
+  EmptyStateUnauthorized,
+  LoadingPageWithHeader,
+  Main,
+  RoleForm,
+  RoleHeader,
+  closeAlertMixin,
+} from 'src/components';
+import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
 import {
   ErrorMessagesType,
   errorMessage,
@@ -9,26 +23,7 @@ import {
   translateLockedRolesDescription,
   validateInput,
 } from 'src/utilities';
-
-import { RoleAPI } from 'src/api/role';
-
-import { Navigate } from 'react-router-dom';
 import { RouteProps, withRouter } from 'src/utilities';
-
-import {
-  AlertList,
-  AlertType,
-  closeAlertMixin,
-  EmptyStateUnauthorized,
-  LoadingPageWithHeader,
-  Main,
-  RoleForm,
-  RoleHeader,
-} from 'src/components';
-
-import { Paths, formatPath } from 'src/paths';
-import { AppContext } from 'src/loaders/app-context';
-import { RoleType } from 'src/api/response-types/role';
 
 interface IState {
   role: RoleType;

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -1,28 +1,4 @@
-import React from 'react';
-import { t, Trans } from '@lingui/macro';
-import { AppContext } from 'src/loaders/app-context';
-import { Link, Navigate } from 'react-router-dom';
-import { RouteProps, withRouter } from 'src/utilities';
-import {
-  AlertType,
-  Pagination,
-  BaseHeader,
-  closeAlertMixin,
-  CompoundFilter,
-  EmptyStateFilter,
-  LoadingPageSpinner,
-  Main,
-  AlertList,
-  EmptyStateUnauthorized,
-  EmptyStateNoData,
-  AppliedFilters,
-  DeleteModal,
-  RoleListTable,
-  ExpandableRow,
-  ListItemActions,
-  DateComponent,
-  PermissionCategories,
-} from 'src/components';
+import { Trans, t } from '@lingui/macro';
 import {
   Button,
   DropdownItem,
@@ -32,17 +8,40 @@ import {
   ToolbarItem,
   Tooltip,
 } from '@patternfly/react-core';
+import React from 'react';
+import { Link, Navigate } from 'react-router-dom';
 import { RoleType } from 'src/api/response-types/role';
+import { RoleAPI } from 'src/api/role';
 import {
+  AlertList,
+  AlertType,
+  AppliedFilters,
+  BaseHeader,
+  CompoundFilter,
+  DateComponent,
+  DeleteModal,
+  EmptyStateFilter,
+  EmptyStateNoData,
+  EmptyStateUnauthorized,
+  ExpandableRow,
+  ListItemActions,
+  LoadingPageSpinner,
+  Main,
+  Pagination,
+  PermissionCategories,
+  RoleListTable,
+  closeAlertMixin,
+} from 'src/components';
+import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import {
+  ParamHelper,
   errorMessage,
   filterIsSet,
-  ParamHelper,
   parsePulpIDFromURL,
   translateLockedRolesDescription,
 } from 'src/utilities';
-
-import { RoleAPI } from 'src/api/role';
-import { Paths, formatPath } from 'src/paths';
 
 interface IState {
   roles: RoleType[];

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -1,8 +1,35 @@
 import { t } from '@lingui/macro';
+import { Button, DataList, DropdownItem, Switch } from '@patternfly/react-core';
 import * as React from 'react';
 import { Navigate } from 'react-router-dom';
-import { DataList, Switch, DropdownItem, Button } from '@patternfly/react-core';
-import './search.scss';
+import {
+  CollectionAPI,
+  CollectionListType,
+  MyNamespaceAPI,
+  MySyncListAPI,
+  SyncListType,
+} from 'src/api';
+import {
+  AlertList,
+  AlertType,
+  BaseHeader,
+  CardListSwitcher,
+  CollectionCard,
+  CollectionFilter,
+  CollectionListItem,
+  DeleteCollectionModal,
+  EmptyStateFilter,
+  EmptyStateNoData,
+  ImportModal,
+  LoadingPageSpinner,
+  Pagination,
+  RepoSelector,
+  StatefulDropdown,
+  closeAlertMixin,
+} from 'src/components';
+import { Constants } from 'src/constants';
+import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
 import {
   DeleteCollectionUtils,
   RouteProps,
@@ -12,35 +39,8 @@ import {
   waitForTask,
   withRouter,
 } from 'src/utilities';
-import {
-  BaseHeader,
-  CardListSwitcher,
-  CollectionCard,
-  CollectionFilter,
-  CollectionListItem,
-  EmptyStateFilter,
-  EmptyStateNoData,
-  LoadingPageSpinner,
-  Pagination,
-  RepoSelector,
-  StatefulDropdown,
-  AlertList,
-  AlertType,
-  closeAlertMixin,
-  ImportModal,
-  DeleteCollectionModal,
-} from 'src/components';
-import {
-  CollectionAPI,
-  CollectionListType,
-  SyncListType,
-  MySyncListAPI,
-  MyNamespaceAPI,
-} from 'src/api';
 import { ParamHelper } from 'src/utilities/param-helper';
-import { Constants } from 'src/constants';
-import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath } from 'src/paths';
+import './search.scss';
 
 interface IState {
   collections: CollectionListType[];

--- a/src/containers/settings/user-profile.tsx
+++ b/src/containers/settings/user-profile.tsx
@@ -1,19 +1,19 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
+import { Button } from '@patternfly/react-core';
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { Button } from '@patternfly/react-core';
-import { RouteProps, withRouter } from 'src/utilities';
+import { ActiveUserAPI, UserType } from 'src/api';
 import {
+  AlertList,
+  AlertType,
   LoadingPageWithHeader,
   UserFormPage,
-  AlertType,
-  AlertList,
   closeAlertMixin,
 } from 'src/components';
-import { UserType, ActiveUserAPI } from 'src/api';
-import { Paths, formatPath } from 'src/paths';
-import { mapErrorMessages, ErrorMessagesType } from 'src/utilities';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ErrorMessagesType, mapErrorMessages } from 'src/utilities';
 
 interface IState {
   user: UserType;

--- a/src/containers/signature-keys/list.tsx
+++ b/src/containers/signature-keys/list.tsx
@@ -1,6 +1,4 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
-import { RouteProps, withRouter } from 'src/utilities';
 import {
   DropdownItem,
   Toolbar,
@@ -8,7 +6,8 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { ParamHelper, filterIsSet, errorMessage } from 'src/utilities';
+import * as React from 'react';
+import { SigningServiceAPI, SigningServiceType } from 'src/api';
 import {
   AlertList,
   AlertType,
@@ -27,8 +26,9 @@ import {
   SortTable,
   closeAlertMixin,
 } from 'src/components';
-import { SigningServiceAPI, SigningServiceType } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ParamHelper, errorMessage, filterIsSet } from 'src/utilities';
 
 interface IState {
   params: {

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -1,28 +1,23 @@
-import { t, Trans } from '@lingui/macro';
 import { i18n } from '@lingui/core';
-
-import * as React from 'react';
-import './task.scss';
-import { Constants } from 'src/constants';
-import { RouteProps, withRouter } from 'src/utilities';
-import { Link } from 'react-router-dom';
+import { Trans, t } from '@lingui/macro';
 import {
   Button,
   Toolbar,
+  ToolbarContent,
   ToolbarGroup,
   ToolbarItem,
-  ToolbarContent,
 } from '@patternfly/react-core';
-import { ParamHelper, filterIsSet, errorMessage } from 'src/utilities';
-import { parsePulpIDFromURL } from 'src/utilities/parse-pulp-id';
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { TaskManagementAPI } from 'src/api';
+import { TaskType } from 'src/api/response-types/task';
 import {
   AlertList,
   AlertType,
   AppliedFilters,
   BaseHeader,
-  closeAlertMixin,
-  ConfirmModal,
   CompoundFilter,
+  ConfirmModal,
   DateComponent,
   EmptyStateFilter,
   EmptyStateNoData,
@@ -31,13 +26,17 @@ import {
   Main,
   Pagination,
   SortTable,
-  Tooltip,
   StatusIndicator,
+  Tooltip,
+  closeAlertMixin,
 } from 'src/components';
-import { TaskManagementAPI } from 'src/api';
-import { TaskType } from 'src/api/response-types/task';
-import { formatPath, Paths } from 'src/paths';
+import { Constants } from 'src/constants';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ParamHelper, errorMessage, filterIsSet } from 'src/utilities';
+import { parsePulpIDFromURL } from 'src/utilities/parse-pulp-id';
+import './task.scss';
 
 interface IState {
   params: {

--- a/src/containers/task-management/task_detail.tsx
+++ b/src/containers/task-management/task_detail.tsx
@@ -1,21 +1,5 @@
-import * as React from 'react';
-import './task.scss';
 import { i18n } from '@lingui/core';
-import { t, Trans } from '@lingui/macro';
-import { Link, Navigate } from 'react-router-dom';
-import {
-  AlertList,
-  AlertType,
-  BaseHeader,
-  Breadcrumbs,
-  closeAlertMixin,
-  ConfirmModal,
-  DateComponent,
-  EmptyStateCustom,
-  LoadingPageSpinner,
-  Main,
-  StatusIndicator,
-} from 'src/components';
+import { Trans, t } from '@lingui/macro';
 import {
   Button,
   CodeBlock,
@@ -29,12 +13,28 @@ import {
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 import { capitalize } from 'lodash';
-import { TaskType } from 'src/api/response-types/task';
+import * as React from 'react';
+import { Link, Navigate } from 'react-router-dom';
 import { GenericPulpAPI, TaskManagementAPI } from 'src/api';
-import { Paths, formatPath } from 'src/paths';
+import { TaskType } from 'src/api/response-types/task';
+import {
+  AlertList,
+  AlertType,
+  BaseHeader,
+  Breadcrumbs,
+  ConfirmModal,
+  DateComponent,
+  EmptyStateCustom,
+  LoadingPageSpinner,
+  Main,
+  StatusIndicator,
+  closeAlertMixin,
+} from 'src/components';
 import { Constants } from 'src/constants';
+import { Paths, formatPath } from 'src/paths';
+import { RouteProps, errorMessage, withRouter } from 'src/utilities';
 import { parsePulpIDFromURL } from 'src/utilities/parse-pulp-id';
-import { errorMessage, withRouter, RouteProps } from 'src/utilities';
+import './task.scss';
 
 interface IState {
   loading: boolean;

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -1,21 +1,20 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
+import { Button, ClipboardCopyVariant } from '@patternfly/react-core';
 import * as React from 'react';
-
-import { RouteProps, withRouter } from 'src/utilities';
 import { Link } from 'react-router-dom';
-import { ClipboardCopyVariant, Button } from '@patternfly/react-core';
-import { Paths, formatPath } from 'src/paths';
+import { MyDistributionAPI } from 'src/api';
 import {
-  BaseHeader,
-  Main,
-  ClipboardCopy,
   AlertList,
   AlertType,
+  BaseHeader,
+  ClipboardCopy,
+  Main,
   closeAlertMixin,
 } from 'src/components';
-import { errorMessage, getRepoUrl } from 'src/utilities';
 import { AppContext } from 'src/loaders/app-context';
-import { MyDistributionAPI } from 'src/api';
+import { Paths, formatPath } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { errorMessage, getRepoUrl } from 'src/utilities';
 
 interface IState {
   tokenData: {

--- a/src/containers/token/token-standalone.tsx
+++ b/src/containers/token/token-standalone.tsx
@@ -1,24 +1,22 @@
-import { t, Trans } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
+import { Button, Card, CardBody, CardTitle } from '@patternfly/react-core';
 import * as React from 'react';
-import './token.scss';
-
-import { RouteProps, withRouter } from 'src/utilities';
-import { Button, Card, CardTitle, CardBody } from '@patternfly/react-core';
-
+import { ActiveUserAPI } from 'src/api';
 import {
-  BaseHeader,
-  Main,
-  ClipboardCopy,
-  EmptyStateUnauthorized,
-  DateComponent,
   AlertList,
   AlertType,
-  closeAlertMixin,
+  BaseHeader,
+  ClipboardCopy,
+  DateComponent,
+  EmptyStateUnauthorized,
   LoadingPageSpinner,
+  Main,
+  closeAlertMixin,
 } from 'src/components';
-import { ActiveUserAPI } from 'src/api';
 import { AppContext } from 'src/loaders/app-context';
+import { RouteProps, withRouter } from 'src/utilities';
 import { errorMessage } from 'src/utilities';
+import './token.scss';
 
 interface IState {
   token: string;

--- a/src/containers/user-management/user-create.tsx
+++ b/src/containers/user-management/user-create.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
 import { Navigate } from 'react-router-dom';
-import { UserType, UserAPI } from 'src/api';
+import { UserAPI, UserType } from 'src/api';
 import {
   BaseHeader,
   Breadcrumbs,
@@ -11,10 +11,10 @@ import {
 import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import {
-  mapErrorMessages,
   ErrorMessagesType,
-  withRouter,
   RouteProps,
+  mapErrorMessages,
+  withRouter,
 } from 'src/utilities';
 
 interface IState {

--- a/src/containers/user-management/user-detail.tsx
+++ b/src/containers/user-management/user-detail.tsx
@@ -1,8 +1,8 @@
 import { t } from '@lingui/macro';
+import { Button } from '@patternfly/react-core';
 import React from 'react';
 import { Link, Navigate } from 'react-router-dom';
-import { Button } from '@patternfly/react-core';
-import { UserType, UserAPI } from 'src/api';
+import { UserAPI, UserType } from 'src/api';
 import {
   AlertList,
   AlertType,
@@ -12,8 +12,8 @@ import {
   UserFormPage,
   closeAlertMixin,
 } from 'src/components';
-import { Paths, formatPath } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
 import { ErrorMessagesType, RouteProps, withRouter } from 'src/utilities';
 
 interface IState {

--- a/src/containers/user-management/user-edit.tsx
+++ b/src/containers/user-management/user-edit.tsx
@@ -1,18 +1,17 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
 import { Navigate } from 'react-router-dom';
-import { RouteProps, withRouter } from 'src/utilities';
-
+import { UserAPI, UserType } from 'src/api';
 import {
   BaseHeader,
   EmptyStateUnauthorized,
   LoadingPageWithHeader,
   UserFormPage,
 } from 'src/components';
-import { mapErrorMessages, ErrorMessagesType } from 'src/utilities';
-import { UserType, UserAPI } from 'src/api';
-import { Paths, formatPath } from 'src/paths';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ErrorMessagesType, mapErrorMessages } from 'src/utilities';
 
 interface IState {
   user: UserType;

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -1,18 +1,18 @@
 import { t } from '@lingui/macro';
-import React from 'react';
-import { Link, Navigate } from 'react-router-dom';
 import {
-  Toolbar,
-  ToolbarGroup,
-  ToolbarItem,
-  ToolbarContent,
   Button,
   DropdownItem,
   Label,
-  Tooltip,
   LabelGroup,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  Tooltip,
 } from '@patternfly/react-core';
 import { UserPlusIcon } from '@patternfly/react-icons';
+import React from 'react';
+import { Link, Navigate } from 'react-router-dom';
 import { UserAPI, UserType } from 'src/api';
 import {
   AlertList,
@@ -25,12 +25,12 @@ import {
   EmptyStateFilter,
   EmptyStateNoData,
   EmptyStateUnauthorized,
+  ListItemActions,
   LoadingPageSpinner,
   Main,
   Pagination,
   SortTable,
   closeAlertMixin,
-  ListItemActions,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';

--- a/src/entry-insights.tsx
+++ b/src/entry-insights.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { I18nProvider } from '@lingui/react';
 import { i18n } from '@lingui/core';
-import App from './loaders/insights/loader';
+import { I18nProvider } from '@lingui/react';
+import React from 'react';
 import 'src/l10n';
+import App from './loaders/insights/loader';
 
 // Entrypoint for compiling the app to run in insights mode.
 

--- a/src/entry-standalone.tsx
+++ b/src/entry-standalone.tsx
@@ -1,10 +1,10 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { I18nProvider } from '@lingui/react';
-import { i18n } from '@lingui/core';
-import App from './loaders/standalone/loader';
 import 'src/l10n';
+import App from './loaders/standalone/loader';
 
 // Entrypoint for compiling the app to run in standalone mode
 

--- a/src/loaders/app-context.ts
+++ b/src/loaders/app-context.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { UserType, FeatureFlagsType, SettingsType } from 'src/api';
+import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { AlertType } from 'src/components';
 
 export interface IAppContextType {

--- a/src/loaders/insights/loader.tsx
+++ b/src/loaders/insights/loader.tsx
@@ -1,16 +1,16 @@
 import { t } from '@lingui/macro';
-import React, { useEffect, useState } from 'react';
-import { matchPath, useLocation } from 'react-router-dom';
 import { Alert } from '@patternfly/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
-import '../app.scss';
-import { AppContext } from '../app-context';
-import { loadContext } from '../load-context';
-import { InsightsRoutes } from './routes';
+import React, { useEffect, useState } from 'react';
+import { matchPath, useLocation } from 'react-router-dom';
 import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { AlertType, UIVersion } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { hasPermission } from 'src/utilities';
+import { AppContext } from '../app-context';
+import '../app.scss';
+import { loadContext } from '../load-context';
+import { InsightsRoutes } from './routes';
 
 const DEFAULT_REPO = 'published';
 

--- a/src/loaders/insights/loader.tsx
+++ b/src/loaders/insights/loader.tsx
@@ -1,3 +1,4 @@
+import '../app.scss';
 import { t } from '@lingui/macro';
 import { Alert } from '@patternfly/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
@@ -8,7 +9,6 @@ import { AlertType, UIVersion } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { hasPermission } from 'src/utilities';
 import { AppContext } from '../app-context';
-import '../app.scss';
 import { loadContext } from '../load-context';
 import { InsightsRoutes } from './routes';
 

--- a/src/loaders/insights/routes.tsx
+++ b/src/loaders/insights/routes.tsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense } from 'react';
+import React, { Suspense, lazy } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import { LoadingPageWithHeader } from 'src/components';
 import { Paths } from 'src/paths';

--- a/src/loaders/load-context.ts
+++ b/src/loaders/load-context.ts
@@ -3,8 +3,8 @@ import {
   FeatureFlagsAPI,
   FeatureFlagsType,
   SettingsAPI,
-  UserType,
   SettingsType,
+  UserType,
 } from 'src/api';
 import { AlertType } from 'src/components';
 

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -1,6 +1,4 @@
-import { t, Trans } from '@lingui/macro';
-import React, { useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
+import { Trans, t } from '@lingui/macro';
 import {
   DropdownItem,
   DropdownSeparator,
@@ -13,7 +11,9 @@ import {
   ExternalLinkAltIcon,
   QuestionCircleIcon,
 } from '@patternfly/react-icons';
-import { StandaloneMenu } from './menu';
+import React, { useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import Logo from 'src/../static/images/logo_large.svg';
 import {
   ActiveUserAPI,
   FeatureFlagsType,
@@ -27,7 +27,7 @@ import {
   StatefulDropdown,
 } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
-import Logo from 'src/../static/images/logo_large.svg';
+import { StandaloneMenu } from './menu';
 
 interface IProps {
   children: React.ReactNode;

--- a/src/loaders/standalone/loader.tsx
+++ b/src/loaders/standalone/loader.tsx
@@ -1,14 +1,14 @@
+import '@patternfly/patternfly/patternfly.scss';
 import React, { useEffect, useState } from 'react';
 import { matchPath, useLocation } from 'react-router-dom';
-import '../app.scss';
-import '@patternfly/patternfly/patternfly.scss';
-import { AppContext } from '../app-context';
-import { StandaloneLayout } from './layout';
-import { StandaloneRoutes } from './routes';
 import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { AlertType, UIVersion } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { hasPermission } from 'src/utilities';
+import { AppContext } from '../app-context';
+import '../app.scss';
+import { StandaloneLayout } from './layout';
+import { StandaloneRoutes } from './routes';
 
 const isRepoURL = (pathname) =>
   matchPath({ path: formatPath(Paths.searchByRepo) + '*' }, pathname);

--- a/src/loaders/standalone/loader.tsx
+++ b/src/loaders/standalone/loader.tsx
@@ -1,3 +1,4 @@
+import '../app.scss';
 import '@patternfly/patternfly/patternfly.scss';
 import React, { useEffect, useState } from 'react';
 import { matchPath, useLocation } from 'react-router-dom';
@@ -6,7 +7,6 @@ import { AlertType, UIVersion } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { hasPermission } from 'src/utilities';
 import { AppContext } from '../app-context';
-import '../app.scss';
 import { StandaloneLayout } from './layout';
 import { StandaloneRoutes } from './routes';
 

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -1,9 +1,5 @@
 /* eslint react/prop-types: 0 */
 import { t } from '@lingui/macro';
-import React, { useEffect, useState } from 'react';
-import { Link, useLocation } from 'react-router-dom';
-import { reject, some } from 'lodash';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import {
   Nav,
   NavExpandable,
@@ -11,6 +7,10 @@ import {
   NavItem,
   NavList,
 } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { reject, some } from 'lodash';
+import React, { useEffect, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 import { Paths, formatPath } from 'src/paths';
 import { hasPermission } from 'src/utilities';
 

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { AlertType } from 'src/components';
 import {

--- a/src/utilities/delete-collection.tsx
+++ b/src/utilities/delete-collection.tsx
@@ -1,6 +1,6 @@
-import { t, Trans } from '@lingui/macro';
-import React from 'react';
+import { Trans, t } from '@lingui/macro';
 import { DropdownItem, Tooltip } from '@patternfly/react-core';
+import React from 'react';
 import { CollectionAPI } from 'src/api';
 import { errorMessage, parsePulpIDFromURL, waitForTask } from 'src/utilities';
 

--- a/src/utilities/fail-alerts.ts
+++ b/src/utilities/fail-alerts.ts
@@ -1,4 +1,5 @@
 import { t } from '@lingui/macro';
+
 export function errorMessage(statusCode: number, statusText: string) {
   const messages = {
     500: t`Error ${statusCode} - ${statusText}: The server encountered an error and was unable to complete your request.`,

--- a/src/utilities/filter-is-set.ts
+++ b/src/utilities/filter-is-set.ts
@@ -1,5 +1,6 @@
 // Checks that at least one filter is set
 import { some } from 'lodash';
+
 export function filterIsSet(params, filters) {
   return some(filters, (filter) => filter in params);
 }

--- a/src/utilities/repo-signing.ts
+++ b/src/utilities/repo-signing.ts
@@ -1,8 +1,6 @@
-import { SignContainersAPI } from 'src/api';
-
-import { waitForTaskUrl } from 'src/utilities';
-
 import { t } from '@lingui/macro';
+import { SignContainersAPI } from 'src/api';
+import { waitForTaskUrl } from 'src/utilities';
 
 export class RepoSigningUtils {
   public static getContainerPulpType(item) {

--- a/src/utilities/translate-locked-roles-desc.ts
+++ b/src/utilities/translate-locked-roles-desc.ts
@@ -1,5 +1,5 @@
-import { Constants } from 'src/constants';
 import { i18n } from '@lingui/core';
+import { Constants } from 'src/constants';
 
 // Locked roles description can't be translated on the API
 // To solve this problem, description for the locked roles

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -1,7 +1,6 @@
 // https://on.cypress.io/custom-commands
-
-import shell from 'shell-escape-tag';
 import { range } from 'lodash';
+import shell from 'shell-escape-tag';
 
 const apiPrefix = Cypress.env('apiPrefix');
 const uiPrefix = Cypress.env('uiPrefix');

--- a/test/cypress/support/e2e.js
+++ b/test/cypress/support/e2e.js
@@ -1,4 +1,3 @@
 // https://on.cypress.io/configuration
-
-import './commands';
 import 'cypress-file-upload';
+import './commands';


### PR DESCRIPTION
Bump prettier from 2.3 to 2.8
Clean up deprecated prettier config, config that is already default and config already set in `.editorconfig`.

Add prettier plugin to sort js/ts imports:
* (force `../app.scss` to go before `patternfly.css` - reordering breaks token page paddings)
* sort external imports first,
* then src/,
* then any relative paths

(within those groups, sort imports by source name; sort specifiers within import asciibetically)