### PR TITLE
src/components: convert first few components to functional

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -2,6 +2,7 @@ export { APISearchTypeAhead } from './typeahead/typeahead';
 export {
   AlertList,
   AlertType,
+  closeAlert,
   closeAlertMixin,
 } from './patternfly-wrappers/alert-list';
 export { AppliedFilters } from './patternfly-wrappers/applied-filters';

--- a/src/components/namespace-form/resources-form.tsx
+++ b/src/components/namespace-form/resources-form.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 import { NamespaceType } from 'src/api';
 import { MarkdownEditor } from '..';
 import './namespace-form.scss';
@@ -23,24 +23,12 @@ interface IProps {
   updateNamespace: (data) => void;
 }
 
-export class ResourcesForm extends React.Component<IProps> {
-  render() {
-    const { namespace } = this.props;
-
-    return (
-      <MarkdownEditor
-        text={namespace.resources}
-        placeholder={placeholder}
-        helperText={t`You can can customize the Resources tab on your profile by entering custom markdown here.`}
-        updateText={(value) => this.updateResources(value)}
-        editing={true}
-      />
-    );
-  }
-
-  private updateResources(data) {
-    const update = { ...this.props.namespace };
-    update.resources = data;
-    this.props.updateNamespace(update);
-  }
-}
+export const ResourcesForm = ({ namespace, updateNamespace }: IProps) => (
+  <MarkdownEditor
+    text={namespace.resources}
+    placeholder={placeholder}
+    helperText={t`You can can customize the Resources tab on your profile by entering custom markdown here.`}
+    updateText={(resources) => updateNamespace({ ...namespace, resources })}
+    editing={true}
+  />
+);

--- a/src/components/numeric-label/numeric-label.tsx
+++ b/src/components/numeric-label/numeric-label.tsx
@@ -1,5 +1,5 @@
 import { plural } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 
 interface IProps {
   number: number;
@@ -7,55 +7,47 @@ interface IProps {
   label: string;
 }
 
-class NumericLabel extends React.Component<IProps> {
-  render() {
-    const { number, newline, label } = this.props;
-
-    let numberElem = (
-      <span key='number'>{NumericLabel.roundNumber(number)} </span>
-    );
-    let labelElem = (
-      <span key='label' className='hub-numeric-label-label'>
-        {label}
-      </span>
-    );
-
-    if (newline) {
-      numberElem = <div>{numberElem}</div>;
-      labelElem = <div>{labelElem}</div>;
-    }
-
-    return (
-      <div>
-        {numberElem}
-        {labelElem}
-      </div>
-    );
+function roundNumber(n: number): string {
+  if (n < 1000) {
+    // returns 1 to 999
+    return n.toString();
+  } else if (n < 10000) {
+    // returns 1K to 9.9K
+    return (Math.floor(n / 100) / 10).toString() + 'K';
+  } else if (n < 1000000) {
+    // returns 10K to 999K
+    return Math.floor(n / 1000).toString() + 'K';
+  } else if (n < 100000000) {
+    // returns 1M to 9.9M
+    return (Math.floor(n / 100000) / 10).toString() + 'M';
+  } else if (n < 1000000000) {
+    return Math.floor(n / 1000000).toString() + 'M';
   }
 
-  // Make this a static property so that we can use this function outside of
-  // rendering the whole component
-  static roundNumber(n: number): string {
-    if (n < 1000) {
-      // returns 1 to 999
-      return n.toString();
-    } else if (n < 10000) {
-      // returns 1K to 9.9K
-      return (Math.floor(n / 100) / 10).toString() + 'K';
-    } else if (n < 1000000) {
-      // returns 10K to 999K
-      return Math.floor(n / 1000).toString() + 'K';
-    } else if (n < 100000000) {
-      // returns 1M to 9.9M
-      return (Math.floor(n / 100000) / 10).toString() + 'M';
-    } else if (n < 1000000000) {
-      return Math.floor(n / 1000000).toString() + 'M';
-    }
-
-    // If larger than a billion, don't even bother.
-    return '1B+';
-  }
+  // If larger than a billion, don't even bother.
+  return '1B+';
 }
+
+const NumericLabel = ({ number, newline, label }: IProps) => {
+  let numberElem = <span key='number'>{roundNumber(number)} </span>;
+  let labelElem = (
+    <span key='label' className='hub-numeric-label-label'>
+      {label}
+    </span>
+  );
+
+  if (newline) {
+    numberElem = <div>{numberElem}</div>;
+    labelElem = <div>{labelElem}</div>;
+  }
+
+  return (
+    <div>
+      {numberElem}
+      {labelElem}
+    </div>
+  );
+};
 
 interface ICNLProps {
   count: number;
@@ -63,30 +55,26 @@ interface ICNLProps {
   type: string;
 }
 
-export class CollectionNumericLabel extends React.Component<ICNLProps> {
-  render() {
-    const { count, newline, type } = this.props;
+const label = (count, type) =>
+  ({
+    module: plural(count, {
+      one: 'Module',
+      other: 'Modules',
+    }),
+    role: plural(count, {
+      one: 'Role',
+      other: 'Roles',
+    }),
+    plugin: plural(count, {
+      one: 'Plugin',
+      other: 'Plugins',
+    }),
+    dependency: plural(count, {
+      one: 'Dependency',
+      other: 'Dependencies',
+    }),
+  }[type] || type);
 
-    const label =
-      {
-        module: plural(count, {
-          one: 'Module',
-          other: 'Modules',
-        }),
-        role: plural(count, {
-          one: 'Role',
-          other: 'Roles',
-        }),
-        plugin: plural(count, {
-          one: 'Plugin',
-          other: 'Plugins',
-        }),
-        dependency: plural(count, {
-          one: 'Dependency',
-          other: 'Dependencies',
-        }),
-      }[type] || type;
-
-    return <NumericLabel number={count} newline={newline} label={label} />;
-  }
-}
+export const CollectionNumericLabel = ({ count, newline, type }: ICNLProps) => (
+  <NumericLabel number={count} newline={newline} label={label(count, type)} />
+);

--- a/src/components/patternfly-wrappers/alert-list.tsx
+++ b/src/components/patternfly-wrappers/alert-list.tsx
@@ -3,7 +3,7 @@ import {
   AlertActionCloseButton,
   AlertProps,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 
 interface IProps {
   /** List of alerts to display */
@@ -20,47 +20,43 @@ export class AlertType {
   description?: string | JSX.Element;
 }
 
-export class AlertList extends React.Component<IProps> {
-  render() {
-    const { alerts, closeAlert } = this.props;
-    return (
-      <div
-        style={{
-          position: 'fixed',
-          right: '5px',
-          top: '80px',
-          zIndex: 300,
-          display: 'flex',
-          flexDirection: 'column',
-        }}
-        data-cy='AlertList'
+export const AlertList = ({ alerts, closeAlert }: IProps) => (
+  <div
+    style={{
+      position: 'fixed',
+      right: '5px',
+      top: '80px',
+      zIndex: 300,
+      display: 'flex',
+      flexDirection: 'column',
+    }}
+    data-cy='AlertList'
+  >
+    {alerts.map((alert, i) => (
+      <Alert
+        style={{ marginBottom: '16px' }}
+        key={i}
+        title={alert.title}
+        variant={alert.variant}
+        actionClose={<AlertActionCloseButton onClose={() => closeAlert(i)} />}
       >
-        {alerts.map((alert, i) => (
-          <Alert
-            style={{ marginBottom: '16px' }}
-            key={i}
-            title={alert.title}
-            variant={alert.variant}
-            actionClose={
-              <AlertActionCloseButton onClose={() => closeAlert(i)} />
-            }
-          >
-            {alert.description}
-          </Alert>
-        ))}
-      </div>
-    );
-  }
+        {alert.description}
+      </Alert>
+    ))}
+  </div>
+);
+
+export function closeAlert(alertIndex, { alerts, setAlerts }) {
+  const newList = [...alerts];
+  newList.splice(alertIndex, 1);
+  setAlerts(newList);
 }
 
 export function closeAlertMixin(alertStateVariable) {
   return function (alertIndex) {
-    const newList = [...this.state['alerts']];
-    newList.splice(alertIndex, 1);
-
-    const newState = {};
-    newState[alertStateVariable] = newList;
-
-    this.setState(newState);
+    closeAlert(alertIndex, {
+      alerts: this.state[alertStateVariable],
+      setAlerts: (newList) => this.setState({ [alertStateVariable]: newList }),
+    });
   };
 }

--- a/src/components/patternfly-wrappers/breadcrumbs.tsx
+++ b/src/components/patternfly-wrappers/breadcrumbs.tsx
@@ -1,5 +1,5 @@
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 export class BreadcrumbType {
@@ -12,23 +12,12 @@ interface IProps {
   links: BreadcrumbType[];
 }
 
-export class Breadcrumbs extends React.Component<IProps> {
-  render() {
-    return (
-      <Breadcrumb>
-        {this.props.links.map((link, i) => this.renderLink(link, i))}
-      </Breadcrumb>
-    );
-  }
-
-  renderLink(link, index) {
-    return (
-      <BreadcrumbItem
-        key={index}
-        isActive={index + 1 === this.props.links.length}
-      >
+export const Breadcrumbs = ({ links }: IProps) => (
+  <Breadcrumb>
+    {links.map((link, index) => (
+      <BreadcrumbItem key={index} isActive={index + 1 === links.length}>
         {link.url ? <Link to={link.url}>{link.name}</Link> : link.name}
       </BreadcrumbItem>
-    );
-  }
-}
+    ))}
+  </Breadcrumb>
+);

--- a/src/components/patternfly-wrappers/clipboard-copy.tsx
+++ b/src/components/patternfly-wrappers/clipboard-copy.tsx
@@ -1,23 +1,18 @@
 import { t } from '@lingui/macro';
 import { ClipboardCopy as PFClipboardCopy } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 
 interface IProps {
   children: string;
   [key: string]: string | number | boolean;
 }
 
-export class ClipboardCopy extends React.Component<IProps> {
-  render() {
-    const { children, ...props } = this.props;
-    return (
-      <PFClipboardCopy
-        hoverTip={t`Copy to clipboard`}
-        clickTip={t`Successfully copied to clipboard!`}
-        {...props}
-      >
-        {children}
-      </PFClipboardCopy>
-    );
-  }
-}
+export const ClipboardCopy = ({ children, ...props }: IProps) => (
+  <PFClipboardCopy
+    hoverTip={t`Copy to clipboard`}
+    clickTip={t`Successfully copied to clipboard!`}
+    {...props}
+  >
+    {children}
+  </PFClipboardCopy>
+);

--- a/src/components/patternfly-wrappers/fileupload.tsx
+++ b/src/components/patternfly-wrappers/fileupload.tsx
@@ -3,17 +3,13 @@ import {
   FileUploadProps,
   FileUpload as PFFileUpload,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 
-export class FileUpload extends React.Component<FileUploadProps> {
-  render() {
-    return (
-      <PFFileUpload
-        browseButtonText={t`Browse...`}
-        clearButtonText={t`Clear`}
-        filenamePlaceholder={t`Drag a file here or browse to upload`}
-        {...this.props}
-      />
-    );
-  }
-}
+export const FileUpload = (props: FileUploadProps) => (
+  <PFFileUpload
+    browseButtonText={t`Browse...`}
+    clearButtonText={t`Clear`}
+    filenamePlaceholder={t`Drag a file here or browse to upload`}
+    {...props}
+  />
+);

--- a/src/components/patternfly-wrappers/link-tabs.tsx
+++ b/src/components/patternfly-wrappers/link-tabs.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 
 export interface IProps {
@@ -11,31 +11,23 @@ export interface IProps {
   }[];
 }
 
-// We're not using the Tab react component because they don't support links.
-export class LinkTabs extends React.Component<IProps> {
-  render() {
-    return (
-      <div className='pf-c-tabs'>
-        <ul className='pf-c-tabs__list'>
-          {this.props.tabs.map((tab) => this.renderTab(tab))}
-        </ul>
-      </div>
-    );
-  }
+const renderTab = ({ link, title, active = false }) => (
+  <li
+    className={cx({
+      'pf-c-tabs__item': true,
+      'pf-m-current': active,
+    })}
+    key={title}
+  >
+    <Link to={link} className='pf-c-tabs__link'>
+      <span className='pf-c-tabs__item-text'>{title}</span>
+    </Link>
+  </li>
+);
 
-  private renderTab({ link, title, active = false }) {
-    return (
-      <li
-        className={cx({
-          'pf-c-tabs__item': true,
-          'pf-m-current': active,
-        })}
-        key={title}
-      >
-        <Link to={link} className='pf-c-tabs__link'>
-          <span className='pf-c-tabs__item-text'>{title}</span>
-        </Link>
-      </li>
-    );
-  }
-}
+// We're not using the Tab react component because they don't support links.
+export const LinkTabs = ({ tabs }: IProps) => (
+  <div className='pf-c-tabs'>
+    <ul className='pf-c-tabs__list'>{tabs.map((tab) => renderTab(tab))}</ul>
+  </div>
+);

--- a/src/components/patternfly-wrappers/main.tsx
+++ b/src/components/patternfly-wrappers/main.tsx
@@ -1,25 +1,20 @@
 import cx from 'classnames';
-import * as React from 'react';
+import React from 'react';
 
 interface IProps extends React.HTMLProps<HTMLElement> {
   children: React.ReactNode;
   className?: string;
 }
 
-export class Main extends React.Component<IProps> {
-  render() {
-    const { children, className, ...extra } = this.props;
-    return (
-      <section
-        className={cx(
-          'pf-l-page__main-section',
-          'pf-c-page__main-section',
-          className,
-        )}
-        {...extra}
-      >
-        {children}
-      </section>
-    );
-  }
-}
+export const Main = ({ children, className, ...extra }: IProps) => (
+  <section
+    className={cx(
+      'pf-l-page__main-section',
+      'pf-c-page__main-section',
+      className,
+    )}
+    {...extra}
+  >
+    {children}
+  </section>
+);

--- a/src/components/patternfly-wrappers/pagination.tsx
+++ b/src/components/patternfly-wrappers/pagination.tsx
@@ -3,7 +3,7 @@ import {
   Pagination as PaginationPF,
   PaginationVariant,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Constants } from 'src/constants';
 import { ParamHelper } from 'src/utilities/param-helper';
 
@@ -48,47 +48,49 @@ const ToggleTemplate = ({
   </Trans>
 );
 
-export class Pagination extends React.Component<IProps> {
-  render() {
-    const { count, params, updateParams, isTop, perPageOptions, isCompact } =
-      this.props;
-
-    const extraProps = {};
-    if (!isTop) {
-      extraProps['widgetId'] = 'pagination-options-menu-bottom';
-      extraProps['variant'] = PaginationVariant.bottom;
-    }
-
-    return (
-      <PaginationPF
-        itemCount={count}
-        perPage={params.page_size || Constants.DEFAULT_PAGE_SIZE}
-        page={params.page || 1}
-        onSetPage={(_, p) =>
-          updateParams(ParamHelper.setParam(params, 'page', p))
-        }
-        onPerPageSelect={(_, p) => {
-          updateParams({ ...params, page: 1, page_size: p });
-        }}
-        {...extraProps}
-        isCompact={isTop || isCompact}
-        perPageOptions={this.mapPerPageOptions(
-          perPageOptions || Constants.DEFAULT_PAGINATION_OPTIONS,
-        )}
-        titles={{
-          ofWord: t`of`,
-          perPageSuffix: t`per page`,
-          items: null,
-        }}
-        toggleTemplate={(props) => <ToggleTemplate {...props} />}
-      />
-    );
+export const Pagination = ({
+  count,
+  params,
+  updateParams,
+  isTop,
+  perPageOptions,
+  isCompact,
+}: IProps) => {
+  const extraProps = {};
+  if (!isTop) {
+    extraProps['widgetId'] = 'pagination-options-menu-bottom';
+    extraProps['variant'] = PaginationVariant.bottom;
   }
 
-  private mapPerPageOptions(options) {
-    return options.map((option) => ({
-      title: String(option),
-      value: option,
-    }));
-  }
+  return (
+    <PaginationPF
+      itemCount={count}
+      perPage={params.page_size || Constants.DEFAULT_PAGE_SIZE}
+      page={params.page || 1}
+      onSetPage={(_, p) =>
+        updateParams(ParamHelper.setParam(params, 'page', p))
+      }
+      onPerPageSelect={(_, p) => {
+        updateParams({ ...params, page: 1, page_size: p });
+      }}
+      {...extraProps}
+      isCompact={isTop || isCompact}
+      perPageOptions={mapPerPageOptions(
+        perPageOptions || Constants.DEFAULT_PAGINATION_OPTIONS,
+      )}
+      titles={{
+        ofWord: t`of`,
+        perPageSuffix: t`per page`,
+        items: null,
+      }}
+      toggleTemplate={(props) => <ToggleTemplate {...props} />}
+    />
+  );
+};
+
+function mapPerPageOptions(options) {
+  return options.map((option) => ({
+    title: String(option),
+    value: option,
+  }));
 }

--- a/src/components/patternfly-wrappers/stateful-dropdown.tsx
+++ b/src/components/patternfly-wrappers/stateful-dropdown.tsx
@@ -5,7 +5,7 @@ import {
   DropdownToggle,
   KebabToggle,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React, { useState } from 'react';
 
 interface IProps {
   /** List of patternfly DropdownItem components */
@@ -29,87 +29,59 @@ interface IProps {
   ariaLabel?: string;
 }
 
-interface IState {
-  isOpen: boolean;
-  selected: string;
+export const StatefulDropdown = ({
+  items,
+  onSelect: onSelectProp,
+  toggleType = 'kebab',
+  position,
+  defaultText,
+  isPlain = true,
+  ariaLabel,
+}: IProps) => {
+  const [isOpen, setOpen] = useState<boolean>(false);
+  const [selected, setSelected] = useState<string>(undefined);
+  const onToggle = (open) => setOpen(open);
+
+  return (
+    <Dropdown
+      onSelect={(e) =>
+        onSelect(e, { isOpen, onSelectProp, setOpen, setSelected })
+      }
+      toggle={renderToggle({ toggleType, defaultText, onToggle, selected })}
+      isOpen={isOpen}
+      isPlain={isPlain}
+      dropdownItems={items}
+      position={position || DropdownPosition.right}
+      autoFocus={false}
+      aria-label={ariaLabel}
+    />
+  );
+};
+
+function renderToggle({ toggleType, defaultText, onToggle, selected }) {
+  switch (toggleType) {
+    case 'dropdown':
+      return (
+        <DropdownToggle onToggle={onToggle}>
+          {selected ? selected : defaultText || t`Dropdown`}
+        </DropdownToggle>
+      );
+    case 'icon':
+      return (
+        <DropdownToggle toggleIndicator={null} onToggle={onToggle}>
+          {selected ? selected : defaultText || t`Dropdown`}
+        </DropdownToggle>
+      );
+    case 'kebab':
+      return <KebabToggle onToggle={onToggle} />;
+  }
 }
 
-export class StatefulDropdown extends React.Component<IProps, IState> {
-  static defaultProps = {
-    isPlain: true,
-    toggleType: 'kebab',
-  };
+function onSelect(event, { isOpen, onSelectProp, setOpen, setSelected }) {
+  setOpen(!isOpen);
+  setSelected(event.currentTarget.value);
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      isOpen: false,
-      selected: undefined,
-    };
-  }
-
-  render() {
-    const { isOpen } = this.state;
-    const { items, toggleType, defaultText, position, isPlain, ariaLabel } =
-      this.props;
-
-    return (
-      <Dropdown
-        onSelect={(e) => this.onSelect(e)}
-        toggle={this.renderToggle(toggleType, defaultText)}
-        isOpen={isOpen}
-        isPlain={isPlain}
-        dropdownItems={items}
-        position={position || DropdownPosition.right}
-        autoFocus={false}
-        aria-label={ariaLabel}
-      />
-    );
-  }
-
-  private renderToggle(toggleType, defaultText) {
-    switch (toggleType) {
-      case 'dropdown':
-        return (
-          <DropdownToggle onToggle={(e) => this.onToggle(e)}>
-            {this.state.selected
-              ? this.state.selected
-              : defaultText || t`Dropdown`}
-          </DropdownToggle>
-        );
-      case 'icon':
-        return (
-          <DropdownToggle
-            toggleIndicator={null}
-            onToggle={(e) => this.onToggle(e)}
-          >
-            {this.state.selected
-              ? this.state.selected
-              : defaultText || t`Dropdown`}
-          </DropdownToggle>
-        );
-      case 'kebab':
-        return <KebabToggle onToggle={(e) => this.onToggle(e)} />;
-    }
-  }
-
-  private onToggle(isOpen) {
-    this.setState({
-      isOpen,
-    });
-  }
-
-  private onSelect(event) {
-    this.setState(
-      {
-        isOpen: !this.state.isOpen,
-        selected: event.currentTarget.value,
-      },
-      () => {
-        if (this.props.onSelect) {
-          this.props.onSelect(event);
-        }
-      },
-    );
+  if (onSelectProp) {
+    onSelectProp(event);
   }
 }

--- a/src/components/patternfly-wrappers/tabs.tsx
+++ b/src/components/patternfly-wrappers/tabs.tsx
@@ -1,5 +1,5 @@
 import { Tabs as PFTabs, Tab, TabTitleText } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { ParamHelper } from 'src/utilities/param-helper';
 
 export class TabsType {
@@ -22,51 +22,50 @@ interface IProps {
 }
 
 // FIXME: use LinkTabs, switch from ?tab to routes, rename to Tabs
-export class Tabs extends React.Component<IProps> {
-  render() {
-    const { tabs, params, updateParams, isDisabled, disabledTitle } =
-      this.props;
-    return (
-      <PFTabs
-        activeKey={this.getActiveTab()}
-        onSelect={(_, key) =>
-          !isDisabled &&
-          updateParams(
-            ParamHelper.setParam(params, 'tab', tabs[key].id.toLowerCase()),
-          )
-        }
-      >
-        {tabs.map((tab, i) => (
-          <Tab
-            key={i}
-            eventKey={i}
-            title={
-              <TabTitleText title={isDisabled ? disabledTitle : null}>
-                {tab.name}
-              </TabTitleText>
-            }
-            className={isDisabled ? 'disabled' : null}
-          />
-        ))}
-      </PFTabs>
-    );
-  }
-
-  private getActiveTab() {
-    const { params, tabs } = this.props;
-    if (params.tab) {
-      const i = tabs.findIndex(
-        (x) => x.id.toLowerCase() === params.tab.toLowerCase(),
-      );
-
-      // If tab is not found, default to the first tab.
-      if (i === -1) {
-        return 0;
-      } else {
-        return i;
-      }
-    } else {
-      return 0;
+export const Tabs = ({
+  tabs,
+  params,
+  updateParams,
+  isDisabled,
+  disabledTitle,
+}: IProps) => (
+  <PFTabs
+    activeKey={getActiveTab({ params, tabs })}
+    onSelect={(_, key) =>
+      !isDisabled &&
+      updateParams(
+        ParamHelper.setParam(params, 'tab', tabs[key].id.toLowerCase()),
+      )
     }
+  >
+    {tabs.map((tab, i) => (
+      <Tab
+        key={i}
+        eventKey={i}
+        title={
+          <TabTitleText title={isDisabled ? disabledTitle : null}>
+            {tab.name}
+          </TabTitleText>
+        }
+        className={isDisabled ? 'disabled' : null}
+      />
+    ))}
+  </PFTabs>
+);
+
+function getActiveTab({ params, tabs }) {
+  if (params.tab) {
+    const i = tabs.findIndex(
+      (x) => x.id.toLowerCase() === params.tab.toLowerCase(),
+    );
+
+    // If tab is not found, default to the first tab.
+    if (i === -1) {
+      return 0;
+    } else {
+      return i;
+    }
+  } else {
+    return 0;
   }
 }

--- a/src/components/patternfly-wrappers/tooltip.tsx
+++ b/src/components/patternfly-wrappers/tooltip.tsx
@@ -1,18 +1,13 @@
 import { Tooltip as PFTooltip } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 
 interface IProps {
   children: React.ReactNode;
   content: string;
 }
 
-export class Tooltip extends React.Component<IProps> {
-  render() {
-    const { content, children } = this.props;
-    return (
-      <PFTooltip content={content}>
-        <span>{children}</span>
-      </PFTooltip>
-    );
-  }
-}
+export const Tooltip = ({ content, children }: IProps) => (
+  <PFTooltip content={content}>
+    <span>{children}</span>
+  </PFTooltip>
+);

--- a/src/components/patternfly-wrappers/write-only-field.tsx
+++ b/src/components/patternfly-wrappers/write-only-field.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { Button, InputGroup, TextInput } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 
 interface IProps {
   /** Specify if the value is set on the backend already */
@@ -13,28 +13,21 @@ interface IProps {
   children: React.ReactNode;
 }
 
-export class WriteOnlyField extends React.Component<IProps> {
-  render() {
-    const { onClear, isValueSet, children } = this.props;
-
-    if (!isValueSet) {
-      return children;
-    }
-
-    return (
-      <InputGroup>
-        <TextInput
-          aria-label={t`hidden value`}
-          placeholder='••••••••••••••••••••••'
-          type='password'
-          isDisabled={isValueSet}
-        />
-        {isValueSet && (
-          <Button onClick={() => onClear()} variant='control'>
-            {t`Clear`}
-          </Button>
-        )}
-      </InputGroup>
-    );
-  }
-}
+export const WriteOnlyField = ({ onClear, isValueSet, children }: IProps) =>
+  !isValueSet ? (
+    <>{children}</>
+  ) : (
+    <InputGroup>
+      <TextInput
+        aria-label={t`hidden value`}
+        placeholder='••••••••••••••••••••••'
+        type='password'
+        isDisabled={isValueSet}
+      />
+      {isValueSet && (
+        <Button onClick={() => onClear()} variant='control'>
+          {t`Clear`}
+        </Button>
+      )}
+    </InputGroup>
+  );

--- a/src/components/rbac/role-header.tsx
+++ b/src/components/rbac/role-header.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 import { BaseHeader, BreadcrumbType, Breadcrumbs } from 'src/components';
 
 interface IProps {
@@ -8,23 +8,14 @@ interface IProps {
   breadcrumbs: BreadcrumbType[];
 }
 
-export class RoleHeader extends React.Component<IProps> {
-  constructor(props) {
-    super(props);
-  }
-
-  render() {
-    const { title, subTitle, breadcrumbs } = this.props;
-    return (
-      <BaseHeader
-        breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}
-        title={title}
-      >
-        {' '}
-        <div style={{ paddingBottom: '10px' }}>
-          <Trans>{subTitle}</Trans>
-        </div>
-      </BaseHeader>
-    );
-  }
-}
+export const RoleHeader = ({ title, subTitle, breadcrumbs }: IProps) => (
+  <BaseHeader
+    breadcrumbs={<Breadcrumbs links={breadcrumbs}></Breadcrumbs>}
+    title={title}
+  >
+    {' '}
+    <div style={{ paddingBottom: '10px' }}>
+      <Trans>{subTitle}</Trans>
+    </div>
+  </BaseHeader>
+);

--- a/src/components/sha-label/sha-label.tsx
+++ b/src/components/sha-label/sha-label.tsx
@@ -1,5 +1,5 @@
 import { Label, Tooltip } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { truncateSha } from 'src/utilities';
 
 interface IProps {
@@ -8,16 +8,10 @@ interface IProps {
   long?: boolean;
 }
 
-export class ShaLabel extends React.Component<IProps> {
-  render() {
-    const { digest, grey, long } = this.props;
-
-    return (
-      <Tooltip content={digest}>
-        <Label color={grey ? 'grey' : 'blue'}>
-          {long ? digest : truncateSha(digest)}
-        </Label>
-      </Tooltip>
-    );
-  }
-}
+export const ShaLabel = ({ digest, grey, long }: IProps) => (
+  <Tooltip content={digest}>
+    <Label color={grey ? 'grey' : 'blue'}>
+      {long ? digest : truncateSha(digest)}
+    </Label>
+  </Tooltip>
+);

--- a/src/components/shared/login-link.tsx
+++ b/src/components/shared/login-link.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
-import { AppContext } from 'src/loaders/app-context';
+import { useContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 
 interface IProps {
@@ -9,26 +9,19 @@ interface IProps {
   next?: string;
 }
 
-export class LoginLink extends React.Component<IProps> {
-  static contextType = AppContext;
+export const LoginLink = ({ button, next }: IProps) => {
+  const { featureFlags } = useContext();
+  const className = button ? 'pf-c-button pf-m-primary' : '';
 
-  render() {
-    const { button, next } = this.props;
-    const { featureFlags } = this.context;
-    const className = button ? 'pf-c-button pf-m-primary' : '';
-
-    // NOTE: also update AuthHandler#render (src/loaders/standalone/routes.tsx) when changing this
-    if (featureFlags?.external_authentication && UI_EXTERNAL_LOGIN_URI) {
-      return (
-        <a className={className} href={UI_EXTERNAL_LOGIN_URI}>{t`Login`}</a>
-      );
-    } else {
-      return (
-        <Link
-          className={className}
-          to={formatPath(Paths.login, {}, { next })}
-        >{t`Login`}</Link>
-      );
-    }
+  // NOTE: also update AuthHandler#render (src/loaders/standalone/routes.tsx) when changing this
+  if (featureFlags?.external_authentication && UI_EXTERNAL_LOGIN_URI) {
+    return <a className={className} href={UI_EXTERNAL_LOGIN_URI}>{t`Login`}</a>;
+  } else {
+    return (
+      <Link
+        className={className}
+        to={formatPath(Paths.login, {}, { next })}
+      >{t`Login`}</Link>
+    );
   }
-}
+};

--- a/src/components/sort-table/sort-table.tsx
+++ b/src/components/sort-table/sort-table.tsx
@@ -3,7 +3,7 @@ import {
   LongArrowAltDownIcon,
   LongArrowAltUpIcon,
 } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { ParamHelper } from 'src/utilities';
 import './sort-table.scss';
 
@@ -16,35 +16,34 @@ interface IProps {
       className?: string;
     }[];
   };
-  params: object;
+  params: {
+    sort?: string;
+  };
   updateParams: (params) => void;
 }
 
-export class SortTable extends React.Component<IProps> {
-  private sort(id, isMinus) {
+export const SortTable = ({ options, params, updateParams }: IProps) => {
+  function sort(id, isMinus) {
     // Alphabetical sorting is inverted in Django, so flip it here to make
     // things match up with the UI.
     isMinus = !isMinus;
-    this.props.updateParams({
-      ...ParamHelper.setParam(
-        this.props.params,
-        'sort',
-        (isMinus ? '-' : '') + id,
-      ),
+    updateParams({
+      ...ParamHelper.setParam(params, 'sort', (isMinus ? '-' : '') + id),
       page: 1,
     });
   }
-  private getIcon(type, id) {
+
+  function getIcon(type, id) {
     if (type == 'none') {
       return;
     }
+
     let Icon;
-    const activeIcon =
-      !!this.props.params['sort'] &&
-      id == this.props.params['sort'].replace('-', '');
     let isMinus = false;
+
+    const activeIcon = !!params.sort && id == params.sort.replace('-', '');
     if (activeIcon) {
-      isMinus = this.props.params['sort'].includes('-');
+      isMinus = params.sort.includes('-');
       let up = isMinus;
       if (type == 'alpha') {
         up = !up;
@@ -58,29 +57,23 @@ export class SortTable extends React.Component<IProps> {
       <Icon
         data-cy={'sort_' + id}
         size='sm'
-        onClick={() => this.sort(id, isMinus)}
+        onClick={() => sort(id, isMinus)}
         className={'clickable ' + (activeIcon ? 'active' : 'inactive')}
       />
     );
   }
 
-  private getHeaderItem(item) {
-    return (
-      <th key={item.id} className={item?.className}>
-        {item.title} {this.getIcon(item.type, item.id)}
-      </th>
-    );
-  }
+  const getHeaderItem = (item) => (
+    <th key={item.id} className={item?.className}>
+      {item.title} {getIcon(item.type, item.id)}
+    </th>
+  );
 
-  render() {
-    return (
-      <thead>
-        <tr className='hub-SortTable-headers' data-cy='SortTable-headers'>
-          {this.props.options['headers'].map((element) =>
-            this.getHeaderItem(element),
-          )}
-        </tr>
-      </thead>
-    );
-  }
-}
+  return (
+    <thead>
+      <tr className='hub-SortTable-headers' data-cy='SortTable-headers'>
+        {options.headers.map((element) => getHeaderItem(element))}
+      </tr>
+    </thead>
+  );
+};

--- a/src/components/status/status-indicator.tsx
+++ b/src/components/status/status-indicator.tsx
@@ -7,7 +7,7 @@ import {
   OutlinedClockIcon,
   SyncAltIcon,
 } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { PulpStatus } from 'src/api';
 
 interface IProps {
@@ -22,71 +22,67 @@ interface LabelPropType {
   text: string;
 }
 
-export class StatusIndicator extends React.Component<IProps> {
-  static defaultProps = {
-    type: 'primary',
-  };
+const typeToVariantMap: Record<string, LabelProps['variant']> = {
+  primary: 'outline',
+  secondary: 'filled',
+};
 
-  typeToVariantMap: Record<string, LabelProps['variant']> = {
-    primary: 'outline',
-    secondary: 'filled',
-  };
+const statusToProps = (status): LabelPropType => {
+  switch (status) {
+    case PulpStatus.waiting:
+      return {
+        color: 'blue',
+        text: t`Pending`,
+        icon: <OutlinedClockIcon />,
+      };
 
-  render() {
-    let labelProps: LabelPropType;
-    const { status, type } = this.props;
+    // TODO: what does skipped mean in pulp
+    case PulpStatus.skipped:
+    case PulpStatus.canceled:
+      return {
+        color: 'orange',
+        text: t`Canceled`,
+        icon: <ExclamationIcon />,
+      };
 
-    switch (status) {
-      case PulpStatus.waiting:
-        labelProps = {
-          color: 'blue',
-          text: t`Pending`,
-          icon: <OutlinedClockIcon />,
-        };
-        break;
+    case PulpStatus.running:
+      return { color: 'blue', text: t`Running`, icon: <SyncAltIcon /> };
 
-      // TODO: what does skipped mean in pulp
-      case PulpStatus.skipped:
-      case PulpStatus.canceled:
-        labelProps = {
-          color: 'orange',
-          text: t`Canceled`,
-          icon: <ExclamationIcon />,
-        };
-        break;
+    case PulpStatus.completed:
+      return {
+        color: 'green',
+        text: t`Completed`,
+        icon: <CheckCircleIcon />,
+      };
 
-      case PulpStatus.running:
-        labelProps = { color: 'blue', text: t`Running`, icon: <SyncAltIcon /> };
-        break;
-
-      case PulpStatus.completed:
-        labelProps = {
-          color: 'green',
-          text: t`Completed`,
-          icon: <CheckCircleIcon />,
-        };
-        break;
-
-      case PulpStatus.failed:
-        labelProps = {
-          color: 'red',
-          text: t`Failed`,
-          icon: <ExclamationCircleIcon />,
-        };
-        break;
-      default:
-        return '---';
-    }
-
-    return (
-      <Label
-        variant={this.typeToVariantMap[type]}
-        color={labelProps.color}
-        icon={labelProps.icon}
-        className={this.props.className}
-      >
-        {labelProps.text}
-      </Label>
-    );
+    case PulpStatus.failed:
+      return {
+        color: 'red',
+        text: t`Failed`,
+        icon: <ExclamationCircleIcon />,
+      };
   }
-}
+  return null;
+};
+
+export const StatusIndicator = ({
+  status,
+  type = 'primary',
+  className,
+}: IProps) => {
+  const labelProps = statusToProps(status);
+  if (!labelProps) {
+    return <>---</>;
+  }
+
+  return (
+    <Label
+      variant={typeToVariantMap[type]}
+      color={labelProps.color}
+      icon={labelProps.icon}
+      className={className}
+    >
+      {labelProps.text}
+    </Label>
+  );
+};

--- a/src/components/tag-label/tag-label.tsx
+++ b/src/components/tag-label/tag-label.tsx
@@ -1,18 +1,13 @@
 import { Label } from '@patternfly/react-core';
 import { TagIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 
 interface IProps {
   tag: string;
 }
 
-export class TagLabel extends React.Component<IProps> {
-  render() {
-    const { tag } = this.props;
-    return (
-      <Label variant='outline' icon={<TagIcon />}>
-        {tag}
-      </Label>
-    );
-  }
-}
+export const TagLabel = ({ tag }: IProps) => (
+  <Label variant='outline' icon={<TagIcon />}>
+    {tag}
+  </Label>
+);

--- a/src/components/tags/deprecated-tag.tsx
+++ b/src/components/tags/deprecated-tag.tsx
@@ -1,25 +1,21 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 
-export class DeprecatedTag extends React.Component {
-  render() {
-    return (
-      <div
-        style={{
-          display: 'inline-block',
-          margin: '4px',
-          backgroundColor: '#C9190B',
-          color: 'white',
-          fontSize: '14px',
-          paddingLeft: '5px',
-          paddingRight: '5px',
-          paddingBottom: '2px',
-          paddingTop: '2px',
-          borderRadius: '3px',
-        }}
-      >
-        {t`DEPRECATED`}
-      </div>
-    );
-  }
-}
+export const DeprecatedTag = () => (
+  <div
+    style={{
+      display: 'inline-block',
+      margin: '4px',
+      backgroundColor: '#C9190B',
+      color: 'white',
+      fontSize: '14px',
+      paddingLeft: '5px',
+      paddingRight: '5px',
+      paddingBottom: '2px',
+      paddingTop: '2px',
+      borderRadius: '3px',
+    }}
+  >
+    {t`DEPRECATED`}
+  </div>
+);

--- a/src/components/tags/tag.tsx
+++ b/src/components/tags/tag.tsx
@@ -1,5 +1,5 @@
 import { Label } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import './tag.scss';
 
 interface IProps {
@@ -7,12 +7,8 @@ interface IProps {
   children: string;
 }
 
-export class Tag extends React.Component<IProps> {
-  render() {
-    return (
-      <Label className='hub-c-label-tag' readOnly data-cy='tag'>
-        {this.props.children}
-      </Label>
-    );
-  }
-}
+export const Tag = ({ children }: IProps) => (
+  <Label className='hub-c-label-tag' readOnly data-cy='tag'>
+    {children}
+  </Label>
+);

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -55,7 +55,7 @@ interface IState {
   loading: boolean;
   images: ContainerManifestType[];
   numberOfImages: number;
-  params: { page?: number; page_size?: number };
+  params: { page?: number; page_size?: number; sort?: string };
   redirect: string;
   inputText: string;
 


### PR DESCRIPTION
Converting class components from `src/components` to functional.
See also #3201, #3223, #3224, #3226

* `AlertList({ alerts, closeAlert })`
* `AppliedFilters({ params, ignoredParams?, niceNames?, niceValues, className, style, updateParams })`
* `Breadcrumbs({ links })`
* `ClipboardCopy({ children, ...props })`
* `DeprecatedTag({})`
* `FileUpload({ ...props })`
* `LinkTabs({ tabs })`
* `LoginLink({ button, next })`
* `Main({ children, className, ...extra })`
* `NumericLabel({ number, newline?, label }), CollectionNumericLabel({ count, newline?, type })`
* `Pagination({ count, params, updateParams, isTop, perPageOptions, isCompact })`
* `ResourcesForm({ namespace, updaateNamespace })`
* `RoleHeader({ title, subTitle, breadcrumbs })`
* `ShaLabel({ digest, grey, long })`
* `SortTable({ options, params, updateParams })`
* `StatefulDropdown({ items, onSelect, toggleType?, position, defaultText, isPlain?, ariaLabel })`
* `StatusIndicator({ status, type?, className })`
* `Tabs({ tabs, params, updateParams, isDisabled, disabledTitle })`
* `Tag({ children })`
* `TagLabel({ tag })`
* `Tooltip({ content, children })`
* `WriteOnlyField({ onClear, isValueSet, children })`
