### PR TITLE
Localization fixes

### DIFF
--- a/src/components/patternfly-wrappers/applied-filters.tsx
+++ b/src/components/patternfly-wrappers/applied-filters.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { Button, Chip, ChipGroup } from '@patternfly/react-core';
 import * as React from 'react';
-import { ParamHelper } from 'src/utilities';
+import { ParamHelper, chipGroupProps } from 'src/utilities';
 
 interface IProps {
   /** Sets the current page params to p */
@@ -61,7 +61,7 @@ export class AppliedFilters extends React.Component<IProps> {
 
     return (
       <div style={{ display: 'inline', marginRight: '8px' }} key={key}>
-        <ChipGroup categoryName={niceNames[key] || key}>
+        <ChipGroup categoryName={niceNames[key] || key} {...chipGroupProps()}>
           {chips.map((v, i) => (
             <Chip
               key={i}

--- a/src/components/patternfly-wrappers/pagination.tsx
+++ b/src/components/patternfly-wrappers/pagination.tsx
@@ -1,8 +1,7 @@
-import { t } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import {
   Pagination as PaginationPF,
   PaginationVariant,
-  ToggleTemplate,
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { Constants } from 'src/constants';
@@ -30,6 +29,24 @@ interface IProps {
   /** Options for the number of items that can be displayed per page */
   perPageOptions?: number[];
 }
+
+// AAP-3737 - support both "1 - 2 of 3" and "3 的 1 - 2"
+const ToggleTemplate = ({
+  firstIndex = 0,
+  lastIndex = 0,
+  itemCount = 0,
+}: {
+  firstIndex?: number;
+  lastIndex?: number;
+  itemCount?: number;
+}) => (
+  <Trans>
+    <b>
+      {firstIndex} - {lastIndex}
+    </b>{' '}
+    of <b>{itemCount}</b>
+  </Trans>
+);
 
 export class Pagination extends React.Component<IProps> {
   render() {
@@ -63,7 +80,7 @@ export class Pagination extends React.Component<IProps> {
           perPageSuffix: t`per page`,
           items: null,
         }}
-        toggleTemplate={(props) => <ToggleTemplate ofWord={t`of`} {...props} />}
+        toggleTemplate={(props) => <ToggleTemplate {...props} />}
       />
     );
   }

--- a/src/components/patternfly-wrappers/wizard-modal.tsx
+++ b/src/components/patternfly-wrappers/wizard-modal.tsx
@@ -33,6 +33,10 @@ export const WizardModal = ({
       hasNoBodyPadding
       navAriaLabel={t`${title} steps`}
       mainAriaLabel={t`${title} content`}
+      backButtonText={t`Back`}
+      cancelButtonText={t`Cancel`}
+      closeButtonAriaLabel={t`Close`}
+      nextButtonText={t`Next`}
       titleId='wizard-modal-title'
       descriptionId='wizard-modal-description'
       title={title}

--- a/src/components/rbac/permission-chip-selector.tsx
+++ b/src/components/rbac/permission-chip-selector.tsx
@@ -8,6 +8,7 @@ import {
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { AppContext } from 'src/loaders/app-context';
+import { chipGroupProps } from 'src/utilities';
 
 interface IProps {
   availablePermissions?: string[];
@@ -72,6 +73,7 @@ export class PermissionChipSelector extends React.Component<IProps, IState> {
       <Select
         menuAppendTo='inline'
         variant={SelectVariant.typeaheadMulti}
+        chipGroupProps={chipGroupProps()}
         typeAheadAriaLabel={t`Select permissions`}
         onToggle={(isOpen) => this.setState({ isOpen })}
         onSelect={(event, permission) =>

--- a/src/components/rbac/role-form.tsx
+++ b/src/components/rbac/role-form.tsx
@@ -1,4 +1,4 @@
-import { t } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import {
   ActionGroup,
   Button,
@@ -92,7 +92,7 @@ export class RoleForm extends React.Component<IProps, IState> {
                     onChange={onNameChange}
                     type='text'
                     validated={nameValidated}
-                    placeholder='Role name'
+                    placeholder={t`Role name`}
                   />
                 </InputGroup>
               </FormGroup>
@@ -112,7 +112,7 @@ export class RoleForm extends React.Component<IProps, IState> {
                   onChange={onDescriptionChange}
                   type='text'
                   validated={descriptionValidated}
-                  placeholder='Add a role description here'
+                  placeholder={t`Add a role description here`}
                 />
               </FormGroup>
             </div>
@@ -121,7 +121,9 @@ export class RoleForm extends React.Component<IProps, IState> {
             <br />
             <Divider />
             <br />
-            <Title headingLevel='h2'>Permissions</Title>
+            <Title headingLevel='h2'>
+              <Trans>Permissions</Trans>
+            </Title>
 
             <PermissionCategories
               permissions={permissions}

--- a/src/components/typeahead/typeahead.tsx
+++ b/src/components/typeahead/typeahead.tsx
@@ -1,6 +1,7 @@
 import { t } from '@lingui/macro';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import * as React from 'react';
+import { chipGroupProps } from 'src/utilities';
 
 interface IProps {
   results: { name: string; id: number | string }[];
@@ -61,6 +62,7 @@ export class APISearchTypeAhead extends React.Component<IProps, IState> {
         isDisabled={this.props.isDisabled}
         toggleIcon={this.props.toggleIcon}
         style={this.props.style}
+        chipGroupProps={chipGroupProps()}
       >
         {this.getOptions()}
       </Select>

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -138,7 +138,9 @@ class ExecutionEnvironmentManifest extends React.Component<RouteProps, IState> {
             ))}
           </LabelGroup>
 
-          <div style={{ padding: '4px 0' }}>Size: {size}</div>
+          <div style={{ padding: '4px 0' }}>
+            <Trans>Size: {size}</Trans>
+          </div>
         </BaseHeader>
 
         <Main>

--- a/src/containers/legacy-roles/legacy-role.tsx
+++ b/src/containers/legacy-roles/legacy-role.tsx
@@ -51,7 +51,9 @@ class LegacyRoleInstall extends React.Component<RoleMeta, RoleMeta> {
     const installCMD = `ansible-galaxy role install ${this.props.github_user}.${this.props.name}`;
     return (
       <>
-        <h1>Installation:</h1>
+        <h1>
+          <Trans>Installation:</Trans>
+        </h1>
         <ClipboardCopy isCode isReadOnly variant={'expansion'}>
           {installCMD}
         </ClipboardCopy>

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -221,6 +221,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
                         }}
                         params={params}
                         ignoredParams={['page_size', 'page', 'sort']}
+                        niceNames={{ keywords: t`keywords` }}
                       />
                     </ToolbarItem>
                   </ToolbarGroup>

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -53,6 +53,9 @@ interface IState {
   inputText: string;
 }
 
+const maybeTranslate = (name) =>
+  (Constants.TASK_NAMES[name] && i18n._(Constants.TASK_NAMES[name])) || name;
+
 export class TaskListView extends React.Component<RouteProps, IState> {
   constructor(props) {
     super(props);
@@ -280,15 +283,7 @@ export class TaskListView extends React.Component<RouteProps, IState> {
       <tr key={index}>
         <td>
           <Link to={formatPath(Paths.taskDetail, { task: taskId })}>
-            <Tooltip
-              content={
-                (Constants.TASK_NAMES[name] &&
-                  i18n._(Constants.TASK_NAMES[name])) ||
-                name
-              }
-            >
-              {name}
-            </Tooltip>
+            <Tooltip content={maybeTranslate(name)}>{name}</Tooltip>
           </Link>
         </td>
         <td>
@@ -346,9 +341,9 @@ export class TaskListView extends React.Component<RouteProps, IState> {
   }
 
   private renderCancelModal() {
-    const name =
-      Constants.TASK_NAMES[this.state.selectedTask.name] ||
-      this.state.selectedTask.name;
+    const { selectedTask } = this.state;
+    const name = maybeTranslate(selectedTask.name);
+
     return (
       <ConfirmModal
         cancelAction={() => this.setState({ cancelModalVisible: false })}

--- a/src/containers/task-management/task_detail.tsx
+++ b/src/containers/task-management/task_detail.tsx
@@ -53,6 +53,9 @@ interface IState {
   polling: ReturnType<typeof setInterval>;
 }
 
+const maybeTranslate = (name) =>
+  (Constants.TASK_NAMES[name] && i18n._(Constants.TASK_NAMES[name])) || name;
+
 class TaskDetail extends React.Component<RouteProps, IState> {
   constructor(props) {
     super(props);
@@ -204,9 +207,7 @@ class TaskDetail extends React.Component<RouteProps, IState> {
                               task: parentTaskId,
                             })}
                           >
-                            {(Constants.TASK_NAMES[parentTask.name] &&
-                              i18n._(Constants.TASK_NAMES[parentTask.name])) ||
-                              parentTask.name}
+                            {maybeTranslate(parentTask.name)}
                           </Link>
                         ) : (
                           t`No parent task`
@@ -228,11 +229,7 @@ class TaskDetail extends React.Component<RouteProps, IState> {
                                       task: childTaskId,
                                     })}
                                   >
-                                    {(Constants.TASK_NAMES[childTask.name] &&
-                                      i18n._(
-                                        Constants.TASK_NAMES[childTask.name],
-                                      )) ||
-                                      childTask.name}
+                                    {maybeTranslate(childTask.name)}
                                   </Link>
                                   <br />
                                 </React.Fragment>
@@ -506,10 +503,7 @@ class TaskDetail extends React.Component<RouteProps, IState> {
             childTasks,
             parentTask,
             loading: false,
-            taskName:
-              (Constants.TASK_NAMES[result.data.name] &&
-                i18n._(Constants.TASK_NAMES[result.data.name])) ||
-              result.data.name,
+            taskName: maybeTranslate(result.data.name),
             resources,
           });
         });

--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -5,6 +5,11 @@ import * as moment from 'moment';
 // remember to update .linguirc as well
 const availableLanguages = ['en', 'es', 'fr', 'ko', 'nl', 'ja', 'zh'];
 
+// map missing moment locales (node_modules/moment/src/locale/<locale>.js must exist, except for english)
+const momentLocales = {
+  zh: 'zh-cn',
+};
+
 async function activate(locale: string, pseudolocalization = false) {
   const { messages } = await import(`src/../locale/${locale}.js`);
 
@@ -24,7 +29,7 @@ async function activate(locale: string, pseudolocalization = false) {
   i18n.load(locale, messages);
   i18n.activate(locale);
 
-  moment.locale(locale);
+  moment.locale(momentLocales[locale] || locale);
 }
 
 // Accept-Language

--- a/src/utilities/chip-group-props.ts
+++ b/src/utilities/chip-group-props.ts
@@ -1,0 +1,9 @@
+import { t } from '@lingui/macro';
+
+export const chipGroupProps = () => {
+  const count = '${remaining}'; // pf templating
+  return {
+    collapsedText: t`${count} more`,
+    expandedText: t`Show Less`,
+  };
+};

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,3 +1,4 @@
+export { chipGroupProps } from './chip-group-props';
 export { convertContentSummaryCounts } from './content-summary';
 export { ParamHelper } from './param-helper';
 export { sanitizeDocsUrls } from './sanitize-docs-urls';


### PR DESCRIPTION
Related to AAP-3913,
specifically fixes:

AAP-3401: 
namespace-list: add niceNames for keywords
otherwise, AppliedFilters will display `keywords` in all locales
![20230131202919](https://user-images.githubusercontent.com/289743/215875952-83c0b60f-3fea-422d-b2de-70371d003435.png)
(already in locales)

AAP-3737:
pagination - allow translators to reorder the "1-2 of 3" in translations
this allows for a "3 的 1-2" ordering in chinese
(but needs a new translation for all languages: `msgid "<0>{firstIndex} - {lastIndex}</0> of <1>{itemCount}</1>"`)

AAP-3749:
map our zh locale to moment.js zh-cn locale
(moment supports all other dashless locales we do, but doesn't have an entry for `zh`, only `zh-cn`, `zh-hk`, `zh-mo`, `zh-tw` - mapping to the first one
![20230131213811](https://user-images.githubusercontent.com/289743/215889536-2dc6fd5d-f167-4ff7-92b7-0b0e6e20ad1e.png)
(already in moment locales)

AAP-3708:
ensure TASK_NAMES always go through translation,
task cancel modal was skipping the `i18n._` call
(already in locales)

AAP-3734,
AAP-7344:
ensure `Select` (`typeaheadMulti` variant only) and `ChipGroup` always use our translation of `1 more` and `Show Less` chips
(but needs a new translation for `msgid "{count} more"` & `msgid "Show Less"`)

AAP-7341:
translate "Back", "Next", "Cancel", "Close" for WizardModal
(but needs a new translation for `msgid "Back"` & `msgid "Next"`)

AAP-7343:
mark "Add a role description here", "Permissions" and "Role name" for translations,
(needs a new translation for `msgid "Add a role description here"`, `msgid "Permissions"`)