### PR TITLE
[stable-4.5] Update product docs url version

### DIFF
--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -254,7 +254,7 @@ export class PublishToControllerModal extends React.Component<IProps, IState> {
     } = this.state;
 
     const docsLink =
-      'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1';
+      'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2';
 
     const noData =
       controllers?.length === 0 &&

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -132,7 +132,7 @@ class ExecutionEnvironmentList extends React.Component<
         variant='link'
         onClick={() =>
           window.open(
-            'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1/html-single/managing_containers_in_private_automation_hub/index',
+            'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2/html-single/managing_containers_in_private_automation_hub/index',
             '_blank',
           )
         }

--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -384,7 +384,7 @@ class App extends React.Component<RouteComponentProps, IState> {
         condition: ({ user }) => !user.is_anonymous,
       }),
       menuItem(t`Documentation`, {
-        url: 'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
+        url: 'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2',
         external: true,
         condition: ({ settings, user }) =>
           settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||

--- a/test/cypress/integration/menu.js
+++ b/test/cypress/integration/menu.js
@@ -62,7 +62,7 @@ describe('Hub Menu Tests', () => {
       cy.menuPresent('Documentation').should(
         'have.attr',
         'href',
-        'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
+        'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.2',
       );
     });
   });


### PR DESCRIPTION
parent: https://github.com/ansible/ansible-hub-ui/pull/3422

links to https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform redirect to latest (2.3), add specific version here (2.2)
and update links set to 2.1
