### PR TITLE
Repositories & Remote - utility functions, menu test fix

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,7 +21,10 @@ export { CollectionListItem } from './collection-list/collection-list-item';
 export { ConfirmModal } from './confirm-modal/confirm-modal';
 export { CollectionDependenciesList } from './collection-dependencies-list/collection-dependencies-list';
 export { CollectionUsedbyDependenciesList } from './collection-dependencies-list/collection-usedby-dependencies-list';
-export { CompoundFilter } from './patternfly-wrappers/compound-filter';
+export {
+  CompoundFilter,
+  FilterOption,
+} from './patternfly-wrappers/compound-filter';
 export { DateComponent } from './date-component/date-component';
 export { DeleteExecutionEnvironmentModal } from './delete-modal/delete-execution-environment-modal';
 export { DeleteGroupModal } from './rbac/delete-group-modal';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -25,6 +25,7 @@ export {
   CompoundFilter,
   FilterOption,
 } from './patternfly-wrappers/compound-filter';
+export { CopyURL } from './patternfly-wrappers/copy-url';
 export { DateComponent } from './date-component/date-component';
 export { DeleteExecutionEnvironmentModal } from './delete-modal/delete-execution-environment-modal';
 export { DeleteGroupModal } from './rbac/delete-group-modal';

--- a/src/components/list-item-actions/list-item-actions.tsx
+++ b/src/components/list-item-actions/list-item-actions.tsx
@@ -10,22 +10,24 @@ export class ListItemActions extends React.Component<IProps> {
   render() {
     const buttons = this.props.buttons?.filter(Boolean);
     const kebabItems = this.props.kebabItems?.filter(Boolean);
+    const anyButtons = buttons?.length;
+    const anyKebab = kebabItems?.length;
 
     return (
       <td
         style={{
-          paddingRight: '0px',
+          paddingRight: anyKebab ? '0px' : '16px',
           textAlign: 'right',
           display: 'flex',
           justifyContent: 'flex-end',
         }}
       >
-        {buttons?.length ? (
+        {anyButtons ? (
           <>
             <List>{buttons}</List>{' '}
           </>
         ) : null}
-        {kebabItems?.length ? (
+        {anyKebab ? (
           <div data-cy='kebab-toggle'>
             <StatefulDropdown items={kebabItems} />{' '}
           </div>

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -15,7 +15,7 @@ import * as React from 'react';
 import { StatefulDropdown } from 'src/components';
 import { ParamHelper } from 'src/utilities';
 
-class FilterOption {
+export class FilterOption {
   id: string;
   title: string;
   placeholder?: string;

--- a/src/components/patternfly-wrappers/copy-url.tsx
+++ b/src/components/patternfly-wrappers/copy-url.tsx
@@ -1,0 +1,28 @@
+import { t } from '@lingui/macro';
+import { ClipboardCopy } from '@patternfly/react-core';
+import React from 'react';
+
+export const CopyURL = ({
+  url,
+  fallback = null,
+}: {
+  url: string;
+  fallback?: true | string;
+}) => {
+  if (fallback === true) {
+    fallback = t`None`;
+  }
+
+  return url ? (
+    <ClipboardCopy
+      hoverTip={t`Copy`}
+      clickTip={t`Copied`}
+      variant='inline-compact'
+      isCode
+    >
+      {url}
+    </ClipboardCopy>
+  ) : (
+    <>{fallback}</>
+  );
+};

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -16,14 +16,18 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
-import * as FileSaver from 'file-saver';
-import * as React from 'react';
+import React from 'react';
 import { RemoteType, WriteOnlyFieldType } from 'src/api';
 import { FileUpload, HelperText, WriteOnlyField } from 'src/components';
 import { Constants } from 'src/constants';
 import { AppContext } from 'src/loaders/app-context';
-import { ErrorMessagesType, isFieldSet, isWriteOnly } from 'src/utilities';
-import { validateURLHelper } from 'src/utilities';
+import {
+  ErrorMessagesType,
+  downloadString,
+  isFieldSet,
+  isWriteOnly,
+  validateURLHelper,
+} from 'src/utilities';
 
 interface IProps {
   allowEditName?: boolean;
@@ -325,14 +329,12 @@ export class RemoteForm extends React.Component<IProps, IState> {
               <FlexItem>
                 <Button
                   isDisabled={!this.props.remote.requirements_file}
-                  onClick={() => {
-                    FileSaver.saveAs(
-                      new Blob([this.props.remote.requirements_file], {
-                        type: 'text/plain;charset=utf-8',
-                      }),
+                  onClick={() =>
+                    downloadString(
+                      this.props.remote.requirements_file,
                       filenames.requirements_file.name,
-                    );
-                  }}
+                    )
+                  }
                   variant='plain'
                   aria-label={t`Download requirements file`}
                 >
@@ -571,14 +573,12 @@ export class RemoteForm extends React.Component<IProps, IState> {
                   <Button
                     data-cy='client_cert'
                     isDisabled={!this.props.remote.client_cert}
-                    onClick={() => {
-                      FileSaver.saveAs(
-                        new Blob([this.props.remote.client_cert], {
-                          type: 'text/plain;charset=utf-8',
-                        }),
+                    onClick={() =>
+                      downloadString(
+                        this.props.remote.client_cert,
                         filenames.client_cert.name,
-                      );
-                    }}
+                      )
+                    }
                     variant='plain'
                     aria-label={t`Download client certification file`}
                   >
@@ -617,14 +617,12 @@ export class RemoteForm extends React.Component<IProps, IState> {
                   <Button
                     data-cy='ca_cert'
                     isDisabled={!this.props.remote.ca_cert}
-                    onClick={() => {
-                      FileSaver.saveAs(
-                        new Blob([this.props.remote.ca_cert], {
-                          type: 'text/plain;charset=utf-8',
-                        }),
+                    onClick={() =>
+                      downloadString(
+                        this.props.remote.ca_cert,
                         filenames.ca_cert.name,
-                      );
-                    }}
+                      )
+                    }
                     variant='plain'
                     aria-label={t`Download CA certification file`}
                   >

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -16,6 +16,7 @@ import {
   AppliedFilters,
   BaseHeader,
   CompoundFilter,
+  CopyURL,
   DateComponent,
   DeleteModal,
   EmptyStateFilter,
@@ -431,7 +432,9 @@ class ExecutionEnvironmentRegistryList extends React.Component<
         <td>
           <DateComponent date={item.updated_at} />
         </td>
-        <td>{item.url}</td>
+        <td>
+          <CopyURL url={item.url} />
+        </td>
         <td>
           {lastSyncStatus(item) || '---'}
           {lastSynced(item)}

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -12,6 +12,7 @@ import { reject, some } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Paths, formatPath } from 'src/paths';
+import { isLoggedIn } from 'src/permissions';
 import { hasPermission } from 'src/utilities';
 
 const menuItem = (name, options = {}) => ({
@@ -49,12 +50,12 @@ function standaloneMenu({ repository }) {
           !user.is_anonymous,
       }),
       menuItem(t`Repository Management`, {
-        condition: ({ user }) => !user.is_anonymous,
+        condition: isLoggedIn,
         url: formatPath(Paths.repositories),
       }),
       menuItem(t`API token`, {
         url: formatPath(Paths.token),
-        condition: ({ user }) => !user.is_anonymous,
+        condition: isLoggedIn,
       }),
       menuItem(t`Approval`, {
         condition: (context) =>
@@ -93,7 +94,7 @@ function standaloneMenu({ repository }) {
     ),
     menuItem(t`Task Management`, {
       url: formatPath(Paths.taskList),
-      condition: ({ user }) => !user.is_anonymous,
+      condition: isLoggedIn,
     }),
     menuItem(t`Signature Keys`, {
       url: formatPath(Paths.signatureKeys),

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,0 +1,11 @@
+import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
+
+export type PermissionContextType = (o: {
+  featureFlags: FeatureFlagsType;
+  settings: SettingsType;
+  user: UserType;
+  hasPermission: (string) => boolean;
+}) => boolean;
+
+export const isLoggedIn: PermissionContextType = ({ user }) =>
+  user && !user.is_anonymous;

--- a/src/utilities/download-data.ts
+++ b/src/utilities/download-data.ts
@@ -1,0 +1,9 @@
+import { saveAs } from 'file-saver';
+
+export const downloadString = (data, filename) =>
+  saveAs(
+    new Blob([data], {
+      type: 'text/plain;charset=utf-8',
+    }),
+    filename,
+  );

--- a/src/utilities/fail-alerts.ts
+++ b/src/utilities/fail-alerts.ts
@@ -11,3 +11,13 @@ export function errorMessage(statusCode: number, statusText: string) {
   };
   return messages[statusCode] || messages.default;
 }
+
+export const handleHttpError = (title, callback, addAlert) => (e) => {
+  const { status, statusText } = e.response;
+  addAlert({
+    title,
+    variant: 'danger',
+    description: errorMessage(status, statusText),
+  });
+  callback();
+};

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,5 +1,6 @@
 export { chipGroupProps } from './chip-group-props';
 export { convertContentSummaryCounts } from './content-summary';
+export { downloadString } from './download-data';
 export { ParamHelper } from './param-helper';
 export { sanitizeDocsUrls } from './sanitize-docs-urls';
 export {

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -23,7 +23,7 @@ export { parsePulpIDFromURL } from './parse-pulp-id';
 export { lastSynced, lastSyncStatus } from './last-sync-task';
 export { waitForTask, waitForTaskUrl } from './wait-for-task';
 export { taskAlert } from './task-alert';
-export { errorMessage } from './fail-alerts';
+export { errorMessage, handleHttpError } from './fail-alerts';
 export { validateURLHelper } from './validateURLHelper';
 export { canSignNamespace, canSignEE } from './can-sign';
 export { DeleteCollectionUtils } from './delete-collection';

--- a/test/cypress/e2e/misc/docs_menu.js
+++ b/test/cypress/e2e/misc/docs_menu.js
@@ -1,6 +1,6 @@
 const uiPrefix = Cypress.env('uiPrefix');
 
-describe('Token Management Tests', () => {
+describe('Documentation dropdown', () => {
   beforeEach(() => {
     cy.visit(uiPrefix);
     cy.login();

--- a/test/cypress/e2e/misc/menu.js
+++ b/test/cypress/e2e/misc/menu.js
@@ -1,8 +1,8 @@
 describe('Hub Menu Tests', () => {
-  let username = 'nopermission';
-  let password = 'n0permissi0n';
+  const username = 'nopermission';
+  const password = 'n0permissi0n';
 
-  let menuItems = [
+  const menuItems = [
     'Collections > Collections',
     'Collections > Namespaces',
     'Collections > Repository Management',
@@ -11,9 +11,11 @@ describe('Hub Menu Tests', () => {
     'Execution Environments > Execution Environments',
     'Execution Environments > Remote Registries',
     'Task Management',
+    'Signature Keys',
     'Documentation',
     'User Access > Users',
     'User Access > Groups',
+    'User Access > Roles',
   ];
 
   before(() => {
@@ -30,7 +32,7 @@ describe('Hub Menu Tests', () => {
 
   describe('user without permissions', () => {
     // one more similar test in view-only
-    let visibleMenuItems = [
+    const visibleMenuItems = [
       'Collections > Collections',
       'Collections > Namespaces',
       'Collections > Repository Management',
@@ -38,11 +40,13 @@ describe('Hub Menu Tests', () => {
       'Execution Environments > Execution Environments',
       'Execution Environments > Remote Registries',
       'Task Management',
+      'Signature Keys',
       'Documentation',
     ];
-    let missingMenuItems = [
+    const missingMenuItems = [
       'User Access > Users',
       'User Access > Groups',
+      'User Access > Roles',
       'Collections > Approval',
     ];
 

--- a/test/cypress/e2e/view-only-download/view-only.js
+++ b/test/cypress/e2e/view-only-download/view-only.js
@@ -21,8 +21,10 @@ describe('view-only mode - with download', () => {
       'Execution Environments > Execution Environments',
       'Execution Environments > Remote Registries',
       'Task Management',
+      'Signature Keys',
       'User Access > Users',
       'User Access > Groups',
+      'User Access > Roles',
     ].forEach((item) => cy.menuMissing(item));
 
     // login button in top right nav


### PR DESCRIPTION
Precedes #3144 

these are changes which #3144 depends on/incorporates, but are not related to page or repositories and remotes themselves.

* export FilterOption type
* ListItemAction: fix padding when only buttons are present, no kebab
* add handleHttpError
* add downloadString, use
* menu tests - update list of menu items
* menu: use isLoggedIn from permissions
* create CopyURL component, use where displaying non-link urls