### PR TITLE
[stable-4.5] AuthHandler - wait for user, settings, featureFlags before deciding where to find the login screen

### DIFF
--- a/CHANGES/1146.bug
+++ b/CHANGES/1146.bug
@@ -1,0 +1,1 @@
+keycloak: wait for feature flags to load before login redirect

--- a/CHANGES/2141.bug
+++ b/CHANGES/2141.bug
@@ -1,0 +1,1 @@
+keycloak: wait for feature flags to load before login redirect

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -84,37 +84,44 @@ class AuthHandler extends React.Component<
   IAuthHandlerState
 > {
   static contextType = AppContext;
+
   constructor(props, context) {
     super(props);
-    this.state = { isLoading: !context.user };
+
+    this.state = {
+      isLoading: !context.user || !context.settings || !context.featureFlags,
+    };
   }
 
   componentDidMount() {
     // This component is mounted on every route change, so it's a good place
     // to check for an active user.
-    const { user, settings } = this.context;
-    if (!user || !settings) {
-      const promises = [];
-      promises.push(
-        FeatureFlagsAPI.get().then(({ data }) => {
-          // we need this even if ActiveUserAPI fails, otherwise isExternalAuth will always be false, breaking keycloak redirect
-          this.props.updateInitialData({ featureFlags: data });
-        }),
-      );
-      promises.push(ActiveUserAPI.getUser());
-      promises.push(SettingsAPI.get());
-      Promise.all(promises)
-        .then((results) => {
-          this.props.updateInitialData(
-            {
-              user: results[1],
-              settings: results[2].data,
-            },
-            () => this.setState({ isLoading: false }),
-          );
-        })
-        .catch(() => this.setState({ isLoading: false }));
+    const { user, settings, featureFlags } = this.context;
+    if (user && settings && featureFlags) {
+      return;
     }
+
+    const promises = [];
+    promises.push(
+      FeatureFlagsAPI.get().then(({ data }) => {
+        // we need this even if ActiveUserAPI fails, otherwise isExternalAuth will always be false, breaking keycloak redirect
+        this.props.updateInitialData({ featureFlags: data });
+      }),
+    );
+    promises.push(ActiveUserAPI.getUser());
+    promises.push(SettingsAPI.get());
+
+    Promise.all(promises).then((results) => {
+      this.props.updateInitialData({
+        user: results[1],
+        settings: results[2].data,
+      });
+    });
+
+    // don't render until all requests are processed
+    Promise.allSettled(promises).then(() =>
+      this.setState({ isLoading: false }),
+    );
   }
 
   render() {

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -111,12 +111,14 @@ class AuthHandler extends React.Component<
     promises.push(ActiveUserAPI.getUser());
     promises.push(SettingsAPI.get());
 
-    Promise.all(promises).then((results) => {
-      this.props.updateInitialData({
-        user: results[1],
-        settings: results[2].data,
-      });
-    });
+    Promise.all(promises)
+      .then((results) => {
+        this.props.updateInitialData({
+          user: results[1],
+          settings: results[2].data,
+        });
+      })
+      .catch((_e) => null);
 
     // don't render until all requests are processed
     Promise.allSettled(promises).then(() =>

--- a/test/cypress/integration/login.js
+++ b/test/cypress/integration/login.js
@@ -12,6 +12,9 @@ describe('Login helpers', () => {
   });
 
   it('can login manually and logout as admin or different user', () => {
+    // prevent blowing up on unauthenticated requests on the login page
+    cy.on('uncaught:exception', () => false);
+
     cy.manualLogin(username, password);
     cy.contains(username);
     cy.logout();
@@ -20,6 +23,9 @@ describe('Login helpers', () => {
   });
 
   it('can use apiLogin', () => {
+    // prevent blowing up on unauthenticated requests on the login page
+    cy.on('uncaught:exception', () => false);
+
     cy.apiLogin(adminUsername, adminPassword);
     cy.contains(adminUsername);
 


### PR DESCRIPTION
Fixes AAH-1146, AAH-2141 and AAP-9768

This covers the screnario where SSO is configured correctly, but user API responds much sooner than feature flags, causing AuthHandler to redirect to `/ui/login`, ignoring the external auth feature flag, because `isLoading` is only checking user, and the `catch` is not waiting for feature flags.

---

Testing:

```diff
diff --git a/dev/standalone-keycloak/docker-compose.yml b/dev/standalone-keycloak/docker-compose.yml
index 63e3641..5157a35 100644
--- a/dev/standalone-keycloak/docker-compose.yml
+++ b/dev/standalone-keycloak/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - './standalone-keycloak/galaxy_ng.env'
       - '../.compose.env'
   keycloak:
-    image: quay.io/keycloak/keycloak:latest
+    image: quay.io/keycloak/keycloak:legacy
     env_file:
       - './standalone-keycloak/keycloak.env'
       - '../.compose.env'
diff --git a/galaxy_ng/app/api/ui/views/feature_flags.py b/galaxy_ng/app/api/ui/views/feature_flags.py
index 77af73d..ba81f2b 100755
--- a/galaxy_ng/app/api/ui/views/feature_flags.py
+++ b/galaxy_ng/app/api/ui/views/feature_flags.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
+import time
 
 from pulpcore.plugin.models import SigningService
 from galaxy_ng.app.api import base as api_base
@@ -12,6 +13,7 @@ class FeatureFlagsView(api_base.APIView):
     def get(self, request, *args, **kwargs):
         flags = settings.get("GALAXY_FEATURE_FLAGS", {})
         _load_conditional_signing_flags(flags)
+        time.sleep(3)
         return Response(flags)
 
 ```

and visit http://localhost:8080/ui/ when not logged in :)

---

stable-4.4: #3392 
stable-4.5: this
stable-4.6+: #2335