### PR TITLE
[stable-4.6] LocalRepositoryTable - fix error when distribution repository is null (#3439)

### DIFF
--- a/src/components/repositories/local-repository-table.tsx
+++ b/src/components/repositories/local-repository-table.tsx
@@ -92,9 +92,9 @@ export class LocalRepositoryTable extends React.Component<IProps> {
   private renderRow(distribution) {
     const cliConfig = [
       '[galaxy]',
-      `server_list = ${distribution.repository.name}_repo`,
+      `server_list = ${distribution.repository?.name}_repo`,
       '',
-      `[galaxy_server.${distribution.repository.name}_repo]`,
+      `[galaxy_server.${distribution.repository?.name}_repo]`,
       `url=${getRepoUrl(distribution.base_path)}`,
       'token=<put your token here>',
     ];
@@ -102,11 +102,11 @@ export class LocalRepositoryTable extends React.Component<IProps> {
     return (
       <tr key={distribution.name}>
         <td>{distribution.name}</td>
-        <td>{distribution.repository.name}</td>
+        <td>{distribution.repository?.name}</td>
         <td>
           <CollectionCount distributionPath={distribution.base_path} />
         </td>
-        {distribution.repository.pulp_last_updated ? (
+        {distribution.repository?.pulp_last_updated ? (
           <td>
             <DateComponent date={distribution.repository.pulp_last_updated} />
           </td>
@@ -119,9 +119,13 @@ export class LocalRepositoryTable extends React.Component<IProps> {
           </ClipboardCopy>
         </td>
         <td>
-          <ClipboardCopy isCode isReadOnly variant={'expansion'}>
-            {cliConfig.join('\n')}
-          </ClipboardCopy>
+          {distribution.repository ? (
+            <ClipboardCopy isCode isReadOnly variant={'expansion'}>
+              {cliConfig.join('\n')}
+            </ClipboardCopy>
+          ) : (
+            '---'
+          )}
         </td>
       </tr>
     );


### PR DESCRIPTION
Backport #3439

---

* local-repository-table: handle distributions with null repository
(cherry picked from commit d6f45be6143bc7f4cd5df6a127377f3f133f363a)

