### PR TITLE
Repositories & Remotes - access checks

### DIFF
--- a/src/actions/action.tsx
+++ b/src/actions/action.tsx
@@ -1,38 +1,41 @@
 import { Button, DropdownItem } from '@patternfly/react-core';
 import React from 'react';
 import { Tooltip } from 'src/components';
+import { type PermissionContextType } from 'src/permissions';
 
 type ModalType = ({ addAlert, state, setState, query }) => React.ReactNode;
 
 interface ActionParams {
   buttonVariant?: 'primary' | 'secondary';
+  condition?: PermissionContextType;
+  disabled?: (item, actionContext) => string | null;
   modal?: ModalType;
   onClick: (item, actionContext) => void;
   title: string;
   visible?: (item, actionContext) => boolean;
-  disabled?: (item, actionContext) => string | null;
 }
 
 export class ActionType {
-  title: string;
   button: (item, actionContext) => React.ReactNode | null;
+  disabled: (item, actionContext) => string | null;
   dropdownItem: (item, actionContext) => React.ReactNode | null;
   modal?: ModalType;
+  title: string;
   visible: (item, actionContext) => boolean;
-  disabled: (item, actionContext) => string | null;
 }
 
 export const Action = ({
   buttonVariant,
-  title,
-  onClick,
-  modal = null,
-  visible = () => true,
+  condition = () => true,
   disabled = () => null,
+  modal = null,
+  onClick,
+  title,
+  visible = () => true,
 }: ActionParams): ActionType => ({
   title,
   button: (item, actionContext) =>
-    visible(item, actionContext) ? (
+    condition(actionContext, item) && visible(item, actionContext) ? (
       disabled(item, actionContext) ? (
         <Tooltip content={disabled(item, actionContext)} key={title}>
           <Button variant={buttonVariant} isDisabled>
@@ -50,7 +53,7 @@ export const Action = ({
       )
     ) : null,
   dropdownItem: (item, actionContext) =>
-    visible(item, actionContext) ? (
+    condition(actionContext, item) && visible(item, actionContext) ? (
       disabled(item, actionContext) ? (
         <DropdownItem
           key={title}

--- a/src/actions/ansible-remote-create.tsx
+++ b/src/actions/ansible-remote-create.tsx
@@ -1,8 +1,10 @@
 import { t } from '@lingui/macro';
 import { Paths, formatPath } from 'src/paths';
+import { canAddAnsibleRemote } from 'src/permissions';
 import { Action } from './action';
 
 export const ansibleRemoteCreateAction = Action({
+  condition: canAddAnsibleRemote,
   title: t`Add remote`,
   onClick: (item, { navigate }) =>
     navigate(formatPath(Paths.ansibleRemoteEdit, { name: '_' })),

--- a/src/actions/ansible-remote-delete.tsx
+++ b/src/actions/ansible-remote-delete.tsx
@@ -2,10 +2,12 @@ import { t } from '@lingui/macro';
 import React from 'react';
 import { AnsibleRemoteAPI } from 'src/api';
 import { DeleteAnsibleRemoteModal } from 'src/components';
+import { canDeleteAnsibleRemote } from 'src/permissions';
 import { handleHttpError, parsePulpIDFromURL, taskAlert } from 'src/utilities';
 import { Action } from './action';
 
 export const ansibleRemoteDeleteAction = Action({
+  condition: canDeleteAnsibleRemote,
   title: t`Delete`,
   modal: ({ addAlert, query, setState, state }) =>
     state.deleteModalOpen ? (

--- a/src/actions/ansible-remote-edit.tsx
+++ b/src/actions/ansible-remote-edit.tsx
@@ -1,8 +1,10 @@
 import { t } from '@lingui/macro';
 import { Paths, formatPath } from 'src/paths';
+import { canEditAnsibleRemote } from 'src/permissions';
 import { Action } from './action';
 
 export const ansibleRemoteEditAction = Action({
+  condition: canEditAnsibleRemote,
   title: t`Edit`,
   onClick: ({ name }, { navigate }) =>
     navigate(formatPath(Paths.ansibleRemoteEdit, { name })),

--- a/src/actions/ansible-repository-create.tsx
+++ b/src/actions/ansible-repository-create.tsx
@@ -1,8 +1,10 @@
 import { t } from '@lingui/macro';
 import { Paths, formatPath } from 'src/paths';
+import { canAddAnsibleRepository } from 'src/permissions';
 import { Action } from './action';
 
 export const ansibleRepositoryCreateAction = Action({
+  condition: canAddAnsibleRepository,
   title: t`Add repository`,
   onClick: (item, { navigate }) =>
     navigate(formatPath(Paths.ansibleRepositoryEdit, { name: '_' })),

--- a/src/actions/ansible-repository-delete.tsx
+++ b/src/actions/ansible-repository-delete.tsx
@@ -2,10 +2,12 @@ import { t } from '@lingui/macro';
 import React from 'react';
 import { AnsibleRepositoryAPI } from 'src/api';
 import { DeleteAnsibleRepositoryModal } from 'src/components';
+import { canDeleteAnsibleRepository } from 'src/permissions';
 import { handleHttpError, parsePulpIDFromURL, taskAlert } from 'src/utilities';
 import { Action } from './action';
 
 export const ansibleRepositoryDeleteAction = Action({
+  condition: canDeleteAnsibleRepository,
   title: t`Delete`,
   modal: ({ addAlert, query, setState, state }) =>
     state.deleteModalOpen ? (

--- a/src/actions/ansible-repository-edit.tsx
+++ b/src/actions/ansible-repository-edit.tsx
@@ -1,8 +1,10 @@
 import { t } from '@lingui/macro';
 import { Paths, formatPath } from 'src/paths';
+import { canEditAnsibleRepository } from 'src/permissions';
 import { Action } from './action';
 
 export const ansibleRepositoryEditAction = Action({
+  condition: canEditAnsibleRepository,
   title: t`Edit`,
   onClick: ({ name }, { navigate }) =>
     navigate(formatPath(Paths.ansibleRepositoryEdit, { name })),

--- a/src/actions/ansible-repository-sync.tsx
+++ b/src/actions/ansible-repository-sync.tsx
@@ -1,9 +1,11 @@
 import { t } from '@lingui/macro';
 import { AnsibleRepositoryAPI } from 'src/api';
+import { canSyncAnsibleRepository } from 'src/permissions';
 import { handleHttpError, parsePulpIDFromURL, taskAlert } from 'src/utilities';
 import { Action } from './action';
 
 export const ansibleRepositorySyncAction = Action({
+  condition: canSyncAnsibleRepository,
   title: t`Sync`,
   onClick: ({ name, pulp_href }, { addAlert, query }) => {
     const pulpId = parsePulpIDFromURL(pulp_href);

--- a/src/actions/ansible-repository-version-revert.tsx
+++ b/src/actions/ansible-repository-version-revert.tsx
@@ -2,6 +2,7 @@ import { Trans, t } from '@lingui/macro';
 import { Button, Modal, Spinner } from '@patternfly/react-core';
 import React, { useState } from 'react';
 import { AnsibleRepositoryAPI } from 'src/api';
+import { canRevertAnsibleRepositoryVersion } from 'src/permissions';
 import { handleHttpError, parsePulpIDFromURL, taskAlert } from 'src/utilities';
 import { Action } from './action';
 
@@ -81,6 +82,7 @@ function revert(
 }
 
 export const ansibleRepositoryVersionRevertAction = Action({
+  condition: canRevertAnsibleRepositoryVersion,
   title: t`Revert to this version`,
   modal: ({ addAlert, state, setState, query }) =>
     state.revertModal ? (

--- a/src/api/response-types/ansible-remote.ts
+++ b/src/api/response-types/ansible-remote.ts
@@ -28,4 +28,6 @@ export class AnsibleRemoteType {
     is_set: boolean;
     name: string;
   }[];
+
+  my_permissions?: string[];
 }

--- a/src/api/response-types/ansible-repository.ts
+++ b/src/api/response-types/ansible-repository.ts
@@ -11,6 +11,8 @@ export class AnsibleRepositoryType {
   // gpgkey
   // last_synced_metadata_time
   // versions_href
+
+  my_permissions?: string[];
 }
 
 type ContentSummary = { [key: string]: { count: number; href: string } };

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -205,13 +205,14 @@ export const ListPage = function <T, ExtraState = Record<string, never>>({
 
       const actionContext = {
         addAlert: (alert) => this.addAlert(alert),
+        hasObjectPermission: () => false, // list items don't load my_permissions .. but superadmin should still work
         hasPermission: this.context.hasPermission,
         navigate: this.props.navigate,
         query: () => this.query(),
         queueAlert: this.context.queueAlert,
         setState: (s) => this.setState(s),
         state: this.state,
-        hasObjectPermission: () => false, // list items don't load my_permissions .. but superadmin should still work
+        user: this.context.user,
       };
 
       return (

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -211,6 +211,7 @@ export const ListPage = function <T, ExtraState = Record<string, never>>({
         queueAlert: this.context.queueAlert,
         setState: (s) => this.setState(s),
         state: this.state,
+        hasObjectPermission: () => false, // list items don't load my_permissions .. but superadmin should still work
       };
 
       return (

--- a/src/components/page/page-with-tabs.tsx
+++ b/src/components/page/page-with-tabs.tsx
@@ -154,14 +154,15 @@ export const PageWithTabs = function <
 
       const actionContext = {
         addAlert: (alert) => this.addAlert(alert),
+        hasObjectPermission: (permission) =>
+          item?.my_permissions?.includes?.(permission),
         hasPermission: this.context.hasPermission,
         navigate: this.props.navigate,
         query: () => this.query(),
         queueAlert: this.context.queueAlert,
         setState: (s) => this.setState(s),
         state: this.state,
-        hasObjectPermission: (permission) =>
-          item?.my_permissions?.includes?.(permission),
+        user: this.context.user,
       };
 
       const name = item?.name || routeParams.name;

--- a/src/components/page/page-with-tabs.tsx
+++ b/src/components/page/page-with-tabs.tsx
@@ -160,6 +160,8 @@ export const PageWithTabs = function <
         queueAlert: this.context.queueAlert,
         setState: (s) => this.setState(s),
         state: this.state,
+        hasObjectPermission: (permission) =>
+          item?.my_permissions?.includes?.(permission),
       };
 
       const name = item?.name || routeParams.name;

--- a/src/components/page/page-with-tabs.tsx
+++ b/src/components/page/page-with-tabs.tsx
@@ -61,7 +61,7 @@ interface PageWithTabsParams<T, ExtraState> {
 }
 
 export const PageWithTabs = function <
-  T extends { name: string },
+  T extends { name: string; my_permissions?: string[] },
   ExtraState = Record<string, never>,
 >({
   // ({ name }) => [{ url?, name }]

--- a/src/components/page/page.tsx
+++ b/src/components/page/page.tsx
@@ -125,14 +125,15 @@ export const Page = function <
 
       const actionContext = {
         addAlert: (alert) => this.addAlert(alert),
+        hasObjectPermission: (permission) =>
+          item?.my_permissions?.includes?.(permission),
         hasPermission: this.context.hasPermission,
         navigate: this.props.navigate,
         query: () => this.query(),
         queueAlert: this.context.queueAlert,
         setState: (s) => this.setState(s),
         state: this.state,
-        hasObjectPermission: (permission) =>
-          item?.my_permissions?.includes?.(permission),
+        user: this.context.user,
       };
 
       const name = item?.name || transformParams(routeParams)?.name || null;

--- a/src/components/page/page.tsx
+++ b/src/components/page/page.tsx
@@ -50,7 +50,7 @@ interface PageParams<T, ExtraState> {
 }
 
 export const Page = function <
-  T extends { name: string },
+  T extends { name: string; my_permissions?: string[] },
   ExtraState = Record<string, never>,
 >({
   // ({ name }) => [{ url?, name }]

--- a/src/components/page/page.tsx
+++ b/src/components/page/page.tsx
@@ -131,6 +131,8 @@ export const Page = function <
         queueAlert: this.context.queueAlert,
         setState: (s) => this.setState(s),
         state: this.state,
+        hasObjectPermission: (permission) =>
+          item?.my_permissions?.includes?.(permission),
       };
 
       const name = item?.name || transformParams(routeParams)?.name || null;

--- a/src/components/shared/detail-list.tsx
+++ b/src/components/shared/detail-list.tsx
@@ -22,7 +22,14 @@ import {
 import { filterIsSet, handleHttpError } from 'src/utilities';
 
 interface IProps<T> {
-  actionContext: { addAlert; state; setState; query };
+  actionContext: {
+    addAlert;
+    hasObjectPermission?;
+    hasPermission;
+    query;
+    setState;
+    state;
+  };
   defaultPageSize: number;
   defaultSort?: string;
   errorTitle: string;

--- a/src/containers/ansible-remote/detail.tsx
+++ b/src/containers/ansible-remote/detail.tsx
@@ -10,7 +10,7 @@ import {
 import { AnsibleRemoteAPI, AnsibleRemoteType } from 'src/api';
 import { PageWithTabs } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
-import { isLoggedIn } from 'src/permissions';
+import { canViewAnsibleRemotes } from 'src/permissions';
 import { RemoteAccessTab } from './tab-access';
 import { DetailsTab } from './tab-details';
 
@@ -38,7 +38,7 @@ export const AnsibleRemoteDetail = PageWithTabs<AnsibleRemoteType>({
         ? { name: t`Group ${group}` }
         : { name: tab.name },
     ].filter(Boolean),
-  condition: isLoggedIn,
+  condition: canViewAnsibleRemotes,
   displayName: 'AnsibleRemoteDetail',
   errorTitle: t`Remote could not be displayed.`,
   headerActions: [

--- a/src/containers/ansible-remote/edit.tsx
+++ b/src/containers/ansible-remote/edit.tsx
@@ -41,8 +41,21 @@ export const AnsibleRemoteEdit = Page<AnsibleRemoteType>({
     canAddAnsibleRemote(context) || canEditAnsibleRemote(context, item),
   displayName: 'AnsibleRemoteEdit',
   errorTitle: t`Remote could not be displayed.`,
-  query: ({ name }) =>
-    AnsibleRemoteAPI.list({ name }).then(({ data: { results } }) => results[0]),
+  query: ({ name }) => {
+    return AnsibleRemoteAPI.list({ name })
+      .then(({ data: { results } }) => results[0])
+      .then((remote) => {
+        return AnsibleRemoteAPI.myPermissions(
+          parsePulpIDFromURL(remote.pulp_href),
+        )
+          .then(({ data: { permissions } }) => permissions)
+          .catch((e) => {
+            console.error(e);
+            return [];
+          })
+          .then((my_permissions) => ({ ...remote, my_permissions }));
+      });
+  },
 
   title: ({ name }) => name || t`Add new remote`,
   transformParams: ({ name, ...rest }) => ({

--- a/src/containers/ansible-remote/edit.tsx
+++ b/src/containers/ansible-remote/edit.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { AnsibleRemoteAPI, AnsibleRemoteType } from 'src/api';
 import { Page, RemoteForm } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
-import { isLoggedIn } from 'src/permissions';
+import { canAddAnsibleRemote, canEditAnsibleRemote } from 'src/permissions';
 import { parsePulpIDFromURL, taskAlert } from 'src/utilities';
 
 const initialRemote: AnsibleRemoteType = {
@@ -37,7 +37,8 @@ export const AnsibleRemoteEdit = Page<AnsibleRemoteType>({
       name ? { name: t`Edit` } : { name: t`Add` },
     ].filter(Boolean),
 
-  condition: isLoggedIn,
+  condition: (context, item?) =>
+    canAddAnsibleRemote(context) || canEditAnsibleRemote(context, item),
   displayName: 'AnsibleRemoteEdit',
   errorTitle: t`Remote could not be displayed.`,
   query: ({ name }) =>

--- a/src/containers/ansible-remote/list.tsx
+++ b/src/containers/ansible-remote/list.tsx
@@ -12,7 +12,7 @@ import {
 import { AnsibleRemoteAPI, AnsibleRemoteType } from 'src/api';
 import { CopyURL, ListItemActions, ListPage } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
-import { isLoggedIn } from 'src/permissions';
+import { canViewAnsibleRemotes } from 'src/permissions';
 import { parsePulpIDFromURL } from 'src/utilities';
 
 const listItemActions = [
@@ -29,7 +29,7 @@ const listItemActions = [
 ];
 
 export const AnsibleRemoteList = ListPage<AnsibleRemoteType>({
-  condition: isLoggedIn,
+  condition: canViewAnsibleRemotes,
   defaultPageSize: 10,
   defaultSort: '-pulp_created',
   displayName: 'AnsibleRemoteList',

--- a/src/containers/ansible-remote/tab-access.tsx
+++ b/src/containers/ansible-remote/tab-access.tsx
@@ -51,6 +51,14 @@ export const RemoteAccessTab = ({
     setGroups(null);
     AnsibleRemoteAPI.myPermissions(id)
       .then(({ data: { permissions } }) => {
+        setCanEditOwners(
+          canEditAnsibleRemoteAccess({
+            hasPermission,
+            hasObjectPermission: (p: string): boolean =>
+              permissions.includes(p),
+            user,
+          }),
+        );
         AnsibleRemoteAPI.listRoles(id)
           .then(({ data: { roles } }) => {
             const groupRoles = [];
@@ -67,14 +75,6 @@ export const RemoteAccessTab = ({
 
             setName(name);
             setGroups(groupRoles);
-            setCanEditOwners(
-              canEditAnsibleRemoteAccess({
-                hasPermission,
-                hasObjectPermission: (p: string): boolean =>
-                  permissions.includes(p),
-                user,
-              }),
-            );
           })
           .catch(() => {
             setGroups([]);

--- a/src/containers/ansible-remote/tab-access.tsx
+++ b/src/containers/ansible-remote/tab-access.tsx
@@ -9,6 +9,7 @@ import {
 } from 'src/api';
 import { AccessTab } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
+import { canEditAnsibleRemoteAccess } from 'src/permissions';
 import { errorMessage, parsePulpIDFromURL } from 'src/utilities';
 
 interface TabProps {
@@ -17,6 +18,7 @@ interface TabProps {
     addAlert: (alert) => void;
     state: { params };
     hasPermission;
+    user;
   };
 }
 
@@ -26,6 +28,7 @@ export const RemoteAccessTab = ({
     addAlert,
     state: { params },
     hasPermission,
+    user,
   },
 }: TabProps) => {
   const id = item?.pulp_href && parsePulpIDFromURL(item.pulp_href);
@@ -65,8 +68,12 @@ export const RemoteAccessTab = ({
             setName(name);
             setGroups(groupRoles);
             setCanEditOwners(
-              permissions.includes('ansible.change_collectionremote') ||
-                hasPermission('ansible.change_collectionremote'),
+              canEditAnsibleRemoteAccess({
+                hasPermission,
+                hasObjectPermission: (p: string): boolean =>
+                  permissions.includes(p),
+                user,
+              }),
             );
           })
           .catch(() => {

--- a/src/containers/ansible-repository/detail.tsx
+++ b/src/containers/ansible-repository/detail.tsx
@@ -10,6 +10,7 @@ import { AnsibleRepositoryAPI, AnsibleRepositoryType } from 'src/api';
 import { PageWithTabs } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { canViewAnsibleRepositories } from 'src/permissions';
+import { parsePulpIDFromURL } from 'src/utilities';
 import { lastSyncStatus, lastSynced } from 'src/utilities';
 import { RepositoryAccessTab } from './tab-access';
 import { CollectionVersionsTab } from './tab-collection-versions';
@@ -66,10 +67,21 @@ export const AnsibleRepositoryDetail = PageWithTabs<AnsibleRepositoryType>({
       )}
     </>
   ),
-  query: ({ name }) =>
-    AnsibleRepositoryAPI.list({ name }).then(
-      ({ data: { results } }) => results[0],
-    ),
+  query: ({ name }) => {
+    return AnsibleRepositoryAPI.list({ name })
+      .then(({ data: { results } }) => results[0])
+      .then((repository) => {
+        return AnsibleRepositoryAPI.myPermissions(
+          parsePulpIDFromURL(repository.pulp_href),
+        )
+          .then(({ data: { permissions } }) => permissions)
+          .catch((e) => {
+            console.error(e);
+            return [];
+          })
+          .then((my_permissions) => ({ ...repository, my_permissions }));
+      });
+  },
   renderTab: (tab, item, actionContext) =>
     ({
       details: <DetailsTab item={item} actionContext={actionContext} />,

--- a/src/containers/ansible-repository/detail.tsx
+++ b/src/containers/ansible-repository/detail.tsx
@@ -9,7 +9,7 @@ import {
 import { AnsibleRepositoryAPI, AnsibleRepositoryType } from 'src/api';
 import { PageWithTabs } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
-import { isLoggedIn } from 'src/permissions';
+import { canViewAnsibleRepositories } from 'src/permissions';
 import { lastSyncStatus, lastSynced } from 'src/utilities';
 import { RepositoryAccessTab } from './tab-access';
 import { CollectionVersionsTab } from './tab-collection-versions';
@@ -47,7 +47,7 @@ export const AnsibleRepositoryDetail = PageWithTabs<AnsibleRepositoryType>({
         ? { name: t`Group ${group}` }
         : { name: tab.name },
     ].filter(Boolean),
-  condition: isLoggedIn,
+  condition: canViewAnsibleRepositories,
   displayName: 'AnsibleRepositoryDetail',
   errorTitle: t`Repository could not be displayed.`,
   headerActions: [

--- a/src/containers/ansible-repository/edit.tsx
+++ b/src/containers/ansible-repository/edit.tsx
@@ -7,7 +7,10 @@ import {
 } from 'src/api';
 import { AnsibleRepositoryForm, Page } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
-import { isLoggedIn } from 'src/permissions';
+import {
+  canAddAnsibleRepository,
+  canEditAnsibleRepository,
+} from 'src/permissions';
 import { parsePulpIDFromURL, taskAlert } from 'src/utilities';
 
 const initialRepository: AnsibleRepositoryType = {
@@ -29,7 +32,8 @@ export const AnsibleRepositoryEdit = Page<AnsibleRepositoryType>({
       name ? { name: t`Edit` } : { name: t`Add` },
     ].filter(Boolean),
 
-  condition: isLoggedIn,
+  condition: (context, item?) =>
+    canAddAnsibleRepository(context) || canEditAnsibleRepository(context, item),
   displayName: 'AnsibleRepositoryEdit',
   errorTitle: t`Repository could not be displayed.`,
   query: ({ name }) =>

--- a/src/containers/ansible-repository/edit.tsx
+++ b/src/containers/ansible-repository/edit.tsx
@@ -36,10 +36,21 @@ export const AnsibleRepositoryEdit = Page<AnsibleRepositoryType>({
     canAddAnsibleRepository(context) || canEditAnsibleRepository(context, item),
   displayName: 'AnsibleRepositoryEdit',
   errorTitle: t`Repository could not be displayed.`,
-  query: ({ name }) =>
-    AnsibleRepositoryAPI.list({ name }).then(
-      ({ data: { results } }) => results[0],
-    ),
+  query: ({ name }) => {
+    return AnsibleRepositoryAPI.list({ name })
+      .then(({ data: { results } }) => results[0])
+      .then((repository) => {
+        return AnsibleRepositoryAPI.myPermissions(
+          parsePulpIDFromURL(repository.pulp_href),
+        )
+          .then(({ data: { permissions } }) => permissions)
+          .catch((e) => {
+            console.error(e);
+            return [];
+          })
+          .then((my_permissions) => ({ ...repository, my_permissions }));
+      });
+  },
 
   title: ({ name }) => name || t`Add new repository`,
   transformParams: ({ name, ...rest }) => ({

--- a/src/containers/ansible-repository/list.tsx
+++ b/src/containers/ansible-repository/list.tsx
@@ -11,7 +11,7 @@ import {
 import { AnsibleRepositoryAPI, AnsibleRepositoryType } from 'src/api';
 import { DateComponent, ListItemActions, ListPage } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
-import { isLoggedIn } from 'src/permissions';
+import { canViewAnsibleRepositories } from 'src/permissions';
 import { lastSyncStatus, lastSynced, parsePulpIDFromURL } from 'src/utilities';
 
 const listItemActions = [
@@ -26,7 +26,7 @@ const listItemActions = [
 ];
 
 export const AnsibleRepositoryList = ListPage<AnsibleRepositoryType>({
-  condition: isLoggedIn,
+  condition: canViewAnsibleRepositories,
   defaultPageSize: 10,
   defaultSort: '-pulp_created',
   displayName: 'AnsibleRepositoryList',

--- a/src/containers/ansible-repository/tab-access.tsx
+++ b/src/containers/ansible-repository/tab-access.tsx
@@ -9,6 +9,7 @@ import {
 } from 'src/api';
 import { AccessTab } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
+import { canEditAnsibleRepositoryAccess } from 'src/permissions';
 import { errorMessage, parsePulpIDFromURL } from 'src/utilities';
 
 interface TabProps {
@@ -17,6 +18,7 @@ interface TabProps {
     addAlert: (alert) => void;
     state: { params };
     hasPermission;
+    user;
   };
 }
 
@@ -26,6 +28,7 @@ export const RepositoryAccessTab = ({
     addAlert,
     state: { params },
     hasPermission,
+    user,
   },
 }: TabProps) => {
   const id = item?.pulp_href && parsePulpIDFromURL(item.pulp_href);
@@ -65,8 +68,12 @@ export const RepositoryAccessTab = ({
             setName(name);
             setGroups(groupRoles);
             setCanEditOwners(
-              permissions.includes('ansible.change_ansiblerepository') ||
-                hasPermission('ansible.change_ansiblerepository'),
+              canEditAnsibleRepositoryAccess({
+                hasPermission,
+                hasObjectPermission: (p: string): boolean =>
+                  permissions.includes(p),
+                user,
+              }),
             );
           })
           .catch(() => {

--- a/src/containers/ansible-repository/tab-access.tsx
+++ b/src/containers/ansible-repository/tab-access.tsx
@@ -51,6 +51,14 @@ export const RepositoryAccessTab = ({
     setGroups(null);
     AnsibleRepositoryAPI.myPermissions(id)
       .then(({ data: { permissions } }) => {
+        setCanEditOwners(
+          canEditAnsibleRepositoryAccess({
+            hasPermission,
+            hasObjectPermission: (p: string): boolean =>
+              permissions.includes(p),
+            user,
+          }),
+        );
         AnsibleRepositoryAPI.listRoles(id)
           .then(({ data: { roles } }) => {
             const groupRoles = [];
@@ -67,14 +75,6 @@ export const RepositoryAccessTab = ({
 
             setName(name);
             setGroups(groupRoles);
-            setCanEditOwners(
-              canEditAnsibleRepositoryAccess({
-                hasPermission,
-                hasObjectPermission: (p: string): boolean =>
-                  permissions.includes(p),
-                user,
-              }),
-            );
           })
           .catch(() => {
             setGroups([]);

--- a/src/containers/ansible-repository/tab-repository-versions.tsx
+++ b/src/containers/ansible-repository/tab-repository-versions.tsx
@@ -20,7 +20,12 @@ import { parsePulpIDFromURL } from 'src/utilities';
 
 interface TabProps {
   item: AnsibleRepositoryType;
-  actionContext: { addAlert: (alert) => void; state: { params } };
+  actionContext: {
+    addAlert: (alert) => void;
+    state: { params };
+    hasPermission: (string) => boolean;
+    hasObjectPermission: (string) => boolean;
+  };
 }
 
 const AnyAPI = (href) =>
@@ -32,9 +37,11 @@ const AnyAPI = (href) =>
 const VersionContent = ({
   href,
   addAlert,
+  hasPermission,
 }: {
   href: string;
   addAlert: (alert) => void;
+  hasPermission: (string) => boolean;
 }) => {
   const [state, setState] = useState({});
   const API = AnyAPI(href);
@@ -73,6 +80,7 @@ const VersionContent = ({
         state,
         setState,
         query,
+        hasPermission,
       }}
       defaultPageSize={10}
       defaultSort={'name'}
@@ -151,7 +159,7 @@ const BaseVersion = ({
 
 export const RepositoryVersionsTab = ({
   item,
-  actionContext: { addAlert, state },
+  actionContext: { addAlert, state, hasPermission, hasObjectPermission },
 }: TabProps) => {
   const pulpId = parsePulpIDFromURL(item.pulp_href);
   const latest_href = item.latest_version_href;
@@ -273,6 +281,8 @@ export const RepositoryVersionsTab = ({
         state: modalState,
         setState: setModalState,
         query: queryList,
+        hasPermission,
+        hasObjectPermission, // needs item=repository, not repository version
       }}
       defaultPageSize={10}
       defaultSort={'-pulp_created'}

--- a/src/containers/ansible-repository/tab-repository-versions.tsx
+++ b/src/containers/ansible-repository/tab-repository-versions.tsx
@@ -44,6 +44,10 @@ const VersionContent = ({
   hasPermission: (string) => boolean;
 }) => {
   const [state, setState] = useState({});
+  if (!href) {
+    return null;
+  }
+
   const API = AnyAPI(href);
   const query = ({ params }) => API.list(params);
   const renderTableRow = ({

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -32,7 +32,7 @@ export function loadCollection({
 
   CollectionVersionAPI.getCached(
     {
-      repository_name: repo,
+      ...(repo ? { repository_name: repo } : {}),
       namespace,
       name,
       order_by: '-version',

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -32,6 +32,7 @@ import { StandaloneMenu } from './menu';
 interface IProps {
   children: React.ReactNode;
   featureFlags: FeatureFlagsType;
+  hasPermission: (string) => boolean;
   setUser: (user) => void;
   settings: SettingsType;
   user: UserType;
@@ -40,6 +41,7 @@ interface IProps {
 export const StandaloneLayout = ({
   children,
   featureFlags,
+  hasPermission,
   setUser,
   settings,
   user,
@@ -156,7 +158,11 @@ export const StandaloneLayout = ({
   const Sidebar = (
     <PageSidebar
       theme='dark'
-      nav={<StandaloneMenu context={{ user, settings, featureFlags }} />}
+      nav={
+        <StandaloneMenu
+          context={{ user, settings, featureFlags, hasPermission }}
+        />
+      }
     />
   );
 

--- a/src/loaders/standalone/loader.tsx
+++ b/src/loaders/standalone/loader.tsx
@@ -5,7 +5,7 @@ import { useLocation } from 'react-router-dom';
 import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { AlertType, UIVersion } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
-import { hasPermission } from 'src/utilities';
+import { hasPermission as hasPermissionUtil } from 'src/utilities';
 import { AppContext } from '../app-context';
 import { StandaloneLayout } from './layout';
 import { StandaloneRoutes } from './routes';
@@ -25,7 +25,19 @@ const App = (_props) => {
     setUser(user);
   };
 
+  const queueAlert = (alert) => setAlerts((alerts) => [...alerts, alert]);
+  const hasPermission = (name) =>
+    hasPermissionUtil(
+      {
+        user,
+        settings,
+        featureFlags,
+      },
+      name,
+    );
+
   let component = <StandaloneRoutes updateInitialData={updateInitialData} />;
+
   // Hide navs on login page
   if (
     location.pathname !== formatPath(Paths.login) &&
@@ -37,13 +49,12 @@ const App = (_props) => {
         settings={settings}
         user={user}
         setUser={setUser}
+        hasPermission={hasPermission}
       >
         {component}
       </StandaloneLayout>
     );
   }
-
-  const queueAlert = (alert) => setAlerts((alerts) => [...alerts, alert]);
 
   return (
     <AppContext.Provider
@@ -55,15 +66,7 @@ const App = (_props) => {
         setUser,
         settings,
         user,
-        hasPermission: (name) =>
-          hasPermission(
-            {
-              user,
-              settings,
-              featureFlags,
-            },
-            name,
-          ),
+        hasPermission,
       }}
     >
       {component}

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -12,7 +12,11 @@ import { reject, some } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Paths, formatPath } from 'src/paths';
-import { isLoggedIn } from 'src/permissions';
+import {
+  canViewAnsibleRemotes,
+  canViewAnsibleRepositories,
+  isLoggedIn,
+} from 'src/permissions';
 import { hasPermission } from 'src/utilities';
 
 const menuItem = (name, options = {}) => ({
@@ -52,11 +56,11 @@ function standaloneMenu() {
         url: formatPath(Paths.repositories),
       }),
       menuItem(t`Repositories`, {
-        condition: isLoggedIn,
+        condition: canViewAnsibleRepositories,
         url: formatPath(Paths.ansibleRepositories),
       }),
       menuItem(t`Remotes`, {
-        condition: isLoggedIn,
+        condition: canViewAnsibleRemotes,
         url: formatPath(Paths.ansibleRemotes),
       }),
       menuItem(t`API token`, {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -54,13 +54,12 @@ export const canEditAnsibleRepository = has_model_or_obj_perms(
   'ansible.change_ansiblerepository',
 );
 export const canSyncAnsibleRepository = canEditAnsibleRepository;
-export const canViewAnsibleRepositories = has_model_or_obj_perms(
-  'ansible.view_ansiblerepository',
-);
+// everybody can list/view, not has_model_or_obj_perms('ansible.view_ansiblerepository')
+export const canViewAnsibleRepositories = isLoggedIn;
 export const canEditAnsibleRepositoryAccess = has_model_or_obj_perms(
   'ansible.manage_roles_ansiblerepository',
 );
 
 // Ansible Repository Versions
-// has_repository_model_or_obj_perms
+// simulating has_repository_model_or_obj_perms by passing in repository as item
 export const canRevertAnsibleRepositoryVersion = canEditAnsibleRepository;

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,11 +1,66 @@
 import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 
-export type PermissionContextType = (o: {
-  featureFlags: FeatureFlagsType;
-  settings: SettingsType;
-  user: UserType;
-  hasPermission: (string) => boolean;
-}) => boolean;
+export type PermissionContextType = (
+  o: {
+    featureFlags?: FeatureFlagsType;
+    settings?: SettingsType;
+    user: UserType;
+    hasPermission: (string) => boolean;
+    hasObjectPermission?: (string, item?) => boolean;
+  },
+  item?,
+) => boolean;
 
 export const isLoggedIn: PermissionContextType = ({ user }) =>
   user && !user.is_anonymous;
+
+const has_model_perms =
+  (permission: string): PermissionContextType =>
+  ({ hasPermission }) =>
+    hasPermission(permission);
+
+const has_model_or_obj_perms =
+  (permission: string): PermissionContextType =>
+  ({ hasPermission, hasObjectPermission, user }, item?) =>
+    hasPermission(permission) ||
+    hasObjectPermission?.(permission, item) ||
+    user?.is_superuser;
+
+// Ansible Remotes
+export const canAddAnsibleRemote = has_model_perms(
+  'ansible.add_collectionremote',
+);
+export const canDeleteAnsibleRemote = has_model_or_obj_perms(
+  'ansible.delete_collectionremote',
+);
+export const canEditAnsibleRemote = has_model_or_obj_perms(
+  'ansible.change_collectionremote',
+);
+export const canViewAnsibleRemotes = has_model_or_obj_perms(
+  'ansible.view_collectionremote',
+);
+export const canEditAnsibleRemoteAccess = has_model_or_obj_perms(
+  'ansible.manage_roles_collectionremote',
+);
+
+// Ansible Repositories
+export const canAddAnsibleRepository = has_model_perms(
+  'ansible.add_ansiblerepository',
+);
+export const canDeleteAnsibleRepository = has_model_or_obj_perms(
+  'ansible.delete_ansiblerepository',
+);
+export const canEditAnsibleRepository = has_model_or_obj_perms(
+  'ansible.change_ansiblerepository',
+);
+export const canSyncAnsibleRepository = canEditAnsibleRepository;
+export const canViewAnsibleRepositories = has_model_or_obj_perms(
+  'ansible.view_ansiblerepository',
+);
+export const canEditAnsibleRepositoryAccess = has_model_or_obj_perms(
+  'ansible.manage_roles_ansiblerepository',
+);
+
+// Ansible Repository Versions
+// has_repository_model_or_obj_perms
+export const canRevertAnsibleRepositoryVersion = canEditAnsibleRepository;

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -16,8 +16,8 @@ export const isLoggedIn: PermissionContextType = ({ user }) =>
 
 const has_model_perms =
   (permission: string): PermissionContextType =>
-  ({ hasPermission }) =>
-    hasPermission(permission);
+  ({ hasPermission, user }) =>
+    hasPermission(permission) || user?.is_superuser;
 
 const has_model_or_obj_perms =
   (permission: string): PermissionContextType =>

--- a/src/utilities/has-permission.tsx
+++ b/src/utilities/has-permission.tsx
@@ -4,5 +4,10 @@ export function hasPermission({ user, settings, featureFlags }, name) {
     return false;
   }
 
+  if (!user.model_permissions[name]) {
+    console.error(`Unknown permission ${name}`);
+    return !!user.is_superadmin;
+  }
+
   return !!user.model_permissions[name].has_model_permission;
 }

--- a/test/cypress/e2e/misc/menu.js
+++ b/test/cypress/e2e/misc/menu.js
@@ -34,19 +34,19 @@ describe('Hub Menu Tests', () => {
   describe('user without permissions', () => {
     // one more similar test in view-only
     const visibleMenuItems = [
+      'Collections > API token',
       'Collections > Collections',
       'Collections > Namespaces',
-      'Collections > API token',
+      'Collections > Repositories',
+      'Documentation',
       'Execution Environments > Execution Environments',
       'Execution Environments > Remote Registries',
-      'Task Management',
       'Signature Keys',
-      'Documentation',
+      'Task Management',
     ];
     const missingMenuItems = [
       'Collections > Approval',
       'Collections > Remotes',
-      'Collections > Repositories',
       'User Access > Groups',
       'User Access > Roles',
       'User Access > Users',

--- a/test/cypress/e2e/misc/menu.js
+++ b/test/cypress/e2e/misc/menu.js
@@ -36,8 +36,6 @@ describe('Hub Menu Tests', () => {
     const visibleMenuItems = [
       'Collections > Collections',
       'Collections > Namespaces',
-      'Collections > Repositories',
-      'Collections > Remotes',
       'Collections > API token',
       'Execution Environments > Execution Environments',
       'Execution Environments > Remote Registries',
@@ -46,10 +44,12 @@ describe('Hub Menu Tests', () => {
       'Documentation',
     ];
     const missingMenuItems = [
-      'User Access > Users',
+      'Collections > Approval',
+      'Collections > Remotes',
+      'Collections > Repositories',
       'User Access > Groups',
       'User Access > Roles',
-      'Collections > Approval',
+      'User Access > Users',
     ];
 
     it('sees limited menu', () => {


### PR DESCRIPTION
Follows #3429 , AAH-1998, AAH-1999

This adds permission checks to Repository and Remotes screens and actions.

Permissions come from https://github.com/newswangerd/galaxy_ng/blob/fe0470ee087c97560579e005a28788570536c334/galaxy_ng/app/access_control/statements/pulp.py#L198

For list views, only superadmin will see actions when object permissions are required (users will still see them if they have the model level permission)
for detail/edit views, /my_permissions will always get loaded before evaluating permissions.
(The assumption is that query() yields an object with .my_permissions[].)

![20230330045451](https://user-images.githubusercontent.com/289743/228733530-6a669747-52ba-4759-b69d-fca0eaeea4c7.png)
![20230330045458](https://user-images.githubusercontent.com/289743/228733536-2d29a5b2-59e6-459d-92c3-9c4e4b9fbc26.png)
![20230330045508](https://user-images.githubusercontent.com/289743/228733538-bad6ddd2-59f5-472f-afec-4af76e9cb33a.png)
![20230330045515](https://user-images.githubusercontent.com/289743/228733541-27d15659-9503-45df-9600-4de6286e0487.png)
