### PR TITLE
[Stable-4.5] Undefined staging `repoName` in repo-selector (9318ea4)

### DIFF
--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -97,6 +97,6 @@ export class RepoSelector extends React.Component<IProps, IState> {
 
   private getRepoName(repoName) {
     const repo = Constants.REPOSITORYNAMES[repoName];
-    return i18n._(repo);
+    return repo ? i18n._(repo) : repoName;
   }
 }


### PR DESCRIPTION
No-Issue

In my `ui/imy-mports`, if uploaded collection is waiting for approval, redirecting to the staging repository doesn't work

Error:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'values')
    at I18n._ (index.js:389:1)
    at RepoSelector.getRepoName (repo-selector.tsx:100:12)
```

Fixed in https://github.com/ansible/ansible-hub-ui/pull/2449 (9318ea4)