### PR TITLE
labeler: drop stable-4.5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,9 +2,6 @@
 # to be looked at by PR author and reviewer to keep or remove
 # called by .github/workflows/labeler.yml
 
-backport-4.5:
-- src/**/*
-
 backport-4.6:
 - src/**/*
 - test/**/*


### PR DESCRIPTION
https://access.redhat.com/support/policy/updates/ansible-automation-platform

4.5 went out of full support on Nov 24,
so we should no longer be backporting anything to 4.5 unless explicitly marked so.
