### PR TITLE
Repositories - Collection versions tab

### DIFF
--- a/src/components/shared/detail-list.tsx
+++ b/src/components/shared/detail-list.tsx
@@ -44,7 +44,7 @@ interface IProps<T> {
   title: string;
 }
 
-export function DetailList<T extends { pulp_href: string }>({
+export function DetailList<T>({
   actionContext,
   defaultPageSize,
   defaultSort,

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -150,19 +150,21 @@ export class Constants {
 
   static LOCKED_ROLES_WITH_DESCRIPTION = {
     // galaxy roles
-    'galaxy.content_admin': t`Manage all content types.`,
+    'galaxy.ansible_repository_owner': t`Manage ansible repositories.`,
     'galaxy.collection_admin': t`Create, delete and change collection namespaces. Upload and delete collections. Sync collections from remotes. Approve and reject collections.`,
-    'galaxy.collection_publisher': t`Upload and modify collections.`,
     'galaxy.collection_curator': t`Approve, reject and sync collections from remotes.`,
     'galaxy.collection_namespace_owner': t`Change and upload collections to namespaces.`,
+    'galaxy.collection_publisher': t`Upload and modify collections.`,
+    'galaxy.collection_remote_owner': t`Manage collection remotes.`,
+    'galaxy.content_admin': t`Manage all content types.`,
     'galaxy.execution_environment_admin': t`Push, delete, and change execution environments. Create, delete and change remote registries.`,
-    'galaxy.execution_environment_publisher': t`Push, and change execution environments.`,
-    'galaxy.execution_environment_namespace_owner': t`Create and update execution environments under existing container namespaces.`,
     'galaxy.execution_environment_collaborator': t`Change existing execution environments.`,
+    'galaxy.execution_environment_namespace_owner': t`Create and update execution environments under existing container namespaces.`,
+    'galaxy.execution_environment_publisher': t`Push, and change execution environments.`,
     'galaxy.group_admin': t`View, add, remove and change groups.`,
-    'galaxy.user_admin': t`View, add, remove and change users.`,
     'galaxy.synclist_owner': t`View, add, remove and change synclists.`,
     'galaxy.task_admin': t`View, and cancel any task.`,
+    'galaxy.user_admin': t`View, add, remove and change users.`,
 
     // core roles
     'core.task_owner': t`Allow all actions on a task.`,

--- a/src/containers/ansible-repository/detail.tsx
+++ b/src/containers/ansible-repository/detail.tsx
@@ -17,12 +17,10 @@ import { CollectionVersionsTab } from './tab-collection-versions';
 import { DetailsTab } from './tab-details';
 import { RepositoryVersionsTab } from './tab-repository-versions';
 
-const wip = '🚧 ';
-
 const tabs = [
   { id: 'details', name: t`Details` },
   { id: 'access', name: t`Access` },
-  { id: 'collection-versions', name: wip + t`Collection versions` },
+  { id: 'collection-versions', name: t`Collection versions` },
   { id: 'repository-versions', name: t`Versions` },
 ];
 


### PR DESCRIPTION
Follows https://github.com/ansible/ansible-hub-ui/pull/3144, #3430 
api from https://github.com/pulp/pulp_ansible/pull/1357
ux mocks https://marvelapp.com/prototype/963i3bd/screen/87998118

Implements the Collection versions tab for Repositories

(Note: action for add/remove from repos moved to https://github.com/ansible/ansible-hub-ui/pull/3472)

![20230331013258](https://user-images.githubusercontent.com/289743/229000469-c358d59b-23d1-4a07-820b-f08ab51f391e.png)
