### PR TITLE
[wisdom] Community EULA - authenticated user

### DIFF
--- a/CHANGES/2144.feature
+++ b/CHANGES/2144.feature
@@ -1,0 +1,1 @@
+Community mode EULA modals

--- a/src/components/eula-modal/user.tsx
+++ b/src/components/eula-modal/user.tsx
@@ -1,0 +1,80 @@
+import { t } from '@lingui/macro';
+import { Button, Modal, Spinner } from '@patternfly/react-core';
+import React, { useEffect, useState } from 'react';
+import { useContext } from 'src/loaders/app-context';
+
+interface IProps {
+  children?: React.ReactNode;
+  title?: string;
+}
+
+// TODO API
+const FakeUserAPI = {
+  eulaAccept: (user) => {
+    console.log('TODO accept eula api', user);
+    return Promise.resolve();
+  },
+  eulaDecline: (user) => {
+    console.log('TODO decline eula api', user);
+    return Promise.resolve();
+  },
+};
+
+// for authenticated users
+// show modal unless user.TODO_eula_confirmed
+// there are two buttons - Accept and Decline
+// both submit to API
+export const EulaModalUser = ({ title, children }: IProps) => {
+  const { user } = useContext();
+  const [isOpen, setOpen] = useState(false);
+  const [spinner, setSpinner] = useState(false);
+
+  useEffect(() => {
+    if (user) {
+      setOpen(!user['TODO_eula_confirmed']);
+    }
+  }, [user]);
+
+  if (!user || user.is_anonymous || !isOpen) {
+    return null;
+  }
+
+  title ||= t`Ansible Galaxy EULA`;
+  children ||= <>🚧 Lorem ipsum...</>;
+
+  const handle = (api) => () => {
+    setSpinner(true);
+    api
+      .then(() => {
+        setSpinner(false);
+        setOpen(false);
+      })
+      .catch((e) => {
+        console.log('TODO handle', e);
+        setSpinner(false);
+      });
+  };
+  const accept = handle(() => FakeUserAPI.eulaAccept(user));
+  const decline = handle(() => FakeUserAPI.eulaDecline(user));
+
+  return (
+    <Modal
+      actions={[
+        <Button key='confirm' onClick={accept} variant='primary'>
+          {t`Accept`}
+        </Button>,
+        <Button key='cancel' onClick={decline} variant='secondary'>
+          {t`Decline`}
+        </Button>,
+        spinner ? <Spinner size='sm'></Spinner> : null,
+      ]}
+      isOpen={true}
+      showClose={false}
+      title={title}
+      titleIconVariant='info'
+      variant='small'
+    >
+      {children}
+    </Modal>
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -33,6 +33,7 @@ export { EmptyStateFilter } from './empty-state/empty-state-filter';
 export { EmptyStateNoData } from './empty-state/empty-state-no-data';
 export { EmptyStateUnauthorized } from './empty-state/empty-state-unauthorized';
 export { ExecutionEnvironmentHeader } from './execution-environment-header/execution-environment-header';
+export { EulaModalUser } from './eula-modal/user';
 export { GroupModal } from './rbac/group-modal';
 export { GroupRolePermissions } from './rbac/group-role-permissions';
 export { HelperText } from './helper-text/helper-text';

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -22,6 +22,7 @@ import {
 } from 'src/api';
 import {
   AboutModalWindow,
+  EulaModalUser,
   LoginLink,
   SmallLogo,
   StatefulDropdown,
@@ -177,6 +178,7 @@ export const StandaloneLayout = ({
     <Page isManagedSidebar={true} header={Header} sidebar={Sidebar}>
       {children}
       {aboutModalVisible && aboutModal}
+      <EulaModalUser />
     </Page>
   );
 };


### PR DESCRIPTION
Issue: AAH-2144, AAP-8138 (with #3311)

A community mode user will see this modal the first time they visit the UI.

`EulaModalUser` can accept or decline, confirms to imaginary API, reads confirmation from imaginary user field
TODO: what happens after decline?

![20230212185046](https://user-images.githubusercontent.com/289743/218330849-f4900c81-7a84-4003-ad0c-84030f11d8c0.png)

---

UX update:

![20230213183419](https://user-images.githubusercontent.com/289743/218545344-228ed967-012a-499d-a147-fe9378eb8c5e.png)

spinner:

![20230213183650](https://user-images.githubusercontent.com/289743/218545540-24687e69-a6d3-4db8-adb2-8683e0c29733.png)

error:

![20230213183435](https://user-images.githubusercontent.com/289743/218545381-95226513-97e5-403d-8ede-b0c9f1ac428f.png)