### PR TITLE
Insights: support /preview/ as well as /beta/

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -210,7 +210,7 @@ jobs:
       run: |
         echo waiting for containers to start
         sleep 30
-        curl http://localhost:8002/preview/ansible/automation-hub/ | tee /dev/stderr | grep '/preview/apps/chrome/js/'
+        curl http://localhost:8002/preview/ansible/automation-hub/ | tee /dev/stderr | grep '/beta/apps/chrome/js/'
         sleep 30
 
     - name: "Ensure galaxykit can connect to API (standalone)"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -210,7 +210,7 @@ jobs:
       run: |
         echo waiting for containers to start
         sleep 30
-        curl http://localhost:8002/beta/ansible/automation-hub/ | tee /dev/stderr | grep '/beta/apps/chrome/js/'
+        curl http://localhost:8002/preview/ansible/automation-hub/ | tee /dev/stderr | grep '/preview/apps/chrome/js/'
         sleep 30
 
     - name: "Ensure galaxykit can connect to API (standalone)"

--- a/.github/workflows/cypress/cypress.env.json.insights
+++ b/.github/workflows/cypress/cypress.env.json.insights
@@ -1,7 +1,7 @@
 {
   "apiPrefix": "/api/automation-hub/",
   "pulpPrefix": "/api/automation-hub/pulp/api/v3/",
-  "uiPrefix": "/beta/ansible/automation-hub/",
+  "uiPrefix": "/preview/ansible/automation-hub/",
   "username": "admin",
   "password": "admin",
   "galaxykit": "galaxykit --ignore-certs --auth-url 'http://localhost:8002/auth/realms/redhat-external/protocol/openid-connect/token'",

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The app will run on http://localhost:8002/ui and proxy requests for `/api` to th
 1. Start the API with `COMPOSE_PROFILE=insights` (compose) or `COMPOSE_PROFILE=galaxy_ng/base:galaxy_ng/insights` (oci-env)
 2. `npm run start-insights`
 
-The app will run on http://localhost:8002/beta/ansible/automation-hub and proxy requests for `/api/automation-hub` to the api on `http://localhost:5001`.
+The app will run on http://localhost:8002/preview/ansible/automation-hub and proxy requests for `/api/automation-hub` to the api on `http://localhost:5001`.
 
 ## Deploying
 
@@ -55,9 +55,9 @@ The Github Action invokes the [RedHatInsights/insights-frontend-builder-common//
 - any push to the `prod-stable` branch will deploy to a `ansible-hub-ui-build` `prod-stable` branch
 - the `ansible-hub-ui-build` `master` branch is not used, as PRs against `master` end up in `qa-beta`
 
-- `qa-beta` builds end up on `console.stage.redhat.com/beta`
+- `qa-beta` builds end up on `console.stage.redhat.com/preview`
 - `qa-stable` builds end up on `console.stage.redhat.com`
-- `prod-beta` builds end up on `console.redhat.com/beta`
+- `prod-beta` builds end up on `console.redhat.com/preview`
 - `prod-stable` builds end up on `console.redhat.com`
 
 ### Workflows

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The app will run on http://localhost:8002/ui and proxy requests for `/api` to th
 1. Start the API with `COMPOSE_PROFILE=insights` (compose) or `COMPOSE_PROFILE=galaxy_ng/base:galaxy_ng/insights` (oci-env)
 2. `npm run start-insights`
 
-The app will run on http://localhost:8002/preview/ansible/automation-hub and proxy requests for `/api/automation-hub` to the api on `http://localhost:5001`.
+The app will run on http://localhost:8002/preview/ansible/automation-hub (and http://localhost:8002/beta/ansible/automation-hub) and proxy requests for `/api/automation-hub` to the api on `http://localhost:5001`.
 
 ## Deploying
 
@@ -55,9 +55,9 @@ The Github Action invokes the [RedHatInsights/insights-frontend-builder-common//
 - any push to the `prod-stable` branch will deploy to a `ansible-hub-ui-build` `prod-stable` branch
 - the `ansible-hub-ui-build` `master` branch is not used, as PRs against `master` end up in `qa-beta`
 
-- `qa-beta` builds end up on `console.stage.redhat.com/preview`
+- `qa-beta` builds end up on `console.stage.redhat.com/preview` (and `/beta`)
 - `qa-stable` builds end up on `console.stage.redhat.com`
-- `prod-beta` builds end up on `console.redhat.com/preview`
+- `prod-beta` builds end up on `console.redhat.com/preview` (and `/beta`)
 - `prod-stable` builds end up on `console.redhat.com`
 
 ### Workflows

--- a/config/insights.dev.webpack.config.js
+++ b/config/insights.dev.webpack.config.js
@@ -18,7 +18,7 @@ module.exports = webpackBase({
   // Path on the host where the UI is found. EX: /apps/automation-hub
   UI_BASE_PATH:
     cloudBeta !== 'false'
-      ? '/beta/ansible/automation-hub/'
+      ? '/preview/ansible/automation-hub/'
       : '/ansible/automation-hub/',
 
   // Port that the UI is served over

--- a/config/insights.prod.webpack.config.js
+++ b/config/insights.prod.webpack.config.js
@@ -8,7 +8,7 @@ module.exports = webpackBase({
   API_BASE_PATH: '/api/automation-hub/',
   UI_BASE_PATH:
     cloudBeta === 'true'
-      ? '/beta/ansible/automation-hub/'
+      ? '/preview/ansible/automation-hub/'
       : '/ansible/automation-hub/',
   DEPLOYMENT_MODE: 'insights',
   NAMESPACE_TERM: 'partners',

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -122,8 +122,13 @@ module.exports = (inputConfigs) => {
     // insights dev
     ...(!isStandalone &&
       !isBuild && {
-        appUrl: customConfigs.UI_BASE_PATH,
-        deployment: cloudBeta !== 'false' ? 'preview/apps' : 'apps',
+        appUrl: customConfigs.UI_BASE_PATH.includes('/preview/')
+          ? [
+              customConfigs.UI_BASE_PATH,
+              customConfigs.UI_BASE_PATH.replace('/preview/', '/beta/'),
+            ]
+          : customConfigs.UI_BASE_PATH,
+        deployment: cloudBeta !== 'false' ? 'beta/apps' : 'apps',
         standalone: {
           api: {
             context: [customConfigs.API_BASE_PATH],
@@ -138,7 +143,7 @@ module.exports = (inputConfigs) => {
     // insights deployments from master
     ...(!isStandalone &&
       cloudBeta && {
-        deployment: cloudBeta === 'true' ? 'preview/apps' : 'apps',
+        deployment: cloudBeta === 'true' ? 'beta/apps' : 'apps',
       }),
   });
 

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -123,7 +123,7 @@ module.exports = (inputConfigs) => {
     ...(!isStandalone &&
       !isBuild && {
         appUrl: customConfigs.UI_BASE_PATH,
-        deployment: cloudBeta !== 'false' ? 'beta/apps' : 'apps',
+        deployment: cloudBeta !== 'false' ? 'preview/apps' : 'apps',
         standalone: {
           api: {
             context: [customConfigs.API_BASE_PATH],
@@ -138,7 +138,7 @@ module.exports = (inputConfigs) => {
     // insights deployments from master
     ...(!isStandalone &&
       cloudBeta && {
-        deployment: cloudBeta === 'true' ? 'beta/apps' : 'apps',
+        deployment: cloudBeta === 'true' ? 'preview/apps' : 'apps',
       }),
   });
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -3,10 +3,12 @@ import { Constants } from 'src/constants';
 import { ParamHelper, ParamType } from 'src/utilities';
 
 export function formatPath(path: Paths, data = {}, params?: ParamType) {
-  // insights router has basename="/" or "/beta/", with hub under a nested "ansible/automation-hub" route - our urls are relative to that
+  // insights router has basename="/", "/beta/" or "/preview/", with hub under a nested "ansible/automation-hub" route - our urls are relative to that
   let url =
     DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-      ? UI_BASE_PATH.replace('/beta/', '/').replace(/\/$/, '')
+      ? UI_BASE_PATH.replace('/preview/', '/')
+          .replace('/beta/', '/')
+          .replace(/\/$/, '')
       : '';
   url += (path as string) + '/';
 

--- a/test/cypress.env.json.template
+++ b/test/cypress.env.json.template
@@ -15,7 +15,7 @@
 {
   "apiPrefix": "/api/automation-hub/",
   "pulpPrefix": "/api/automation-hub/pulp/api/v3/",
-  "uiPrefix": "/beta/ansible/automation-hub/",
+  "uiPrefix": "/preview/ansible/automation-hub/",
   "username": "admin",
   "password": "admin",
   "galaxykit": "galaxykit --ignore-certs --auth-url 'http://localhost:8002/auth/realms/redhat-external/protocol/openid-connect/token'",


### PR DESCRIPTION
On May 1st, `console.redhat.com/beta` changes to `console.redhat.com/preview`, with both `beta` and `preview` being supported for now.

Updating code and build to fit .. we can test on stage before May.

(see hcc-actions-required mail `[ACTION REQUIRED]: Moving from BETA to PREVIEW` for context)