### PR TITLE
taskAlert - handle "task started" alerts

### DIFF
--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -26,7 +26,6 @@ import {
   RepoSigningUtils,
   RouteProps,
   canSignEE,
-  parsePulpIDFromURL,
   taskAlert,
   waitForTask,
 } from 'src/utilities';
@@ -361,10 +360,12 @@ export function withContainerRepo(WrappedComponent) {
 
     private sync(name) {
       ExecutionEnvironmentRemoteAPI.sync(name)
-        .then((result) => {
-          const task_id = parsePulpIDFromURL(result.data.task);
+        .then(({ data }) => {
           this.addAlertObj(
-            taskAlert(task_id, t`Sync started for remote registry "${name}".`),
+            taskAlert(
+              data.task,
+              t`Sync started for remote registry "${name}".`,
+            ),
           );
           this.loadRepo();
         })

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -1,7 +1,7 @@
 import { Trans, t } from '@lingui/macro';
 import { Button, DropdownItem } from '@patternfly/react-core';
 import * as React from 'react';
-import { Link, Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import {
   ContainerRepositoryType,
   ExecutionEnvironmentAPI,
@@ -21,12 +21,13 @@ import {
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatEEPath, formatPath } from 'src/paths';
-import { RouteProps } from 'src/utilities';
 import {
   ParamHelper,
   RepoSigningUtils,
+  RouteProps,
   canSignEE,
   parsePulpIDFromURL,
+  taskAlert,
   waitForTask,
 } from 'src/utilities';
 
@@ -362,18 +363,8 @@ export function withContainerRepo(WrappedComponent) {
       ExecutionEnvironmentRemoteAPI.sync(name)
         .then((result) => {
           const task_id = parsePulpIDFromURL(result.data.task);
-          this.addAlert(
-            <Trans>Sync started for remote registry &quot;{name}&quot;.</Trans>,
-            'info',
-            <span>
-              <Trans>
-                See the task management{' '}
-                <Link to={formatPath(Paths.taskDetail, { task: task_id })}>
-                  detail page{' '}
-                </Link>
-                for the status of this task.
-              </Trans>
-            </span>,
+          this.addAlertObj(
+            taskAlert(task_id, t`Sync started for remote registry "${name}".`),
           );
           this.loadRepo();
         })

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -43,7 +43,6 @@ import {
   ParamHelper,
   RouteProps,
   filterIsSet,
-  parsePulpIDFromURL,
   taskAlert,
   withRouter,
 } from 'src/utilities';
@@ -526,11 +525,10 @@ class ExecutionEnvironmentList extends React.Component<RouteProps, IState> {
 
   private sync(name) {
     ExecutionEnvironmentRemoteAPI.sync(name)
-      .then((result) => {
-        const task_id = parsePulpIDFromURL(result.data.task);
+      .then(({ data }) => {
         this.addAlertObj(
           taskAlert(
-            task_id,
+            data.task,
             t`Sync started for execution environment "${name}".`,
           ),
         );

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -38,9 +38,15 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatEEPath, formatPath } from 'src/paths';
-import { RouteProps, withRouter } from 'src/utilities';
-import { ParamHelper, filterIsSet, parsePulpIDFromURL } from 'src/utilities';
+import { Paths, formatEEPath } from 'src/paths';
+import {
+  ParamHelper,
+  RouteProps,
+  filterIsSet,
+  parsePulpIDFromURL,
+  taskAlert,
+  withRouter,
+} from 'src/utilities';
 import './execution-environment.scss';
 
 interface IState {
@@ -522,20 +528,11 @@ class ExecutionEnvironmentList extends React.Component<RouteProps, IState> {
     ExecutionEnvironmentRemoteAPI.sync(name)
       .then((result) => {
         const task_id = parsePulpIDFromURL(result.data.task);
-        this.addAlert(
-          <Trans>
-            Sync started for execution environment &quot;{name}&quot;.
-          </Trans>,
-          'info',
-          <span>
-            <Trans>
-              See the task management{' '}
-              <Link to={formatPath(Paths.taskDetail, { task: task_id })}>
-                detail page{' '}
-              </Link>
-              for the status of this task.
-            </Trans>
-          </span>,
+        this.addAlertObj(
+          taskAlert(
+            task_id,
+            t`Sync started for execution environment "${name}".`,
+          ),
         );
       })
       .catch(() => this.addAlert(t`Sync failed for ${name}`, 'danger'));

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -39,7 +39,6 @@ import {
   lastSyncStatus,
   lastSynced,
   mapErrorMessages,
-  parsePulpIDFromURL,
   taskAlert,
   withRouter,
 } from 'src/utilities';
@@ -488,10 +487,9 @@ class ExecutionEnvironmentRegistryList extends React.Component<
 
   private syncRegistry({ id, name }) {
     ExecutionEnvironmentRegistryAPI.sync(id)
-      .then((result) => {
-        const task_id = parsePulpIDFromURL(result.data.task);
+      .then(({ data }) => {
         this.addAlertObj(
-          taskAlert(task_id, t`Sync started for remote registry "${name}".`),
+          taskAlert(data.task, t`Sync started for remote registry "${name}".`),
         );
         this.queryRegistries(true);
       })
@@ -507,11 +505,10 @@ class ExecutionEnvironmentRegistryList extends React.Component<
 
   private indexRegistry({ id, name }) {
     ExecutionEnvironmentRegistryAPI.index(id)
-      .then((result) => {
-        const task_id = parsePulpIDFromURL(result.data.task);
+      .then(({ data }) => {
         this.addAlertObj(
           taskAlert(
-            task_id,
+            data.task,
             t`Indexing started for execution environment "${name}".`,
             'success',
           ),

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -9,7 +9,6 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import * as React from 'react';
-import { Link } from 'react-router-dom';
 import { ExecutionEnvironmentRegistryAPI, RemoteType } from 'src/api';
 import {
   AlertList,
@@ -31,17 +30,18 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath } from 'src/paths';
-import { errorMessage } from 'src/utilities';
-import { RouteProps, withRouter } from 'src/utilities';
 import {
   ErrorMessagesType,
   ParamHelper,
+  RouteProps,
+  errorMessage,
   filterIsSet,
   lastSyncStatus,
   lastSynced,
   mapErrorMessages,
   parsePulpIDFromURL,
+  taskAlert,
+  withRouter,
 } from 'src/utilities';
 
 interface IState {
@@ -490,18 +490,8 @@ class ExecutionEnvironmentRegistryList extends React.Component<
     ExecutionEnvironmentRegistryAPI.sync(id)
       .then((result) => {
         const task_id = parsePulpIDFromURL(result.data.task);
-        this.addAlert(
-          <Trans>Sync started for remote registry &quot;{name}&quot;.</Trans>,
-          'info',
-          <span>
-            <Trans>
-              See the task management{' '}
-              <Link to={formatPath(Paths.taskDetail, { task: task_id })}>
-                detail page{' '}
-              </Link>
-              for the status of this task.
-            </Trans>
-          </span>,
+        this.addAlertObj(
+          taskAlert(task_id, t`Sync started for remote registry "${name}".`),
         );
         this.queryRegistries(true);
       })
@@ -519,18 +509,12 @@ class ExecutionEnvironmentRegistryList extends React.Component<
     ExecutionEnvironmentRegistryAPI.index(id)
       .then((result) => {
         const task_id = parsePulpIDFromURL(result.data.task);
-        this.addAlert(
-          t`Indexing started for execution environment "${name}".`,
-          'success',
-          <span>
-            <Trans>
-              See the task management{' '}
-              <Link to={formatPath(Paths.taskDetail, { task: task_id })}>
-                detail page
-              </Link>
-              for the status of this task.
-            </Trans>
-          </span>,
+        this.addAlertObj(
+          taskAlert(
+            task_id,
+            t`Indexing started for execution environment "${name}".`,
+            'success',
+          ),
         );
       })
       .catch((err) => {
@@ -543,16 +527,17 @@ class ExecutionEnvironmentRegistryList extends React.Component<
       });
   }
 
-  private addAlert(title, variant, description?) {
+  private addAlertObj(alert: AlertType) {
     this.setState({
-      alerts: [
-        ...this.state.alerts,
-        {
-          description,
-          title,
-          variant,
-        },
-      ],
+      alerts: [...this.state.alerts, alert],
+    });
+  }
+
+  private addAlert(title, variant, description?) {
+    this.addAlertObj({
+      description,
+      title,
+      variant,
     });
   }
 

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -22,6 +22,7 @@ export { hasPermission } from './has-permission';
 export { parsePulpIDFromURL } from './parse-pulp-id';
 export { lastSynced, lastSyncStatus } from './last-sync-task';
 export { waitForTask, waitForTaskUrl } from './wait-for-task';
+export { taskAlert } from './task-alert';
 export { errorMessage } from './fail-alerts';
 export { validateURLHelper } from './validateURLHelper';
 export { canSignNamespace, canSignEE } from './can-sign';

--- a/src/utilities/task-alert.tsx
+++ b/src/utilities/task-alert.tsx
@@ -2,9 +2,11 @@ import { Trans } from '@lingui/macro';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Paths, formatPath } from 'src/paths';
+import { parsePulpIDFromURL } from 'src/utilities';
 
 type VariantType = 'default' | 'success' | 'danger' | 'warning' | 'info';
 
+// task can be { task: (pulp_href) } or "(pulp_href)" or "(uuid)"
 export const taskAlert = (task, title, variant: VariantType = 'info') => ({
   title,
   variant,
@@ -12,7 +14,13 @@ export const taskAlert = (task, title, variant: VariantType = 'info') => ({
     <span>
       <Trans>
         See the task management{' '}
-        <Link to={formatPath(Paths.taskDetail, { task })}>detail page </Link>
+        <Link
+          to={formatPath(Paths.taskDetail, {
+            task: parsePulpIDFromURL(task?.task || task),
+          })}
+        >
+          detail page{' '}
+        </Link>
         for the status of this task.
       </Trans>
     </span>

--- a/src/utilities/task-alert.tsx
+++ b/src/utilities/task-alert.tsx
@@ -1,0 +1,20 @@
+import { Trans } from '@lingui/macro';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Paths, formatPath } from 'src/paths';
+
+type VariantType = 'default' | 'success' | 'danger' | 'warning' | 'info';
+
+export const taskAlert = (task, title, variant: VariantType = 'info') => ({
+  title,
+  variant,
+  description: (
+    <span>
+      <Trans>
+        See the task management{' '}
+        <Link to={formatPath(Paths.taskDetail, { task })}>detail page </Link>
+        for the status of this task.
+      </Trans>
+    </span>
+  ),
+});


### PR DESCRIPTION
Precedes #3144 

these are changes which #3144 depends on/incorporates, but are not related to page or repositories and remotes themselves.

* taskAlert - shared alert for task detail; accept {task},pulp_href,uuid

Also related to AAH-996