### PR TITLE
[community] Terms of Use link

### DIFF
--- a/CHANGES/2159.feature
+++ b/CHANGES/2159.feature
@@ -1,0 +1,1 @@
+[community] Terms of Use link

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -108,6 +108,11 @@ function standaloneMenu({ repository }) {
         settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
         !user.is_anonymous,
     }),
+    menuItem(t`Terms of Use`, {
+      url: 'https://www.redhat.com/en/about/terms-use',
+      external: true,
+      condition: ({ featureFlags }) => featureFlags.legacy_roles,
+    }),
     menuSection(t`User Access`, {}, [
       menuItem(t`Users`, {
         condition: (context) => hasPermission(context, 'galaxy.view_user'),


### PR DESCRIPTION
Issue: AAH-2159
Replaces #3311, #3262

Add a [Terms of Use]( https://www.redhat.com/en/about/terms-use ) menu link in community mode.


![20230227144952](https://user-images.githubusercontent.com/289743/221595961-889c6314-4e51-4c22-a60d-fcf5b0cffeae.png)

