### PR TITLE
[stable-4.4] Update product docs url version

### DIFF
--- a/src/loaders/standalone/standalone-loader.tsx
+++ b/src/loaders/standalone/standalone-loader.tsx
@@ -376,7 +376,7 @@ class App extends React.Component<RouteComponentProps, IState> {
         condition: ({ user }) => !user.is_anonymous,
       }),
       menuItem(t`Documentation`, {
-        url: 'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
+        url: 'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1',
         external: true,
         condition: ({ settings, user }) =>
           settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||

--- a/test/cypress/integration/menu.js
+++ b/test/cypress/integration/menu.js
@@ -62,7 +62,7 @@ describe('Hub Menu Tests', () => {
       cy.menuPresent('Documentation').should(
         'have.attr',
         'href',
-        'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
+        'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.1',
       );
     });
   });


### PR DESCRIPTION
parent: https://github.com/ansible/ansible-hub-ui/pull/3422

links to https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform redirect to latest (2.3), add specific version here (2.1)