### PR TITLE
webpack: use HtmlWebpackConfig directly

### DIFF
--- a/config/community.dev.webpack.config.js
+++ b/config/community.dev.webpack.config.js
@@ -32,9 +32,6 @@ module.exports = webpackBase({
   // Enables webpack debug mode. Options: true, false
   UI_DEBUG: true,
 
-  // Target compilation environment. Options: dev, prod
-  TARGET_ENVIRONMENT: 'dev',
-
   // Login URI to allow stand alone with and without keycloak
   UI_EXTERNAL_LOGIN_URI: uiExternalLoginURI,
 

--- a/config/community.prod.webpack.config.js
+++ b/config/community.prod.webpack.config.js
@@ -10,7 +10,6 @@ module.exports = webpackBase({
   NAMESPACE_TERM: 'namespaces',
   UI_USE_HTTPS: false,
   UI_DEBUG: false,
-  TARGET_ENVIRONMENT: 'prod',
   UI_EXTERNAL_LOGIN_URI: '/login/github/',
   WEBPACK_PUBLIC_PATH: '/',
 });

--- a/config/insights.dev.webpack.config.js
+++ b/config/insights.dev.webpack.config.js
@@ -34,16 +34,9 @@ module.exports = webpackBase({
   // Determines the title of the app
   APPLICATION_NAME: 'Automation Hub',
 
-  // Disables custom favicons. Used to turn off our favicon so we inherit
-  // the correct one from console.redhat.com
-  USE_FAVICON: false,
-
   // Serve the UI over http or https. Options: true, false
   UI_USE_HTTPS: false,
 
   // Enables webpack debug mode. Options: true, false
   UI_DEBUG: true,
-
-  // Target compilation environment. Options: dev, prod
-  TARGET_ENVIRONMENT: 'dev',
 });

--- a/config/insights.prod.webpack.config.js
+++ b/config/insights.prod.webpack.config.js
@@ -14,7 +14,5 @@ module.exports = webpackBase({
   NAMESPACE_TERM: 'partners',
   UI_USE_HTTPS: false,
   UI_DEBUG: false,
-  TARGET_ENVIRONMENT: 'prod',
   APPLICATION_NAME: 'Automation Hub',
-  USE_FAVICON: false,
 });

--- a/config/standalone.dev.webpack.config.js
+++ b/config/standalone.dev.webpack.config.js
@@ -31,9 +31,6 @@ module.exports = webpackBase({
   // Enables webpack debug mode. Options: true, false
   UI_DEBUG: true,
 
-  // Target compilation environment. Options: dev, prod
-  TARGET_ENVIRONMENT: 'dev',
-
   // Login URI to allow stand alone with and without keycloak
   UI_EXTERNAL_LOGIN_URI: uiExternalLoginURI,
 

--- a/config/standalone.prod.webpack.config.js
+++ b/config/standalone.prod.webpack.config.js
@@ -10,7 +10,6 @@ module.exports = webpackBase({
   NAMESPACE_TERM: 'namespaces',
   UI_USE_HTTPS: false,
   UI_DEBUG: false,
-  TARGET_ENVIRONMENT: 'prod',
   UI_EXTERNAL_LOGIN_URI: '/login',
   WEBPACK_PUBLIC_PATH: '/static/galaxy_ng/',
 });

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -37,11 +37,9 @@ const defaultConfigs = [
   // build time
   { name: 'UI_USE_HTTPS', default: false, scope: 'webpack' },
   { name: 'UI_DEBUG', default: false, scope: 'webpack' },
-  { name: 'TARGET_ENVIRONMENT', default: 'prod', scope: 'webpack' },
   { name: 'UI_PORT', default: 8002, scope: 'webpack' },
   { name: 'WEBPACK_PROXY', default: undefined, scope: 'webpack' },
   { name: 'WEBPACK_PUBLIC_PATH', default: undefined, scope: 'webpack' },
-  { name: 'USE_FAVICON', default: true, scope: 'webpack' },
   { name: 'API_PROXY_TARGET', default: undefined, scope: 'webpack' },
 ];
 
@@ -108,18 +106,11 @@ module.exports = (inputConfigs) => {
   const htmlPluginConfig = {
     // used by src/index.html
     applicationName: customConfigs.APPLICATION_NAME,
-    targetEnv: customConfigs.DEPLOYMENT_MODE,
 
     // standalone needs injecting js and css into dist/index.html
     inject: isStandalone,
+    favicon: isStandalone ? 'static/images/favicon.ico' : '',
   };
-
-  // being able to turn off the favicon is useful for deploying to insights mode
-  // console.redhat.com sets its own favicon and ours tends to override it if we
-  // set one
-  if (customConfigs.USE_FAVICON) {
-    htmlPluginConfig['favicon'] = 'static/images/favicon.ico';
-  }
 
   const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
                 "eslint": "^8.34.0",
                 "eslint-config-prettier": "^8.6.0",
                 "eslint-plugin-react": "^7.32.2",
+                "html-webpack-plugin": "^5.5.0",
                 "husky": "^4.3.0",
                 "npm-run-all": "^4.1.5",
                 "postcss": "^8.4.21",
@@ -8891,8 +8892,9 @@
         },
         "node_modules/html-webpack-plugin": {
             "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
+            "integrity": "sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/html-minifier-terser": "^6.0.0",
                 "html-minifier-terser": "^6.0.2",
@@ -22558,6 +22560,8 @@
         },
         "html-webpack-plugin": {
             "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
+            "integrity": "sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==",
             "dev": true,
             "requires": {
                 "@types/html-minifier-terser": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "eslint": "^8.34.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-plugin-react": "^7.32.2",
+        "html-webpack-plugin": "^5.5.0",
         "husky": "^4.3.0",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.21",


### PR DESCRIPTION
The next version of `@redhat-cloud-services/frontend-components-config` is removing `htmlPlugin` support (and `useChromeTemplate`).

=> switching that part to our own `HtmlWebpackPlugin` config instead

(This also makes `USE_FAVICON` irrelevant (1:1 with when we use the plugin), and `TARGET_ENVIRONMENT` has been dead along with `targetEnv`, removing.)