### PR TITLE
insights dev/test - mock more APIs

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -119,12 +119,20 @@ module.exports = (inputConfigs) => {
           ...defaultServices,
         },
         registry: [
-          ({ app }) =>
+          ({ app }) => {
             app.get('/api/featureflags/v0', (_req, res) => {
               res.send({ toggles: [] });
-            }),
+            });
+            app.post('/api/featureflags/v0/client/metrics', (_req, res) => {
+              res.send({});
+            });
+            app.get('/api/quickstarts/v1/progress', (_req, res) => {
+              res.send({});
+            });
+          },
         ],
       }),
+
     // insights deployments from master
     ...(!isStandalone &&
       cloudBeta && {

--- a/test/cypress/e2e/insights/smoke.js
+++ b/test/cypress/e2e/insights/smoke.js
@@ -28,10 +28,6 @@ describe('cloud smoketest', () => {
 
     // wait for navbar to appear
     cy.get('#nav-toggle').should('be.visible');
-    // wait for the ansible dashboard button to appear and then click on it
-    cy.get('[data-quickstart-id="ansible_ansible-dashboard"]').click({
-      force: true,
-    });
     // wait for the automation-hub button to appear and then click on it
     cy.get('[data-quickstart-id="Automation-Hub"]').click();
     // wait for the collections button to appear and then click on it


### PR DESCRIPTION
in addition to mocking `/api/featureflags/v0` (#3148), we seem to get test failures when `/beta/apps/ansible-dashboard/fed-mods.json` doesn't return json, and more errors in the console.

Fixing `/beta/apps/ansible-dashboard/fed-mods.json`, `/api/quickstarts/v1/progress`,
and POST to `/api/featureflags/v0/client/metrics`.

(should fix test failures in https://github.com/ansible/ansible-hub-ui/actions/runs/3982212723/jobs/6826642902, https://github.com/ansible/ansible-hub-ui/actions/runs/3982207549/jobs/6826463235)