### PR TITLE
CI/insights dev: mock more insights APIs to fix test insights failures

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -120,15 +120,20 @@ module.exports = (inputConfigs) => {
         },
         registry: [
           ({ app }) => {
-            app.get('/api/featureflags/v0', (_req, res) => {
-              res.send({ toggles: [] });
-            });
-            app.post('/api/featureflags/v0/client/metrics', (_req, res) => {
-              res.send({});
-            });
-            app.get('/api/quickstarts/v1/progress', (_req, res) => {
-              res.send({});
-            });
+            app.get('/api/featureflags/v0', (_req, res) =>
+              res.send({ toggles: [] }),
+            );
+            app.get('/api/quickstarts/v1/progress', (_req, res) =>
+              res.send({ data: [] }),
+            );
+            app.get('/api/rbac/v1/cross-account-requests', (_req, res) =>
+              res.send({ data: [] }),
+            );
+            app.get('/api/rbac/v1/access', (_req, res) => res.send(null));
+
+            app.post('/api/featureflags/v0/client/metrics', (_req, res) =>
+              res.send(null),
+            );
           },
         ],
       }),


### PR DESCRIPTION
galaxykit collection upload is failing in insights mode tests..
https://github.com/ansible/ansible-hub-ui/actions/runs/4090416948/jobs/7053814292

it's just new insights code querying more APIs we don't have, adding mocks