### PR TITLE
Repositories & Remotes - Access tab

### DIFF
--- a/src/api/ansible-remote.ts
+++ b/src/api/ansible-remote.ts
@@ -44,6 +44,22 @@ class API extends PulpAPI {
   update(_id, _obj) {
     throw 'use smartUpdate()';
   }
+
+  listRoles(id, params?) {
+    return super.list(params, this.apiPath + id + '/list_roles/');
+  }
+
+  addRole(id, role) {
+    return super.create(role, this.apiPath + id + '/add_role/');
+  }
+
+  myPermissions(id, params?) {
+    return super.list(params, this.apiPath + id + '/my_permissions/');
+  }
+
+  removeRole(id, role) {
+    return super.create(role, this.apiPath + id + '/remove_role/');
+  }
 }
 
 export const AnsibleRemoteAPI = new API();

--- a/src/api/ansible-repository.ts
+++ b/src/api/ansible-repository.ts
@@ -21,6 +21,22 @@ class API extends PulpAPI {
       base_version: version_href,
     });
   }
+
+  listRoles(id, params?) {
+    return super.list(params, this.apiPath + id + '/list_roles/');
+  }
+
+  addRole(id, role) {
+    return super.create(role, this.apiPath + id + '/add_role/');
+  }
+
+  myPermissions(id, params?) {
+    return super.list(params, this.apiPath + id + '/my_permissions/');
+  }
+
+  removeRole(id, role) {
+    return super.create(role, this.apiPath + id + '/remove_role/');
+  }
 }
 
 export const AnsibleRepositoryAPI = new API();

--- a/src/containers/ansible-remote/detail.tsx
+++ b/src/containers/ansible-remote/detail.tsx
@@ -56,6 +56,10 @@ export const AnsibleRemoteDetail = PageWithTabs<AnsibleRemoteType>({
       access: <RemoteAccessTab item={item} actionContext={actionContext} />,
     }[tab]),
   tabs,
+  tabUpdateParams: (p) => {
+    delete p.group;
+    return p;
+  },
 });
 
 export default AnsibleRemoteDetail;

--- a/src/containers/ansible-remote/detail.tsx
+++ b/src/containers/ansible-remote/detail.tsx
@@ -11,22 +11,33 @@ import { AnsibleRemoteAPI, AnsibleRemoteType } from 'src/api';
 import { PageWithTabs } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { isLoggedIn } from 'src/permissions';
-import { AccessTab } from './tab-access';
+import { RemoteAccessTab } from './tab-access';
 import { DetailsTab } from './tab-details';
-
-const wip = '🚧 ';
 
 const tabs = [
   { id: 'details', name: t`Details` },
-  { id: 'access', name: wip + t`Access` },
+  { id: 'access', name: t`Access` },
 ];
 
 export const AnsibleRemoteDetail = PageWithTabs<AnsibleRemoteType>({
-  breadcrumbs: ({ name, tab }) => [
-    { url: formatPath(Paths.ansibleRemotes), name: t`Remotes` },
-    { url: formatPath(Paths.ansibleRemoteDetail, { name }), name },
-    { name: tab.name },
-  ],
+  breadcrumbs: ({ name, tab, params: { group } }) =>
+    [
+      { url: formatPath(Paths.ansibleRemotes), name: t`Remotes` },
+      { url: formatPath(Paths.ansibleRemoteDetail, { name }), name },
+      tab.id === 'access' && group
+        ? {
+            url: formatPath(
+              Paths.ansibleRepositoryDetail,
+              { name },
+              { tab: tab.id },
+            ),
+            name: tab.name,
+          }
+        : null,
+      tab.id === 'access' && group
+        ? { name: t`Group ${group}` }
+        : { name: tab.name },
+    ].filter(Boolean),
   condition: isLoggedIn,
   displayName: 'AnsibleRemoteDetail',
   errorTitle: t`Remote could not be displayed.`,
@@ -42,7 +53,7 @@ export const AnsibleRemoteDetail = PageWithTabs<AnsibleRemoteType>({
   renderTab: (tab, item, actionContext) =>
     ({
       details: <DetailsTab item={item} actionContext={actionContext} />,
-      access: <AccessTab item={item} actionContext={actionContext} />,
+      access: <RemoteAccessTab item={item} actionContext={actionContext} />,
     }[tab]),
   tabs,
 });

--- a/src/containers/ansible-remote/tab-access.tsx
+++ b/src/containers/ansible-remote/tab-access.tsx
@@ -68,16 +68,6 @@ export const RemoteAccessTab = ({
               permissions.includes('ansible.change_collectionremote') ||
                 hasPermission('ansible.change_collectionremote'),
             );
-
-            if (params?.group) {
-              GroupAPI.list({ name: params.group }).then(
-                ({ data: { data } }) => {
-                  setSelectedGroup(
-                    groupRoles.find((g) => g.name === data[0].name),
-                  );
-                },
-              );
-            }
           })
           .catch(() => {
             setGroups([]);
@@ -195,6 +185,20 @@ export const RemoteAccessTab = ({
   };
 
   useEffect(query, [item.pulp_href]);
+  useEffect(() => {
+    if (!groups) {
+      return;
+    }
+
+    if (!params?.group) {
+      setSelectedGroup(null);
+      return;
+    }
+
+    GroupAPI.list({ name: params.group }).then(({ data: { data } }) => {
+      setSelectedGroup(groups.find((g) => g.name === data[0].name));
+    });
+  }, [params?.group, groups]);
 
   return (
     <AccessTab

--- a/src/containers/ansible-remote/tab-access.tsx
+++ b/src/containers/ansible-remote/tab-access.tsx
@@ -70,7 +70,7 @@ export const RemoteAccessTab = ({
             );
 
             if (params?.group) {
-              GroupAPI.list({ name: params.group.name }).then(
+              GroupAPI.list({ name: params.group }).then(
                 ({ data: { data } }) => {
                   setSelectedGroup(
                     groupRoles.find((g) => g.name === data[0].name),

--- a/src/containers/ansible-remote/tab-access.tsx
+++ b/src/containers/ansible-remote/tab-access.tsx
@@ -1,10 +1,67 @@
-import React from 'react';
-import { AnsibleRemoteType } from 'src/api';
-import { Details } from 'src/components';
+import { t } from '@lingui/macro';
+import React, { useEffect, useState } from 'react';
+import {
+  AnsibleRemoteAPI,
+  AnsibleRemoteType,
+  GroupAPI,
+  GroupType,
+  RoleType,
+} from 'src/api';
+import { AccessTab } from 'src/components';
+import { Paths, formatPath } from 'src/paths';
 
 interface TabProps {
   item: AnsibleRemoteType;
-  actionContext: object;
+  actionContext: { addAlert: (alert) => void; state: { params } };
 }
 
-export const AccessTab = ({ item }: TabProps) => <Details item={item} />;
+export const RemoteAccessTab = ({ item, actionContext }: TabProps) => {
+  const [name, setName] = useState<string>(item?.name);
+  const [groups, setGroups] = useState<GroupType[]>(null); // loading
+  const [canEditOwners, setCanEditOwners] = useState<boolean>(false);
+  const [selectedGroup, setSelectedGroup] = useState<GroupType>(null);
+  const [showGroupRemoveModal, setShowGroupRemoveModal] =
+    useState<GroupType>(null);
+  const [showGroupSelectWizard, setShowGroupSelectWizard] = useState<{
+    group?: GroupType;
+    roles?: RoleType[];
+  }>(null);
+  const [showRoleRemoveModal, setShowRoleRemoveModal] = useState<string>(null);
+  const [showRoleSelectWizard, setShowRoleSelectWizard] = useState<{
+    roles?: RoleType[];
+  }>(null);
+
+  const addGroup = (group, roles) => console.log('addGroup', group, roles);
+  const addRole = (group, roles) => console.log('addRole', group, roles);
+  const removeGroup = (group) => console.log('removeGroup', group);
+  const removeRole = (role, group) => console.log('removeRole', role, group);
+  const updateProps = (prop) => console.log('updateProps', prop);
+
+  useEffect(() => {
+    // AnsibleRemoteAPI.myPermissions(id);
+    setGroups([]);
+  }, []);
+
+  return (
+    <AccessTab
+      addGroup={addGroup}
+      addRole={addRole}
+      canEditOwners={canEditOwners}
+      group={selectedGroup}
+      groups={groups}
+      name={name}
+      pulpObjectType='remotes/ansible/collection'
+      removeGroup={removeGroup}
+      removeRole={removeRole}
+      selectRolesMessage={t`The selected roles will be added to this specific Ansible remote.`}
+      showGroupRemoveModal={showGroupRemoveModal}
+      showGroupSelectWizard={showGroupSelectWizard}
+      showRoleRemoveModal={showRoleRemoveModal}
+      showRoleSelectWizard={showRoleSelectWizard}
+      updateProps={updateProps}
+      urlPrefix={formatPath(Paths.ansibleRemotes, {
+        name,
+      })}
+    />
+  );
+};

--- a/src/containers/ansible-repository/detail.tsx
+++ b/src/containers/ansible-repository/detail.tsx
@@ -11,7 +11,7 @@ import { PageWithTabs } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { isLoggedIn } from 'src/permissions';
 import { lastSyncStatus, lastSynced } from 'src/utilities';
-import { AccessTab } from './tab-access';
+import { RepositoryAccessTab } from './tab-access';
 import { CollectionVersionsTab } from './tab-collection-versions';
 import { DetailsTab } from './tab-details';
 import { RepositoryVersionsTab } from './tab-repository-versions';
@@ -20,17 +20,18 @@ const wip = '🚧 ';
 
 const tabs = [
   { id: 'details', name: t`Details` },
-  { id: 'access', name: wip + t`Access` },
+  { id: 'access', name: t`Access` },
   { id: 'collection-versions', name: wip + t`Collection versions` },
   { id: 'repository-versions', name: t`Versions` },
 ];
 
 export const AnsibleRepositoryDetail = PageWithTabs<AnsibleRepositoryType>({
-  breadcrumbs: ({ name, tab, params: { repositoryVersion } }) =>
+  breadcrumbs: ({ name, tab, params: { repositoryVersion, group } }) =>
     [
       { url: formatPath(Paths.ansibleRepositories), name: t`Repositories` },
       { url: formatPath(Paths.ansibleRepositoryDetail, { name }), name },
-      tab.id === 'repository-versions' && repositoryVersion
+      (tab.id === 'repository-versions' && repositoryVersion) ||
+      (tab.id === 'access' && group)
         ? {
             url: formatPath(
               Paths.ansibleRepositoryDetail,
@@ -42,6 +43,8 @@ export const AnsibleRepositoryDetail = PageWithTabs<AnsibleRepositoryType>({
         : null,
       tab.id === 'repository-versions' && repositoryVersion
         ? { name: t`Version ${repositoryVersion}` }
+        : tab.id === 'access' && group
+        ? { name: t`Group ${group}` }
         : { name: tab.name },
     ].filter(Boolean),
   condition: isLoggedIn,
@@ -70,7 +73,7 @@ export const AnsibleRepositoryDetail = PageWithTabs<AnsibleRepositoryType>({
   renderTab: (tab, item, actionContext) =>
     ({
       details: <DetailsTab item={item} actionContext={actionContext} />,
-      access: <AccessTab item={item} actionContext={actionContext} />,
+      access: <RepositoryAccessTab item={item} actionContext={actionContext} />,
       'collection-versions': (
         <CollectionVersionsTab item={item} actionContext={actionContext} />
       ),

--- a/src/containers/ansible-repository/detail.tsx
+++ b/src/containers/ansible-repository/detail.tsx
@@ -84,6 +84,7 @@ export const AnsibleRepositoryDetail = PageWithTabs<AnsibleRepositoryType>({
   tabs,
   tabUpdateParams: (p) => {
     delete p.repositoryVersion;
+    delete p.group;
     return p;
   },
 });

--- a/src/containers/ansible-repository/tab-access.tsx
+++ b/src/containers/ansible-repository/tab-access.tsx
@@ -70,7 +70,7 @@ export const RepositoryAccessTab = ({
             );
 
             if (params?.group) {
-              GroupAPI.list({ name: params.group.name }).then(
+              GroupAPI.list({ name: params.group }).then(
                 ({ data: { data } }) => {
                   setSelectedGroup(
                     groupRoles.find((g) => g.name === data[0].name),

--- a/src/containers/ansible-repository/tab-access.tsx
+++ b/src/containers/ansible-repository/tab-access.tsx
@@ -9,13 +9,26 @@ import {
 } from 'src/api';
 import { AccessTab } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
+import { errorMessage, parsePulpIDFromURL } from 'src/utilities';
 
 interface TabProps {
   item: AnsibleRepositoryType;
-  actionContext: { addAlert: (alert) => void; state: { params } };
+  actionContext: {
+    addAlert: (alert) => void;
+    state: { params };
+    hasPermission;
+  };
 }
 
-export const RepositoryAccessTab = ({ item, actionContext }: TabProps) => {
+export const RepositoryAccessTab = ({
+  item,
+  actionContext: {
+    addAlert,
+    state: { params },
+    hasPermission,
+  },
+}: TabProps) => {
+  const id = item?.pulp_href && parsePulpIDFromURL(item.pulp_href);
   const [name, setName] = useState<string>(item?.name);
   const [groups, setGroups] = useState<GroupType[]>(null); // loading
   const [canEditOwners, setCanEditOwners] = useState<boolean>(false);
@@ -31,16 +44,157 @@ export const RepositoryAccessTab = ({ item, actionContext }: TabProps) => {
     roles?: RoleType[];
   }>(null);
 
-  const addGroup = (group, roles) => console.log('addGroup', group, roles);
-  const addRole = (group, roles) => console.log('addRole', group, roles);
-  const removeGroup = (group) => console.log('removeGroup', group);
-  const removeRole = (role, group) => console.log('removeRole', role, group);
-  const updateProps = (prop) => console.log('updateProps', prop);
+  const query = () => {
+    setGroups(null);
+    AnsibleRepositoryAPI.myPermissions(id)
+      .then(({ data: { permissions } }) => {
+        AnsibleRepositoryAPI.listRoles(id)
+          .then(({ data: { roles } }) => {
+            const groupRoles = [];
+            for (const { groups, role } of roles) {
+              for (const name of groups) {
+                const groupIndex = groupRoles.findIndex((g) => g.name === name);
+                if (groupIndex == -1) {
+                  groupRoles.push({ name, object_roles: [role] });
+                } else {
+                  groupRoles[groupIndex].object_roles.push(role);
+                }
+              }
+            }
 
-  useEffect(() => {
-    // AnsibleRepositoryAPI.myPermissions(id);
-    setGroups([]);
-  }, []);
+            setName(name);
+            setGroups(groupRoles);
+            setCanEditOwners(
+              permissions.includes('ansible.change_ansiblerepository') ||
+                hasPermission('ansible.change_ansiblerepository'),
+            );
+
+            if (params?.group) {
+              GroupAPI.list({ name: params.group.name }).then(
+                ({ data: { data } }) => {
+                  setSelectedGroup(
+                    groupRoles.find((g) => g.name === data[0].name),
+                  );
+                },
+              );
+            }
+          })
+          .catch(() => {
+            setGroups([]);
+          });
+      })
+      .catch(() => {
+        setGroups([]);
+        setCanEditOwners(false);
+      });
+  };
+
+  const updateGroupRoles = ({
+    roles,
+    alertSuccess,
+    alertFailure,
+    stateUpdate,
+  }) => {
+    Promise.all(roles)
+      .then(() => {
+        addAlert({
+          title: alertSuccess,
+          variant: 'success',
+        });
+        query();
+      })
+      .catch(({ response: { status, statusText } }) => {
+        addAlert({
+          title: alertFailure,
+          variant: 'danger',
+          description: errorMessage(status, statusText),
+        });
+      })
+      .finally(() => {
+        updateProps(stateUpdate);
+      });
+  };
+
+  const addGroup = (group, roles) => {
+    const rolePromises = roles.map((role) =>
+      AnsibleRepositoryAPI.addRole(id, {
+        role: role.name,
+        groups: [group.name],
+      }),
+    );
+    updateGroupRoles({
+      roles: rolePromises,
+      alertSuccess: t`Group "${group.name}" has been successfully added to "${name}".`,
+      alertFailure: t`Group "${group.name}" could not be added to "${name}".`,
+      stateUpdate: { showGroupSelectWizard: null },
+    });
+  };
+
+  const removeGroup = (group) => {
+    const roles = group.object_roles.map((role) =>
+      AnsibleRepositoryAPI.removeRole(id, {
+        role,
+        groups: [group.name],
+      }),
+    );
+    updateGroupRoles({
+      roles,
+      alertSuccess: t`Group "${group.name}" has been successfully removed from "${name}".`,
+      alertFailure: t`Group "${group.name}" could not be removed from "${name}".`,
+      stateUpdate: { showGroupRemoveModal: null },
+    });
+  };
+  const addRole = (group, roles) => {
+    const rolePromises = roles.map((role) =>
+      AnsibleRepositoryAPI.addRole(id, {
+        role: role.name,
+        groups: [group.name],
+      }),
+    );
+    updateGroupRoles({
+      roles: rolePromises,
+      alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
+      alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
+      stateUpdate: { showRoleSelectWizard: null },
+    });
+  };
+  const removeRole = (role, group) => {
+    const removedRole = AnsibleRepositoryAPI.removeRole(id, {
+      role,
+      groups: [group.name],
+    });
+    updateGroupRoles({
+      roles: [removedRole],
+      alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
+      alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
+      stateUpdate: { showRoleRemoveModal: null },
+    });
+  };
+
+  const updateProps = (props) => {
+    Object.entries(props).forEach(([k, v]) => {
+      switch (k) {
+        case 'showGroupRemoveModal':
+          setShowGroupRemoveModal(v as GroupType);
+          break;
+        case 'showGroupSelectWizard':
+          setShowGroupSelectWizard(
+            v as { group?: GroupType; roles?: RoleType[] },
+          );
+          break;
+        case 'showRoleRemoveModal':
+          setShowRoleRemoveModal(v as string);
+          break;
+        case 'showRoleSelectWizard':
+          setShowRoleSelectWizard(v as { roles?: RoleType[] });
+          break;
+        default:
+          console.error('updateProps', k, v);
+      }
+    });
+  };
+
+  useEffect(query, [item.pulp_href]);
 
   return (
     <AccessTab
@@ -59,7 +213,7 @@ export const RepositoryAccessTab = ({ item, actionContext }: TabProps) => {
       showRoleRemoveModal={showRoleRemoveModal}
       showRoleSelectWizard={showRoleSelectWizard}
       updateProps={updateProps}
-      urlPrefix={formatPath(Paths.ansibleRepositories, {
+      urlPrefix={formatPath(Paths.ansibleRepositoryDetail, {
         name,
       })}
     />

--- a/src/containers/ansible-repository/tab-access.tsx
+++ b/src/containers/ansible-repository/tab-access.tsx
@@ -1,10 +1,67 @@
-import React from 'react';
-import { AnsibleRepositoryType } from 'src/api';
-import { Details } from 'src/components';
+import { t } from '@lingui/macro';
+import React, { useEffect, useState } from 'react';
+import {
+  AnsibleRepositoryAPI,
+  AnsibleRepositoryType,
+  GroupAPI,
+  GroupType,
+  RoleType,
+} from 'src/api';
+import { AccessTab } from 'src/components';
+import { Paths, formatPath } from 'src/paths';
 
 interface TabProps {
   item: AnsibleRepositoryType;
   actionContext: { addAlert: (alert) => void; state: { params } };
 }
 
-export const AccessTab = ({ item }: TabProps) => <Details item={item} />;
+export const RepositoryAccessTab = ({ item, actionContext }: TabProps) => {
+  const [name, setName] = useState<string>(item?.name);
+  const [groups, setGroups] = useState<GroupType[]>(null); // loading
+  const [canEditOwners, setCanEditOwners] = useState<boolean>(false);
+  const [selectedGroup, setSelectedGroup] = useState<GroupType>(null);
+  const [showGroupRemoveModal, setShowGroupRemoveModal] =
+    useState<GroupType>(null);
+  const [showGroupSelectWizard, setShowGroupSelectWizard] = useState<{
+    group?: GroupType;
+    roles?: RoleType[];
+  }>(null);
+  const [showRoleRemoveModal, setShowRoleRemoveModal] = useState<string>(null);
+  const [showRoleSelectWizard, setShowRoleSelectWizard] = useState<{
+    roles?: RoleType[];
+  }>(null);
+
+  const addGroup = (group, roles) => console.log('addGroup', group, roles);
+  const addRole = (group, roles) => console.log('addRole', group, roles);
+  const removeGroup = (group) => console.log('removeGroup', group);
+  const removeRole = (role, group) => console.log('removeRole', role, group);
+  const updateProps = (prop) => console.log('updateProps', prop);
+
+  useEffect(() => {
+    // AnsibleRepositoryAPI.myPermissions(id);
+    setGroups([]);
+  }, []);
+
+  return (
+    <AccessTab
+      addGroup={addGroup}
+      addRole={addRole}
+      canEditOwners={canEditOwners}
+      group={selectedGroup}
+      groups={groups}
+      name={name}
+      pulpObjectType='repositories/ansible/ansible'
+      removeGroup={removeGroup}
+      removeRole={removeRole}
+      selectRolesMessage={t`The selected roles will be added to this specific Ansible repository.`}
+      showGroupRemoveModal={showGroupRemoveModal}
+      showGroupSelectWizard={showGroupSelectWizard}
+      showRoleRemoveModal={showRoleRemoveModal}
+      showRoleSelectWizard={showRoleSelectWizard}
+      updateProps={updateProps}
+      urlPrefix={formatPath(Paths.ansibleRepositories, {
+        name,
+      })}
+    />
+  );
+};

--- a/src/containers/ansible-repository/tab-access.tsx
+++ b/src/containers/ansible-repository/tab-access.tsx
@@ -68,16 +68,6 @@ export const RepositoryAccessTab = ({
               permissions.includes('ansible.change_ansiblerepository') ||
                 hasPermission('ansible.change_ansiblerepository'),
             );
-
-            if (params?.group) {
-              GroupAPI.list({ name: params.group }).then(
-                ({ data: { data } }) => {
-                  setSelectedGroup(
-                    groupRoles.find((g) => g.name === data[0].name),
-                  );
-                },
-              );
-            }
           })
           .catch(() => {
             setGroups([]);
@@ -195,6 +185,20 @@ export const RepositoryAccessTab = ({
   };
 
   useEffect(query, [item.pulp_href]);
+  useEffect(() => {
+    if (!groups) {
+      return;
+    }
+
+    if (!params?.group) {
+      setSelectedGroup(null);
+      return;
+    }
+
+    GroupAPI.list({ name: params.group }).then(({ data: { data } }) => {
+      setSelectedGroup(groups.find((g) => g.name === data[0].name));
+    });
+  }, [params?.group, groups]);
 
   return (
     <AccessTab


### PR DESCRIPTION
Follows #3144, #3430

Implements the Access tab for Repositories & Remotes,
depends on https://github.com/pulp/pulp_ansible/pull/1338 & https://github.com/ansible/galaxy_ng/pull/1647

Testing:

* remotes - create a new role with all the permissions from the "Collection Remotes" section, but only from that section
* repositories - there's a built-in `galaxy.ansible_repository_owner` role

---


![20230327191923](https://user-images.githubusercontent.com/289743/228045164-276ed879-21cd-4092-9a12-6e012ac148ef.png)
![20230327191933](https://user-images.githubusercontent.com/289743/228045169-1a71591d-b7bd-44d4-a840-5cb10a53e990.png)
![20230327191954](https://user-images.githubusercontent.com/289743/228045171-0195df71-e68a-4317-ae2c-43e9414eebe5.png)
![20230327192001](https://user-images.githubusercontent.com/289743/228045174-9d5e3737-d97b-4ccc-8b9c-9dd7016b4efa.png)
![20230327192016](https://user-images.githubusercontent.com/289743/228045176-6807f7ae-59c2-40a9-9302-50570351dc87.png)
![20230327192037](https://user-images.githubusercontent.com/289743/228045181-c15b3b2d-fa08-4d64-839a-ed4a140d126e.png)
![20230327192140](https://user-images.githubusercontent.com/289743/228045184-ff63814a-5bba-4aac-9628-e47d8e12723d.png)
![20230327192253](https://user-images.githubusercontent.com/289743/228045319-aa228b4e-0272-405e-b067-621f788a3ccf.png)

Note, this only adds a working Access tab to both.
Adressing permission checks separately in https://github.com/ansible/ansible-hub-ui/pull/3463