### PR TITLE
Support `?pseudolocalization=true|false` to enable/disable pseudolocalization; `?lang=` to force language

### DIFF
--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -5,26 +5,10 @@ import * as moment from 'moment';
 // remember to update .linguirc as well
 const availableLanguages = ['en', 'es', 'fr', 'ko', 'nl', 'ja', 'zh'];
 
-// Accept-Language
-const userLanguage =
-  navigator.languages
-    .map((lang) => lang.replace(/[-_].*/, ''))
-    .filter((lang) => availableLanguages.includes(lang))[0] || 'en';
-
-async function activate(locale: string) {
+async function activate(locale: string, pseudolocalization = false) {
   const { messages } = await import(`src/../locale/${locale}.js`);
 
-  const searchParams = Object.fromEntries(
-    new URLSearchParams(window.location.search),
-  );
-  if (searchParams.pseudolocalization === 'true') {
-    window.localStorage.test_l10n = 'true';
-  }
-  if (searchParams.pseudolocalization === 'false') {
-    delete window.localStorage.test_l10n;
-  }
-
-  if (window.localStorage.test_l10n === 'true') {
+  if (pseudolocalization) {
     Object.keys(messages).forEach((key) => {
       if (Array.isArray(messages[key])) {
         // t`Foo ${param}` -> ["Foo ", ['param']] => [">>", "Foo ", ['param'], "<<"]
@@ -43,4 +27,51 @@ async function activate(locale: string) {
   moment.locale(locale);
 }
 
-activate(userLanguage);
+// Accept-Language
+const userLanguage = navigator.languages
+  .map((lang) => lang.replace(/[-_].*/, ''))
+  .filter((lang) => availableLanguages.includes(lang))[0];
+
+const searchParams = Object.fromEntries(
+  new URLSearchParams(window.location.search),
+);
+
+if (searchParams.pseudolocalization === 'true') {
+  window.localStorage.test_l10n = 'true';
+}
+if (searchParams.pseudolocalization === 'false') {
+  delete window.localStorage.test_l10n;
+}
+
+if (searchParams.lang) {
+  window.localStorage.override_l10n = searchParams.lang;
+}
+if (searchParams.lang === '') {
+  delete window.localStorage.override_l10n;
+}
+
+const overrideLanguage =
+  window.localStorage.override_l10n &&
+  availableLanguages.includes(window.localStorage.override_l10n) &&
+  window.localStorage.override_l10n;
+const language = overrideLanguage || userLanguage || 'en';
+const pseudolocalization = window.localStorage.test_l10n === 'true';
+
+if (overrideLanguage) {
+  console.debug(
+    `language autodetection overriden to: ${overrideLanguage}, unset by visiting ${
+      window.location.origin + window.location.pathname + '?lang='
+    }`,
+  );
+}
+if (pseudolocalization) {
+  console.debug(
+    `pseudolocalization enabled, unset by visiting ${
+      window.location.origin +
+      window.location.pathname +
+      '?pseudolocalization=false'
+    }`,
+  );
+}
+
+activate(language, pseudolocalization);

--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -14,6 +14,16 @@ const userLanguage =
 async function activate(locale: string) {
   const { messages } = await import(`src/../locale/${locale}.js`);
 
+  const searchParams = Object.fromEntries(
+    new URLSearchParams(window.location.search),
+  );
+  if (searchParams.pseudolocalization === 'true') {
+    window.localStorage.test_l10n = 'true';
+  }
+  if (searchParams.pseudolocalization === 'false') {
+    delete window.localStorage.test_l10n;
+  }
+
   if (window.localStorage.test_l10n === 'true') {
     Object.keys(messages).forEach((key) => {
       if (Array.isArray(messages[key])) {


### PR DESCRIPTION
Issue AAP-4750

Pseudlocalization (>>marking<< strings marked for translation, instead of actually translating them), is supported since #810 by setting `localStorage.test_l10n = true` in the browser console and reloading the page.

(Note: the current lingui implementation needs `npm run gettext:extract; npm run gettext:compile` for any new strings before they appear as marked. We should try to remove that limitation during the i18next switch.)

User language is currently autodetected based on browser settings, with no way to change.

---

This PR makes it easier to: 
* enable/disable pseudolocalization by setting a `?pseudolocalization=true` (`false` to unset) URL param, which gets used to set/unset `localStorage.test_l10n`. 
* force a different langugage by setting a `?lang=ja` (`?lang=` to unset) URL param, which gets used to set/unset `localStorage.override_l10n`.

Thus, after using `?pseudolocalization=true&lang=ja` once, you will see both until you explicitly set `?pseudolocalization=false&lang=`, even when visiting URLs without the param.

Note: `?lang` only affects UI locale, not API locale, which is based solely on the `Accept-Language` header.
(And pseudolocalization never affected the API either, though django gettext might have a default way of doing that.)

(Both pseudolocalization and languge override also `console.debug` links to unset them.)