### PR TITLE
RemoteForm - support no modal, hidden_fiels/write_only_fields switch

### DIFF
--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -32,7 +32,8 @@ interface IProps {
   remote: RemoteType;
   remoteType?: 'registry';
   saveRemote: () => void;
-  showModal: boolean;
+  showModal?: boolean;
+  showMain?: boolean;
   title?: string;
   updateRemote: (remote) => void;
 }
@@ -91,7 +92,15 @@ export class RemoteForm extends React.Component<IProps, IState> {
   }
 
   render() {
-    const { remote } = this.props;
+    const {
+      allowEditName,
+      closeModal,
+      remote,
+      saveRemote,
+      showMain,
+      showModal,
+      title,
+    } = this.props;
     if (!remote) {
       return null;
     }
@@ -99,7 +108,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
     const remoteType = this.props.remoteType || this.getRemoteType(remote.url);
 
     let requiredFields = ['name', 'url'];
-    let disabledFields = this.props.allowEditName ? [] : ['name'];
+    let disabledFields = allowEditName ? [] : ['name'];
 
     if (remoteType === 'certified') {
       requiredFields = requiredFields.concat(['auth_url']);
@@ -120,29 +129,39 @@ export class RemoteForm extends React.Component<IProps, IState> {
       ]);
     }
 
+    const save = (
+      <Button
+        isDisabled={!this.isValid(requiredFields, remoteType)}
+        key='confirm'
+        variant='primary'
+        onClick={() => saveRemote()}
+      >
+        {t`Save`}
+      </Button>
+    );
+    const cancel = (
+      <Button key='cancel' variant='link' onClick={() => closeModal()}>
+        {t`Cancel`}
+      </Button>
+    );
+
+    if (showMain) {
+      return (
+        <>
+          {this.renderForm(requiredFields, disabledFields)}
+          {save}
+          {cancel}
+        </>
+      );
+    }
+
     return (
       <Modal
-        isOpen={this.props.showModal}
-        title={this.props.title || t`Edit remote`}
+        isOpen={showModal}
+        title={title || t`Edit remote`}
         variant='small'
-        onClose={() => this.props.closeModal()}
-        actions={[
-          <Button
-            isDisabled={!this.isValid(requiredFields, remoteType)}
-            key='confirm'
-            variant='primary'
-            onClick={() => this.props.saveRemote()}
-          >
-            {t`Save`}
-          </Button>,
-          <Button
-            key='cancel'
-            variant='link'
-            onClick={() => this.props.closeModal()}
-          >
-            {t`Cancel`}
-          </Button>,
-        ]}
+        onClose={() => closeModal()}
+        actions={[save, cancel]}
       >
         {this.renderForm(requiredFields, disabledFields)}
       </Modal>

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -110,23 +110,29 @@ export class RemoteForm extends React.Component<IProps, IState> {
     let requiredFields = ['name', 'url'];
     let disabledFields = allowEditName ? [] : ['name'];
 
-    if (remoteType === 'certified') {
-      requiredFields = requiredFields.concat(['auth_url']);
-      disabledFields = disabledFields.concat(['requirements_file']);
-    }
+    switch (remoteType) {
+      case 'none':
+        // require only name, url; nothing disabled
+        break;
 
-    if (remoteType === 'community') {
-      requiredFields = requiredFields.concat(['requirements_file']);
-      disabledFields = disabledFields.concat(['auth_url', 'token']);
-    }
+      case 'certified':
+        requiredFields = requiredFields.concat(['auth_url']);
+        disabledFields = disabledFields.concat(['requirements_file']);
+        break;
 
-    if (remoteType === 'registry') {
-      disabledFields = disabledFields.concat([
-        'auth_url',
-        'token',
-        'requirements_file',
-        'signed_only',
-      ]);
+      case 'community':
+        requiredFields = requiredFields.concat(['requirements_file']);
+        disabledFields = disabledFields.concat(['auth_url', 'token']);
+        break;
+
+      case 'registry':
+        disabledFields = disabledFields.concat([
+          'auth_url',
+          'token',
+          'requirements_file',
+          'signed_only',
+        ]);
+        break;
     }
 
     const save = (

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -258,7 +258,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
           >
             <Switch
               id='signed_only'
-              isChecked={remote.signed_only}
+              isChecked={!!remote.signed_only}
               onChange={(value) => this.updateRemote(value, 'signed_only')}
             />
           </FormGroup>

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -1,5 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import {
+  ActionGroup,
   Button,
   Checkbox,
   ExpandableSection,
@@ -154,9 +155,14 @@ export class RemoteForm extends React.Component<IProps, IState> {
     if (showMain) {
       return (
         <>
-          {this.renderForm(requiredFields, disabledFields)}
-          {save}
-          {cancel}
+          {this.renderForm(
+            requiredFields,
+            disabledFields,
+            <ActionGroup key='actions'>
+              {save}
+              {cancel}
+            </ActionGroup>,
+          )}
         </>
       );
     }
@@ -174,7 +180,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
     );
   }
 
-  private renderForm(requiredFields, disabledFields) {
+  private renderForm(requiredFields, disabledFields, extra?) {
     const { errorMessages, remote } = this.props;
     const { filenames } = this.state;
     const { collection_signing } = this.context.featureFlags;
@@ -723,6 +729,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
             {errorMessages['__nofield']}
           </span>
         ) : null}
+        {extra}
       </Form>
     );
   }

--- a/src/utilities/write-only-fields.ts
+++ b/src/utilities/write-only-fields.ts
@@ -16,7 +16,7 @@ export function isFieldSet(
   if (field) {
     return field.is_set;
   } else {
-    throw 'Field ${name} is not in writeOnlyFields';
+    throw `Field ${name} is not in writeOnlyFields`;
   }
 }
 


### PR DESCRIPTION
Precedes https://github.com/ansible/ansible-hub-ui/pull/3144

these are changes which https://github.com/ansible/ansible-hub-ui/pull/3144 depends on/incorporates, but are not related to page or repositories and remotes themselves.

`RemoteForm`:
* add showMain prop - for use outside modals
* ifs -> switch
* boolify signed_only
* support .hidden_fields / .write_only_fields depending on type; fix write-only-fields error message
* showMain - margin for save/cancel buttons
