### PR TITLE
dependabot: switch to monthly updates for 4.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
     directory: '/'
     target-branch: 'stable-4.5'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     commit-message:
       prefix: '[stable-4.5] '
     ignore:
@@ -98,7 +98,7 @@ updates:
     commit-message:
       prefix: '[stable-4.5] '
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
goes with #3265 

4.5 is getting old, reducing the frequency of package updates to the same as 4.2 & 4.4.

Only master and 4.6 updates will now happen weekly.