### PR TITLE
[Cross Repo Collection Search] Refactor screens to use new CV search API

### DIFF
--- a/CHANGES/767.feature
+++ b/CHANGES/767.feature
@@ -1,0 +1,1 @@
+Replaced existing collection search with pulp_ansible collection version search endpoint

--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 export class API extends HubAPI {
-  apiPath = this.getUIPath('collection-versions/');
+  apiPath = 'v3/plugin/ansible/search/collection-versions/';
 
   setRepository(
     namespace: string,

--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { CollectionVersionSearch } from '../api';
 import { HubAPI } from './hub';
 
@@ -63,6 +64,22 @@ export class API extends HubAPI {
         })
         .catch((err) => reject(err));
     });
+  }
+
+  getUsedDependenciesByCollection(
+    namespace,
+    collection,
+    params = {},
+    cancelToken = undefined,
+  ) {
+    return this.http.get(
+      `${this.apiPath}?dependency=${namespace}.${collection}`,
+      { params: this.mapPageToOffset(params), cancelToken: cancelToken?.token },
+    );
+  }
+
+  getCancelToken() {
+    return axios.CancelToken.source();
   }
 }
 

--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -1,6 +1,10 @@
+import { CollectionVersionSearch } from '../api';
 import { HubAPI } from './hub';
 
 export class API extends HubAPI {
+  // contains collection versions
+  cachedCollection: CollectionVersionSearch[] = [];
+
   apiPath = 'v3/plugin/ansible/search/collection-versions/';
 
   setRepository(
@@ -27,6 +31,38 @@ export class API extends HubAPI {
 
   get(id: string) {
     return super.get(id, 'pulp/api/v3/content/ansible/collection_versions/');
+  }
+
+  // Caches the collection returned from the server.
+  // collection is array of collection versions
+  // If the requested collection matches the cache, return it,
+  // if it doesn't, query the API for the collection versions and
+  // replace the old cache with the new value.
+  // This allows the collection page to be broken into separate components
+  // and routed separately without fetching redundant data from the API
+  getCached(params, forceReload?: boolean) {
+    return new Promise((resolve, reject) => {
+      const { name, namespace, repository_name } = params;
+      const [collection] = this.cachedCollection;
+      if (
+        !forceReload &&
+        collection &&
+        collection.collection_version.name === name &&
+        collection.collection_version.namespace === namespace &&
+        collection.repository.name === repository_name
+      ) {
+        return resolve(this.cachedCollection);
+      }
+
+      super
+        .list(params)
+        .then((result) => {
+          const { data } = result.data;
+          this.cachedCollection = data;
+          return resolve(data);
+        })
+        .catch((err) => reject(err));
+    });
   }
 }
 

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -1,10 +1,10 @@
 import axios from 'axios';
 import {
+  AnsibleDistributionAPI,
   CollectionDetailType,
   CollectionListType,
   CollectionUploadType,
   CollectionVersionSearch,
-  RepositoryDistributionsAPI,
 } from 'src/api';
 import { HubAPI } from './hub';
 
@@ -87,7 +87,7 @@ export class API extends HubAPI {
       is_deprecated,
     } = collection;
     return new Promise((resolve, reject) => {
-      RepositoryDistributionsAPI.list({
+      AnsibleDistributionAPI.list({
         repository: repository.pulp_href,
       })
         .then((result) => {
@@ -140,7 +140,7 @@ export class API extends HubAPI {
   getDownloadURL(repository, namespace, name, version) {
     // UI API doesn't have tarball download link, so query it separately here
     return new Promise((resolve, reject) => {
-      RepositoryDistributionsAPI.list({
+      AnsibleDistributionAPI.list({
         repository: repository.pulp_href,
       })
         .then((result) => {
@@ -163,7 +163,7 @@ export class API extends HubAPI {
   }
 
   async deleteCollectionVersion(collection: CollectionVersionSearch) {
-    const distros = await RepositoryDistributionsAPI.list({
+    const distros = await AnsibleDistributionAPI.list({
       repository: collection.repository.pulp_href,
     });
 
@@ -178,7 +178,7 @@ export class API extends HubAPI {
   }
 
   async deleteCollection(collection: CollectionVersionSearch) {
-    const distros = await RepositoryDistributionsAPI.list({
+    const distros = await AnsibleDistributionAPI.list({
       repository: collection.repository.pulp_href,
     });
 

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -3,9 +3,24 @@ import {
   CollectionDetailType,
   CollectionListType,
   CollectionUploadType,
+  CollectionVersionSearch,
   RepositoryDistributionsAPI,
 } from 'src/api';
 import { HubAPI } from './hub';
+
+// return correct distro
+export function findDistroBasePathByRepo(distributions, repository) {
+  if (distributions.length === 0) {
+    // if distribution doesn't exist, use repository name
+    return repository.name;
+  }
+
+  // try to look for match by name, if not, just use the first distro
+  const distro = distributions.find(
+    (distro) => distro.name === repository.name,
+  );
+  return distro ? distro.base_path : distro[0].base_path;
+}
 
 function filterContents(contents) {
   if (contents) {
@@ -23,24 +38,6 @@ function filterListItem(item: CollectionListType) {
     latest_version: {
       ...item.latest_version,
       contents: null, // deprecated
-      metadata: {
-        ...item.latest_version.metadata,
-        contents: filterContents(item.latest_version.metadata.contents),
-      },
-    },
-  };
-}
-
-function filterDetailItem(item: CollectionDetailType) {
-  return {
-    ...item,
-    latest_version: {
-      ...item.latest_version,
-      contents: null, // deprecated
-      docs_blob: {
-        ...item.latest_version.docs_blob,
-        contents: filterContents(item.latest_version.docs_blob.contents),
-      },
       metadata: {
         ...item.latest_version.metadata,
         contents: filterContents(item.latest_version.metadata.contents),
@@ -82,19 +79,36 @@ export class API extends HubAPI {
   }
 
   setDeprecation(
-    collection: CollectionListType,
-    isDeprecated: boolean,
-    repo: string,
-  ) {
-    const path = `v3/plugin/ansible/content/${repo}/collections/index/`;
+    collection: CollectionVersionSearch,
+  ): Promise<{ data: { task: string } }> {
+    const {
+      collection_version: { namespace, name },
+      repository,
+      is_deprecated,
+    } = collection;
+    return new Promise((resolve, reject) => {
+      RepositoryDistributionsAPI.list({
+        repository: repository.pulp_href,
+      })
+        .then((result) => {
+          const basePath = findDistroBasePathByRepo(
+            result.data.results,
+            repository,
+          );
 
-    return this.patch(
-      `${collection.namespace.name}/${collection.name}`,
-      {
-        deprecated: isDeprecated,
-      },
-      path,
-    );
+          const path = `v3/plugin/ansible/content/${basePath}/collections/index/`;
+          this.patch(
+            `${namespace}/${name}`,
+            {
+              deprecated: !is_deprecated,
+            },
+            path,
+          )
+            .then((res) => resolve(res))
+            .catch((err) => reject(err));
+        })
+        .catch((err) => reject(err));
+    });
   }
 
   upload(
@@ -123,62 +137,17 @@ export class API extends HubAPI {
     return axios.CancelToken.source();
   }
 
-  // Caches the last collection returned from the server. If the requested
-  // collection matches the cache, return it, if it doesn't query the API
-  // for the collection and replace the old cache with the new value.
-  // This allows the collection page to be broken into separate components
-  // and routed separately without fetching redundant data from the API
-  getCached(
-    namespace,
-    name,
-    repo,
-    params?,
-    forceReload?: boolean,
-  ): Promise<CollectionDetailType> {
-    if (
-      !forceReload &&
-      this.cachedCollection &&
-      this.cachedCollection.name === name &&
-      this.cachedCollection.namespace.name === namespace
-    ) {
-      return Promise.resolve(this.cachedCollection);
-    }
-
-    const path = `${this.apiPath}${repo}/${namespace}/${name}/`;
-    return this.http
-      .get(path, {
-        params: params,
-      })
-      .then((result) => {
-        // remove module_utils, doc_fragments from item
-        const item = filterDetailItem(result.data);
-        this.cachedCollection = item;
-        return item;
-      });
-  }
-
   getDownloadURL(repository, namespace, name, version) {
     // UI API doesn't have tarball download link, so query it separately here
     return new Promise((resolve, reject) => {
-      // get distro_base_path first
       RepositoryDistributionsAPI.list({
         repository: repository.pulp_href,
       })
         .then((result) => {
-          const { results, count } = result.data;
-          let basePath;
-
-          // find correct distro
-          if (count === 0) {
-            // if distribution doesn't exist, use repository name
-            basePath = repository.name;
-          } else {
-            // try to look for match by name, if not, just use the first distro
-            const distro = results.find(
-              (distro) => distro.name === repository.name,
-            );
-            basePath = distro ? distro.base_path : distro[0].base_path;
-          }
+          const basePath = findDistroBasePathByRepo(
+            result.data.results,
+            repository,
+          );
 
           this.http
             .get(
@@ -193,15 +162,33 @@ export class API extends HubAPI {
     });
   }
 
-  deleteCollectionVersion(repo, collection) {
+  async deleteCollectionVersion(collection: CollectionVersionSearch) {
+    const distros = await RepositoryDistributionsAPI.list({
+      repository: collection.repository.pulp_href,
+    });
+
+    const distroBasePath = findDistroBasePathByRepo(
+      distros.data.results,
+      collection.repository,
+    );
+
     return this.http.delete(
-      `v3/plugin/ansible/content/${repo}/collections/index/${collection.namespace.name}/${collection.name}/versions/${collection.latest_version.version}/`,
+      `v3/plugin/ansible/content/${distroBasePath}/collections/index/${collection.collection_version.namespace}/${collection.collection_version.name}/versions/${collection.collection_version.version}/`,
     );
   }
 
-  deleteCollection(repo, collection) {
+  async deleteCollection(collection: CollectionVersionSearch) {
+    const distros = await RepositoryDistributionsAPI.list({
+      repository: collection.repository.pulp_href,
+    });
+
+    const distroBasePath = findDistroBasePathByRepo(
+      distros.data.results,
+      collection.repository,
+    );
+
     return this.http.delete(
-      `v3/plugin/ansible/content/${repo}/collections/index/${collection.namespace.name}/${collection.name}/`,
+      `v3/plugin/ansible/content/${distroBasePath}/collections/index/${collection.collection_version.namespace}/${collection.collection_version.name}/`,
     );
   }
 
@@ -216,6 +203,23 @@ export class API extends HubAPI {
         `collection-versions/?dependency=${namespace}.${collection}`,
       ),
       { params: this.mapPageToOffset(params), cancelToken: cancelToken?.token },
+    );
+  }
+
+  getSignatures(distroBasePath, namespace, name, version) {
+    return this.http.get(
+      `v3/plugin/ansible/content/${distroBasePath}/collections/index/${namespace}/${name}/versions/${version}/`,
+    );
+  }
+
+  getContent(namespace, name, version) {
+    return super.list(
+      {
+        namespace,
+        name,
+        version,
+      },
+      `pulp/api/v3/content/ansible/collection_versions/`,
     );
   }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-export { CollectionAPI } from './collection';
+export { CollectionAPI, findDistroBasePathByRepo } from './collection';
 export { NamespaceAPI } from './namespace';
 export {
   NamespaceType,
@@ -13,6 +13,7 @@ export {
   CollectionUsedByDependencies,
   CollectionVersion,
   CollectionVersionSearch,
+  CollectionVersionContentType,
   ContentSummaryType,
   DocsBlobType,
   PluginContentType,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -12,6 +12,7 @@ export {
   CollectionUploadType,
   CollectionUsedByDependencies,
   CollectionVersion,
+  CollectionVersionSearch,
   ContentSummaryType,
   DocsBlobType,
   PluginContentType,
@@ -77,6 +78,7 @@ export {
   AnsibleRepositoryType,
   AnsibleRepositoryVersionType,
 } from './response-types/ansible-repository';
+export { RepositoryDistributions } from './repository-distributions';
 export { SignContainersAPI } from './sign-containers';
 export {
   LegacyRoleDetailType,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -82,8 +82,6 @@ export {
   AnsibleRepositoryType,
   AnsibleRepositoryVersionType,
 } from './response-types/ansible-repository';
-export { RepositoryDistributionsAPI } from './repository-distributions';
-export { RepositoryDistributions } from './repository-distributions';
 export { SignContainersAPI } from './sign-containers';
 export {
   LegacyRoleDetailType,

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -43,7 +43,10 @@ export { ApplicationInfoAPI } from './application-info';
 export { RemoteType } from './response-types/remote';
 export { DistributionAPI } from './distribution';
 export { MyDistributionAPI } from './my-distribution';
-export { DistributionType } from './response-types/distribution';
+export {
+  DistributionType,
+  PulpAnsibleDistributionType,
+} from './response-types/distribution';
 export { ExecutionEnvironmentAPI } from './execution-environment';
 export { ExecutionEnvironmentRegistryAPI } from './execution-environment-registry';
 export {
@@ -78,6 +81,7 @@ export {
   AnsibleRepositoryType,
   AnsibleRepositoryVersionType,
 } from './response-types/ansible-repository';
+export { RepositoryDistributionsAPI } from './repository-distributions';
 export { RepositoryDistributions } from './repository-distributions';
 export { SignContainersAPI } from './sign-containers';
 export {

--- a/src/api/repository-distributions.ts
+++ b/src/api/repository-distributions.ts
@@ -1,0 +1,28 @@
+import { PulpAPI } from './pulp';
+
+class API extends PulpAPI {
+  apiPath = '/distributions/ansible/ansible/';
+
+  queryDistributionsByRepositoryHrefs(repoHrefs: string[]): Promise<any> {
+    return new Promise((resolve, reject) => {
+      const params = {
+        page_size: '999',
+      };
+
+      if (repoHrefs.length > 0) {
+        params['repository__in'] = repoHrefs.join(',');
+      }
+
+      super
+        .list(params)
+        .then((res) => {
+          return resolve(res.data.results);
+        })
+        .catch((err) => {
+          return reject(err);
+        });
+    });
+  }
+}
+
+export const RepositoryDistributions = new API();

--- a/src/api/repository-distributions.ts
+++ b/src/api/repository-distributions.ts
@@ -1,7 +1,0 @@
-import { PulpAPI } from './pulp';
-
-class API extends PulpAPI {
-  apiPath = '/distributions/ansible/ansible/';
-}
-
-export const RepositoryDistributionsAPI = new API();

--- a/src/api/repository-distributions.ts
+++ b/src/api/repository-distributions.ts
@@ -2,27 +2,6 @@ import { PulpAPI } from './pulp';
 
 class API extends PulpAPI {
   apiPath = '/distributions/ansible/ansible/';
-
-  queryDistributionsByRepositoryHrefs(repoHrefs: string[]): Promise<any> {
-    return new Promise((resolve, reject) => {
-      const params = {
-        page_size: '999',
-      };
-
-      if (repoHrefs.length > 0) {
-        params['repository__in'] = repoHrefs.join(',');
-      }
-
-      super
-        .list(params)
-        .then((res) => {
-          return resolve(res.data.results);
-        })
-        .catch((err) => {
-          return reject(err);
-        });
-    });
-  }
 }
 
-export const RepositoryDistributions = new API();
+export const RepositoryDistributionsAPI = new API();

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -52,6 +52,49 @@ export class CollectionVersionDetail extends CollectionVersion {
   docs_blob: DocsBlobType;
 }
 
+export class CollectionVersionSearch {
+  collection_version: {
+    contents: ContentSummaryType[];
+    description: string;
+    name: string;
+    namespace: string;
+    pulp_created: string;
+    pulp_href: string;
+    require_ansible: string;
+    tags: {
+      name: string;
+    }[];
+    version: string;
+  };
+  is_deprecated: boolean;
+  is_highest: boolean;
+  is_signed: boolean;
+  // TODO: ansible namespace metadata doesn't work yet
+  // assuming fields from pulp_ansible/NamespaceSummarySerializer
+  namespace_metadata?: {
+    pulp_href: string;
+    name: string;
+    company: string;
+    description: string;
+    avatar: string;
+    avatar_url: string;
+  };
+  repository: {
+    description: string;
+    latest_version_href: string;
+    name: string;
+    pulp_created: string;
+    pulp_href: string;
+    pulp_labels: {
+      pipeline?: string;
+    };
+    remote?: string;
+    retain_repo_versions: number;
+    versions_href: string;
+  };
+  repository_version: string;
+}
+
 export class CollectionListType {
   id: string;
   name: string;

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -55,6 +55,9 @@ export class CollectionVersionDetail extends CollectionVersion {
 export class CollectionVersionSearch {
   collection_version: {
     contents: ContentSummaryType[];
+    dependencies: {
+      [collection: string]: string;
+    };
     description: string;
     name: string;
     namespace: string;
@@ -93,6 +96,21 @@ export class CollectionVersionSearch {
     versions_href: string;
   };
   repository_version: string;
+}
+
+export class CollectionVersionContentType {
+  contents: ContentSummaryType[];
+  description: string;
+  tags: string[];
+  authors: string[];
+  license: string[];
+  homepage: string;
+  documentation: string;
+  issues: string;
+  repository: string;
+  dependencies: DependencyType[];
+  docs_blob: DocsBlobType;
+  requires_ansible: string;
 }
 
 export class CollectionListType {

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -79,7 +79,6 @@ export class CollectionVersionSearch {
     name: string;
     company: string;
     description: string;
-    avatar: string;
     avatar_url: string;
   };
   repository: {

--- a/src/api/response-types/distribution.ts
+++ b/src/api/response-types/distribution.ts
@@ -10,3 +10,15 @@ export class DistributionType {
     content_count: number;
   };
 }
+
+export class PulpAnsibleDistributionType {
+  base_path: string;
+  client_url: string;
+  content_guard: string;
+  name: string;
+  pulp_created: string;
+  pulp_href: string;
+  pulp_labels: object;
+  repository: string;
+  repository_version: string;
+}

--- a/src/api/sign-collections.ts
+++ b/src/api/sign-collections.ts
@@ -1,8 +1,13 @@
+import {
+  CollectionVersionSearch,
+  RepositoryDistributionsAPI,
+  findDistroBasePathByRepo,
+} from 'src/api';
 import { HubAPI } from './hub';
 
 interface SignNamespace {
   signing_service?: string;
-  distro_base_path?: string;
+  repository: CollectionVersionSearch['repository'];
   namespace: string;
 }
 
@@ -19,8 +24,23 @@ type SignProps = SignNamespace | SignCollection | SignVersion;
 class API extends HubAPI {
   apiPath = this.getUIPath('collection_signing/');
 
-  sign(data: SignProps) {
-    return this.http.post(this.apiPath, data);
+  async sign(data: SignProps) {
+    const { repository, ...args } = data;
+    const distros = await RepositoryDistributionsAPI.list({
+      repository: repository.pulp_href,
+    });
+
+    const distroBasePath = findDistroBasePathByRepo(
+      distros.data.results,
+      repository,
+    );
+
+    const updatedData = {
+      distro_base_path: distroBasePath,
+      ...args,
+    };
+
+    return this.http.post(this.apiPath, updatedData);
   }
 }
 

--- a/src/api/sign-collections.ts
+++ b/src/api/sign-collections.ts
@@ -1,6 +1,6 @@
 import {
+  AnsibleDistributionAPI,
   CollectionVersionSearch,
-  RepositoryDistributionsAPI,
   findDistroBasePathByRepo,
 } from 'src/api';
 import { HubAPI } from './hub';
@@ -26,7 +26,7 @@ class API extends HubAPI {
 
   async sign(data: SignProps) {
     const { repository, ...args } = data;
-    const distros = await RepositoryDistributionsAPI.list({
+    const distros = await AnsibleDistributionAPI.list({
       repository: repository.pulp_href,
     });
 

--- a/src/components/approve-modal/approve-modal.tsx
+++ b/src/components/approve-modal/approve-modal.tsx
@@ -12,11 +12,7 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
-import {
-  CollectionVersionAPI,
-  CollectionVersionSearch,
-  Repositories,
-} from 'src/api';
+import { CollectionVersion, CollectionVersionAPI, Repositories } from 'src/api';
 import { Repository } from 'src/api/response-types/repositories';
 import {
   AlertList,
@@ -27,6 +23,7 @@ import {
   Pagination,
   SortTable,
 } from 'src/components';
+import { Constants } from 'src/constants';
 import {
   errorMessage,
   parsePulpIDFromURL,
@@ -35,8 +32,7 @@ import {
 
 interface IProps {
   closeAction: () => void;
-  collectionVersion: CollectionVersionSearch;
-  collections: CollectionVersionSearch[];
+  collectionVersion: CollectionVersion;
   addAlert: (alert) => void;
   allRepositories: Repository[];
   finishAction: () => void;
@@ -68,8 +64,9 @@ export const ApproveModal = (props: IProps) => {
 
     setLoading(true);
 
-    const originRepoName = props.collectionVersion.repository.name;
-
+    const originRepoName = props.collectionVersion.repository_list.find(
+      (repo) => repo == Constants.NEEDSREVIEW || repo == Constants.NOTCERTIFIED,
+    );
     const reposToApprove = [];
 
     // fill repos that are actualy needed to approve, some of them may already contain the collection, those dont need to be approved again
@@ -90,10 +87,7 @@ export const ApproveModal = (props: IProps) => {
           failedToLoadRepo('', t`Repository name ${originRepoName} not found.`);
         } else {
           const pulp_id = parsePulpIDFromURL(data.data.results[0].pulp_href);
-          const collectionVersionPulpId = parsePulpIDFromURL(
-            props.collectionVersion.collection_version.pulp_href,
-          );
-          CollectionVersionAPI.get(collectionVersionPulpId)
+          CollectionVersionAPI.get(props.collectionVersion.id)
             .then((data) => {
               Repositories.moveCollectionVersion(
                 pulp_id,
@@ -106,12 +100,8 @@ export const ApproveModal = (props: IProps) => {
                 .then(() => {
                   setLoading(false);
                   props.finishAction();
-
-                  const { namespace, name, version } =
-                    props.collectionVersion.collection_version;
-
                   props.addAlert({
-                    title: t`Certification status for collection "${namespace} ${name} v${version}" has been successfully updated.`,
+                    title: t`Certification status for collection "${props.collectionVersion.namespace} ${props.collectionVersion.name} v${props.collectionVersion.version}" has been successfully updated.`,
                     variant: 'success',
                     description: '',
                   });
@@ -229,21 +219,7 @@ export const ApproveModal = (props: IProps) => {
 
     // check for approval repos that are already in collection and select them in UI
     // this is handling of situation when collection is in inconsistent state
-    const { namespace, name, version } =
-      props.collectionVersion.collection_version;
-
-    const collections = props.collections.filter(
-      ({ collection_version: cv }) =>
-        cv.namespace === namespace &&
-        cv.name === name &&
-        cv.version === version,
-    );
-
-    const collectionRepos = collections.map(
-      ({ repository }) => repository.name,
-    );
-
-    collectionRepos.forEach((repo) => {
+    props.collectionVersion.repository_list.forEach((repo) => {
       const count = props.allRepositories.filter((r) => r.name == repo).length;
       if (count > 0) {
         fixedReposLocal.push(repo);

--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -22,6 +22,15 @@
     display: block;
   }
 
+  .card-badge-area {
+    display: flex;
+    justify-content: end;
+    gap: 5px;
+    flex-wrap: wrap;
+    align-content: stretch;
+    align-items: center;
+  }
+
   .name {
     font-weight: bold;
     text-overflow: ellipsis;
@@ -48,10 +57,6 @@
     .icon {
       color: var(--pf-global--info-color--100);
       margin-right: 3px;
-    }
-
-    .hub-signature-badge {
-      margin-left: 5px;
     }
   }
 

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -88,7 +88,29 @@ export const CollectionCard = ({
         <div className='author'>
           <TextContent>
             <Text component={TextVariants.small}>
-              <Trans>Provided by {company}</Trans>
+              <Trans>
+                Provided by&nbsp;
+                <Link
+                  to={formatPath(
+                    // TODO: repository detail page
+                    Paths.ansibleRepositoryDetail,
+                    {
+                      name: repository.name,
+                    },
+                  )}
+                >
+                  {repository.name}
+                </Link>
+                /
+                <Link
+                  to={formatPath(Paths.namespaceByRepo, {
+                    repo: repository.name,
+                    namespace: namespace.name,
+                  })}
+                >
+                  {company}
+                </Link>
+              </Trans>
             </Text>
           </TextContent>
         </div>

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -38,18 +38,6 @@ export const CollectionCard = ({
 }: IProps) => {
   const MAX_DESCRIPTION_LENGTH = 60;
 
-  // FIXME: remove when API switch to AnsibleNamespaceMetadata
-  const mockNamespace = {
-    pulp_href: '',
-    name: collection_version.namespace,
-    company: 'xaz',
-    description: 'foo bar',
-    avatar: '',
-    avatar_url: '',
-    email: 'foo',
-  };
-  namespace = mockNamespace;
-
   const company = namespace.company || namespace.name;
   const contentSummary = convertContentSummaryCounts(collection_version);
 

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -99,8 +99,7 @@ export const CollectionCard = ({
                 </Link>
                 /
                 <Link
-                  to={formatPath(Paths.namespaceByRepo, {
-                    repo: repository.name,
+                  to={formatPath(Paths.namespaceDetail, {
                     namespace: namespace.name,
                   })}
                 >

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -13,35 +13,45 @@ import {
 import cx from 'classnames';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { CollectionListType } from 'src/api';
+import { CollectionVersionSearch } from 'src/api';
 import { CollectionNumericLabel, Logo, SignatureBadge } from 'src/components';
 import { Constants } from 'src/constants';
 import { Paths, formatPath } from 'src/paths';
 import { convertContentSummaryCounts } from 'src/utilities';
 
-interface IProps extends CollectionListType {
+interface IProps extends CollectionVersionSearch {
   className?: string;
   displaySignatures: boolean;
   footer?: React.ReactNode;
-  repo?: string;
   menu?: React.ReactNode;
 }
 
 export const CollectionCard = ({
-  name,
-  latest_version,
-  namespace,
+  collection_version,
+  namespace_metadata: namespace,
+  repository,
+  is_signed,
   className,
   displaySignatures,
-  footer,
-  repo,
-  sign_state,
   menu,
+  footer,
 }: IProps) => {
   const MAX_DESCRIPTION_LENGTH = 60;
 
+  // FIXME: remove when API switch to AnsibleNamespaceMetadata
+  const mockNamespace = {
+    pulp_href: '',
+    name: collection_version.namespace,
+    company: 'xaz',
+    description: 'foo bar',
+    avatar: '',
+    avatar_url: '',
+    email: 'foo',
+  };
+  namespace = mockNamespace;
+
   const company = namespace.company || namespace.name;
-  const contentSummary = convertContentSummaryCounts(latest_version.metadata);
+  const contentSummary = convertContentSummaryCounts(collection_version);
 
   return (
     <Card className={cx('hub-c-card-collection-container ', className)}>
@@ -54,9 +64,12 @@ export const CollectionCard = ({
           unlockWidth
           flexGrow
         />
-        <TextContent>{getCertification(repo)}</TextContent>
+        <TextContent>{getCertification(repository.name)}</TextContent>
         {displaySignatures ? (
-          <SignatureBadge isCompact signState={sign_state} />
+          <SignatureBadge
+            isCompact
+            signState={is_signed ? 'signed' : 'unsigned'}
+          />
         ) : null}
         {menu}
       </CardHeader>
@@ -64,12 +77,12 @@ export const CollectionCard = ({
         <div className='name'>
           <Link
             to={formatPath(Paths.collectionByRepo, {
-              collection: name,
+              collection: collection_version.name,
               namespace: namespace.name,
-              repo: repo,
+              repo: repository.name,
             })}
           >
-            {name}
+            {collection_version.name}
           </Link>
         </div>
         <div className='author'>
@@ -81,10 +94,10 @@ export const CollectionCard = ({
         </div>
       </CardHeader>
       <CardBody>
-        <Tooltip content={<div>{latest_version.metadata.description}</div>}>
+        <Tooltip content={<div>{collection_version.description}</div>}>
           <div className='description'>
             {getDescription(
-              latest_version.metadata.description,
+              collection_version.description,
               MAX_DESCRIPTION_LENGTH,
             )}
           </div>

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -64,13 +64,29 @@ export const CollectionCard = ({
           unlockWidth
           flexGrow
         />
-        <TextContent>{getCertification(repository.name)}</TextContent>
-        {displaySignatures ? (
-          <SignatureBadge
-            isCompact
-            signState={is_signed ? 'signed' : 'unsigned'}
-          />
-        ) : null}
+        <div className='card-badge-area'>
+          <TextContent>
+            <Text component={TextVariants.small}>
+              <Badge isRead>
+                <Link
+                  to={formatPath(Paths.ansibleRepositoryDetail, {
+                    name: repository.name,
+                  })}
+                >
+                  {repository.name === Constants.CERTIFIED_REPO
+                    ? t`Certified`
+                    : repository.name}
+                </Link>
+              </Badge>
+            </Text>
+          </TextContent>
+          {displaySignatures ? (
+            <SignatureBadge
+              isCompact
+              signState={is_signed ? 'signed' : 'unsigned'}
+            />
+          ) : null}
+        </div>
         {menu}
       </CardHeader>
       <CardHeader>
@@ -90,14 +106,6 @@ export const CollectionCard = ({
             <Text component={TextVariants.small}>
               <Trans>
                 Provided by&nbsp;
-                <Link
-                  to={formatPath(Paths.ansibleRepositoryDetail, {
-                    name: repository.name,
-                  })}
-                >
-                  {repository.name}
-                </Link>
-                /
                 <Link
                   to={formatPath(Paths.namespaceDetail, {
                     namespace: namespace.name,
@@ -129,18 +137,6 @@ export const CollectionCard = ({
     </Card>
   );
 };
-
-function getCertification(repo) {
-  if (repo === Constants.CERTIFIED_REPO) {
-    return (
-      <Text component={TextVariants.small}>
-        <Badge isRead>{t`Certified`}</Badge>
-      </Text>
-    );
-  }
-
-  return null;
-}
 
 function getDescription(d: string, MAX_DESCRIPTION_LENGTH) {
   if (!d) {

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -91,13 +91,9 @@ export const CollectionCard = ({
               <Trans>
                 Provided by&nbsp;
                 <Link
-                  to={formatPath(
-                    // TODO: repository detail page
-                    Paths.ansibleRepositoryDetail,
-                    {
-                      name: repository.name,
-                    },
-                  )}
+                  to={formatPath(Paths.ansibleRepositoryDetail, {
+                    name: repository.name,
+                  })}
                 >
                   {repository.name}
                 </Link>

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -2,12 +2,12 @@ import { t } from '@lingui/macro';
 import { List, ListItem, ListVariant } from '@patternfly/react-core';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { CollectionDetailType, CollectionVersion } from 'src/api';
+import { CollectionVersion, CollectionVersionSearch } from 'src/api';
 import { EmptyStateNoData, HelperText } from 'src/components';
 import 'src/containers/collection-detail/collection-dependencies.scss';
 
 interface IProps {
-  collection: CollectionDetailType;
+  collection: CollectionVersionSearch;
   dependencies_repos: (CollectionVersion & {
     path?: string;
   })[];
@@ -17,7 +17,7 @@ export const CollectionDependenciesList = ({
   collection,
   dependencies_repos,
 }: IProps) => {
-  const { dependencies } = collection.latest_version.metadata;
+  const { dependencies } = collection.collection_version;
 
   if (!Object.keys(dependencies).length) {
     return (

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -8,7 +8,7 @@ import 'src/containers/collection-detail/collection-dependencies.scss';
 
 interface IProps {
   collection: CollectionVersionSearch;
-  dependencies_repos: (CollectionVersion & {
+  dependencies_repos?: (CollectionVersion & {
     path?: string;
   })[];
 }

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -9,7 +9,7 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import cx from 'classnames';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { ContentSummaryType } from 'src/api';
+import { CollectionVersionSearch, ContentSummaryType } from 'src/api';
 import { EmptyStateCustom } from 'src/components';
 import { useContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
@@ -18,8 +18,7 @@ import './collection-content-list.scss';
 
 interface IProps {
   contents: ContentSummaryType[];
-  collection: string;
-  namespace: string;
+  collection: CollectionVersionSearch;
   params: {
     keywords?: string;
     showing?: string;
@@ -30,7 +29,6 @@ interface IProps {
 export const CollectionContentList = ({
   contents,
   collection,
-  namespace,
   params,
   updateParams,
 }: IProps) => {
@@ -59,6 +57,8 @@ export const CollectionContentList = ({
       toShow.push(c);
     }
   }
+
+  const { collection_version, repository } = collection;
 
   return (
     <div>
@@ -115,11 +115,11 @@ export const CollectionContentList = ({
                   to={formatPath(
                     Paths.collectionContentDocsByRepo,
                     {
-                      collection: collection,
-                      namespace: namespace,
+                      collection: collection_version.name,
+                      namespace: collection_version.namespace,
                       type: content.content_type,
                       name: content.name,
-                      repo: context.selectedRepo,
+                      repo: repository.name,
                     },
                     ParamHelper.getReduced(params, ignoredParams),
                   )}

--- a/src/components/collection-detail/collection-info.scss
+++ b/src/components/collection-detail/collection-info.scss
@@ -34,6 +34,10 @@
   padding: 8px;
 }
 
+.hub-collection-download-alert {
+  width: 100%;
+}
+
 .hub-collection-download-alert > h4 {
   margin-top: 0;
 }

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -10,57 +10,69 @@ import {
 import { DownloadIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { CollectionAPI, CollectionDetailType } from 'src/api';
-import { ClipboardCopy, LoginLink, Tag } from 'src/components';
+import {
+  CollectionAPI,
+  CollectionVersionContentType,
+  CollectionVersionSearch,
+} from 'src/api';
+import {
+  ClipboardCopy,
+  LoadingPageSpinner,
+  LoginLink,
+  Tag,
+} from 'src/components';
 import { useContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import { errorMessage } from 'src/utilities';
 import './collection-info.scss';
 import { DownloadSignatureGridItem } from './download-signature-grid-item';
 
-interface IProps extends CollectionDetailType {
+interface IProps extends CollectionVersionSearch {
   params: {
     version?: string;
   };
   updateParams: (params) => void;
   addAlert?: (variant, title, description?) => void;
+  content?: CollectionVersionContentType;
 }
 
 export const CollectionInfo = ({
-  name,
-  latest_version,
-  namespace,
+  collection_version,
+  repository,
+  content,
   params,
   addAlert,
 }: IProps) => {
   const downloadLinkRef = React.useRef<HTMLAnchorElement>(null);
   const context = useContext();
 
-  let installCommand = `ansible-galaxy collection install ${namespace.name}.${name}`;
+  let installCommand = `ansible-galaxy collection install ${collection_version.namespace}.${collection_version.name}`;
 
   if (params.version) {
     installCommand += `:${params.version}`;
+  }
+
+  if (!content) {
+    return <LoadingPageSpinner />;
   }
 
   return (
     <div className='pf-c-content info-panel'>
       <h1>{t`Install`}</h1>
       <Grid hasGutter={true}>
-        <GridItem>{latest_version.metadata.description}</GridItem>
+        <GridItem>{collection_version.description}</GridItem>
         <GridItem>
-          {latest_version.metadata.tags.map((tag, i) => (
-            <Tag key={i}>{tag}</Tag>
+          {collection_version.tags.map((tag, i) => (
+            <Tag key={i}>{tag.name}</Tag>
           ))}
         </GridItem>
 
-        {latest_version?.metadata?.license?.length > 0 && (
+        {content.license?.length > 0 && (
           <GridItem>
             <Split hasGutter={true}>
               <SplitItem className='install-title'>{t`License`}</SplitItem>
               <SplitItem isFilled>
-                {latest_version.metadata.license
-                  ? latest_version.metadata.license.join(', ')
-                  : ''}
+                {content.license ? content.license.join(', ') : ''}
               </SplitItem>
             </Split>
           </GridItem>
@@ -100,10 +112,10 @@ export const CollectionInfo = ({
                     icon={<DownloadIcon />}
                     onClick={() =>
                       download(
-                        context.selectedRepo,
-                        namespace,
-                        name,
-                        latest_version,
+                        repository,
+                        collection_version.namespace,
+                        collection_version.name,
+                        collection_version.version,
                         downloadLinkRef,
                         addAlert,
                       )
@@ -116,27 +128,37 @@ export const CollectionInfo = ({
             </SplitItem>
           </Split>
         </GridItem>
-        <DownloadSignatureGridItem version={latest_version} />
-        {latest_version.requires_ansible && (
+        <DownloadSignatureGridItem
+          collectionVersion={collection_version}
+          repository={repository}
+          addAlert={(status, statusText) =>
+            addAlert(
+              'danger',
+              t`Signatures could not be loaded.`,
+              errorMessage(status, statusText),
+            )
+          }
+        />
+        {content?.requires_ansible && (
           <GridItem>
             <Split hasGutter={true}>
               <SplitItem className='install-title'>
                 {t`Requires Ansible`}
               </SplitItem>
               <SplitItem isFilled data-cy='ansible-requirement'>
-                {latest_version.requires_ansible}
+                {content?.requires_ansible}
               </SplitItem>
             </Split>
           </GridItem>
         )}
 
-        {latest_version.docs_blob.collection_readme ? (
+        {content?.docs_blob?.collection_readme ? (
           <GridItem>
             <div className='hub-readme-container'>
               <div
                 className='pf-c-content'
                 dangerouslySetInnerHTML={{
-                  __html: latest_version.docs_blob.collection_readme.html,
+                  __html: content?.docs_blob?.collection_readme.html,
                 }}
               />
               <div className='hub-fade-out'></div>
@@ -145,9 +167,9 @@ export const CollectionInfo = ({
               to={formatPath(
                 Paths.collectionDocsIndexByRepo,
                 {
-                  collection: name,
-                  namespace: namespace.name,
-                  repo: context.selectedRepo,
+                  collection: collection_version.name,
+                  namespace: collection_version.namespace,
+                  repo: repository.name,
                 },
                 params,
               )}
@@ -162,19 +184,14 @@ export const CollectionInfo = ({
 };
 
 function download(
-  reponame,
-  namespace,
-  name,
-  latest_version,
+  repository: CollectionVersionSearch['repository'],
+  namespace: string,
+  name: string,
+  version: string,
   downloadLinkRef,
   addAlert,
 ) {
-  CollectionAPI.getDownloadURL(
-    reponame,
-    namespace.name,
-    name,
-    latest_version.version,
-  )
+  CollectionAPI.getDownloadURL(repository, namespace, name, version)
     .then((downloadURL: string) => {
       // By getting a reference to a hidden <a> tag, setting the href and
       // programmatically clicking it, we can hold off on making the api

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -7,7 +7,7 @@ import {
   Split,
   SplitItem,
 } from '@patternfly/react-core';
-import { DownloadIcon } from '@patternfly/react-icons';
+import { DownloadIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -113,7 +113,16 @@ export const CollectionInfo = ({
                 <div>
                   <Trans>
                     To download this collection, configure your client to
-                    connect to one of this repositories distributions.
+                    connect to one of this repositories distributions.{' '}
+                    <Link
+                      to={formatPath(Paths.collectionDistributionsByRepo, {
+                        repo: repository.name,
+                        namespace: collection_version.namespace,
+                        collection: collection_version.name,
+                      })}
+                    >
+                      <ExternalLinkAltIcon />
+                    </Link>
                   </Trans>
                 </div>
                 <a ref={downloadLinkRef} style={{ display: 'none' }}></a>

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -88,44 +88,55 @@ export const CollectionInfo = ({
                   only supported in ansible 2.9+
                 </Trans>
               </div>
-              {context.user.is_anonymous &&
-              !context.settings
-                .GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD ? (
-                <Alert
-                  className={'hub-collection-download-alert'}
-                  isInline
-                  variant='warning'
-                  title={
-                    <React.Fragment>
-                      {t`You have to be logged in to be able to download the tarball.`}{' '}
-                      <LoginLink />
-                    </React.Fragment>
-                  }
-                />
-              ) : (
-                <div>
-                  <a ref={downloadLinkRef} style={{ display: 'none' }}></a>
-                  <Button
-                    className='download-button'
-                    variant='link'
-                    data-cy='download-collection-tarball-button'
-                    icon={<DownloadIcon />}
-                    onClick={() =>
-                      download(
-                        repository,
-                        collection_version.namespace,
-                        collection_version.name,
-                        collection_version.version,
-                        downloadLinkRef,
-                        addAlert,
-                      )
-                    }
-                  >
-                    {t`Download tarball`}
-                  </Button>
-                </div>
-              )}
             </SplitItem>
+          </Split>
+        </GridItem>
+        <GridItem>
+          <Split hasGutter={true}>
+            <SplitItem className='install-title'>{t`Download`}</SplitItem>
+            {context.user.is_anonymous &&
+            !context.settings
+              .GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD ? (
+              <Alert
+                className={'hub-collection-download-alert'}
+                isInline
+                variant='warning'
+                title={
+                  <React.Fragment>
+                    {t`You have to be logged in to be able to download the tarball.`}{' '}
+                    <LoginLink />
+                  </React.Fragment>
+                }
+              />
+            ) : (
+              <SplitItem isFilled>
+                <div>
+                  <Trans>
+                    To download this collection, configure your client to
+                    connect to one of this repositories distributions.
+                  </Trans>
+                </div>
+                <a ref={downloadLinkRef} style={{ display: 'none' }}></a>
+                <Button
+                  className='download-button'
+                  variant='link'
+                  data-cy='download-collection-tarball-button'
+                  icon={<DownloadIcon />}
+                  onClick={() =>
+                    download(
+                      repository,
+                      collection_version.namespace,
+                      collection_version.name,
+                      collection_version.version,
+                      downloadLinkRef,
+                      addAlert,
+                    )
+                  }
+                >
+                  {t`Download tarball`}
+                </Button>
+              </SplitItem>
+            )}
           </Split>
         </GridItem>
         <DownloadSignatureGridItem

--- a/src/components/collection-detail/download-signature-grid-item.tsx
+++ b/src/components/collection-detail/download-signature-grid-item.tsx
@@ -11,9 +11,9 @@ import {
 import { DownloadIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
 import {
+  AnsibleDistributionAPI,
   CollectionAPI,
   CollectionVersionSearch,
-  RepositoryDistributionsAPI,
   findDistroBasePathByRepo,
 } from 'src/api';
 import 'src/api/response-types/collection';
@@ -43,7 +43,7 @@ export const DownloadSignatureGridItem = ({
 
   React.useEffect(() => {
     if (show && isLoading) {
-      RepositoryDistributionsAPI.list({
+      AnsibleDistributionAPI.list({
         repository: repository.pulp_href,
       }).then((result) => {
         const distroBasePath = findDistroBasePathByRepo(

--- a/src/components/collection-detail/download-signature-grid-item.tsx
+++ b/src/components/collection-detail/download-signature-grid-item.tsx
@@ -10,21 +10,62 @@ import {
 } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
 import React, { useState } from 'react';
-import { CollectionVersionDetail } from 'src/api/response-types/collection';
+import {
+  CollectionAPI,
+  CollectionVersionSearch,
+  RepositoryDistributionsAPI,
+  findDistroBasePathByRepo,
+} from 'src/api';
+import 'src/api/response-types/collection';
 import { useContext } from 'src/loaders/app-context';
+import { LoadingPageSpinner } from '../loading/loading-page-spinner';
 
 interface IProps {
-  version: CollectionVersionDetail;
+  collectionVersion: CollectionVersionSearch['collection_version'];
+  repository: CollectionVersionSearch['repository'];
+  addAlert: (status, statusText) => void;
 }
 
-export const DownloadSignatureGridItem = ({ version }: IProps) => {
+export const DownloadSignatureGridItem = ({
+  collectionVersion,
+  repository,
+  addAlert,
+}: IProps) => {
   const { display_signatures } = useContext().featureFlags;
   const [show, setShow] = useState(false);
+  const [signatures, setSignatures] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
 
-  // No signature object or the signatures is empty
-  if (!display_signatures || version.metadata.signatures?.length < 1) {
+  // No signature object
+  if (!display_signatures) {
     return null;
   }
+
+  React.useEffect(() => {
+    if (show && isLoading) {
+      RepositoryDistributionsAPI.list({
+        repository: repository.pulp_href,
+      }).then((result) => {
+        const distroBasePath = findDistroBasePathByRepo(
+          result.data.results,
+          repository,
+        );
+
+        const { namespace, name, version } = collectionVersion;
+
+        CollectionAPI.getSignatures(distroBasePath, namespace, name, version)
+          .then((res) => {
+            setSignatures(res.data.signatures);
+            setIsLoading(false);
+          })
+          .catch(({ code, message }) => {
+            addAlert(code, message);
+            setIsLoading(false);
+            setShow(false);
+          });
+      });
+    }
+  }, [show]);
 
   return (
     <>
@@ -47,12 +88,19 @@ export const DownloadSignatureGridItem = ({ version }: IProps) => {
         </Split>
       </GridItem>
       <GridItem>
-        {show &&
-          version.metadata.signatures.map(({ signature }, idx) => (
-            <CodeBlock key={idx}>
-              <CodeBlockCode>{signature}</CodeBlockCode>
-            </CodeBlock>
-          ))}
+        {show && (
+          <>
+            {isLoading ? (
+              <LoadingPageSpinner />
+            ) : (
+              signatures.map(({ signature }, idx) => (
+                <CodeBlock key={idx}>
+                  <CodeBlockCode>{signature}</CodeBlockCode>
+                </CodeBlock>
+              ))
+            )}
+          </>
+        )}
       </GridItem>
     </>
   );

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -51,12 +51,12 @@ export const CollectionFilter = (props: IProps) => {
       })),
     },
     display_signatures && {
-      id: 'sign_state',
+      id: 'is_signed',
       title: t`Sign state`,
       inputType: 'select' as const,
       options: [
-        { id: 'signed', title: t`Signed` },
-        { id: 'unsigned', title: t`Unsigned` },
+        { id: 'true', title: t`Signed` },
+        { id: 'false', title: t`Unsigned` },
       ],
     },
   ].filter(Boolean);
@@ -76,9 +76,15 @@ export const CollectionFilter = (props: IProps) => {
             <ToolbarItem>
               <AppliedFilters
                 niceNames={{
-                  sign_state: t`sign state`,
+                  is_signed: t`sign state`,
                   tags: t`tags`,
                   keywords: t`keywords`,
+                }}
+                niceValues={{
+                  is_signed: {
+                    false: t`unsigned`,
+                    true: t`signed`,
+                  },
                 }}
                 style={{ marginTop: '16px' }}
                 updateParams={updateParams}

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -20,6 +20,7 @@ interface IProps {
     page_size?: number;
     tags?: string[];
     view_type?: string;
+    repository_name?: string;
   };
   updateParams: (p) => void;
 }
@@ -35,11 +36,20 @@ export const CollectionFilter = (props: IProps) => {
   const { ignoredParams, params, updateParams } = props;
   const { display_signatures } = context.featureFlags;
   const display_tags = ignoredParams.includes('tags') === false;
+  const display_repos = ignoredParams.includes('repository_name') === false;
 
   const filterConfig = [
     {
       id: 'keywords',
       title: t`Keywords`,
+    },
+    display_repos && {
+      id: 'repository_name',
+      title: t`Repository`,
+    },
+    {
+      id: 'namespace',
+      title: t`Namespace`,
     },
     display_tags && {
       id: 'tags',
@@ -79,6 +89,8 @@ export const CollectionFilter = (props: IProps) => {
                   is_signed: t`sign state`,
                   tags: t`tags`,
                   keywords: t`keywords`,
+                  repository_name: t`repository`,
+                  namespace: t`namespace`,
                 }}
                 niceValues={{
                   is_signed: {

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -55,25 +55,26 @@ export const CollectionFilter = (props: IProps) => {
 
   const { ignoredParams, params, updateParams } = props;
   const { display_signatures } = context.featureFlags;
-  const display_tags = ignoredParams.includes('tags') === false;
-  const display_repos = ignoredParams.includes('repository__name') === false;
+  const displayTags = ignoredParams.includes('tags') === false;
+  const displayRepos = ignoredParams.includes('repository__name') === false;
+  const displayNamespaces = ignoredParams.includes('namespace') === false;
 
   const filterConfig = [
-    display_repos && {
+    {
+      id: 'keywords',
+      title: t`Keywords`,
+    },
+    displayRepos && {
       id: 'repository__name',
       title: t`Repository`,
       inputType: 'typeahead' as const,
       options: repositories,
     },
-    {
-      id: 'keywords',
-      title: t`Keywords`,
-    },
-    {
+    displayNamespaces && {
       id: 'namespace',
       title: t`Namespace`,
     },
-    display_tags && {
+    displayTags && {
       id: 'tags',
       title: t`Tag`,
       inputType: 'multiple' as const,

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -31,6 +31,22 @@ export const CollectionFilter = (props: IProps) => {
   const [repositories, setRepositories] = useState([]);
   const [inputText, setInputText] = useState('');
 
+  const loadRepos = () => {
+    Repositories.list({
+      name__icontains: inputText,
+    }).then((res) => {
+      const repos = res.data.results.map(({ name }) => ({
+        id: name,
+        title: name,
+      }));
+      setRepositories(repos);
+    });
+  };
+
+  useEffect(() => {
+    loadRepos();
+  }, []);
+
   useEffect(() => {
     setInputText(props.params['keywords'] || '');
   }, [props.params.keywords]);
@@ -41,15 +57,7 @@ export const CollectionFilter = (props: IProps) => {
 
   useEffect(() => {
     if (inputText != '') {
-      Repositories.list({
-        name__icontains: inputText,
-      }).then((res) => {
-        const repos = res.data.results.map(({ name }) => ({
-          id: name,
-          title: name,
-        }));
-        setRepositories(repos);
-      });
+      loadRepos();
     }
   }, [inputText]);
 

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -4,6 +4,7 @@ import {
   DataListItem,
   DataListItemCells,
   DataListItemRow,
+  Label,
   LabelGroup,
   Text,
   TextContent,
@@ -93,14 +94,6 @@ export const CollectionListItem = ({
               <Trans>
                 Provided by&nbsp;
                 <Link
-                  to={formatPath(Paths.ansibleRepositoryDetail, {
-                    name: repository.name,
-                  })}
-                >
-                  {repository.name}
-                </Link>
-                /
-                <Link
                   to={formatPath(Paths.namespaceDetail, {
                     namespace: namespace.name,
                   })}
@@ -112,7 +105,6 @@ export const CollectionListItem = ({
           </TextContent>
         ) : null}
       </div>
-      <div className='hub-entry'>{collection_version.description}</div>
       <div className='hub-entry pf-l-flex pf-m-wrap'>
         {Object.keys(contentSummary.contents).map((type) => (
           <div key={type}>
@@ -142,9 +134,19 @@ export const CollectionListItem = ({
         </Trans>
       </div>
       <div className='hub-entry'>v{collection_version.version}</div>
+      <Label variant='outline' className='hub-repository-badge'>
+        <Link
+          to={formatPath(Paths.ansibleRepositoryDetail, {
+            name: repository.name,
+          })}
+        >
+          {repository.name}
+        </Link>
+      </Label>
       {displaySignatures ? (
         <SignatureBadge
           className='hub-entry'
+          variant='outline'
           signState={is_signed ? 'signed' : 'unsigned'}
         />
       ) : null}

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -43,6 +43,18 @@ export const CollectionListItem = ({
 }: IProps) => {
   const cells = [];
 
+  // FIXME: remove when API switch to AnsibleNamespaceMetadata
+  const mockNamespace = {
+    pulp_href: '',
+    name: collection_version.namespace,
+    company: 'xaz',
+    description: 'foo bar',
+    avatar: '',
+    avatar_url: '',
+    email: 'foo',
+  };
+  namespace = mockNamespace;
+
   const company = namespace.company || namespace.name;
 
   if (showNamespace) {

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -101,8 +101,7 @@ export const CollectionListItem = ({
                 </Link>
                 /
                 <Link
-                  to={formatPath(Paths.namespaceByRepo, {
-                    repo: repository.name,
+                  to={formatPath(Paths.namespaceDetail, {
                     namespace: namespace.name,
                   })}
                 >

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -93,13 +93,9 @@ export const CollectionListItem = ({
               <Trans>
                 Provided by&nbsp;
                 <Link
-                  to={formatPath(
-                    // TODO: repository detail page
-                    Paths.ansibleRepositoryDetail,
-                    {
-                      name: repository.name,
-                    },
-                  )}
+                  to={formatPath(Paths.ansibleRepositoryDetail, {
+                    name: repository.name,
+                  })}
                 >
                   {repository.name}
                 </Link>

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -90,7 +90,29 @@ export const CollectionListItem = ({
         {showNamespace ? (
           <TextContent>
             <Text component={TextVariants.small}>
-              <Trans>Provided by {company}</Trans>
+              <Trans>
+                Provided by&nbsp;
+                <Link
+                  to={formatPath(
+                    // TODO: repository detail page
+                    Paths.ansibleRepositoryDetail,
+                    {
+                      name: repository.name,
+                    },
+                  )}
+                >
+                  {repository.name}
+                </Link>
+                /
+                <Link
+                  to={formatPath(Paths.namespaceByRepo, {
+                    repo: repository.name,
+                    namespace: namespace.name,
+                  })}
+                >
+                  {company}
+                </Link>
+              </Trans>
             </Text>
           </TextContent>
         ) : null}

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -43,18 +43,6 @@ export const CollectionListItem = ({
 }: IProps) => {
   const cells = [];
 
-  // FIXME: remove when API switch to AnsibleNamespaceMetadata
-  const mockNamespace = {
-    pulp_href: '',
-    name: collection_version.namespace,
-    company: 'xaz',
-    description: 'foo bar',
-    avatar: '',
-    avatar_url: '',
-    email: 'foo',
-  };
-  namespace = mockNamespace;
-
   const company = namespace.company || namespace.name;
 
   if (showNamespace) {

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { DataList } from '@patternfly/react-core';
 import * as React from 'react';
-import { CollectionListType } from 'src/api';
+import { CollectionVersionSearch } from 'src/api';
 import {
   CollectionListItem,
   EmptyStateFilter,
@@ -11,7 +11,7 @@ import { ParamHelper } from 'src/utilities/param-helper';
 import './list.scss';
 
 interface IProps {
-  collections: CollectionListType[];
+  collections: CollectionVersionSearch[];
   displaySignatures: boolean;
   params: {
     sort?: string;
@@ -22,7 +22,6 @@ interface IProps {
   itemCount: number;
   ignoredParams: string[];
   showControls?: boolean;
-  repo?: string;
   renderCollectionControls: (collection) => React.ReactNode;
 }
 
@@ -36,19 +35,17 @@ export const CollectionList = (props: IProps) => {
     ignoredParams,
     itemCount,
     showControls,
-    repo,
   } = props;
 
   return (
     <React.Fragment>
       <DataList aria-label={t`List of Collections`}>
         {collections.length > 0 ? (
-          collections.map((c) => (
+          collections.map((c, i) => (
             <CollectionListItem
               controls={showControls ? props.renderCollectionControls(c) : null}
-              key={c.id}
+              key={i}
               {...c}
-              repo={repo}
               displaySignatures={displaySignatures}
             />
           ))

--- a/src/components/collection-list/list-item.scss
+++ b/src/components/collection-list/list-item.scss
@@ -10,3 +10,7 @@
   font-size: var(--pf-global--FontSize--xs);
   color: var(--pf-global--color--200);
 }
+
+.hub-repository-badge {
+  margin-right: 5px;
+}

--- a/src/components/delete-modal/delete-collection-modal.tsx
+++ b/src/components/delete-modal/delete-collection-modal.tsx
@@ -1,11 +1,12 @@
 import { Trans, t } from '@lingui/macro';
 import { Checkbox, Text } from '@patternfly/react-core';
 import React from 'react';
-import { CollectionDetailType, CollectionListType } from 'src/api';
+import { CollectionVersionSearch } from 'src/api';
 import { DeleteModal } from 'src/components';
 
 interface IProps {
-  deleteCollection: CollectionDetailType | CollectionListType;
+  deleteCollection: CollectionVersionSearch;
+  collections: CollectionVersionSearch[];
   isDeletionPending: boolean;
   confirmDelete: boolean;
   collectionVersion?: string;
@@ -17,6 +18,7 @@ interface IProps {
 export const DeleteCollectionModal = (props: IProps) => {
   const {
     deleteCollection,
+    collections,
     isDeletionPending,
     confirmDelete,
     collectionVersion,
@@ -41,12 +43,12 @@ export const DeleteCollectionModal = (props: IProps) => {
         <Text style={{ paddingBottom: 'var(--pf-global--spacer--md)' }}>
           {collectionVersion ? (
             <>
-              {(deleteCollection as CollectionDetailType).all_versions
-                .length === 1 ? (
+              {(collections as CollectionVersionSearch[]).length === 1 ? (
                 <Trans>
                   Deleting{' '}
                   <b>
-                    {deleteCollection.name} v{collectionVersion}
+                    {deleteCollection.collection_version.name} v
+                    {collectionVersion}
                   </b>{' '}
                   and its data will be lost and this will cause the entire
                   collection to be deleted.
@@ -55,7 +57,8 @@ export const DeleteCollectionModal = (props: IProps) => {
                 <Trans>
                   Deleting{' '}
                   <b>
-                    {deleteCollection.name} v{collectionVersion}
+                    {deleteCollection.collection_version.name} v
+                    {collectionVersion}
                   </b>{' '}
                   and its data will be lost.
                 </Trans>
@@ -63,7 +66,8 @@ export const DeleteCollectionModal = (props: IProps) => {
             </>
           ) : (
             <Trans>
-              Deleting <b>{deleteCollection.name}</b> and its data will be lost.
+              Deleting <b>{deleteCollection.collection_version.name}</b> and its
+              data will be lost.
             </Trans>
           )}
         </Text>

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -412,8 +412,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           }
           contextSelector={
             <RepoSelector
-              path={Paths.searchByRepo}
-              selectedRepo={this.context.selectedRepo}
+              selectedRepo={collection.repository.name}
               isDisabled
             />
           }
@@ -577,11 +576,11 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   }
 
   private renderTabs(active) {
-    const { params, repo, collection } = this.props;
+    const { params, collection } = this.props;
     const pathParams = {
       namespace: collection.collection_version.namespace,
       collection: collection.collection_version.name,
-      repo: repo,
+      repo: collection.repository.name,
     };
     const reduced = ParamHelper.getReduced(params, this.ignoreParams);
 
@@ -722,6 +721,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       isOpenSignAllModal: false,
     });
 
+    // FIXME: use distor base path
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
       distro_base_path: this.context.selectedRepo,
@@ -776,6 +776,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       isOpenSignModal: false,
     });
 
+    // FIXME: distor base path
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
       distro_base_path: this.context.selectedRepo,
@@ -811,7 +812,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
   private deprecate(collection) {
     CollectionAPI.setDeprecation(collection)
-      .then((res: any) => {
+      .then((res) => {
         const taskId = parsePulpIDFromURL(res.data.task);
         return waitForTask(taskId).then(() => {
           const title = !collection.is_deprecated

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -23,6 +23,8 @@ import {
   CollectionVersionContentType,
   CollectionVersionSearch,
   MyNamespaceAPI,
+  NamespaceAPI,
+  NamespaceType,
   SignCollectionAPI,
 } from 'src/api';
 import {
@@ -93,6 +95,7 @@ interface IState {
   showImportModal: boolean;
   uploadCertificateModalOpen: boolean;
   versionToUploadCertificate: CollectionVersionSearch;
+  namespace: NamespaceType;
 }
 
 export class CollectionHeader extends React.Component<IProps, IState> {
@@ -122,6 +125,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       showImportModal: false,
       uploadCertificateModalOpen: false,
       versionToUploadCertificate: undefined,
+      namespace: null,
     };
   }
 
@@ -130,6 +134,12 @@ export class CollectionHeader extends React.Component<IProps, IState> {
     DeleteCollectionUtils.getUsedbyDependencies(collection)
       .then((noDependencies) => this.setState({ noDependencies }))
       .catch((alert) => this.addAlert(alert));
+
+    NamespaceAPI.get(collection.collection_version.namespace, {
+      include_related: 'my_permissions',
+    }).then(({ data }) => {
+      this.setState({ namespace: data });
+    });
   }
 
   render() {
@@ -210,7 +220,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       return <Navigate to={redirect} />;
     }
 
-    const canSign = canSignNamespace(this.context, namespace);
+    const canSign = canSignNamespace(this.context, this.state.namespace);
 
     const { hasPermission } = this.context;
 

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -20,11 +20,9 @@ import { Navigate } from 'react-router-dom';
 import {
   CertificateUploadAPI,
   CollectionAPI,
-  CollectionDetailType,
-  CollectionListType,
-  CollectionVersion,
+  CollectionVersionContentType,
+  CollectionVersionSearch,
   MyNamespaceAPI,
-  Repositories,
   SignCollectionAPI,
 } from 'src/api';
 import {
@@ -60,7 +58,9 @@ import { SignatureBadge } from '../signing';
 import './header.scss';
 
 interface IProps {
-  collection: CollectionDetailType;
+  collections: CollectionVersionSearch[];
+  collection: CollectionVersionSearch;
+  content: CollectionVersionContentType;
   params: {
     version?: string;
     latestVersion?: string;
@@ -82,17 +82,17 @@ interface IState {
     page: number;
     pageSize: number;
   };
-  deleteCollection: CollectionDetailType;
+  deleteCollection: CollectionVersionSearch;
   collectionVersion: string | null;
   confirmDelete: boolean;
   alerts: AlertType[];
   redirect: string;
   noDependencies: boolean;
   isDeletionPending: boolean;
-  updateCollection: CollectionListType;
+  updateCollection: CollectionVersionSearch;
   showImportModal: boolean;
   uploadCertificateModalOpen: boolean;
-  versionToUploadCertificate: CollectionVersion;
+  versionToUploadCertificate: CollectionVersionSearch;
 }
 
 export class CollectionHeader extends React.Component<IProps, IState> {
@@ -134,7 +134,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
   render() {
     const {
+      collections,
       collection,
+      content,
       params,
       updateParams,
       breadcrumbs,
@@ -158,46 +160,50 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     const numOfshownVersions = 10;
 
-    const all_versions = [...collection.all_versions];
-
-    const match = all_versions.find(
-      (x) => x.version === collection.latest_version.version,
-    );
-
-    if (!match) {
-      all_versions.push({
-        id: collection.latest_version.id,
-        version: collection.latest_version.version,
-        created: collection.latest_version.created_at,
-        sign_state: collection.latest_version.sign_state,
-      });
-    }
-
     const urlKeys = [
       { key: 'documentation', name: t`Docs site` },
       { key: 'homepage', name: t`Website` },
       { key: 'issues', name: t`Issue tracker` },
-      { key: 'repository', name: t`Repo` },
+      { key: 'origin_repository', name: t`Repo` },
     ];
 
-    const latestVersion = collection.latest_version.created_at;
+    const latestVersion = collection.collection_version.pulp_created;
 
     const { display_signatures, can_upload_signatures } =
       this.context.featureFlags;
 
-    const signedString = (v) => {
-      if (display_signatures && 'sign_state' in v) {
-        return v.sign_state === 'signed' ? t`(signed)` : t`(unsigned)`;
-      } else {
+    const signedString = () => {
+      if (!display_signatures) {
         return '';
       }
+
+      return collection.is_signed ? t`(signed)` : t`(unsigned)`;
     };
 
-    const isLatestVersion = (v) =>
-      `${moment(v.created).fromNow()} ${signedString(v)}
-      ${v.version === all_versions[0].version ? t`(latest)` : ''}`;
+    const isLatestVersion = (v) => {
+      return `${moment(v.pulp_created).fromNow()} ${signedString()}
+      ${
+        v.version === collections[0].collection_version.version
+          ? t`(latest)`
+          : ''
+      }`;
+    };
 
-    const { name: collectionName, namespace } = collection;
+    const { collection_version } = collection;
+    const { name: collectionName, version } = collection_version;
+
+    // FIXME: remove when API switch to AnsibleNamespaceMetadata
+    const mockNamespace = {
+      pulp_href: '',
+      name: collection_version.namespace,
+      company: 'xaz',
+      description: 'foo bar',
+      avatar: '',
+      avatar_url: '',
+      email: 'foo',
+    };
+    const namespace = mockNamespace;
+
     const company = namespace.company || namespace.name;
 
     if (redirect) {
@@ -218,11 +224,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         <DropdownItem
           data-cy='delete-version-dropdown'
           key='delete-collection-version'
-          onClick={() =>
-            this.openDeleteModalWithConfirm(collection.latest_version.version)
-          }
+          onClick={() => this.openDeleteModalWithConfirm(version)}
         >
-          {t`Delete version ${collection.latest_version.version}`}
+          {t`Delete version ${version}`}
         </DropdownItem>
       ),
       canSign && !can_upload_signatures && (
@@ -241,7 +245,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             if (can_upload_signatures) {
               this.setState({
                 uploadCertificateModalOpen: true,
-                versionToUploadCertificate: collection.latest_version,
+                versionToUploadCertificate: collection,
               });
             } else {
               this.setState({ isOpenSignModal: true });
@@ -249,11 +253,11 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           }}
           data-cy='sign-version-button'
         >
-          {t`Sign version ${collection.latest_version.version}`}
+          {t`Sign version ${version}`}
         </DropdownItem>
       ),
       <DropdownItem onClick={() => this.deprecate(collection)} key='deprecate'>
-        {collection.deprecated ? t`Undeprecate` : t`Deprecate`}
+        {collection.is_deprecated ? t`Undeprecate` : t`Deprecate`}
       </DropdownItem>,
       <DropdownItem
         key='upload-collection-version'
@@ -266,9 +270,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     const issueUrl =
       'https://access.redhat.com/support/cases/#/case/new/open-case/describe-issue/recommendations?caseCreate=true&product=Ansible%20Automation%20Hub&version=Online&summary=' +
-      encodeURIComponent(
-        `${namespace.name}-${collectionName}-${collection.latest_version.version}`,
-      );
+      encodeURIComponent(`${namespace.name}-${collectionName}-${version}`);
 
     return (
       <React.Fragment>
@@ -281,15 +283,15 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                   Paths.myImports,
                   {},
                   {
-                    namespace: updateCollection.namespace.name,
+                    namespace: updateCollection.collection_version.namespace,
                   },
                 ),
               })
             }
             // onCancel
             setOpen={(isOpen, warn) => this.toggleImportModal(isOpen, warn)}
-            collection={updateCollection}
-            namespace={updateCollection.namespace.name}
+            collection={updateCollection.collection_version}
+            namespace={updateCollection.collection_version.namespace}
           />
         )}
         {canSign && (
@@ -309,7 +311,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             />
             <SignSingleCertificateModal
               name={collectionName}
-              version={collection.latest_version.version}
+              version={version}
               isOpen={this.state.isOpenSignModal}
               onSubmit={this.signVersion}
               onCancel={() => this.setState({ isOpenSignModal: false })}
@@ -332,30 +334,32 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                   page_size: modalPagination.pageSize,
                 }}
                 updateParams={this.updatePaginationParams}
-                count={all_versions.length}
+                count={collections.length}
               />
             </div>
-            {this.paginateVersions(all_versions).map((v, i) => (
-              <ListItem key={i}>
-                <Button
-                  variant='link'
-                  isInline
-                  onClick={() => {
-                    updateParams(
-                      ParamHelper.setParam(
-                        params,
-                        'version',
-                        v.version.toString(),
-                      ),
-                    );
-                    this.setState({ isOpenVersionsModal: false });
-                  }}
-                >
-                  v{v.version}
-                </Button>{' '}
-                {t`updated ${isLatestVersion(v)}`}
-              </ListItem>
-            ))}
+            {this.paginateVersions(collections).map(
+              ({ collection_version }, i) => (
+                <ListItem key={i}>
+                  <Button
+                    variant='link'
+                    isInline
+                    onClick={() => {
+                      updateParams(
+                        ParamHelper.setParam(
+                          params,
+                          'version',
+                          collection_version.version.toString(),
+                        ),
+                      );
+                      this.setState({ isOpenVersionsModal: false });
+                    }}
+                  >
+                    v{collection_version.version}
+                  </Button>{' '}
+                  {t`updated ${isLatestVersion(collection_version)}`}
+                </ListItem>
+              ),
+            )}
           </List>
           <Pagination
             params={{
@@ -363,15 +367,16 @@ export class CollectionHeader extends React.Component<IProps, IState> {
               page_size: modalPagination.pageSize,
             }}
             updateParams={this.updatePaginationParams}
-            count={all_versions.length}
+            count={collections.length}
           />
         </Modal>
         <DeleteCollectionModal
           deleteCollection={deleteCollection}
+          collections={collections}
           isDeletionPending={isDeletionPending}
           confirmDelete={confirmDelete}
           setConfirmDelete={(confirmDelete) => this.setState({ confirmDelete })}
-          collectionVersion={collectionVersion}
+          collectionVersion={version}
           cancelAction={() => this.setState({ deleteCollection: null })}
           deleteAction={() =>
             this.setState({ isDeletionPending: true }, () => {
@@ -382,10 +387,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                     setState: (state) => this.setState(state),
                     load: null,
                     redirect: formatPath(Paths.namespaceByRepo, {
-                      repo: this.context.selectedRepo,
-                      namespace: deleteCollection.namespace.name,
+                      repo: deleteCollection.repository.name,
+                      namespace: deleteCollection.collection_version.namespace,
                     }),
-                    selectedRepo: this.context.selectedRepo,
                     addAlert: (alert) => this.context.queueAlert(alert),
                   });
             })
@@ -393,14 +397,14 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         />
         <BaseHeader
           className={className}
-          title={collection.name}
+          title={collection_version.name}
           logo={
-            collection.namespace.avatar_url && (
+            namespace.avatar_url && (
               <Logo
                 alt={t`${company} logo`}
                 className='image'
                 fallbackToDefault
-                image={collection.namespace.avatar_url}
+                image={namespace.avatar_url}
                 size='40px'
                 unlockWidth
               />
@@ -427,10 +431,10 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                   onSelect={() =>
                     this.setState({ isOpenVersionsSelect: false })
                   }
-                  selections={`v${collection.latest_version.version}`}
+                  selections={`v${version}`}
                   aria-label={t`Select collection version`}
                   loadingVariant={
-                    numOfshownVersions < all_versions.length
+                    numOfshownVersions < collections.length
                       ? {
                           text: t`View more`,
                           onClick: () =>
@@ -443,7 +447,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                   }
                 >
                   {this.renderSelectVersions(
-                    all_versions,
+                    collections,
                     numOfshownVersions,
                   ).map((v) => (
                     <SelectOption
@@ -476,7 +480,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
               {display_signatures ? (
                 <SignatureBadge
                   isCompact
-                  signState={collection.latest_version.sign_state}
+                  signState={collection.is_signed ? 'signed' : 'unsigned'}
                 />
               ) : null}
             </div>
@@ -499,7 +503,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             </Flex>
           }
         >
-          {collection.deprecated && (
+          {collection.is_deprecated && (
             <Alert
               variant='danger'
               isInline
@@ -517,7 +521,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                 <ExternalLinkAltIcon />
               </div>
               {urlKeys.map((link) => {
-                const url = collection.latest_version.metadata[link.key];
+                const url = content[link.key];
                 if (!url) {
                   return null;
                 }
@@ -550,7 +554,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       });
     };
 
-    MyNamespaceAPI.get(collection.namespace.name, {
+    MyNamespaceAPI.get(collection.collection_version.namespace, {
       include_related: 'my_permissions',
     })
       .then((value) => {
@@ -573,11 +577,10 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   }
 
   private renderTabs(active) {
-    const { params, repo } = this.props;
-
+    const { params, repo, collection } = this.props;
     const pathParams = {
-      namespace: this.props.collection.namespace.name,
-      collection: this.props.collection.name,
+      namespace: collection.collection_version.namespace,
+      collection: collection.collection_version.name,
       repo: repo,
     };
     const reduced = ParamHelper.getReduced(params, this.ignoreParams);
@@ -622,15 +625,15 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   }
 
   private renderSelectVersions(versions, count) {
-    return versions.slice(0, count);
+    return versions.slice(0, count).map((c) => c.collection_version);
   }
 
   private async submitCertificate(file: File) {
-    const version = this.state.versionToUploadCertificate;
-    const response = await Repositories.getRepository({
-      name: this.context.selectedRepo,
-    });
-    const signed_collection = `${PULP_API_BASE_PATH}content/ansible/collection_versions/${version.id}/`;
+    const { collection_version: version, repository } =
+      this.state.versionToUploadCertificate;
+
+    const signed_collection =
+      this.props.collection.collection_version.pulp_href;
 
     this.setState({
       alerts: this.state.alerts.concat({
@@ -644,7 +647,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     CertificateUploadAPI.upload({
       file,
-      repository: response.data.results[0].pulp_href,
+      repository: repository.pulp_href,
       signed_collection,
     })
       .then((result) => {
@@ -700,6 +703,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   };
 
   private signCollection = () => {
+    const { namespace, name } = this.props.collection.collection_version;
     const errorAlert = (status: string | number = 500): AlertType => ({
       variant: 'danger',
       title: t`Failed to sign all versions in the collection.`,
@@ -712,7 +716,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         {
           id: 'loading-signing',
           variant: 'success',
-          title: t`Signing started for all versions in collection "${this.props.collection.name}"`,
+          title: t`Signing started for all versions in collection "${name}"`,
         },
       ],
       isOpenSignAllModal: false,
@@ -721,8 +725,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
       distro_base_path: this.context.selectedRepo,
-      namespace: this.props.collection.namespace.name,
-      collection: this.props.collection.name,
+      namespace: namespace,
+      collection: name,
     })
       .then((result) => {
         waitForTask(result.data.task_id)
@@ -751,6 +755,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   };
 
   private signVersion = () => {
+    const { name, version, namespace } =
+      this.props.collection.collection_version;
+
     const errorAlert = (status: string | number = 500): AlertType => ({
       variant: 'danger',
       title: t`Failed to sign the version.`,
@@ -763,7 +770,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         {
           id: 'loading-signing',
           variant: 'success',
-          title: t`Signing started for collection "${this.props.collection.name} v${this.props.collection.latest_version.version}".`,
+          title: t`Signing started for collection "${name} v${version}".`,
         },
       ],
       isOpenSignModal: false,
@@ -772,9 +779,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
       distro_base_path: this.context.selectedRepo,
-      namespace: this.props.collection.namespace.name,
-      collection: this.props.collection.name,
-      version: this.props.collection.latest_version.version,
+      namespace: namespace,
+      collection: name,
+      version: version,
     })
       .then((result) => {
         waitForTask(result.data.task_id)
@@ -803,17 +810,13 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   };
 
   private deprecate(collection) {
-    CollectionAPI.setDeprecation(
-      collection,
-      !collection.deprecated,
-      this.context.selectedRepo,
-    )
-      .then((res) => {
+    CollectionAPI.setDeprecation(collection)
+      .then((res: any) => {
         const taskId = parsePulpIDFromURL(res.data.task);
         return waitForTask(taskId).then(() => {
-          const title = !collection.deprecated
-            ? t`The collection "${collection.name}" has been successfully deprecated.`
-            : t`The collection "${collection.name}" has been successfully undeprecated.`;
+          const title = !collection.is_deprecated
+            ? t`The collection "${collection.collection_version.name}" has been successfully deprecated.`
+            : t`The collection "${collection.collection_version.name}" has been successfully undeprecated.`;
           this.setState({
             alerts: [
               ...this.state.alerts,
@@ -836,9 +839,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             ...this.state.alerts,
             {
               variant: 'danger',
-              title: !collection.deprecated
-                ? t`Collection "${collection.name}" could not be deprecated.`
-                : t`Collection "${collection.name}" could not be undeprecated.`,
+              title: !collection.is_deprecated
+                ? t`Collection "${collection.collection_version.name}" could not be deprecated.`
+                : t`Collection "${collection.collection_version.name}" could not be undeprecated.`,
               description: errorMessage(status, statusText),
             },
           ],
@@ -847,28 +850,25 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   }
 
   private deleteCollectionVersion = (collectionVersion) => {
-    const {
-      deleteCollection,
-      deleteCollection: { name },
-    } = this.state;
-    CollectionAPI.deleteCollectionVersion(
-      this.context.selectedRepo,
-      deleteCollection,
-    )
+    const { deleteCollection } = this.state;
+    const { collections } = this.props;
+    CollectionAPI.deleteCollectionVersion(deleteCollection)
       .then((res) => {
         const taskId = parsePulpIDFromURL(res.data.task);
-        const name = deleteCollection.name;
+        const name = deleteCollection.collection_version.name;
 
         waitForTask(taskId).then(() => {
-          if (deleteCollection.all_versions.length > 1) {
-            const topVersion = deleteCollection.all_versions.filter(
-              ({ version }) => version !== collectionVersion,
+          if (collections.length > 1) {
+            const topVersion = collections.filter(
+              ({ collection_version }) =>
+                collection_version.version !== collectionVersion,
             );
+
             this.props.updateParams(
               ParamHelper.setParam(
                 this.props.params,
                 'version',
-                topVersion[0].version,
+                topVersion[0].collection_version.version,
               ),
             );
 
@@ -902,8 +902,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             });
             this.setState({
               redirect: formatPath(Paths.namespaceByRepo, {
-                repo: this.context.selectedRepo,
-                namespace: deleteCollection.namespace.name,
+                repo: deleteCollection.repository.name,
+                namespace: deleteCollection.collection_version.namespace,
               }),
             });
           }
@@ -949,7 +949,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
               ...this.state.alerts,
               {
                 variant: 'danger',
-                title: t`Collection "${name} v${collectionVersion}" could not be deleted.`,
+                title: t`Collection "${deleteCollection.collection_version.name} v${collectionVersion}" could not be deleted.`,
                 description: errorMessage(status, statusText),
               },
             ],

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -199,20 +199,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       }`;
     };
 
-    const { collection_version } = collection;
+    const { collection_version, namespace_metadata: namespace } = collection;
     const { name: collectionName, version } = collection_version;
-
-    // FIXME: remove when API switch to AnsibleNamespaceMetadata
-    const mockNamespace = {
-      pulp_href: '',
-      name: collection_version.namespace,
-      company: 'xaz',
-      description: 'foo bar',
-      avatar: '',
-      avatar_url: '',
-      email: 'foo',
-    };
-    const namespace = mockNamespace;
 
     const company = namespace.company || namespace.name;
 

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -721,10 +721,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       isOpenSignAllModal: false,
     });
 
-    // FIXME: use distor base path
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
-      distro_base_path: this.context.selectedRepo,
+      repository: this.props.collection.repository,
       namespace: namespace,
       collection: name,
     })
@@ -776,10 +775,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       isOpenSignModal: false,
     });
 
-    // FIXME: distor base path
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
-      distro_base_path: this.context.selectedRepo,
+      repository: this.props.collection.repository,
       namespace: namespace,
       collection: name,
       version: version,

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -199,10 +199,22 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       }`;
     };
 
-    const { collection_version, namespace_metadata: namespace } = collection;
+    const { collection_version } = collection;
     const { name: collectionName, version } = collection_version;
 
-    const company = namespace.company || namespace.name;
+    // FIXME: remove when API switch to AnsibleNamespaceMetadata
+    const mockNamespace = {
+      pulp_href: '',
+      name: collection_version.namespace,
+      company: 'xaz',
+      description: 'foo bar',
+      avatar: '',
+      avatar_url: '',
+      email: 'foo',
+    };
+    const namespace = mockNamespace;
+
+    const company = namespace?.company || namespace.name;
 
     if (redirect) {
       return <Navigate to={redirect} />;

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -627,6 +627,15 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           reduced,
         ),
       },
+      {
+        active: active === 'distributions',
+        title: t`Distributions`,
+        link: formatPath(
+          Paths.collectionDistributionsByRepo,
+          pathParams,
+          reduced,
+        ),
+      },
     ];
 
     return <LinkTabs tabs={tabs} />;

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -396,8 +396,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                     collection: deleteCollection,
                     setState: (state) => this.setState(state),
                     load: null,
-                    redirect: formatPath(Paths.namespaceByRepo, {
-                      repo: deleteCollection.repository.name,
+                    redirect: formatPath(Paths.namespaceDetail, {
                       namespace: deleteCollection.collection_version.namespace,
                     }),
                     addAlert: (alert) => this.context.queueAlert(alert),
@@ -910,8 +909,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
               ),
             });
             this.setState({
-              redirect: formatPath(Paths.namespaceByRepo, {
-                repo: deleteCollection.repository.name,
+              redirect: formatPath(Paths.namespaceDetail, {
                 namespace: deleteCollection.collection_version.namespace,
               }),
             });

--- a/src/components/import-modal/import-modal.tsx
+++ b/src/components/import-modal/import-modal.tsx
@@ -7,6 +7,7 @@ import {
   CollectionAPI,
   CollectionListType,
   CollectionUploadType,
+  CollectionVersionSearch,
 } from 'src/api';
 import './import-modal.scss';
 
@@ -20,7 +21,9 @@ interface IProps {
   setOpen: (isOpen, warnings?) => void;
   onUploadSuccess: (result) => void;
 
-  collection?: CollectionListType;
+  collection?:
+    | CollectionListType // TODO: collection-header is still using CollectionListType
+    | CollectionVersionSearch['collection_version'];
   namespace: string;
 }
 

--- a/src/components/import-modal/import-modal.tsx
+++ b/src/components/import-modal/import-modal.tsx
@@ -5,7 +5,6 @@ import axios from 'axios';
 import * as React from 'react';
 import {
   CollectionAPI,
-  CollectionListType,
   CollectionUploadType,
   CollectionVersionSearch,
 } from 'src/api';
@@ -21,9 +20,7 @@ interface IProps {
   setOpen: (isOpen, warnings?) => void;
   onUploadSuccess: (result) => void;
 
-  collection?:
-    | CollectionListType // FIXME: collection-header is still using CollectionListType
-    | CollectionVersionSearch['collection_version'];
+  collection?: CollectionVersionSearch['collection_version'];
   namespace: string;
 }
 

--- a/src/components/import-modal/import-modal.tsx
+++ b/src/components/import-modal/import-modal.tsx
@@ -22,7 +22,7 @@ interface IProps {
   onUploadSuccess: (result) => void;
 
   collection?:
-    | CollectionListType // TODO: collection-header is still using CollectionListType
+    | CollectionListType // FIXME: collection-header is still using CollectionListType
     | CollectionVersionSearch['collection_version'];
   namespace: string;
 }

--- a/src/components/my-imports/import-console.tsx
+++ b/src/components/my-imports/import-console.tsx
@@ -4,7 +4,7 @@ import cx from 'classnames';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import {
-  CollectionVersion,
+  CollectionVersionSearch,
   ImportDetailType,
   ImportListType,
   PulpStatus,
@@ -24,7 +24,7 @@ interface IProps {
 
   setFollowMessages: (follow: boolean) => void;
   hideCollectionName?: boolean;
-  collectionVersion?: CollectionVersion;
+  collection?: CollectionVersionSearch;
 }
 
 export class ImportConsole extends React.Component<IProps> {
@@ -125,7 +125,7 @@ export class ImportConsole extends React.Component<IProps> {
   }
 
   private renderTitle(selectedImport) {
-    const { task, hideCollectionName, collectionVersion, empty } = this.props;
+    const { task, hideCollectionName, collection, empty } = this.props;
 
     if (empty) {
       return;
@@ -138,13 +138,13 @@ export class ImportConsole extends React.Component<IProps> {
     );
     let approvalStatus = t`waiting for import to finish`;
 
-    if (collectionVersion) {
-      const rlist = collectionVersion.repository_list;
-      if (rlist.includes(Constants.NOTCERTIFIED)) {
+    if (collection) {
+      const repoStatus = collection.repository.pulp_labels?.pipeline;
+      if (repoStatus === Constants.NOTCERTIFIED) {
         approvalStatus = t`rejected`;
-      } else if (rlist.includes(Constants.NEEDSREVIEW)) {
+      } else if (repoStatus === Constants.NEEDSREVIEW) {
         approvalStatus = t`waiting for approval`;
-      } else if (rlist.includes(Constants.PUBLISHED)) {
+      } else if (repoStatus === Constants.APPROVED) {
         approvalStatus = t`approved`;
       } else {
         approvalStatus = t`could not be determined yet`;
@@ -158,7 +158,7 @@ export class ImportConsole extends React.Component<IProps> {
             {
               namespace: selectedImport.namespace,
               collection: selectedImport.name,
-              repo: rlist[0],
+              repo: collection?.repository.name,
             },
             {
               version: selectedImport.version,

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -12,14 +12,14 @@ import {
 } from '@patternfly/react-core';
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { StatefulDropdown } from 'src/components';
+import { APISearchTypeAhead, StatefulDropdown } from 'src/components';
 import { ParamHelper } from 'src/utilities';
 
 export class FilterOption {
   id: string;
   title: string;
   placeholder?: string;
-  inputType?: 'text-field' | 'select' | 'multiple';
+  inputType?: 'text-field' | 'select' | 'multiple' | 'typeahead';
   options?: { id: string; title: string }[];
 }
 
@@ -46,6 +46,7 @@ interface IState {
   isCreatable: boolean;
   isOpen: boolean;
   hasOnCreateOption: boolean;
+  selections: any[];
 }
 
 export class CompoundFilter extends React.Component<IProps, IState> {
@@ -58,6 +59,8 @@ export class CompoundFilter extends React.Component<IProps, IState> {
       isCreatable: false,
       isOpen: false,
       hasOnCreateOption: false,
+      // results: [],
+      selections: [],
     };
   }
 
@@ -162,6 +165,38 @@ export class CompoundFilter extends React.Component<IProps, IState> {
             ))}
           />
         );
+      case 'typeahead': {
+        const typeAheadResults = this.props.filterConfig
+          .find(({ id }) => id === selectedFilter.id)
+          .options.map(({ id, title }) => ({ id, name: title }));
+        return (
+          <APISearchTypeAhead
+            multiple={false}
+            loadResults={(name) => {
+              this.props.onChange(name);
+            }}
+            onClear={() => {
+              this.props.onChange('');
+              this.setState({ selections: [] });
+            }}
+            onSelect={(event, value) => {
+              this.submitFilter(value);
+              // this.props.onChange(value);
+              this.setState({
+                selections: typeAheadResults.filter(
+                  ({ name }) => name === value,
+                ),
+              });
+            }}
+            placeholderText={
+              selectedFilter?.placeholder ||
+              t`Filter by ${selectedFilter.title.toLowerCase()}`
+            }
+            results={typeAheadResults}
+            selections={this.state.selections}
+          />
+        );
+      }
       default:
         return (
           <TextInput

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -46,7 +46,6 @@ interface IState {
   isCreatable: boolean;
   isOpen: boolean;
   hasOnCreateOption: boolean;
-  selections: any[];
 }
 
 export class CompoundFilter extends React.Component<IProps, IState> {
@@ -59,8 +58,6 @@ export class CompoundFilter extends React.Component<IProps, IState> {
       isCreatable: false,
       isOpen: false,
       hasOnCreateOption: false,
-      // results: [],
-      selections: [],
     };
   }
 
@@ -177,23 +174,15 @@ export class CompoundFilter extends React.Component<IProps, IState> {
             }}
             onClear={() => {
               this.props.onChange('');
-              this.setState({ selections: [] });
             }}
             onSelect={(event, value) => {
               this.submitFilter(value);
-              // this.props.onChange(value);
-              this.setState({
-                selections: typeAheadResults.filter(
-                  ({ name }) => name === value,
-                ),
-              });
             }}
             placeholderText={
               selectedFilter?.placeholder ||
               t`Filter by ${selectedFilter.title.toLowerCase()}`
             }
             results={typeAheadResults}
-            selections={this.state.selections}
           />
         );
       }

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -18,7 +18,7 @@ interface IProps {
   selectedRepo: string;
   // Path of the component that's using the component. This is required so that
   // the url for the repo can be updated correctly.
-  path: Paths;
+  path?: Paths;
   pathParams?: Record<string, string>;
   isDisabled?: boolean;
 }
@@ -48,11 +48,11 @@ export const RepoSelector = ({
             variant='plain'
             className='hub-input-group-text-no-wrap'
           >
-            {t`Filter by repository`}
+            {t`Repository`}
           </InputGroupText>
           <Select
             className='nav-select'
-            isDisabled={isDisabled}
+            isDisabled={!path || isDisabled}
             isOpen={selectExpanded}
             isPlain={false}
             onSelect={(event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/signing/upload-sign-certificate-modal.tsx
+++ b/src/components/signing/upload-sign-certificate-modal.tsx
@@ -55,7 +55,7 @@ export const UploadSingCertificateModal: React.FC<Props> = ({
       <FileUpload
         id='certificate-file'
         filename={filename}
-        filenamePlaceholder={t`Drag and drop a file or upload one'`}
+        filenamePlaceholder={t`Drag and drop a file or upload one.`}
         browseButtonText={t`Select file`}
         onFileInputChange={handleFileInputChange}
         onClearClick={() => setFilename('')}

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -21,6 +21,8 @@ export class Constants {
   static NOTCERTIFIED = 'rejected';
   static NEEDSREVIEW = 'staging';
 
+  static APPROVED = 'approved';
+
   static USER_GROUP_MGMT_PERMISSIONS = [
     'galaxy.delete_user',
     'galaxy.add_user',

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -22,7 +22,6 @@ import {
   CollectionAPI,
   CollectionVersionAPI,
   CollectionVersionSearch,
-  Repositories,
 } from 'src/api';
 import { Repository } from 'src/api/response-types/repositories';
 import {

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -84,7 +84,7 @@ interface IState {
   approveModalInfo: {
     collectionVersion: CollectionVersion;
   };
-  repositoryList: Repository[];
+  approvedRepositoryList: Repository[];
 }
 
 class CertificationDashboard extends React.Component<RouteProps, IState> {
@@ -120,7 +120,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
       uploadCertificateModalOpen: false,
       versionToUploadCertificate: null,
       approveModalInfo: null,
-      repositoryList: [],
+      approvedRepositoryList: [],
     };
   }
 
@@ -140,7 +140,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
       promises.push(
         Repositories.listApproved()
           .then((data) => {
-            this.setState({ repositoryList: data.data.results });
+            this.setState({ approvedRepositoryList: data.data.results });
           })
           .catch(({ response: { status, statusText } }) => {
             this.addAlertObj({
@@ -290,7 +290,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
                   this.state.approveModalInfo.collectionVersion
                 }
                 addAlert={(alert) => this.addAlertObj(alert)}
-                allRepositories={this.state.repositoryList}
+                allRepositories={this.state.approvedRepositoryList}
               />
             )}
           </Main>
@@ -632,7 +632,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
       return false;
     }
 
-    return this.state.repositoryList.find(
+    return this.state.approvedRepositoryList.find(
       (r) => r.name == collection.repository.name,
     );
   }
@@ -648,21 +648,14 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
       return;
     }
 
-    const { name, namespace, version } = collection.collection_version;
+    const { approvedRepositoryList } = this.state;
 
-    const collections = this.state.versions.filter(
-      ({ collection_version: cv }) =>
-        cv.namespace === namespace &&
-        cv.name === name &&
-        cv.version === version,
-    );
-
-    if (collections.length == 1) {
+    if (approvedRepositoryList.length == 1) {
       if (collection.repository) {
         this.updateCertification(
           collection.collection_version,
           collection.repository.name,
-          this.state.repositoryList[0].name,
+          this.state.approvedRepositoryList[0].name,
         );
       } else {
         // I hope that this may not occure ever, but to be sure...

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -1,4 +1,9 @@
-import { CollectionAPI, CollectionDetailType } from 'src/api';
+import {
+  CollectionAPI,
+  CollectionVersionAPI,
+  CollectionVersionContentType,
+  CollectionVersionSearch,
+} from 'src/api';
 import { AlertType } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 
@@ -8,8 +13,11 @@ export interface IBaseCollectionState {
     showing?: string;
     keywords?: string;
   };
-  collection: CollectionDetailType;
+  collections?: CollectionVersionSearch[];
+  collection?: CollectionVersionSearch;
+  content?: CollectionVersionContentType;
   alerts?: AlertType[];
+  distroBasePath?: string;
 }
 
 export function loadCollection({
@@ -20,22 +28,31 @@ export function loadCollection({
   setCollection,
   stateParams,
 }) {
-  CollectionAPI.getCached(
-    matchParams['namespace'],
-    matchParams['collection'],
-    selectedRepo,
-    { ...stateParams, include_related: 'my_permissions' },
+  const { version } = stateParams;
+  CollectionVersionAPI.getCached(
+    {
+      repository_name: selectedRepo,
+      namespace: matchParams['namespace'],
+      name: matchParams['collection'],
+      order_by: '-version',
+    },
     forceReload,
   )
-    .then((result) => {
-      return CollectionAPI.list(
-        {
-          name: matchParams['collection'],
-        },
-        selectedRepo,
-      ).then((collections) => {
-        result.deprecated = collections.data.data[0].deprecated;
-        setCollection(result);
+    .then((collections: CollectionVersionSearch[]) => {
+      const collection = version
+        ? collections.find(
+            ({ collection_version }) => collection_version.version == version,
+          )
+        : collections.find((cv) => cv.is_highest);
+
+      // TODO: cache the content as well
+      CollectionAPI.getContent(
+        matchParams['namespace'],
+        matchParams['collection'],
+        collection.collection_version.version,
+      ).then((res) => {
+        const content = res.data.results[0];
+        setCollection(collections, collection, content);
       });
     })
     .catch(() => {

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -38,25 +38,24 @@ export function loadCollection({
       order_by: '-version',
     },
     forceReload,
-  ).then((collections: CollectionVersionSearch[]) => {
-    const collection = version
-      ? collections.find(
-          ({ collection_version }) => collection_version.version == version,
-        )
-      : collections.find((cv) => cv.is_highest);
+  )
+    .then((collections: CollectionVersionSearch[]) => {
+      const collection = version
+        ? collections.find(
+            ({ collection_version }) => collection_version.version == version,
+          )
+        : collections.find((cv) => cv.is_highest);
 
-    console.log(collections);
-    // TODO: cache the content as well
-    CollectionAPI.getContent(
-      namespace,
-      name,
-      collection.collection_version.version,
-    ).then((res) => {
-      const [content] = res.data.results;
-      setCollection(collections, collection, content);
+      CollectionAPI.getContent(
+        namespace,
+        name,
+        collection.collection_version.version,
+      ).then((res) => {
+        const [content] = res.data.results;
+        setCollection(collections, collection, content);
+      });
+    })
+    .catch(() => {
+      navigate(formatPath(Paths.notFound));
     });
-  });
-  // .catch(() => {
-  //   navigate(formatPath(Paths.notFound));
-  // });
 }

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -24,38 +24,39 @@ export function loadCollection({
   forceReload,
   matchParams,
   navigate,
-  selectedRepo,
   setCollection,
   stateParams,
 }) {
   const { version } = stateParams;
+  const { collection: name, namespace, repo } = matchParams;
+
   CollectionVersionAPI.getCached(
     {
-      repository_name: selectedRepo,
-      namespace: matchParams['namespace'],
-      name: matchParams['collection'],
+      repository_name: repo,
+      namespace,
+      name,
       order_by: '-version',
     },
     forceReload,
-  )
-    .then((collections: CollectionVersionSearch[]) => {
-      const collection = version
-        ? collections.find(
-            ({ collection_version }) => collection_version.version == version,
-          )
-        : collections.find((cv) => cv.is_highest);
+  ).then((collections: CollectionVersionSearch[]) => {
+    const collection = version
+      ? collections.find(
+          ({ collection_version }) => collection_version.version == version,
+        )
+      : collections.find((cv) => cv.is_highest);
 
-      // TODO: cache the content as well
-      CollectionAPI.getContent(
-        matchParams['namespace'],
-        matchParams['collection'],
-        collection.collection_version.version,
-      ).then((res) => {
-        const content = res.data.results[0];
-        setCollection(collections, collection, content);
-      });
-    })
-    .catch(() => {
-      navigate(formatPath(Paths.notFound));
+    console.log(collections);
+    // TODO: cache the content as well
+    CollectionAPI.getContent(
+      namespace,
+      name,
+      collection.collection_version.version,
+    ).then((res) => {
+      const [content] = res.data.results;
+      setCollection(collections, collection, content);
     });
+  });
+  // .catch(() => {
+  //   navigate(formatPath(Paths.notFound));
+  // });
 }

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -46,9 +46,8 @@ class CollectionContent extends React.Component<
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
-        url: formatPath(Paths.namespaceByRepo, {
+        url: formatPath(Paths.namespaceDetail, {
           namespace: collection_version.namespace,
-          repo: repository.name,
         }),
         name: collection_version.namespace,
       },
@@ -76,7 +75,6 @@ class CollectionContent extends React.Component<
           }
           breadcrumbs={breadcrumbs}
           activeTab='contents'
-          repo={this.context.selectedRepo}
         />
         <Main>
           <section className='body'>

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -23,38 +23,42 @@ class CollectionContent extends React.Component<
     const params = ParamHelper.parseParamString(props.location.search);
 
     this.state = {
-      collection: undefined,
+      collections: [],
+      collection: null,
+      content: null,
       params: params,
     };
   }
 
   componentDidMount() {
-    this.loadCollection(false);
+    this.loadCollections(false);
   }
 
   render() {
-    const { collection, params } = this.state;
+    const { collections, collection, params, content } = this.state;
 
-    if (!collection) {
+    if (collections.length <= 0) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
+
+    const { collection_version, repository } = collection;
 
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
         url: formatPath(Paths.namespaceByRepo, {
-          namespace: collection.namespace.name,
-          repo: this.context.selectedRepo,
+          namespace: collection_version.namespace,
+          repo: repository.name,
         }),
-        name: collection.namespace.name,
+        name: collection_version.namespace,
       },
       {
         url: formatPath(Paths.collectionByRepo, {
-          namespace: collection.namespace.name,
-          collection: collection.name,
-          repo: this.context.selectedRepo,
+          namespace: collection_version.namespace,
+          collection: collection_version.name,
+          repo: repository.name,
         }),
-        name: collection.name,
+        name: collection_version.name,
       },
       { name: t`Content` },
     ];
@@ -62,11 +66,13 @@ class CollectionContent extends React.Component<
     return (
       <React.Fragment>
         <CollectionHeader
-          reload={() => this.loadCollection(true)}
+          reload={() => this.loadCollections(true)}
+          collections={collections}
           collection={collection}
+          content={content}
           params={params}
           updateParams={(params) =>
-            this.updateParams(params, () => this.loadCollection(true))
+            this.updateParams(params, () => this.loadCollections(true))
           }
           breadcrumbs={breadcrumbs}
           activeTab='contents'
@@ -75,9 +81,9 @@ class CollectionContent extends React.Component<
         <Main>
           <section className='body'>
             <CollectionContentList
-              contents={collection.latest_version.metadata.contents}
-              collection={collection.name}
-              namespace={collection.namespace.name}
+              contents={content.contents}
+              collection={collection_version.name}
+              namespace={collection_version.namespace}
               params={params}
               updateParams={(p) => this.updateParams(p)}
             ></CollectionContentList>
@@ -87,13 +93,15 @@ class CollectionContent extends React.Component<
     );
   }
 
-  private loadCollection(forceReload) {
+  private loadCollections(forceReload) {
     loadCollection({
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
       selectedRepo: this.context.selectedRepo,
-      setCollection: (collection) => this.setState({ collection }),
+      setCollection: (collections, collection, content) => {
+        this.setState({ collections, collection, content });
+      },
       stateParams: this.state.params,
     });
   }

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -82,8 +82,7 @@ class CollectionContent extends React.Component<
           <section className='body'>
             <CollectionContentList
               contents={content.contents}
-              collection={collection_version.name}
-              namespace={collection_version.namespace}
+              collection={collection}
               params={params}
               updateParams={(p) => this.updateParams(p)}
             ></CollectionContentList>
@@ -98,7 +97,6 @@ class CollectionContent extends React.Component<
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      selectedRepo: this.context.selectedRepo,
       setCollection: (collections, collection, content) => {
         this.setState({ collections, collection, content });
       },

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -96,9 +96,8 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
-        url: formatPath(Paths.namespaceByRepo, {
+        url: formatPath(Paths.namespaceDetail, {
           namespace: version.namespace,
-          repo: repository.name,
         }),
         name: version.namespace,
       },

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -91,14 +91,14 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    const { collection_version: version } = collection;
+    const { collection_version: version, repository } = collection;
 
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
         url: formatPath(Paths.namespaceByRepo, {
           namespace: version.namespace,
-          repo: this.context.selectedRepo,
+          repo: repository.name,
         }),
         name: version.namespace,
       },
@@ -106,7 +106,7 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
         url: formatPath(Paths.collectionByRepo, {
           namespace: version.namespace,
           collection: version.name,
-          repo: this.context.selectedRepo,
+          repo: repository.name,
         }),
         name: version.name,
       },
@@ -135,7 +135,7 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
           }}
           breadcrumbs={breadcrumbs}
           activeTab='dependencies'
-          repo={this.context.selectedRepo}
+          repo={repository.name}
         />
         <Main>
           <section className='body'>
@@ -221,25 +221,25 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
   }
 
   private loadDependencyRepo(dependency_repo) {
-    return CollectionVersionAPI.list({
-      namespace: dependency_repo.namespace,
-      name: dependency_repo.name,
-      version_range: dependency_repo.version_range,
-      page_size: 1,
-    })
-      .then((result) => {
-        dependency_repo.repo = result.data.data[0].repository_list[0];
-        dependency_repo.path = formatPath(Paths.collectionByRepo, {
-          collection: dependency_repo.name,
-          namespace: dependency_repo.namespace,
-          repo: dependency_repo.repo,
-        });
-      })
-      .catch(() => {
-        // do nothing, dependency_repo.path and repo stays empty
-        // this may mean that collection was not found - thus is not in the system.
-        // user will be notified in the list of dependencies rather than alerts
-      });
+    // return CollectionVersionAPI.list({
+    //   namespace: dependency_repo.namespace,
+    //   name: dependency_repo.name,
+    //   version_range: dependency_repo.version_range,
+    //   page_size: 1,
+    // })
+    //   .then((result) => {
+    //     dependency_repo.repo = result.data.data[0].repository_list[0];
+    //     dependency_repo.path = formatPath(Paths.collectionByRepo, {
+    //       collection: dependency_repo.name,
+    //       namespace: dependency_repo.namespace,
+    //       repo: dependency_repo.repo,
+    //     });
+    //   })
+    //   .catch(() => {
+    //     // do nothing, dependency_repo.path and repo stays empty
+    //     // this may mean that collection was not found - thus is not in the system.
+    //     // user will be notified in the list of dependencies rather than alerts
+    //   });
   }
 
   private loadUsedByDependencies() {
@@ -292,7 +292,6 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      selectedRepo: this.context.selectedRepo,
       setCollection: (collections, collection, content) =>
         this.setState({ collections, collection, content }, callback),
       stateParams: this.state.params.version

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -84,7 +84,7 @@ class CollectionDetail extends React.Component<
           }
           breadcrumbs={breadcrumbs}
           activeTab='install'
-          repo={this.context.selectedRepo}
+          repo={this.props.routeParams.published}
         />
         <Main>
           <section className='body'>
@@ -113,15 +113,10 @@ class CollectionDetail extends React.Component<
   }
 
   private loadCollections(forceReload) {
-    const { repo, ...routeParams } = this.props.routeParams;
     loadCollection({
       forceReload,
-      matchParams: {
-        repository_name: repo,
-        ...routeParams,
-      },
+      matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      selectedRepo: this.context.selectedRepo,
       setCollection: (collections, collection, content) => {
         this.setState({
           collections,

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -25,40 +25,45 @@ class CollectionDetail extends React.Component<
     const params = ParamHelper.parseParamString(props.location.search);
 
     this.state = {
-      collection: undefined,
+      collections: [],
+      collection: null,
+      content: null,
+      distroBasePath: null,
       params: params,
       alerts: [],
     };
   }
 
   componentDidMount() {
-    this.loadCollection(true);
+    this.loadCollections(true);
   }
 
   componentDidUpdate(prevProps) {
     if (!isEqual(prevProps.location, this.props.location)) {
-      this.loadCollection(false);
+      this.loadCollections(false);
     }
   }
 
   render() {
-    const { collection, params, alerts } = this.state;
+    const { collections, collection, content, params, alerts } = this.state;
 
-    if (!collection) {
+    if (collections.length <= 0) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
+
+    const { collection_version: version, repository } = collection;
 
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
         url: formatPath(Paths.namespaceByRepo, {
-          namespace: collection.namespace.name,
-          repo: this.context.selectedRepo,
+          namespace: version.namespace,
+          repo: repository.name,
         }),
-        name: collection.namespace.name,
+        name: version.namespace,
       },
       {
-        name: collection.name,
+        name: version.name,
       },
     ];
 
@@ -69,11 +74,13 @@ class CollectionDetail extends React.Component<
           closeAlert={(i) => this.closeAlert(i)}
         ></AlertList>
         <CollectionHeader
-          reload={() => this.loadCollection(true)}
+          reload={() => this.loadCollections(true)}
+          collections={collections}
           collection={collection}
+          content={content}
           params={params}
           updateParams={(p) =>
-            this.updateParams(p, () => this.loadCollection(true))
+            this.updateParams(p, () => this.loadCollections(true))
           }
           breadcrumbs={breadcrumbs}
           activeTab='install'
@@ -83,6 +90,7 @@ class CollectionDetail extends React.Component<
           <section className='body'>
             <CollectionInfo
               {...collection}
+              content={content}
               updateParams={(p) => this.updateParams(p)}
               params={this.state.params}
               addAlert={(variant, title, description) =>
@@ -104,13 +112,23 @@ class CollectionDetail extends React.Component<
     );
   }
 
-  private loadCollection(forceReload) {
+  private loadCollections(forceReload) {
+    const { repo, ...routeParams } = this.props.routeParams;
     loadCollection({
       forceReload,
-      matchParams: this.props.routeParams,
+      matchParams: {
+        repository_name: repo,
+        ...routeParams,
+      },
       navigate: this.props.navigate,
       selectedRepo: this.context.selectedRepo,
-      setCollection: (collection) => this.setState({ collection }),
+      setCollection: (collections, collection, content) => {
+        this.setState({
+          collections,
+          collection,
+          content,
+        });
+      },
       stateParams: this.state.params,
     });
   }

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -51,14 +51,13 @@ class CollectionDetail extends React.Component<
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
-    const { collection_version: version, repository } = collection;
+    const { collection_version: version } = collection;
 
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
-        url: formatPath(Paths.namespaceByRepo, {
+        url: formatPath(Paths.namespaceDetail, {
           namespace: version.namespace,
-          repo: repository.name,
         }),
         name: version.namespace,
       },

--- a/src/containers/collection-detail/collection-distributions.tsx
+++ b/src/containers/collection-detail/collection-distributions.tsx
@@ -23,7 +23,6 @@ const CollectionDistributions = (props: RouteProps) => {
   const [collection, setCollection] = useState(null);
   const [content, setContent] = useState(null);
 
-  console.log(routeParams);
   const [params, setParams] = useState(
     Object.keys(routeParams).length
       ? routeParams

--- a/src/containers/collection-detail/collection-distributions.tsx
+++ b/src/containers/collection-detail/collection-distributions.tsx
@@ -1,19 +1,29 @@
 import { t } from '@lingui/macro';
+import { Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
 import { AnsibleDistributionAPI } from 'src/api';
 import {
+  AppliedFilters,
   ClipboardCopy,
   CollectionHeader,
+  CompoundFilter,
   DateComponent,
+  EmptyStateFilter,
+  EmptyStateNoData,
+  LoadingPageSpinner,
   LoadingPageWithHeader,
   Main,
   Pagination,
   SortTable,
 } from 'src/components';
 import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
-import { RouteProps, withRouter } from 'src/utilities';
-import { getRepoUrl } from 'src/utilities';
-import { ParamHelper } from 'src/utilities/param-helper';
+import {
+  ParamHelper,
+  RouteProps,
+  filterIsSet,
+  getRepoUrl,
+  withRouter,
+} from 'src/utilities';
 import { loadCollection } from './base';
 
 const CollectionDistributions = (props: RouteProps) => {
@@ -22,6 +32,11 @@ const CollectionDistributions = (props: RouteProps) => {
   const [collections, setCollections] = useState([]);
   const [collection, setCollection] = useState(null);
   const [content, setContent] = useState(null);
+  const [inputText, setInputText] = useState('');
+
+  const [distributions, setDistributions] = useState(null);
+  const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(true);
 
   const [params, setParams] = useState(
     Object.keys(routeParams).length
@@ -30,9 +45,6 @@ const CollectionDistributions = (props: RouteProps) => {
           sort: '-pulp_created',
         },
   );
-  const [distributions, setDistributions] = useState(null);
-  const [count, setCount] = useState(0);
-
   const loadCollections = (forceReload) => {
     loadCollection({
       forceReload,
@@ -50,6 +62,7 @@ const CollectionDistributions = (props: RouteProps) => {
   };
 
   const loadDistributions = async (repositoryHref: string) => {
+    setLoading(true);
     const distroList = await AnsibleDistributionAPI.list({
       repository: repositoryHref,
       ...ParamHelper.getReduced(params, ['version']),
@@ -57,6 +70,7 @@ const CollectionDistributions = (props: RouteProps) => {
 
     setDistributions(distroList.data.results);
     setCount(distroList.data.count);
+    setLoading(false);
   };
 
   useEffect(() => {
@@ -67,7 +81,7 @@ const CollectionDistributions = (props: RouteProps) => {
     loadCollections(false);
   }, [params]);
 
-  if (!collection || !content || collections.length <= 0 || !distributions) {
+  if (!collection || !content || collections.length <= 0) {
     return <LoadingPageWithHeader></LoadingPageWithHeader>;
   }
 
@@ -102,35 +116,84 @@ const CollectionDistributions = (props: RouteProps) => {
       'token=<put your token here>',
     ].join('\n');
 
-  const sortTableOptions = {
-    headers: [
-      {
-        title: t`Name`,
-        type: 'alpha',
-        id: 'name',
-      },
-      {
-        title: t`Base path`,
-        type: 'alpha',
-        id: 'base_path',
-      },
-      {
-        title: t`Created`,
-        type: 'alpha',
-        id: 'pulp_created',
-      },
-      {
-        title: t`CLI configuration`,
-        type: 'none',
-        id: '',
-      },
-    ],
-  };
-
   const updateParamsMixin = (params) => {
     props.navigate({
       search: '?' + ParamHelper.getQueryString(params || []),
     });
+
+    setParams(params);
+  };
+
+  const renderTable = (distributions, params) => {
+    if (distributions.length === 0) {
+      return filterIsSet(params, [
+        'name__icontains',
+        'base_path__icontains',
+      ]) ? (
+        <EmptyStateFilter />
+      ) : (
+        <EmptyStateNoData
+          title={t`No distributions yet`}
+          description={t`Collection doesn't have any distribution assigned.`}
+        />
+      );
+    }
+
+    const sortTableOptions = {
+      headers: [
+        {
+          title: t`Name`,
+          type: 'alpha',
+          id: 'name',
+        },
+        {
+          title: t`Base path`,
+          type: 'alpha',
+          id: 'base_path',
+        },
+        {
+          title: t`Created`,
+          type: 'alpha',
+          id: 'pulp_created',
+        },
+        {
+          title: t`CLI configuration`,
+          type: 'none',
+          id: '',
+        },
+      ],
+    };
+
+    return (
+      <table
+        aria-label={t`Collection distributions`}
+        className='hub-c-table-content pf-c-table'
+      >
+        <SortTable
+          options={sortTableOptions}
+          params={params}
+          updateParams={(params) => {
+            updateParamsMixin(params);
+          }}
+        />
+        <tbody>
+          {distributions.map((distribution, i) => (
+            <tr key={i}>
+              <td>{distribution.name}</td>
+              <td>{distribution.base_path}</td>
+              <td>
+                <DateComponent date={distribution.pulp_created} />
+              </td>
+              <td>
+                <ClipboardCopy isCode isReadOnly variant={'expansion'} key={i}>
+                  {cliConfig(distribution)}
+                </ClipboardCopy>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
   };
 
   return (
@@ -145,53 +208,71 @@ const CollectionDistributions = (props: RouteProps) => {
           updateParamsMixin(
             ParamHelper.setParam(params, 'version', params.version),
           );
-          setParams(params);
         }}
         breadcrumbs={breadcrumbs}
         activeTab='distributions'
       />
       <Main>
         <section className='body'>
-          <table
-            aria-label={t`Collection distributions`}
-            className='hub-c-table-content pf-c-table'
-          >
-            <SortTable
-              options={sortTableOptions}
-              params={params}
-              updateParams={(params) => {
-                updateParamsMixin(params);
-                setParams(params);
-              }}
-            />
-            <tbody>
-              {distributions.map((distribution, i) => (
-                <tr key={i}>
-                  <td>{distribution.name}</td>
-                  <td>{distribution.base_path}</td>
-                  <td>
-                    <DateComponent date={distribution.pulp_created} />
-                  </td>
-                  <td>
-                    <ClipboardCopy
-                      isCode
-                      isReadOnly
-                      variant={'expansion'}
-                      key={i}
-                    >
-                      {cliConfig(distribution)}
-                    </ClipboardCopy>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <div className='toolbar hub-toolbar'>
+            <Toolbar>
+              <ToolbarGroup>
+                <ToolbarItem>
+                  <CompoundFilter
+                    inputText={inputText}
+                    onChange={(text) => {
+                      setInputText(text);
+                    }}
+                    updateParams={(p) => {
+                      updateParamsMixin(p);
+                    }}
+                    params={params}
+                    filterConfig={[
+                      {
+                        id: 'name__icontains',
+                        title: t`Name`,
+                      },
+                      {
+                        id: 'base_path__icontains',
+                        title: t`Base path`,
+                      },
+                    ]}
+                  />
+                </ToolbarItem>
+              </ToolbarGroup>
+            </Toolbar>
 
+            <Pagination
+              params={params}
+              updateParams={(p) => {
+                updateParamsMixin(p);
+              }}
+              count={count}
+              isTop
+            />
+          </div>
+
+          <AppliedFilters
+            updateParams={(p) => {
+              updateParamsMixin(p);
+              setInputText('');
+            }}
+            params={params}
+            ignoredParams={['page_size', 'page', 'sort']}
+            niceNames={{
+              base_path__icontains: t`Base path`,
+              name__icontains: t`Name`,
+            }}
+          />
+          {loading ? (
+            <LoadingPageSpinner />
+          ) : (
+            renderTable(distributions, params)
+          )}
           <Pagination
             params={params}
             updateParams={(p) => {
               updateParamsMixin(p);
-              setParams(p);
             }}
             count={count}
           />

--- a/src/containers/collection-detail/collection-distributions.tsx
+++ b/src/containers/collection-detail/collection-distributions.tsx
@@ -1,0 +1,205 @@
+import { t } from '@lingui/macro';
+import React, { useEffect, useState } from 'react';
+import { AnsibleDistributionAPI } from 'src/api';
+import {
+  ClipboardCopy,
+  CollectionHeader,
+  DateComponent,
+  LoadingPageWithHeader,
+  Main,
+  Pagination,
+  SortTable,
+} from 'src/components';
+import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { RouteProps, withRouter } from 'src/utilities';
+import { getRepoUrl } from 'src/utilities';
+import { ParamHelper } from 'src/utilities/param-helper';
+import { loadCollection } from './base';
+
+const CollectionDistributions = (props: RouteProps) => {
+  const routeParams = ParamHelper.parseParamString(props.location.search);
+
+  const [collections, setCollections] = useState([]);
+  const [collection, setCollection] = useState(null);
+  const [content, setContent] = useState(null);
+
+  console.log(routeParams);
+  const [params, setParams] = useState(
+    Object.keys(routeParams).length
+      ? routeParams
+      : {
+          sort: '-pulp_created',
+        },
+  );
+  const [distributions, setDistributions] = useState(null);
+  const [count, setCount] = useState(0);
+
+  const loadCollections = (forceReload) => {
+    loadCollection({
+      forceReload,
+      matchParams: props.routeParams,
+      navigate: props.navigate,
+      setCollection: (collections, collection, content) => {
+        setCollections(collections);
+        setCollection(collection);
+        setContent(content);
+
+        loadDistributions(collection.repository.pulp_href);
+      },
+      stateParams: params,
+    });
+  };
+
+  const loadDistributions = async (repositoryHref: string) => {
+    const distroList = await AnsibleDistributionAPI.list({
+      repository: repositoryHref,
+      ...ParamHelper.getReduced(params, ['version']),
+    });
+
+    setDistributions(distroList.data.results);
+    setCount(distroList.data.count);
+  };
+
+  useEffect(() => {
+    loadCollections(false);
+  }, []);
+
+  useEffect(() => {
+    loadCollections(false);
+  }, [params]);
+
+  if (!collection || !content || collections.length <= 0 || !distributions) {
+    return <LoadingPageWithHeader></LoadingPageWithHeader>;
+  }
+
+  const { collection_version, repository } = collection;
+
+  const breadcrumbs = [
+    namespaceBreadcrumb,
+    {
+      url: formatPath(Paths.namespaceDetail, {
+        namespace: collection_version.namespace,
+      }),
+      name: collection_version.namespace,
+    },
+    {
+      url: formatPath(Paths.collectionByRepo, {
+        namespace: collection_version.namespace,
+        collection: collection_version.name,
+        repo: repository.name,
+      }),
+      name: collection_version.name,
+    },
+    { name: t`Distributions` },
+  ];
+
+  const cliConfig = (distribution) =>
+    [
+      '[galaxy]',
+      `server_list = ${distribution.base_path}`,
+      '',
+      `[galaxy_server.${distribution.base_path}]`,
+      `url=${getRepoUrl()}`,
+      'token=<put your token here>',
+    ].join('\n');
+
+  const sortTableOptions = {
+    headers: [
+      {
+        title: t`Name`,
+        type: 'alpha',
+        id: 'name',
+      },
+      {
+        title: t`Base path`,
+        type: 'alpha',
+        id: 'base_path',
+      },
+      {
+        title: t`Created`,
+        type: 'alpha',
+        id: 'pulp_created',
+      },
+      {
+        title: t`CLI configuration`,
+        type: 'none',
+        id: '',
+      },
+    ],
+  };
+
+  const updateParamsMixin = (params) => {
+    props.navigate({
+      search: '?' + ParamHelper.getQueryString(params || []),
+    });
+  };
+
+  return (
+    <React.Fragment>
+      <CollectionHeader
+        reload={() => loadCollections(true)}
+        collections={collections}
+        collection={collection}
+        content={content}
+        params={params}
+        updateParams={(params) => {
+          updateParamsMixin(
+            ParamHelper.setParam(params, 'version', params.version),
+          );
+          setParams(params);
+        }}
+        breadcrumbs={breadcrumbs}
+        activeTab='distributions'
+      />
+      <Main>
+        <section className='body'>
+          <table
+            aria-label={t`Collection distributions`}
+            className='hub-c-table-content pf-c-table'
+          >
+            <SortTable
+              options={sortTableOptions}
+              params={params}
+              updateParams={(params) => {
+                updateParamsMixin(params);
+                setParams(params);
+              }}
+            />
+            <tbody>
+              {distributions.map((distribution, i) => (
+                <tr key={i}>
+                  <td>{distribution.name}</td>
+                  <td>{distribution.base_path}</td>
+                  <td>
+                    <DateComponent date={distribution.pulp_created} />
+                  </td>
+                  <td>
+                    <ClipboardCopy
+                      isCode
+                      isReadOnly
+                      variant={'expansion'}
+                      key={i}
+                    >
+                      {cliConfig(distribution)}
+                    </ClipboardCopy>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <Pagination
+            params={params}
+            updateParams={(p) => {
+              updateParamsMixin(p);
+              setParams(p);
+            }}
+            count={count}
+          />
+        </section>
+      </Main>
+    </React.Fragment>
+  );
+};
+
+export default withRouter(CollectionDistributions);

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -283,7 +283,6 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      selectedRepo: this.context.selectedRepo,
       setCollection: (collections, collection, content) => {
         this.setState({ collections, collection, content });
       },

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -7,6 +7,7 @@ import {
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
+import { CollectionVersionSearch } from 'src/api';
 import {
   CollectionHeader,
   EmptyStateCustom,
@@ -93,22 +94,23 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
       }
     }
 
+    const { collection_version, repository } = collection;
+
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
-        url: formatPath(Paths.namespaceByRepo, {
-          namespace: collection.collection_version.namespace,
-          repo: this.context.selectedRepo,
+        url: formatPath(Paths.namespaceDetail, {
+          namespace: collection_version.namespace,
         }),
         name: collection.collection_version.namespace,
       },
       {
         url: formatPath(Paths.collectionByRepo, {
-          namespace: collection.collection_version.namespace,
-          collection: collection.collection_version.name,
-          repo: this.context.selectedRepo,
+          namespace: collection_version.namespace,
+          collection: collection_version.name,
+          repo: repository.name,
         }),
-        name: collection.collection_version.name,
+        name: collection_version.name,
       },
       { name: t`Documentation` },
     ];
@@ -136,7 +138,6 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
           breadcrumbs={breadcrumbs}
           activeTab='documentation'
           className='header'
-          repo={this.context.selectedRepo}
         />
         <Main className='main'>
           <section className='docs-container'>
@@ -185,7 +186,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
                     )}
                   />
                 )
-              ) : this.context.selectedRepo === 'community' &&
+              ) : collection.repository.name === 'community' &&
                 !content.docs_blob.contents ? (
                 this.renderCommunityWarningMessage()
               ) : (
@@ -198,7 +199,12 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
     );
   }
 
-  private renderDocLink(name, href, collection, params) {
+  private renderDocLink(
+    name,
+    href,
+    collection: CollectionVersionSearch,
+    params,
+  ) {
     if (!!href && href.startsWith('http')) {
       return (
         <a href={href} target='_blank' rel='noreferrer'>
@@ -209,15 +215,18 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
       // TODO: right now this will break if people put
       // ../ at the front of their urls. Need to find a
       // way to document this
+
+      const { collection_version, repository } = collection;
+
       return (
         <Link
           to={formatPath(
             Paths.collectionDocsPageByRepo,
             {
-              namespace: collection.namespace.name,
-              collection: collection.name,
+              namespace: collection_version.namespace,
+              collection: collection_version.name,
               page: sanitizeDocsUrls(href),
-              repo: this.context.selectedRepo,
+              repo: repository.name,
             },
             params,
           )}
@@ -245,7 +254,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
               collection: collection.name,
               type: 'module',
               name: moduleName,
-              repo: this.context.selectedRepo,
+              repo: this.props.routeParams.repo,
             },
             params,
           )}

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -63,9 +63,8 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
-        url: formatPath(Paths.namespaceByRepo, {
+        url: formatPath(Paths.namespaceDetail, {
           namespace: collection_version.namespace,
-          repo: repository.name,
         }),
         name: collection_version.namespace,
       },
@@ -93,7 +92,6 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
           }
           breadcrumbs={breadcrumbs}
           activeTab='import-log'
-          repo={this.context.selectedRepo}
         />
         <Main>
           <section className='body'>

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -27,7 +27,9 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
     const params = ParamHelper.parseParamString(props.location.search);
 
     this.state = {
-      collection: undefined,
+      collection: null,
+      collections: [],
+      content: null,
       params: params,
       loadingImports: true,
       selectedImportDetail: undefined,
@@ -43,33 +45,37 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
   render() {
     const {
       collection,
+      collections,
       params,
       loadingImports,
       selectedImportDetail,
       selectedImport,
       apiError,
+      content,
     } = this.state;
 
     if (!collection) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
+    const { collection_version, repository } = collection;
+
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
         url: formatPath(Paths.namespaceByRepo, {
-          namespace: collection.namespace.name,
-          repo: this.context.selectedRepo,
+          namespace: collection_version.namespace,
+          repo: repository.name,
         }),
-        name: collection.namespace.name,
+        name: collection_version.namespace,
       },
       {
         url: formatPath(Paths.collectionByRepo, {
-          namespace: collection.namespace.name,
-          collection: collection.name,
-          repo: this.context.selectedRepo,
+          namespace: collection_version.namespace,
+          collection: collection_version.name,
+          repo: repository.name,
         }),
-        name: collection.name,
+        name: collection_version.name,
       },
       { name: t`Import log` },
     ];
@@ -78,7 +84,9 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
       <React.Fragment>
         <CollectionHeader
           reload={() => this.loadData(true)}
+          collections={collections}
           collection={collection}
+          content={content}
           params={params}
           updateParams={(params) =>
             this.updateParams(params, () => this.loadData(true))
@@ -110,9 +118,9 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
     this.setState({ loadingImports: true }, () => {
       this.loadCollection(forceReload, () => {
         ImportAPI.list({
-          namespace: this.state.collection.namespace.name,
-          name: this.state.collection.name,
-          version: this.state.collection.latest_version.version,
+          namespace: this.state.collection.collection_version.namespace,
+          name: this.state.collection.collection_version.name,
+          version: this.state.collection.collection_version.version,
           sort: '-created',
         })
           .then((importListResult) => {
@@ -149,7 +157,8 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
       selectedRepo: this.context.selectedRepo,
-      setCollection: (collection) => this.setState({ collection }, callback),
+      setCollection: (collections, collection, content) =>
+        this.setState({ collections, collection, content }, callback),
       stateParams: this.state.params,
     });
   }

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -156,7 +156,6 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      selectedRepo: this.context.selectedRepo,
       setCollection: (collections, collection, content) =>
         this.setState({ collections, collection, content }, callback),
       stateParams: this.state.params,

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -113,8 +113,7 @@ class EditNamespace extends React.Component<RouteProps, IState> {
             namespaceBreadcrumb,
             {
               name: namespace.name,
-              url: formatPath(Paths.namespaceByRepo, {
-                repo: this.context.selectedRepo,
+              url: formatPath(Paths.namespaceDetail, {
                 namespace: namespace.name,
               }),
             },
@@ -223,8 +222,7 @@ class EditNamespace extends React.Component<RouteProps, IState> {
               errorMessages: {},
               saving: false,
               unsavedData: false,
-              redirect: formatPath(Paths.namespaceByRepo, {
-                repo: this.context.selectedRepo,
+              redirect: formatPath(Paths.namespaceDetail, {
                 namespace: this.state.namespace.name,
               }),
             },
@@ -267,8 +265,7 @@ class EditNamespace extends React.Component<RouteProps, IState> {
 
   private cancel() {
     this.setState({
-      redirect: formatPath(Paths.namespaceByRepo, {
-        repo: this.context.selectedRepo,
+      redirect: formatPath(Paths.namespaceDetail, {
         namespace: this.state.namespace.name,
       }),
     });

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -10,6 +10,7 @@ export { default as CollectionDetail } from './collection-detail/collection-deta
 export { default as CollectionDocs } from './collection-detail/collection-docs';
 export { default as CollectionImportLog } from './collection-detail/collection-import-log';
 export { default as CollectionDependencies } from './collection-detail/collection-dependencies';
+export { default as CollectionDistributions } from './collection-detail/collection-distributions';
 export { default as EditNamespace } from './edit-namespace/edit-namespace';
 export { default as LoginPage } from './login/login';
 export { default as MyImports } from './my-imports/my-imports';

--- a/src/containers/legacy-namespaces/legacy-namespaces.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespaces.tsx
@@ -90,6 +90,7 @@ class LegacyNamespaces extends React.Component<
   render() {
     const ignoredParams = [
       'namespace',
+      'repository__name',
       'page',
       'page_size',
       'sort',

--- a/src/containers/legacy-roles/legacy-roles.tsx
+++ b/src/containers/legacy-roles/legacy-roles.tsx
@@ -98,6 +98,7 @@ class LegacyRoles extends React.Component<RouteProps, IProps> {
     const ignoredParams = [
       'order_by',
       'namespace',
+      'repository__name',
       'page',
       'page_size',
       'sort',

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -2,8 +2,8 @@ import { t } from '@lingui/macro';
 import { cloneDeep } from 'lodash';
 import * as React from 'react';
 import {
-  CollectionVersion,
   CollectionVersionAPI,
+  CollectionVersionSearch,
   ImportAPI,
   ImportDetailType,
   ImportListType,
@@ -26,7 +26,7 @@ interface IState {
   selectedImport: ImportListType;
   importList: ImportListType[];
   selectedImportDetails: ImportDetailType;
-  selectedCollectionVersion: CollectionVersion;
+  collection: CollectionVersionSearch;
   params: {
     page_size?: number;
     page?: number;
@@ -65,7 +65,7 @@ class MyImports extends React.Component<RouteProps, IState> {
       followLogs: false,
       loadingImports: true,
       loadingImportDetails: true,
-      selectedCollectionVersion: undefined,
+      collection: null,
       alerts: [],
     };
   }
@@ -118,7 +118,7 @@ class MyImports extends React.Component<RouteProps, IState> {
       loadingImportDetails,
       importDetailError,
       followLogs,
-      selectedCollectionVersion,
+      collection,
     } = this.state;
 
     if (!importList) {
@@ -180,7 +180,7 @@ class MyImports extends React.Component<RouteProps, IState> {
                   }}
                   selectedImport={selectedImport}
                   apiError={importDetailError}
-                  collectionVersion={selectedCollectionVersion}
+                  collection={collection}
                 />
               </div>
             </div>
@@ -275,7 +275,7 @@ class MyImports extends React.Component<RouteProps, IState> {
               importDetailError: '',
               loadingImportDetails: false,
               selectedImportDetails: result.data,
-              selectedCollectionVersion: undefined,
+              collection: null,
             },
             () => {
               const importDeets = this.state.selectedImportDetails;
@@ -290,7 +290,7 @@ class MyImports extends React.Component<RouteProps, IState> {
                 .then((result) => {
                   if (result.data.meta.count === 1) {
                     this.setState({
-                      selectedCollectionVersion: result.data.data[0],
+                      collection: result.data.data[0],
                     });
                   }
                 })

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -676,7 +676,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
   private loadCollections() {
     CollectionVersionAPI.list({
       ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
-      repository_label: '!hide_from_search',
+      // repository_label: '!hide_from_search',
       namespace: this.props.routeParams.namespace,
     }).then((result) => {
       this.setState({
@@ -690,7 +690,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     Promise.all([
       CollectionVersionAPI.list({
         ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
-        repository_label: '!hide_from_search',
+        // repository_label: '!hide_from_search',
         namespace: this.props.routeParams.namespace,
         is_highest: true,
       }),

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -274,6 +274,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
     const ignoredParams = [
       'namespace',
+      'repository_name',
       'page',
       'page_size',
       'sort',
@@ -383,13 +384,6 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           params={tabParams}
           updateParams={(p) => this.updateParams(p)}
           pageControls={this.renderPageControls()}
-          contextSelector={
-            <RepoSelector
-              path={this.props.routePath}
-              pathParams={{ namespace: namespace.name }}
-              selectedRepo={this.context.selectedRepo}
-            />
-          }
           filters={
             tab === 'collections' ? (
               <div className='hub-toolbar-wrapper namespace-detail'>
@@ -411,6 +405,9 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                 </div>
               </div>
             ) : null
+          }
+          contextSelector={
+            <RepoSelector selectedRepo={this.context.selectedRepo} isDisabled />
           }
         ></PartnerHeader>
         <Main>
@@ -652,6 +649,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       isOpenSignModal: false,
     });
 
+    // TODO: use distro base path
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
       distro_base_path: this.context.selectedRepo,
@@ -687,7 +685,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
     CollectionVersionAPI.list({
       ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
       repository_label: '!hide_from_search',
-      repository_name: this.context.selectedRepo,
+      namespace: this.props.routeParams.namespace,
     }).then((result) => {
       this.setState({
         collections: result.data.data,
@@ -701,7 +699,8 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       CollectionVersionAPI.list({
         ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
         repository_label: '!hide_from_search',
-        repository_name: this.context.selectedRepo,
+        namespace: this.props.routeParams.namespace,
+        is_highest: true,
       }),
       NamespaceAPI.get(this.props.routeParams.namespace, {
         include_related: 'my_permissions',

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -274,7 +274,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
     const ignoredParams = [
       'namespace',
-      'repository_name',
+      'repository__name',
       'page',
       'page_size',
       'sort',
@@ -631,6 +631,10 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
   }
 
   private signAllCertificates(namespace: NamespaceType) {
+    // get the repository from first collection
+    // all collections are in same repo, so this should be fine.
+    const [collection] = this.state.collections;
+
     const errorAlert = (status: string | number = 500): AlertType => ({
       variant: 'danger',
       title: t`Failed to sign all collections.`,
@@ -649,11 +653,13 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       isOpenSignModal: false,
     });
 
-    // TODO: use distro base path
+    const { name } = collection.collection_version;
+
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
-      distro_base_path: this.context.selectedRepo,
+      repository: collection.repository,
       namespace: namespace.name,
+      collection: name,
     })
       .then((result) => {
         waitForTask(result.data.task_id)

--- a/src/containers/namespace-list/my-namespaces.tsx
+++ b/src/containers/namespace-list/my-namespaces.tsx
@@ -13,7 +13,7 @@ class MyNamespaces extends React.Component<RouteProps> {
     return (
       <NamespaceList
         {...this.props}
-        namespacePath={Paths.myCollectionsByRepo}
+        namespacePath={Paths.namespaceDetail}
         filterOwner={true}
       />
     );

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -346,7 +346,6 @@ export class NamespaceList extends React.Component<IProps, IState> {
         .list(this.state.params)
         .then((results) => {
           this.setState({
-            // TODO: remove this when after new namespaces
             namespaces: results.data.data,
             itemCount: results.data.meta.count,
             loading: false,

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -166,9 +166,8 @@ export class NamespaceList extends React.Component<IProps, IState> {
           onCreateSuccess={(result) =>
             this.setState({
               redirect: formatPath(
-                Paths.namespaceByRepo,
+                Paths.namespaceDetail,
                 {
-                  repo: 'published',
                   namespace: result.name,
                 },
                 { tab: 'collections' },
@@ -328,7 +327,6 @@ export class NamespaceList extends React.Component<IProps, IState> {
             <NamespaceCard
               namespaceURL={formatPath(namespacePath, {
                 namespace: ns.name,
-                repo: ns['repository'],
               })}
               key={i}
               {...ns}
@@ -349,10 +347,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
         .then((results) => {
           this.setState({
             // TODO: remove this when after new namespaces
-            namespaces: results.data.data.map((res) => ({
-              ...res,
-              repository: 'published',
-            })),
+            namespaces: results.data.data,
             itemCount: results.data.meta.count,
             loading: false,
           });

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -328,7 +328,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
             <NamespaceCard
               namespaceURL={formatPath(namespacePath, {
                 namespace: ns.name,
-                repo: this.context.selectedRepo,
+                repo: ns['repository'],
               })}
               key={i}
               {...ns}
@@ -348,7 +348,11 @@ export class NamespaceList extends React.Component<IProps, IState> {
         .list(this.state.params)
         .then((results) => {
           this.setState({
-            namespaces: results.data.data,
+            // TODO: remove this when after new namespaces
+            namespaces: results.data.data.map((res) => ({
+              ...res,
+              repository: 'published',
+            })),
             itemCount: results.data.meta.count,
             loading: false,
           });

--- a/src/containers/namespace-list/partners.tsx
+++ b/src/containers/namespace-list/partners.tsx
@@ -8,7 +8,7 @@ class Partners extends React.Component<RouteProps> {
     return (
       <NamespaceList
         {...this.props}
-        namespacePath={Paths.namespaceByRepo}
+        namespacePath={Paths.namespaceDetail}
         filterOwner={false}
       />
     );

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -57,7 +57,7 @@ interface IState {
   loading: boolean;
   synclist: SyncListType;
   alerts: AlertType[];
-  updateCollection: CollectionListType;
+  updateCollection: CollectionVersionSearch;
   showImportModal: boolean;
   redirect: string;
   noDependencies: boolean;
@@ -186,15 +186,15 @@ class Search extends React.Component<RouteProps, IState> {
                   Paths.myImports,
                   {},
                   {
-                    namespace: updateCollection.namespace.name,
+                    namespace: updateCollection.collection_version.namespace,
                   },
                 ),
               })
             }
             // onCancel
             setOpen={(isOpen, warn) => this.toggleImportModal(isOpen, warn)}
-            collection={updateCollection}
-            namespace={updateCollection.namespace.name}
+            collection={updateCollection.collection_version}
+            namespace={updateCollection.collection_version.namespace}
           />
         )}
         <BaseHeader

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -51,7 +51,7 @@ interface IState {
     keywords?: string;
     tags?: string[];
     view_type?: string;
-    repository_name?: string;
+    repository__name?: string;
     namespace?: string;
   };
   loading: boolean;
@@ -150,7 +150,7 @@ class Search extends React.Component<RouteProps, IState> {
         'keywords',
         'tags',
         'is_signed',
-        'repository_name',
+        'repository__name',
         'namespace',
       ]);
 

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -5,6 +5,8 @@ import { Navigate } from 'react-router-dom';
 import {
   CollectionAPI,
   CollectionListType,
+  CollectionVersionAPI,
+  CollectionVersionSearch,
   MyNamespaceAPI,
   MySyncListAPI,
   SyncListType,
@@ -43,7 +45,7 @@ import { ParamHelper } from 'src/utilities/param-helper';
 import './search.scss';
 
 interface IState {
-  collections: CollectionListType[];
+  collections: CollectionVersionSearch[];
   numberOfResults: number;
   params: {
     page?: number;
@@ -59,7 +61,7 @@ interface IState {
   showImportModal: boolean;
   redirect: string;
   noDependencies: boolean;
-  deleteCollection: CollectionListType;
+  deleteCollection: CollectionVersionSearch;
   confirmDelete: boolean;
   isDeletionPending: boolean;
 }
@@ -144,7 +146,7 @@ class Search extends React.Component<RouteProps, IState> {
     } = this.state;
     const noData =
       collections.length === 0 &&
-      !filterIsSet(params, ['keywords', 'tags', 'sign_state']);
+      !filterIsSet(params, ['keywords', 'tags', 'is_signed']);
 
     const updateParams = (p) =>
       this.updateParams(p, () => this.queryCollections());
@@ -157,6 +159,7 @@ class Search extends React.Component<RouteProps, IState> {
         />
         <DeleteCollectionModal
           deleteCollection={deleteCollection}
+          collections={collections}
           isDeletionPending={isDeletionPending}
           confirmDelete={confirmDelete}
           setConfirmDelete={(confirmDelete) => this.setState({ confirmDelete })}
@@ -168,7 +171,6 @@ class Search extends React.Component<RouteProps, IState> {
                 setState: (state) => this.setState(state),
                 load: () => this.load(),
                 redirect: false,
-                selectedRepo: this.context.selectedRepo,
                 addAlert: (alert) => this.addAlert(alert),
               }),
             )
@@ -308,14 +310,16 @@ class Search extends React.Component<RouteProps, IState> {
   private renderCards(collections) {
     return (
       <div className='hub-cards'>
-        {collections.map((c) => {
+        {collections.map((c, i) => {
           return (
             <CollectionCard
               className='card'
-              key={c.id}
+              key={i}
               {...c}
-              footer={this.renderSyncToogle(c.name, c.namespace.name)}
-              repo={this.context.selectedRepo}
+              footer={this.renderSyncToogle(
+                c.collection_version.name,
+                c.collection_version.namespace.name,
+              )}
               menu={this.renderMenu(false, c)}
               displaySignatures={this.context.featureFlags.display_signatures}
             />
@@ -326,17 +330,14 @@ class Search extends React.Component<RouteProps, IState> {
   }
 
   private handleControlClick(collection) {
-    CollectionAPI.setDeprecation(
-      collection,
-      !collection.deprecated,
-      this.context.selectedRepo,
-    )
+    const { name } = collection.collection_version;
+    CollectionAPI.setDeprecation(collection)
       .then((res) => {
         const taskId = parsePulpIDFromURL(res.data.task);
         return waitForTask(taskId).then(() => {
           const title = !collection.deprecated
-            ? t`The collection "${collection.name}" has been successfully deprecated.`
-            : t`The collection "${collection.name}" has been successfully undeprecated.`;
+            ? t`The collection "${name}" has been successfully deprecated.`
+            : t`The collection "${name}" has been successfully undeprecated.`;
           this.setState({
             alerts: [
               ...this.state.alerts,
@@ -357,8 +358,8 @@ class Search extends React.Component<RouteProps, IState> {
             {
               variant: 'danger',
               title: !collection.deprecated
-                ? t`Collection "${collection.name}" could not be deprecated.`
-                : t`Collection "${collection.name}" could not be undeprecated.`,
+                ? t`Collection "${name}" could not be deprecated.`
+                : t`Collection "${name}" could not be undeprecated.`,
               description: errorMessage(status, statusText),
             },
           ],
@@ -383,7 +384,7 @@ class Search extends React.Component<RouteProps, IState> {
         onClick={() => this.handleControlClick(collection)}
         key='deprecate'
       >
-        {collection.deprecated ? t`Undeprecate` : t`Deprecate`}
+        {collection.is_deprecated ? t`Undeprecate` : t`Deprecate`}
       </DropdownItem>,
     ];
 
@@ -506,14 +507,17 @@ class Search extends React.Component<RouteProps, IState> {
       <div className='list-container'>
         <div className='hub-list'>
           <DataList className='data-list' aria-label={t`List of Collections`}>
-            {collections.map((c) => (
+            {collections.map((c, i) => (
               <CollectionListItem
                 showNamespace={true}
-                key={c.id}
+                key={i}
                 {...c}
                 controls={
                   <>
-                    {this.renderSyncToogle(c.name, c.namespace.name)}
+                    {this.renderSyncToogle(
+                      c.collection_version.name,
+                      c.collection_version.namespace,
+                    )}
                     {this.renderMenu(true, c)}
                   </>
                 }
@@ -543,13 +547,12 @@ class Search extends React.Component<RouteProps, IState> {
 
   private queryCollections() {
     this.setState({ loading: true }, () => {
-      CollectionAPI.list(
-        {
-          ...ParamHelper.getReduced(this.state.params, ['view_type']),
-          deprecated: false,
-        },
-        this.context.selectedRepo,
-      ).then((result) => {
+      CollectionVersionAPI.list({
+        ...ParamHelper.getReduced(this.state.params, ['view_type']),
+        is_deprecated: false,
+        repository_name: this.context.selectedRepo,
+        repository_label: '!hide_from_search',
+      }).then((result) => {
         this.setState({
           collections: result.data.data,
           numberOfResults: result.data.meta.count,

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -445,26 +445,26 @@ class Search extends React.Component<RouteProps, IState> {
       });
     };
 
-    // MyNamespaceAPI.get(collection.namespace.name, {
-    //   include_related: 'my_permissions',
-    // })
-    //   .then((value) => {
-    //     if (
-    //       value.data.related_fields.my_permissions.includes(
-    //         'galaxy.upload_to_namespace',
-    //       )
-    //     ) {
-    //       this.setState({
-    //         updateCollection: collection,
-    //         showImportModal: true,
-    //       });
-    //     } else {
-    //       addAlert();
-    //     }
-    //   })
-    //   .catch(() => {
-    //     addAlert();
-    //   });
+    MyNamespaceAPI.get(collection.namespace.name, {
+      include_related: 'my_permissions',
+    })
+      .then((value) => {
+        if (
+          value.data.related_fields.my_permissions.includes(
+            'galaxy.upload_to_namespace',
+          )
+        ) {
+          this.setState({
+            updateCollection: collection,
+            showImportModal: true,
+          });
+        } else {
+          addAlert();
+        }
+      })
+      .catch(() => {
+        addAlert();
+      });
   }
 
   private toggleCollectionSync(name: string, namespace: string) {

--- a/src/loaders/insights/loader.tsx
+++ b/src/loaders/insights/loader.tsx
@@ -19,11 +19,11 @@ const isRepoURL = (pathname) =>
 
 const App = (_props) => {
   const location = useLocation();
-  const match = isRepoURL(location.pathname);
+  // const match = isRepoURL(location.pathname);
 
   const [alerts, setAlerts] = useState<AlertType[]>([]);
   const [featureFlags, setFeatureFlags] = useState<FeatureFlagsType>(null);
-  const [selectedRepo, setSelectedRepo] = useState<string>(DEFAULT_REPO);
+  // const [selectedRepo, setSelectedRepo] = useState<string>(DEFAULT_REPO);
   const [settings, setSettings] = useState<SettingsType>(null);
   const [user, setUser] = useState<UserType>(null);
 
@@ -46,26 +46,25 @@ const App = (_props) => {
   useEffect(() => {
     // This is sort of a dirty hack to make it so that collection details can view repositories other than "published", but all other views are locked to "published"
     // We do this because there is not currently a way to toggle repositories in automation hub on console.redhat.com, so it's important to ensure the user always lands on the published repo
-
     // check if the URL matches the base path for the collection detail page
-    if (match) {
-      // if the URL matches, allow the repo to be switched to the repo defined in the url
-      if (match.params.repo !== selectedRepo) {
-        setSelectedRepo(match.params.repo);
-      }
-    } else {
-      // For all other URLs, switch the global state back to the "publised" repo if the repo is set to anything else.
-      if (selectedRepo !== DEFAULT_REPO) {
-        setSelectedRepo(DEFAULT_REPO);
-      }
-    }
+    // if (match) {
+    //   // if the URL matches, allow the repo to be switched to the repo defined in the url
+    //   if (match.params.repo !== selectedRepo) {
+    //     setSelectedRepo(match.params.repo);
+    //   }
+    // } else {
+    //   // For all other URLs, switch the global state back to the "publised" repo if the repo is set to anything else.
+    //   if (selectedRepo !== DEFAULT_REPO) {
+    //     setSelectedRepo(DEFAULT_REPO);
+    //   }
+    // }
   });
 
   // block the page from rendering if we're on a repo route and the repo in the url doesn't match the current state
   // This gives componentDidUpdate a chance to recognize that route has changed and update the internal state to match the route before any pages can redirect the URL to a 404 state.
-  if (match && match.params.repo !== selectedRepo) {
-    return null;
-  }
+  // if (match && match.params.repo !== selectedRepo) {
+  //   return null;
+  // }
 
   // Wait for the user data to load before any of the child components are rendered. This will prevent API calls from happening before the app can authenticate
   if (!user) {
@@ -80,7 +79,6 @@ const App = (_props) => {
         alerts,
         featureFlags,
         queueAlert,
-        selectedRepo,
         setAlerts,
         setUser,
         settings,

--- a/src/loaders/insights/loader.tsx
+++ b/src/loaders/insights/loader.tsx
@@ -3,27 +3,16 @@ import { t } from '@lingui/macro';
 import { Alert } from '@patternfly/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import React, { useEffect, useState } from 'react';
-import { matchPath, useLocation } from 'react-router-dom';
 import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { AlertType, UIVersion } from 'src/components';
-import { Paths, formatPath } from 'src/paths';
 import { hasPermission } from 'src/utilities';
 import { AppContext } from '../app-context';
 import { loadContext } from '../load-context';
 import { InsightsRoutes } from './routes';
 
-const DEFAULT_REPO = 'published';
-
-const isRepoURL = (pathname) =>
-  matchPath({ path: formatPath(Paths.searchByRepo) + '*' }, pathname);
-
 const App = (_props) => {
-  const location = useLocation();
-  // const match = isRepoURL(location.pathname);
-
   const [alerts, setAlerts] = useState<AlertType[]>([]);
   const [featureFlags, setFeatureFlags] = useState<FeatureFlagsType>(null);
-  // const [selectedRepo, setSelectedRepo] = useState<string>(DEFAULT_REPO);
   const [settings, setSettings] = useState<SettingsType>(null);
   const [user, setUser] = useState<UserType>(null);
 
@@ -41,30 +30,6 @@ const App = (_props) => {
       setUser(user);
     });
   }, []);
-
-  // componentDidUpdate
-  useEffect(() => {
-    // This is sort of a dirty hack to make it so that collection details can view repositories other than "published", but all other views are locked to "published"
-    // We do this because there is not currently a way to toggle repositories in automation hub on console.redhat.com, so it's important to ensure the user always lands on the published repo
-    // check if the URL matches the base path for the collection detail page
-    // if (match) {
-    //   // if the URL matches, allow the repo to be switched to the repo defined in the url
-    //   if (match.params.repo !== selectedRepo) {
-    //     setSelectedRepo(match.params.repo);
-    //   }
-    // } else {
-    //   // For all other URLs, switch the global state back to the "publised" repo if the repo is set to anything else.
-    //   if (selectedRepo !== DEFAULT_REPO) {
-    //     setSelectedRepo(DEFAULT_REPO);
-    //   }
-    // }
-  });
-
-  // block the page from rendering if we're on a repo route and the repo in the url doesn't match the current state
-  // This gives componentDidUpdate a chance to recognize that route has changed and update the internal state to match the route before any pages can redirect the URL to a 404 state.
-  // if (match && match.params.repo !== selectedRepo) {
-  //   return null;
-  // }
 
   // Wait for the user data to load before any of the child components are rendered. This will prevent API calls from happening before the app can authenticate
   if (!user) {

--- a/src/loaders/insights/routes.tsx
+++ b/src/loaders/insights/routes.tsx
@@ -107,7 +107,7 @@ const routes = [
     component: CollectionDependencies,
   },
   { path: Paths.collectionByRepo, component: CollectionDetail },
-  { path: Paths.namespaceByRepo, component: NamespaceDetail },
+  { path: Paths.namespaceDetail, component: NamespaceDetail },
   { path: Paths.collections, component: Search },
   { path: Paths.collectionDocsPage, component: CollectionDocs },
   { path: Paths.collectionDocsIndex, component: CollectionDocs },

--- a/src/loaders/insights/routes.tsx
+++ b/src/loaders/insights/routes.tsx
@@ -108,7 +108,7 @@ const routes = [
   },
   { path: Paths.collectionByRepo, component: CollectionDetail },
   { path: Paths.namespaceByRepo, component: NamespaceDetail },
-  { path: Paths.searchByRepo, component: Search },
+  { path: Paths.collections, component: Search },
   { path: Paths.collectionDocsPage, component: CollectionDocs },
   { path: Paths.collectionDocsIndex, component: CollectionDocs },
   {
@@ -126,7 +126,7 @@ const routes = [
   { path: Paths.myImports, component: MyImports },
   { path: Paths.collection, component: CollectionDetail },
   { path: Paths.namespace, component: NamespaceDetail },
-  { path: Paths.search, component: Search },
+  { path: Paths.collections, component: Search },
 ];
 
 /**

--- a/src/loaders/insights/routes.tsx
+++ b/src/loaders/insights/routes.tsx
@@ -28,6 +28,10 @@ const CollectionImportLog = lazy(
   () => import('src/containers/collection-detail/collection-import-log'),
 );
 
+const CollectionDistributions = lazy(
+  () => import('src/containers/collection-detail/collection-distributions'),
+);
+
 const EditNamespace = lazy(
   () => import('src/containers/edit-namespace/edit-namespace'),
 );
@@ -106,6 +110,10 @@ const routes = [
     path: Paths.collectionDependenciesByRepo,
     component: CollectionDependencies,
   },
+  {
+    component: CollectionDistributions,
+    path: Paths.collectionDistributionsByRepo,
+  },
   { path: Paths.collectionByRepo, component: CollectionDetail },
   { path: Paths.namespaceDetail, component: NamespaceDetail },
   { path: Paths.collections, component: Search },
@@ -127,6 +135,7 @@ const routes = [
   { path: Paths.collection, component: CollectionDetail },
   { path: Paths.namespace, component: NamespaceDetail },
   { path: Paths.collections, component: Search },
+  { path: Paths.search, component: Search },
 ];
 
 /**

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -32,7 +32,6 @@ import { StandaloneMenu } from './menu';
 interface IProps {
   children: React.ReactNode;
   featureFlags: FeatureFlagsType;
-  selectedRepo: string;
   setUser: (user) => void;
   settings: SettingsType;
   user: UserType;
@@ -41,7 +40,6 @@ interface IProps {
 export const StandaloneLayout = ({
   children,
   featureFlags,
-  selectedRepo,
   setUser,
   settings,
   user,
@@ -127,13 +125,7 @@ export const StandaloneLayout = ({
     <PageHeader
       logo={<SmallLogo alt={APPLICATION_NAME}></SmallLogo>}
       logoComponent={({ children }) => (
-        <Link
-          to={formatPath(Paths.searchByRepo, {
-            repo: selectedRepo,
-          })}
-        >
-          {children}
-        </Link>
+        <Link to={formatPath(Paths.collections)}>{children}</Link>
       )}
       headerTools={
         <PageHeaderTools>
@@ -164,12 +156,7 @@ export const StandaloneLayout = ({
   const Sidebar = (
     <PageSidebar
       theme='dark'
-      nav={
-        <StandaloneMenu
-          repository={selectedRepo}
-          context={{ user, settings, featureFlags }}
-        />
-      }
+      nav={<StandaloneMenu context={{ user, settings, featureFlags }} />}
     />
   );
 

--- a/src/loaders/standalone/loader.tsx
+++ b/src/loaders/standalone/loader.tsx
@@ -19,24 +19,24 @@ const App = (_props) => {
 
   const [alerts, setAlerts] = useState<AlertType[]>([]);
   const [featureFlags, setFeatureFlags] = useState<FeatureFlagsType>(null);
-  const [selectedRepo, setSelectedRepo] = useState<string>('published');
+  // const [selectedRepo, setSelectedRepo] = useState<string>('published');
   const [settings, setSettings] = useState<SettingsType>(null);
   const [user, setUser] = useState<UserType>(null);
 
-  useEffect(() => {
-    if (match && match.params.repo !== selectedRepo) {
-      setSelectedRepo(match.params.repo);
-    }
-  }, [location]);
+  // useEffect(() => {
+  //   if (match && match.params.repo !== selectedRepo) {
+  //     setSelectedRepo(match.params.repo);
+  //   }
+  // }, [location]);
 
   // block the page from rendering if we're on a repo route and the repo in the
   // url doesn't match the current state
   // This gives componentDidUpdate a chance to recognize that route has chnaged
   // and update the internal state to match the route before any pages can
   // redirect the URL to a 404 state.
-  if (match && match.params.repo !== selectedRepo) {
-    return null;
-  }
+  // if (match && match.params.repo !== selectedRepo) {
+  //   return null;
+  // }
 
   const updateInitialData = ({ alerts, featureFlags, settings, user }) => {
     setAlerts(alerts);
@@ -54,7 +54,6 @@ const App = (_props) => {
     component = (
       <StandaloneLayout
         featureFlags={featureFlags}
-        selectedRepo={selectedRepo}
         settings={settings}
         user={user}
         setUser={setUser}
@@ -72,7 +71,6 @@ const App = (_props) => {
         alerts,
         featureFlags,
         queueAlert,
-        selectedRepo,
         setAlerts,
         setUser,
         settings,

--- a/src/loaders/standalone/loader.tsx
+++ b/src/loaders/standalone/loader.tsx
@@ -1,7 +1,7 @@
 import '../app.scss';
 import '@patternfly/patternfly/patternfly.scss';
-import React, { useEffect, useState } from 'react';
-import { matchPath, useLocation } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { AlertType, UIVersion } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
@@ -10,33 +10,13 @@ import { AppContext } from '../app-context';
 import { StandaloneLayout } from './layout';
 import { StandaloneRoutes } from './routes';
 
-const isRepoURL = (pathname) =>
-  matchPath({ path: formatPath(Paths.searchByRepo) + '*' }, pathname);
-
 const App = (_props) => {
   const location = useLocation();
-  const match = isRepoURL(location.pathname);
 
   const [alerts, setAlerts] = useState<AlertType[]>([]);
   const [featureFlags, setFeatureFlags] = useState<FeatureFlagsType>(null);
-  // const [selectedRepo, setSelectedRepo] = useState<string>('published');
   const [settings, setSettings] = useState<SettingsType>(null);
   const [user, setUser] = useState<UserType>(null);
-
-  // useEffect(() => {
-  //   if (match && match.params.repo !== selectedRepo) {
-  //     setSelectedRepo(match.params.repo);
-  //   }
-  // }, [location]);
-
-  // block the page from rendering if we're on a repo route and the repo in the
-  // url doesn't match the current state
-  // This gives componentDidUpdate a chance to recognize that route has chnaged
-  // and update the internal state to match the route before any pages can
-  // redirect the URL to a 404 state.
-  // if (match && match.params.repo !== selectedRepo) {
-  //   return null;
-  // }
 
   const updateInitialData = ({ alerts, featureFlags, settings, user }) => {
     setAlerts(alerts);

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -32,13 +32,11 @@ const menuSection = (name, options = {}, items = []) => ({
   items,
 });
 
-function standaloneMenu({ repository }) {
+function standaloneMenu() {
   return [
     menuSection(t`Collections`, {}, [
       menuItem(t`Collections`, {
-        url: formatPath(Paths.searchByRepo, {
-          repo: repository || 'published',
-        }),
+        url: formatPath(Paths.collections),
         condition: ({ settings, user }) =>
           settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
           !user.is_anonymous,
@@ -224,16 +222,15 @@ function Menu({ items, context, expandedSections }) {
   );
 }
 
-export const StandaloneMenu = ({ repository, context }) => {
+export const StandaloneMenu = ({ context }) => {
   const [expandedSections, setExpandedSections] = useState([]);
 
   const location = useLocation();
   const [menu, setMenu] = useState([]);
 
   useEffect(() => {
-    setMenu(standaloneMenu({ repository }));
-  }, [repository]);
-
+    setMenu(standaloneMenu());
+  }, []);
   useEffect(() => {
     activateMenu(menu, location.pathname);
     setExpandedSections(

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -274,7 +274,7 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
         path: Paths.collectionDependenciesByRepo,
       },
       { component: CollectionDetail, path: Paths.collectionByRepo },
-      { component: NamespaceDetail, path: Paths.namespaceByRepo },
+      { component: NamespaceDetail, path: Paths.namespaceDetail },
       { component: Search, path: Paths.collections },
       { component: CollectionDocs, path: Paths.collectionDocsPage },
       { component: CollectionDocs, path: Paths.collectionDocsIndex },

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -289,6 +289,7 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
       { component: MyImports, path: Paths.myImports },
       { component: CollectionDetail, path: Paths.collection },
       { component: NamespaceDetail, path: Paths.namespace },
+      { component: Search, path: Paths.collections },
       { component: Search, path: Paths.search },
     ];
   }

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -13,6 +13,7 @@ import {
   CollectionContent,
   CollectionDependencies,
   CollectionDetail,
+  CollectionDistributions,
   CollectionDocs,
   CollectionImportLog,
   EditNamespace,
@@ -269,6 +270,10 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
       { component: CollectionDocs, path: Paths.collectionContentDocsByRepo },
       { component: CollectionContent, path: Paths.collectionContentListByRepo },
       { component: CollectionImportLog, path: Paths.collectionImportLogByRepo },
+      {
+        component: CollectionDistributions,
+        path: Paths.collectionDistributionsByRepo,
+      },
       {
         component: CollectionDependencies,
         path: Paths.collectionDependenciesByRepo,

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -275,7 +275,7 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
       },
       { component: CollectionDetail, path: Paths.collectionByRepo },
       { component: NamespaceDetail, path: Paths.namespaceByRepo },
-      { component: Search, path: Paths.searchByRepo },
+      { component: Search, path: Paths.collections },
       { component: CollectionDocs, path: Paths.collectionDocsPage },
       { component: CollectionDocs, path: Paths.collectionDocsIndex },
       { component: CollectionDocs, path: Paths.collectionContentDocs },

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -106,6 +106,7 @@ export enum Paths {
   namespaceByRepo = '/repo/:repo/:namespace',
   collection = '/:namespace/:collection',
   namespace = '/:namespace',
+  namespaceDetail = '/namespaces/:namespace',
   partners = '/partners',
   namespaces = '/namespaces',
   notFound = '/not-found',

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -103,6 +103,7 @@ export enum Paths {
   collectionContentListByRepo = '/repo/:repo/:namespace/:collection/content',
   collectionImportLogByRepo = '/repo/:repo/:namespace/:collection/import-log',
   collectionDependenciesByRepo = '/repo/:repo/:namespace/:collection/dependencies',
+  collectionDistributionsByRepo = '/repo/:repo/:namespace/:collection/distributions',
   namespaceByRepo = '/repo/:repo/:namespace',
   collection = '/:namespace/:collection',
   namespace = '/:namespace',

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -119,6 +119,7 @@ export enum Paths {
   repositories = '/repositories',
   taskList = '/tasks',
   signatureKeys = '/signature-keys',
+  collections = '/collections',
 }
 
 export const namespaceBreadcrumb = {

--- a/src/utilities/can-sign.tsx
+++ b/src/utilities/can-sign.tsx
@@ -5,7 +5,12 @@ export const canSignNamespace = (
   namespace,
 ) => {
   const { can_create_signatures } = featureFlags;
-  const permissions = namespace?.related_fields?.my_permissions || [];
+
+  // TODO: fix RBAC namespaces
+  const permissions = namespace?.related_fields?.my_permissions || [
+    'galaxy.change_namespace',
+    'galaxy.upload_to_namespace',
+  ];
 
   return (
     // (can_create_signatures also implies signatures_enabled and collection_signing)

--- a/src/utilities/can-sign.tsx
+++ b/src/utilities/can-sign.tsx
@@ -6,11 +6,7 @@ export const canSignNamespace = (
 ) => {
   const { can_create_signatures } = featureFlags;
 
-  // TODO: fix RBAC namespaces
-  const permissions = namespace?.related_fields?.my_permissions || [
-    'galaxy.change_namespace',
-    'galaxy.upload_to_namespace',
-  ];
+  const permissions = namespace?.related_fields?.my_permissions || [];
 
   return (
     // (can_create_signatures also implies signatures_enabled and collection_signing)

--- a/src/utilities/content-summary.ts
+++ b/src/utilities/content-summary.ts
@@ -1,4 +1,4 @@
-import { CollectionVersion } from 'src/api';
+import { CollectionVersionSearch } from 'src/api';
 
 class Summary {
   total_count: number;
@@ -11,10 +11,10 @@ class Summary {
   };
 }
 
-export function convertContentSummaryCounts(
-  metadata: CollectionVersion['metadata'],
-): Summary {
-  const { contents: content, dependencies } = metadata;
+export function convertContentSummaryCounts({
+  contents: content,
+  dependencies,
+}: CollectionVersionSearch['collection_version']): Summary {
   const summary: Summary = {
     total_count: content.length,
     contents: {

--- a/src/utilities/delete-collection.tsx
+++ b/src/utilities/delete-collection.tsx
@@ -1,13 +1,17 @@
 import { Trans, t } from '@lingui/macro';
 import { DropdownItem, Tooltip } from '@patternfly/react-core';
 import React from 'react';
-import { CollectionAPI, CollectionVersionSearch } from 'src/api';
+import {
+  CollectionAPI,
+  CollectionVersionAPI,
+  CollectionVersionSearch,
+} from 'src/api';
 import { errorMessage, parsePulpIDFromURL, waitForTask } from 'src/utilities';
 
 export class DeleteCollectionUtils {
   public static getUsedbyDependencies(collection: CollectionVersionSearch) {
     const { name, namespace } = collection.collection_version;
-    return CollectionAPI.getUsedDependenciesByCollection(namespace, name)
+    return CollectionVersionAPI.getUsedDependenciesByCollection(namespace, name)
       .then(({ data }) => data.data.length === 0)
       .catch((err) => {
         const { status, statusText } = err.response;

--- a/src/utilities/delete-collection.tsx
+++ b/src/utilities/delete-collection.tsx
@@ -1,13 +1,13 @@
 import { Trans, t } from '@lingui/macro';
 import { DropdownItem, Tooltip } from '@patternfly/react-core';
 import React from 'react';
-import { CollectionAPI } from 'src/api';
+import { CollectionAPI, CollectionVersionSearch } from 'src/api';
 import { errorMessage, parsePulpIDFromURL, waitForTask } from 'src/utilities';
 
 export class DeleteCollectionUtils {
-  public static getUsedbyDependencies(collection) {
-    const { name, namespace } = collection;
-    return CollectionAPI.getUsedDependenciesByCollection(namespace.name, name)
+  public static getUsedbyDependencies(collection: CollectionVersionSearch) {
+    const { name, namespace } = collection.collection_version;
+    return CollectionAPI.getUsedDependenciesByCollection(namespace, name)
       .then(({ data }) => data.data.length === 0)
       .catch((err) => {
         const { status, statusText } = err.response;
@@ -109,13 +109,12 @@ export class DeleteCollectionUtils {
     setState,
     load,
     redirect,
-    selectedRepo,
     addAlert,
   }) {
-    CollectionAPI.deleteCollection(selectedRepo, collection)
+    CollectionAPI.deleteCollection(collection)
       .then((res) => {
         const taskId = parsePulpIDFromURL(res.data.task);
-        const name = collection.name;
+        const name = collection.collection_version.name;
 
         waitForTask(taskId).then(() => {
           addAlert({
@@ -142,7 +141,7 @@ export class DeleteCollectionUtils {
 
         addAlert({
           variant: 'danger',
-          title: t`Collection "${name}" could not be deleted.`,
+          title: t`Collection "${collection.collection_version.name}" could not be deleted.`,
           description: errorMessage(status, statusText),
         });
       })

--- a/test/cypress/e2e/approval/approval_dashboard_list.js
+++ b/test/cypress/e2e/approval/approval_dashboard_list.js
@@ -31,7 +31,7 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
   function loadData() {
     // we cant delete all data using galaxykit right now, because when collection is rejected
     // it cant be deleted. So we must load the data, that are right now in the table
-    let intercept_url = `${apiPrefix}_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=100`;
+    let intercept_url = `${apiPrefix}v3/plugin/ansible/search/collection-versions/?order_by=-pulp_created&offset=0&limit=100`;
 
     cy.visit(`${uiPrefix}approval-dashboard?page_size=100`);
     cy.intercept('GET', intercept_url).as('data');
@@ -40,7 +40,7 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
     cy.wait('@data').then((res) => {
       let data = res.response.body.data;
       data.forEach((record) => {
-        items.push({ name: record.name });
+        items.push({ name: record.collection_version.name });
       });
       items = sortBy(items, 'name');
     });
@@ -48,7 +48,7 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
 
   before(() => {
     cy.login();
-    cy.deleteNamespacesAndCollections();
+    // cy.deleteNamespacesAndCollections();
     createData();
     loadData();
   });
@@ -72,8 +72,8 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
   });
 
   it('should sort alphabetically and paging is working.', () => {
-    cy.get('[data-cy="sort_collection"]').click();
-    cy.get('[data-cy="sort_collection"]').click();
+    cy.get('[data-cy="sort_name"]').click();
+    cy.get('[data-cy="sort_name"]').click();
 
     cy.get('[data-cy="body"]').contains(items[0].name);
 
@@ -84,7 +84,7 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
   });
 
   it('should sort collection.', () => {
-    cy.get('[data-cy="sort_collection"]').click();
+    cy.get('[data-cy="sort_name"]').click();
     cy.get('[data-cy="body"]').contains('approval');
 
     cy.get('[data-cy="CertificationDashboard-row"]:first').contains(
@@ -108,8 +108,8 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
       '[data-cy="body"] [data-cy="compound_filter"] a',
       'Collection Name',
     ).click();
-    cy.get('[data-cy="sort_collection"]').click();
-    cy.get('[data-cy="sort_collection"]').click();
+    cy.get('[data-cy="sort_name"]').click();
+    cy.get('[data-cy="sort_name"]').click();
 
     cy.get('[data-cy="body"] [data-cy="compound_filter"] input').type(
       'approval_dashboard_collection_test0{enter}',
@@ -139,8 +139,8 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
       'approval_dashboard_namespace_test{enter}',
     );
 
-    cy.get('[data-cy="sort_collection"]').click();
-    cy.get('[data-cy="sort_collection"]').click();
+    cy.get('[data-cy="sort_name"]').click();
+    cy.get('[data-cy="sort_name"]').click();
 
     cy.get('[data-cy="body"]').contains('approval_dashboard_collection_test0');
     cy.get('[data-cy="body"]')
@@ -170,8 +170,8 @@ describe('Approval Dashboard list tests for sorting, paging and filtering', () =
       .click();
     cy.get('[data-cy="body"]').contains('20 per page').click();
 
-    cy.get('[data-cy="sort_collection"]').click();
-    cy.get('[data-cy="sort_collection"]').click();
+    cy.get('[data-cy="sort_name"]').click();
+    cy.get('[data-cy="sort_name"]').click();
 
     range(11).forEach((i) => {
       cy.get('[data-cy="body"]').contains(items[i].name);

--- a/test/cypress/e2e/approval/collection_approval.js
+++ b/test/cypress/e2e/approval/collection_approval.js
@@ -17,7 +17,7 @@ describe('tests the approval list screen ', () => {
   it('rejects certification status and approves it again', () => {
     cy.intercept(
       'GET',
-      `${apiPrefix}_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=10`,
+      `${apiPrefix}v3/plugin/ansible/search/collection-versions/?sort=-pulp_created&offset=0&limit=10`,
     ).as('reload');
     cy.get('.pf-c-chip > button[aria-label="close"]').click();
     cy.wait('@reload');
@@ -42,7 +42,7 @@ describe('tests the approval list screen ', () => {
   it('view the imports logs', () => {
     cy.intercept(
       'GET',
-      `${apiPrefix}_ui/v1/collection-versions/?sort=-pulp_created&offset=0&limit=10`,
+      `${apiPrefix}v3/plugin/ansible/search/collection-versions/?sort=-pulp_created&offset=0&limit=10`,
     ).as('reload');
     cy.get('.pf-c-chip > button[aria-label="close"]').click();
     cy.wait('@reload');

--- a/test/cypress/e2e/collections/collection_upload.js
+++ b/test/cypress/e2e/collections/collection_upload.js
@@ -82,7 +82,7 @@ describe('Collection Upload Tests', () => {
       cy.login(userName, userPassword);
       cy.intercept(
         'GET',
-        `${apiPrefix}_ui/v1/collection-versions/?namespace=*`,
+        `${apiPrefix}v3/plugin/ansible/search/collection-versions/?namespace=*`,
       ).as('upload');
       cy.galaxykit('-i namespace create', 'ansible');
       cy.menuGo('Collections > Namespaces');
@@ -100,7 +100,7 @@ describe('Collection Upload Tests', () => {
     cy.login();
     cy.intercept(
       'GET',
-      `${apiPrefix}_ui/v1/collection-versions/?namespace=*`,
+      `${apiPrefix}v3/plugin/ansible/search/collection-versions/?namespace=*`,
     ).as('upload');
     cy.galaxykit('-i namespace create', 'ansible');
     cy.goToNamespaces();

--- a/test/cypress/e2e/imports/imports_filter.js
+++ b/test/cypress/e2e/imports/imports_filter.js
@@ -59,7 +59,7 @@ describe('Imports filter test', () => {
     );
     cy.intercept(
       'GET',
-      `${apiPrefix}_ui/v1/collection-versions/?namespace=test_namespace&name=*`,
+      `${apiPrefix}v3/plugin/ansible/search/collection-versions/?namespace=test_namespace&name=*`,
     ).as('collectionVersions');
 
     cy.get('[placeholder="Select namespace"]').clear();
@@ -81,7 +81,7 @@ describe('Imports filter test', () => {
     );
     cy.intercept(
       'GET',
-      `${apiPrefix}_ui/v1/collection-versions/?namespace=filter_test_namespace&name=*`,
+      `${apiPrefix}v3/plugin/ansible/search/collection-versions/?namespace=filter_test_namespace&name=*`,
     ).as('collectionVersions2');
 
     cy.get('[placeholder="Select namespace"]').click();

--- a/test/cypress/e2e/imports/imports_filter_search.js
+++ b/test/cypress/e2e/imports/imports_filter_search.js
@@ -30,7 +30,10 @@ describe('Imports filter test', () => {
   });
 
   it('partial filter for name is working.', () => {
-    cy.intercept('GET', `${apiPrefix}_ui/v1/collection-versions/?*`).as('wait');
+    cy.intercept(
+      'GET',
+      `${apiPrefix}v3/plugin/ansible/search/collection-versions/?*`,
+    ).as('wait');
 
     cy.get('input[aria-label="keywords"').type('my_collection{enter}');
     cy.wait('@wait');
@@ -43,7 +46,10 @@ describe('Imports filter test', () => {
   });
 
   it('exact filter for name is working.', () => {
-    cy.intercept('GET', `${apiPrefix}_ui/v1/collection-versions/?*`).as('wait');
+    cy.intercept(
+      'GET',
+      `${apiPrefix}v3/plugin/ansible/search/collection-versions/?*`,
+    ).as('wait');
 
     cy.get('input[aria-label="keywords"').type('my_collection1{enter}');
     cy.wait('@wait');
@@ -66,7 +72,7 @@ describe('Imports filter test', () => {
     // waiting to another query, otherwise sporadic failuers
     cy.intercept(
       'GET',
-      `${apiPrefix}_ui/v1/collection-versions/?namespace=*`,
+      `${apiPrefix}v3/plugin/ansible/search/collection-versions/?namespace=*`,
     ).as('wait');
     cy.contains('[data-cy="compound_filter"] a', 'Completed').click();
 
@@ -98,7 +104,7 @@ describe('Imports filter test', () => {
     // waiting to another query, otherwise sporadic failuers
     cy.intercept(
       'GET',
-      `${apiPrefix}_ui/v1/collection-versions/?namespace=*`,
+      `${apiPrefix}v3/plugin/ansible/search/collection-versions/?namespace=*`,
     ).as('wait');
     cy.contains('a', 'Completed').click();
 
@@ -122,7 +128,7 @@ describe('Imports filter test', () => {
     // waiting to another query, otherwise sporadic failuers
     cy.intercept(
       'GET',
-      `${apiPrefix}_ui/v1/collection-versions/?namespace=*`,
+      `${apiPrefix}v3/plugin/ansible/search/collection-versions/?namespace=*`,
     ).as('wait');
     cy.contains('a', 'Completed').click();
     cy.wait('@wait');


### PR DESCRIPTION
Issue: [AAH-767](https://issues.redhat.com/browse/AAH-767)

Requires: 
- https://github.com/ansible/galaxy_ng/pull/1642
- https://github.com/pulp/pulp_ansible/pull/1395
- ~https://github.com/pulp/pulp_ansible/pull/1357~


Switching to new pulp_ansible cross repo collection version search. 
Updated screens: 
- My Approval dashboard
- My imports
- Namespace detail
- Collection list (search)
- Collection detail (install, documentation, contents, import log, dependencies)

Changes: 
- removed repo selector for `namespace-detail`
- changed URL for namespace detail to `/ui/namespaces/<namespace>`
- changed URL for collection list (search.tsx) to `/ui/collections` 
