### PR TITLE
queueAlert - save alert in context, for next container

### DIFF
--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -386,8 +386,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                       namespace: deleteCollection.namespace.name,
                     }),
                     selectedRepo: this.context.selectedRepo,
-                    addAlert: (alert) =>
-                      this.context.setAlerts([...this.state.alerts, alert]),
+                    addAlert: (alert) => this.context.queueAlert(alert),
                   });
             })
           }
@@ -892,18 +891,15 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             });
           } else {
             // last version in collection => collection will be deleted => redirect
-            this.context.setAlerts([
-              ...this.context.alerts,
-              {
-                variant: 'success',
-                title: (
-                  <Trans>
-                    Collection &quot;{name} v{collectionVersion}&quot; has been
-                    successfully deleted.
-                  </Trans>
-                ),
-              },
-            ]);
+            this.context.queueAlert({
+              variant: 'success',
+              title: (
+                <Trans>
+                  Collection &quot;{name} v{collectionVersion}&quot; has been
+                  successfully deleted.
+                </Trans>
+              ),
+            });
             this.setState({
               redirect: formatPath(Paths.namespaceByRepo, {
                 repo: this.context.selectedRepo,

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -229,18 +229,15 @@ class EditNamespace extends React.Component<RouteProps, IState> {
               }),
             },
             () =>
-              this.context.setAlerts([
-                ...this.context.alerts,
-                {
-                  variant: 'success',
-                  title: (
-                    <Trans>
-                      Saved changes to namespace &quot;
-                      {this.state.namespace.name}&quot;.
-                    </Trans>
-                  ),
-                },
-              ]),
+              this.context.queueAlert({
+                variant: 'success',
+                title: (
+                  <Trans>
+                    Saved changes to namespace &quot;
+                    {this.state.namespace.name}&quot;.
+                  </Trans>
+                ),
+              }),
           );
         })
         .catch((error) => {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -908,17 +908,14 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             confirmDelete: false,
             isNamespacePending: false,
           });
-          this.context.setAlerts([
-            ...this.context.alerts,
-            {
-              variant: 'success',
-              title: (
-                <Trans>
-                  Namespace &quot;{name}&quot; has been successfully deleted.
-                </Trans>
-              ),
-            },
-          ]);
+          this.context.queueAlert({
+            variant: 'success',
+            title: (
+              <Trans>
+                Namespace &quot;{name}&quot; has been successfully deleted.
+              </Trans>
+            ),
+          });
         })
         .catch((e) => {
           const { status, statusText } = e.response;

--- a/src/loaders/app-context.ts
+++ b/src/loaders/app-context.ts
@@ -7,8 +7,9 @@ export interface IAppContextType {
   setUser: (user: UserType) => void;
   selectedRepo?: string;
   featureFlags: FeatureFlagsType;
-  alerts?: AlertType[];
-  setAlerts?: (alerts: AlertType[]) => void;
+  alerts: AlertType[];
+  setAlerts: (alerts: AlertType[]) => void;
+  queueAlert: (alert: AlertType) => void;
   settings: SettingsType;
   hasPermission: (name: string) => boolean;
 }

--- a/src/loaders/insights/loader.tsx
+++ b/src/loaders/insights/loader.tsx
@@ -72,11 +72,14 @@ const App = (_props) => {
     return null;
   }
 
+  const queueAlert = (alert) => setAlerts((alerts) => [...alerts, alert]);
+
   return (
     <AppContext.Provider
       value={{
         alerts,
         featureFlags,
+        queueAlert,
         selectedRepo,
         setAlerts,
         setUser,

--- a/src/loaders/standalone/loader.tsx
+++ b/src/loaders/standalone/loader.tsx
@@ -64,11 +64,14 @@ const App = (_props) => {
     );
   }
 
+  const queueAlert = (alert) => setAlerts((alerts) => [...alerts, alert]);
+
   return (
     <AppContext.Provider
       value={{
         alerts,
         featureFlags,
+        queueAlert,
         selectedRepo,
         setAlerts,
         setUser,


### PR DESCRIPTION
Precedes #3144 

these are changes which #3144 depends on/incorporates, but are not related to page or repositories and remotes themselves.

* context.queueAlert - addAlert for saving to context and displaying on next container

This is already implemented in EE, the rest will come as part of AAH-1462.
For this to work, the next container needs to copy alerts from context on component mount, and context.setAlerts([])