### PR TITLE
Insights tests: fix Cannot POST /api/chrome-service/...

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -45,6 +45,40 @@ const defaultConfigs = [
   { name: 'API_PROXY_TARGET', default: undefined, scope: 'webpack' },
 ];
 
+const insightsMockAPIs = ({ app }) => {
+  // GET
+  [
+    {
+      url: '/api/chrome-service/v1/user',
+      response: {
+        data: {
+          lastVisited: [],
+          favoritePages: [],
+          visitedBundles: {},
+        },
+      },
+    },
+    { url: '/api/featureflags/v0', response: { toggles: [] } },
+    { url: '/api/quickstarts/v1/progress', response: { data: [] } },
+    { url: '/api/rbac/v1/access', response: { data: [] } },
+    { url: '/api/rbac/v1/cross-account-requests', response: { data: [] } },
+  ].forEach(({ url, response }) =>
+    app.get(url, (_req, res) => res.send(response)),
+  );
+
+  // POST
+  [
+    { url: '/api/chrome-service/v1/last-visited', response: { data: [] } },
+    {
+      url: '/api/chrome-service/v1/user/visited-bundles',
+      response: { data: [] },
+    },
+    { url: '/api/featureflags/v0/client/metrics', response: {} },
+  ].forEach(({ url, response }) =>
+    app.post(url, (_req, res) => res.send(response)),
+  );
+};
+
 module.exports = (inputConfigs) => {
   const customConfigs = {};
   const globals = {};
@@ -118,24 +152,7 @@ module.exports = (inputConfigs) => {
           rbac,
           ...defaultServices,
         },
-        registry: [
-          ({ app }) => {
-            app.get('/api/featureflags/v0', (_req, res) =>
-              res.send({ toggles: [] }),
-            );
-            app.get('/api/quickstarts/v1/progress', (_req, res) =>
-              res.send({ data: [] }),
-            );
-            app.get('/api/rbac/v1/cross-account-requests', (_req, res) =>
-              res.send({ data: [] }),
-            );
-            app.get('/api/rbac/v1/access', (_req, res) => res.send(null));
-
-            app.post('/api/featureflags/v0/client/metrics', (_req, res) =>
-              res.send(null),
-            );
-          },
-        ],
+        registry: [insightsMockAPIs],
       }),
 
     // insights deployments from master


### PR DESCRIPTION
Failing job: https://github.com/ansible/ansible-hub-ui/actions/runs/4309642320/jobs/7587811663

Mocking more APIs:
* POST `/api/chrome-service/v1/last-visited`
* POST `/api/chrome-service/v1/user/visited-bundles`
* GET `/api/chrome-service/v1/user`

(values based on https://github.com/RedHatInsights/insights-chrome/blob/ff00b3fa5ba9110dc1d827e48bc8593394da6b0d/cypress/component/helptopics/HelpTopicManager.cy.tsx#L88-L125)