### PR TITLE
Drop babel-plugin-lodash

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,7 +7,6 @@
     "plugins": [
         "@babel/plugin-syntax-dynamic-import",
         "@babel/plugin-transform-runtime",
-        "babel-plugin-lodash",
         "babel-plugin-macros",
     ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
                 "@typescript-eslint/eslint-plugin": "^5.54.0",
                 "@typescript-eslint/parser": "^5.54.0",
                 "babel-core": "^7.0.0-bridge.0",
-                "babel-plugin-lodash": "^3.3.4",
                 "babel-plugin-macros": "^3.1.0",
                 "css-loader": "^6.7.3",
                 "eslint": "^8.34.0",
@@ -5148,18 +5147,6 @@
             "peerDependencies": {
                 "@babel/core": "^7.0.0",
                 "webpack": ">=2"
-            }
-        },
-        "node_modules/babel-plugin-lodash": {
-            "version": "3.3.4",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/helper-module-imports": "^7.0.0-beta.49",
-                "@babel/types": "^7.0.0-beta.49",
-                "glob": "^7.1.1",
-                "lodash": "^4.17.10",
-                "require-package-name": "^2.0.1"
             }
         },
         "node_modules/babel-plugin-macros": {
@@ -13487,11 +13474,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/require-package-name": {
-            "version": "2.0.1",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/requires-port": {
             "version": "1.0.0",
             "dev": true,
@@ -19940,17 +19922,6 @@
                 "schema-utils": "^2.6.5"
             }
         },
-        "babel-plugin-lodash": {
-            "version": "3.3.4",
-            "dev": true,
-            "requires": {
-                "@babel/helper-module-imports": "^7.0.0-beta.49",
-                "@babel/types": "^7.0.0-beta.49",
-                "glob": "^7.1.1",
-                "lodash": "^4.17.10",
-                "require-package-name": "^2.0.1"
-            }
-        },
         "babel-plugin-macros": {
             "version": "3.1.0",
             "dev": true,
@@ -25477,10 +25448,6 @@
         },
         "require-from-string": {
             "version": "2.0.2",
-            "dev": true
-        },
-        "require-package-name": {
-            "version": "2.0.1",
             "dev": true
         },
         "requires-port": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
         "@typescript-eslint/eslint-plugin": "^5.54.0",
         "@typescript-eslint/parser": "^5.54.0",
         "babel-core": "^7.0.0-bridge.0",
-        "babel-plugin-lodash": "^3.3.4",
         "babel-plugin-macros": "^3.1.0",
         "css-loader": "^6.7.3",
         "eslint": "^8.34.0",


### PR DESCRIPTION
it now produces ~2800 lines of warnings (https://github.com/ansible/ansible-hub-ui/actions/runs/4349433032/jobs/7599098189#step:15:41)

    Trace: `isModuleDeclaration` has been deprecated, please migrate to `isImportOrExportDeclaration`.
        at isModuleDeclaration (/home/runner/work/ansible-hub-ui/ansible-hub-ui/ansible-hub-ui/node_modules/@babel/types/lib/validators/generated/index.js:3939:11)
        at PluginPass.Program (/home/runner/work/ansible-hub-ui/ansible-hub-ui/ansible-hub-ui/node_modules/babel-plugin-lodash/lib/index.js:102:44)

removing babel-plugin-lodash, we don't *really* need it
(removing this increases uncompressed bundle size from 13.1 MiB to 13.5 MiB)

(and the [repo](https://github.com/lodash/babel-plugin-lodash/) hasn't seen any changes since 2018)