### PR TITLE
[stable-4.6] CI: run collectstatic manually, fix 404

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -173,6 +173,7 @@ jobs:
         mv -v dist/ ../pulp_galaxy_ng/static/galaxy_ng
 
         # apply changes, runs collectstatic and serves static assets
+        podman exec pulp pulpcore-manager collectstatic --no-input --clear
         podman exec pulp bash -c "s6-svc -r /var/run/s6-rc/servicedirs/pulpcore-api"
 
     - name: "Reset admin password"


### PR DESCRIPTION
Test failure: https://github.com/ansible/ansible-hub-ui/actions/runs/4293339560/jobs/7480897727

`/var/lib/operator/static/` ends up empty in the container, we need to run `pulpcore-manager collectstatic` (but it asks and fails when it's non-empty, hence `--clear --no-input`)