### PR TITLE
[stable-4.6] CI: run signing-setup as pulp, not root

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -183,7 +183,8 @@ jobs:
 
     - name: "Enable signing service"
       run: |
-        podman exec pulp /tmp/signing-setup.sh
+        podman exec pulp chown pulp.pulp /etc/pulp/certs/
+        podman exec pulp su - pulp -c /tmp/signing-setup.sh
 
     - name: "Install Cypress & test dependencies"
       working-directory: 'ansible-hub-ui/test'


### PR DESCRIPTION
Follows #3362,
fixes https://github.com/ansible/ansible-hub-ui/actions/runs/4293699945/jobs/7482171960

adding a signing service runs it, so adding the service as root runs it as root
 => any further signing attempts can't rewrite root-owned /tmp/key_password.txt

but also, running gpg as root uses a different keystore than running as pulp
=> signature keys get added but signing fails claiming they don't exist

fixing by running signing-setup as pulp,
adding PULP_SETTINGS and running pulpcore-manager instead of django-admin