### PR TITLE
pr-checks: catch use of `this` outside of files using `class`

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -57,6 +57,21 @@ jobs:
         # run linters
         npm run lint
 
+        # uses `this` but not `class`
+        sudo apt install -y ripgrep
+        rg '\bclass\b' src/ | cut -d: -f1 | sort -u > src.class
+        rg '\bthis[\.,)\]}]\b' src/ | cut -d: -f1 | sort -u > src.this
+        if [ `comm -13 src.class src.this | wc -l` -ne 0 ]; then
+          echo
+          echo "Files using this but not class:"
+          echo
+          comm -13 src.class src.this
+          echo
+          rg '\bthis[\.,)\]}]\b' `comm -13 src.class src.this`
+          echo
+          exit 1
+        fi
+
   merge-commits:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
eventually we can use eslint-plugin-fp/no-this, but it doesn't allow for conditional warning only in files not using `class`

Cc @MilanPospisil .. would something like this help catching more issues when converting components?