### PR TITLE
Update product docs url version

### DIFF
--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -237,8 +237,9 @@ export const PublishToControllerModal = (props: IProps) => {
 
   const { image, isOpen, onClose } = props;
 
+  // redirects to ./2.x (latest)
   const docsLink =
-    'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1';
+    'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/';
 
   const noData =
     controllers?.length === 0 &&

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -131,7 +131,7 @@ class ExecutionEnvironmentList extends React.Component<RouteProps, IState> {
         variant='link'
         onClick={() =>
           window.open(
-            'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/managing_containers_in_private_automation_hub/index',
+            'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html-single/managing_containers_in_private_automation_hub/index',
             '_blank',
           )
         }


### PR DESCRIPTION
link to https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform instead of ...`/2.1` - it redirects to `/2.3` now

link to 2.3 version of https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html-single/managing_containers_in_private_automation_hub/index - no way to skip the version there

---

docs links & targets...

|version|place|link|change|pr|
|-|-|-|-|-|
|4.2|`standalone-loader`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/ (since #260)|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/1.2|#3426|
| |
|4.4|`standalone-loader`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1|#3425|
|4.4|`execution_environment_list`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/managing_containers_in_private_automation_hub/index|-|-|
|4.4|`publish-to-controller-modal`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1|-|-|
| |
|4.5|`standalone-loader`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2|#3424|
|4.5|`execution_environment_list`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/managing_containers_in_private_automation_hub/index|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html-single/managing_containers_in_private_automation_hub/index|#3424|
|4.5|`publish-to-controller-modal`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2|#3424|
| |
|4.6|`standalone-loader`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3|#3423|
|4.6|`execution_environment_list`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/managing_containers_in_private_automation_hub/index|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html-single/managing_containers_in_private_automation_hub/index|#3423|
|4.6|`publish-to-controller-modal`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3|#3423|
| |
|master|`menu`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/|-|-|
|master|`token-insights`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/|-|-|
|master|`execution_environment_list`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/managing_containers_in_private_automation_hub/index|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3/html-single/managing_containers_in_private_automation_hub/index|#3422 (here)|
|master|`publish-to-controller-modal`|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1|https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/|#3422 (here)|

(`rg access.redhat src/`)

(the intent being - released branches point to their specific versions, master points to versionless or latest)