### PR TITLE
Repositories - add helper text, remove obsolete `approved_for_use`, change `is_private` label to `private` field

### DIFF
--- a/src/api/response-types/ansible-repository.ts
+++ b/src/api/response-types/ansible-repository.ts
@@ -7,6 +7,7 @@ export class AnsibleRepositoryType {
   pulp_labels?: { [key: string]: string };
   remote?: string;
   retain_repo_versions: number;
+  private?: boolean;
 
   // gpgkey
   // last_synced_metadata_time

--- a/src/components/repositories/ansible-repository-form.tsx
+++ b/src/components/repositories/ansible-repository-form.tsx
@@ -24,7 +24,7 @@ interface IProps {
   allowEditName: boolean;
   errorMessages: ErrorMessagesType;
   onCancel: () => void;
-  onSave: ({ createDistribution, hideFromSearch, isPrivate, pipeline }) => void;
+  onSave: ({ createDistribution, hideFromSearch, pipeline }) => void;
   repository: AnsibleRepositoryType;
   updateRepository: (r) => void;
 }
@@ -99,9 +99,6 @@ export const AnsibleRepositoryForm = ({
 
   const [hideFromSearch, setHideFromSearch] = useState(
     repository?.pulp_labels?.hide_from_search === '',
-  );
-  const [isPrivate, setIsPrivate] = useState(
-    repository?.pulp_labels?.is_private === 'true',
   );
   const [pipeline, setPipeline] = useState(repository?.pulp_labels?.pipeline);
   const [disableHideFromSearch, setDisableHideFromSearch] = useState(
@@ -195,11 +192,6 @@ export const AnsibleRepositoryForm = ({
           page
         </li>
         <li>
-          <b>Make private</b> (
-          <pre style={{ display: 'inline-block' }}>is_private=true</pre>) - make
-          repository private
-        </li>
-        <li>
           (<pre style={{ display: 'inline-block' }}>pipeline: *</pre>) - see
           Pipeline above
         </li>
@@ -277,14 +269,22 @@ export const AnsibleRepositoryForm = ({
               id='hide_from_search'
               onChange={(value) => setHideFromSearch(value)}
             />
-            <Checkbox
-              isChecked={isPrivate}
-              label={t`Make private`}
-              id='is_private'
-              onChange={(value) => setIsPrivate(value)}
-            />
           </div>
         </>,
+      )}
+
+      {formGroup(
+        'private',
+        t`Make private`,
+        t`Make the repository private.`,
+        <Checkbox
+          id='private'
+          isChecked={repository.private}
+          label={t`Make private`}
+          onChange={(value) =>
+            updateRepository({ ...repository, private: value })
+          }
+        />,
       )}
 
       {formGroup(
@@ -348,7 +348,6 @@ export const AnsibleRepositoryForm = ({
             onSave({
               createDistribution,
               hideFromSearch,
-              isPrivate,
               pipeline,
             })
           }

--- a/src/components/repositories/ansible-repository-form.tsx
+++ b/src/components/repositories/ansible-repository-form.tsx
@@ -169,14 +169,17 @@ export const AnsibleRepositoryForm = ({
       Pipeline adds repository labels with pre-defined meanings:
       <ul>
         <li>
-          <b>None</b> - no special handling
+          <b>None</b> - users require permissions to modify content in this
+          repository to upload collection.
         </li>
         <li>
-          <b>Approved</b> - collections can be moved here on approval
+          <b>Approved</b> - collections can be moved here on approval.
+          Publishing directly to this repository is disabled.
         </li>
         <li>
-          <b>Staging</b> - collections uploaded here can be approved or rejected
-          in the UI
+          <b>Staging</b> - collections uploaded here require approval before
+          showing up on the search page. Anyone with upload permissions for a
+          namespace can upload collections to this repository.
         </li>
       </ul>
     </Trans>
@@ -217,7 +220,7 @@ export const AnsibleRepositoryForm = ({
       {formGroup(
         'distributions',
         t`Distributions`,
-        t`Some actions will not work without a distribution.`,
+        t`Content in repositories without a distribution will not be visible to clients for sync, download or search.`,
         <>
           <LazyDistributions
             emptyText={t`None`}

--- a/src/components/repositories/ansible-repository-form.tsx
+++ b/src/components/repositories/ansible-repository-form.tsx
@@ -23,13 +23,7 @@ interface IProps {
   allowEditName: boolean;
   errorMessages: ErrorMessagesType;
   onCancel: () => void;
-  onSave: ({
-    createDistribution,
-    createLabel,
-    hideFromSearch,
-    isPrivate,
-    pipeline,
-  }) => void;
+  onSave: ({ createDistribution, hideFromSearch, isPrivate, pipeline }) => void;
   repository: AnsibleRepositoryType;
   updateRepository: (r) => void;
 }
@@ -87,7 +81,6 @@ export const AnsibleRepositoryForm = ({
     }
   };
 
-  const createLabel = repository?.pulp_labels?.content !== 'approved_for_use';
   const [hideFromSearch, setHideFromSearch] = useState(
     repository?.pulp_labels?.hide_from_search === '',
   );
@@ -207,12 +200,6 @@ export const AnsibleRepositoryForm = ({
         </div>
         <div style={{ marginTop: '12px' }}>
           <Checkbox
-            isChecked={createLabel}
-            isDisabled={true}
-            label={t`Create a "content: approved_for_use" label`}
-            id='create_label'
-          />
-          <Checkbox
             isChecked={hideFromSearch}
             isDisabled={disableHideFromSearch}
             label={t`Hide from search`}
@@ -278,7 +265,6 @@ export const AnsibleRepositoryForm = ({
           onClick={() =>
             onSave({
               createDistribution,
-              createLabel,
               hideFromSearch,
               isPrivate,
               pipeline,

--- a/src/components/repositories/ansible-repository-form.tsx
+++ b/src/components/repositories/ansible-repository-form.tsx
@@ -1,4 +1,4 @@
-import { t } from '@lingui/macro';
+import { Trans, t } from '@lingui/macro';
 import {
   ActionGroup,
   Button,
@@ -14,6 +14,7 @@ import React, { useEffect, useState } from 'react';
 import { AnsibleRemoteAPI, AnsibleRepositoryType } from 'src/api';
 import {
   APISearchTypeAhead,
+  HelperText,
   LazyDistributions,
   PulpLabels,
 } from 'src/components';
@@ -40,15 +41,31 @@ export const AnsibleRepositoryForm = ({
   const disabledFields = allowEditName ? [] : ['name'];
 
   const toError = (bool) => (bool ? 'default' : 'error');
-  const inputField = (fieldName, label, props) => (
+  const formGroup = (fieldName, label, helperText, children) => (
     <FormGroup
       key={fieldName}
       fieldId={fieldName}
-      label={label}
+      label={
+        helperText ? (
+          <>
+            {label} <HelperText content={helperText} />
+          </>
+        ) : (
+          label
+        )
+      }
       isRequired={requiredFields.includes(fieldName)}
       validated={toError(!(fieldName in errorMessages))}
       helperTextInvalid={errorMessages[fieldName]}
     >
+      {children}
+    </FormGroup>
+  );
+  const inputField = (fieldName, label, helperText, props) =>
+    formGroup(
+      fieldName,
+      label,
+      helperText,
       <TextInput
         validated={toError(!(fieldName in errorMessages))}
         isRequired={requiredFields.includes(fieldName)}
@@ -59,13 +76,12 @@ export const AnsibleRepositoryForm = ({
           updateRepository({ ...repository, [fieldName]: value })
         }
         {...props}
-      />
-    </FormGroup>
-  );
-  const stringField = (fieldName, label) =>
-    inputField(fieldName, label, { type: 'text' });
-  const numericField = (fieldName, label) =>
-    inputField(fieldName, label, { type: 'number' });
+      />,
+    );
+  const stringField = (fieldName, label, helperText?) =>
+    inputField(fieldName, label, helperText, { type: 'text' });
+  const numericField = (fieldName, label, helperText?) =>
+    inputField(fieldName, label, helperText, { type: 'number' });
 
   const isValid = !requiredFields.find((field) => !repository[field]);
 
@@ -148,33 +164,81 @@ export const AnsibleRepositoryForm = ({
     none: { id: 'none', toString: () => t`None` },
   };
 
+  const pipelineHelp = (
+    <Trans>
+      Pipeline adds repository labels with pre-defined meanings:
+      <ul>
+        <li>
+          <b>None</b> - no special handling
+        </li>
+        <li>
+          <b>Approved</b> - collections can be moved here on approval
+        </li>
+        <li>
+          <b>Staging</b> - collections uploaded here can be approved or rejected
+          in the UI
+        </li>
+      </ul>
+    </Trans>
+  );
+  const labelsHelp = (
+    <Trans>
+      Repository labels can change the context in which a repository is seen.
+      <ul>
+        <li>
+          <b>Hide from search</b> (
+          <pre style={{ display: 'inline-block' }}>hide_from_search</pre>) -
+          prevent collections in this repository from showing up on the home
+          page
+        </li>
+        <li>
+          <b>Make private</b> (
+          <pre style={{ display: 'inline-block' }}>is_private=true</pre>) - make
+          repository private
+        </li>
+        <li>
+          (<pre style={{ display: 'inline-block' }}>pipeline: *</pre>) - see
+          Pipeline above
+        </li>
+      </ul>
+    </Trans>
+  );
+
   return (
     <Form>
       {stringField('name', t`Name`)}
       {stringField('description', t`Description`)}
-      {numericField('retain_repo_versions', t`Retained number of versions`)}
+      {numericField(
+        'retain_repo_versions',
+        t`Retained number of versions`,
+        t`In order to retain all versions, leave this field blank.`,
+      )}
 
-      <FormGroup
-        key={'distributions'}
-        fieldId={'distributions'}
-        label={t`Distributions`}
-      >
-        <LazyDistributions
-          emptyText={t`None`}
-          repositoryHref={repository.pulp_href}
-          onLoad={onDistributionsLoad}
-        />
-        <br />
-        <Checkbox
-          isChecked={createDistribution}
-          isDisabled={disabledDistribution}
-          onChange={(value) => setCreateDistribution(value)}
-          label={t`Create a "${repository.name}" distribution`}
-          id='create_distribution'
-        />
-      </FormGroup>
+      {formGroup(
+        'distributions',
+        t`Distributions`,
+        t`Some actions will not work without a distribution.`,
+        <>
+          <LazyDistributions
+            emptyText={t`None`}
+            repositoryHref={repository.pulp_href}
+            onLoad={onDistributionsLoad}
+          />
+          <br />
+          <Checkbox
+            isChecked={createDistribution}
+            isDisabled={disabledDistribution}
+            onChange={(value) => setCreateDistribution(value)}
+            label={t`Create a "${repository.name}" distribution`}
+            id='create_distribution'
+          />
+        </>,
+      )}
 
-      <FormGroup key='pipeline' fieldId='pipeline' label={t`Pipeline`}>
+      {formGroup(
+        'pipeline',
+        t`Pipeline`,
+        pipelineHelp,
         <Select
           variant='single'
           isOpen={selectOpen}
@@ -185,67 +249,82 @@ export const AnsibleRepositoryForm = ({
           {Object.entries(selectOptions).map(([k, v]) => (
             <SelectOption key={k} value={v} />
           ))}
-        </Select>
-      </FormGroup>
+        </Select>,
+      )}
 
-      <FormGroup key={'labels'} fieldId={'labels'} label={t`Labels`}>
-        <div
-          // prevents "N more" clicks from submitting the form
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-          }}
-        >
-          <PulpLabels labels={repository.pulp_labels} />
-        </div>
-        <div style={{ marginTop: '12px' }}>
-          <Checkbox
-            isChecked={hideFromSearch}
-            isDisabled={disableHideFromSearch}
-            label={t`Hide from search`}
-            id='hide_from_search'
-            onChange={(value) => setHideFromSearch(value)}
-          />
-          <Checkbox
-            isChecked={isPrivate}
-            label={t`Make private`}
-            id='is_private'
-            onChange={(value) => setIsPrivate(value)}
-          />
-        </div>
-      </FormGroup>
-
-      <FormGroup key='remote' fieldId='remote' label={t`Remote`}>
-        {remotes ? (
-          <APISearchTypeAhead
-            loadResults={loadRemotes}
-            onClear={() => updateRepository({ ...repository, remote: null })}
-            onSelect={(_event, value) =>
-              updateRepository({
-                ...repository,
-                remote: remotes.find(({ name }) => name === value)?.pulp_href,
-              })
-            }
-            placeholderText={t`Select a remote`}
-            results={remotes}
-            selections={
-              selectedRemote
-                ? [{ name: selectedRemote.name, id: selectedRemote.pulp_href }]
-                : []
-            }
-          />
-        ) : null}
-        {remotesError ? (
-          <span
-            style={{
-              color: 'var(--pf-global--danger-color--200)',
+      {formGroup(
+        'labels',
+        t`Labels`,
+        labelsHelp,
+        <>
+          <div
+            // prevents "N more" clicks from submitting the form
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
             }}
           >
-            {t`Failed to load remotes: ${remotesError}`}
-          </span>
-        ) : null}
-        {!remotes && !remotesError ? <Spinner size='sm' /> : null}
-      </FormGroup>
+            <PulpLabels labels={repository.pulp_labels} />
+          </div>
+          <div style={{ marginTop: '12px' }}>
+            <Checkbox
+              isChecked={hideFromSearch}
+              isDisabled={disableHideFromSearch}
+              label={t`Hide from search`}
+              id='hide_from_search'
+              onChange={(value) => setHideFromSearch(value)}
+            />
+            <Checkbox
+              isChecked={isPrivate}
+              label={t`Make private`}
+              id='is_private'
+              onChange={(value) => setIsPrivate(value)}
+            />
+          </div>
+        </>,
+      )}
+
+      {formGroup(
+        'remote',
+        t`Remote`,
+        t`Setting a remote allows a repository to sync from elsewhere.`,
+        <>
+          {remotes ? (
+            <APISearchTypeAhead
+              loadResults={loadRemotes}
+              onClear={() => updateRepository({ ...repository, remote: null })}
+              onSelect={(_event, value) =>
+                updateRepository({
+                  ...repository,
+                  remote: remotes.find(({ name }) => name === value)?.pulp_href,
+                })
+              }
+              placeholderText={t`Select a remote`}
+              results={remotes}
+              selections={
+                selectedRemote
+                  ? [
+                      {
+                        name: selectedRemote.name,
+                        id: selectedRemote.pulp_href,
+                      },
+                    ]
+                  : []
+              }
+            />
+          ) : null}
+          {remotesError ? (
+            <span
+              style={{
+                color: 'var(--pf-global--danger-color--200)',
+              }}
+            >
+              {t`Failed to load remotes: ${remotesError}`}
+            </span>
+          ) : null}
+          {!remotes && !remotesError ? <Spinner size='sm' /> : null}
+        </>,
+      )}
 
       {errorMessages['__nofield'] ? (
         <span

--- a/src/containers/ansible-repository/edit.tsx
+++ b/src/containers/ansible-repository/edit.tsx
@@ -60,7 +60,6 @@ export const AnsibleRepositoryEdit = Page<AnsibleRepositoryType>({
     const saveRepository = ({
       createDistribution,
       hideFromSearch,
-      isPrivate,
       pipeline,
     }) => {
       const { repositoryToEdit } = state;
@@ -88,11 +87,6 @@ export const AnsibleRepositoryEdit = Page<AnsibleRepositoryType>({
         data.pulp_labels.hide_from_search = '';
       } else {
         delete data.pulp_labels.hide_from_search;
-      }
-      if (isPrivate) {
-        data.pulp_labels.is_private = 'true';
-      } else {
-        delete data.pulp_labels.is_private;
       }
       if (pipeline) {
         data.pulp_labels.pipeline = pipeline;

--- a/src/containers/ansible-repository/edit.tsx
+++ b/src/containers/ansible-repository/edit.tsx
@@ -59,7 +59,6 @@ export const AnsibleRepositoryEdit = Page<AnsibleRepositoryType>({
 
     const saveRepository = ({
       createDistribution,
-      createLabel,
       hideFromSearch,
       isPrivate,
       pipeline,
@@ -85,9 +84,6 @@ export const AnsibleRepositoryEdit = Page<AnsibleRepositoryType>({
       }
 
       data.pulp_labels ||= {};
-      if (createLabel) {
-        data.pulp_labels.content = 'approved_for_use';
-      }
       if (hideFromSearch) {
         data.pulp_labels.hide_from_search = '';
       } else {

--- a/src/containers/ansible-repository/tab-details.tsx
+++ b/src/containers/ansible-repository/tab-details.tsx
@@ -45,6 +45,10 @@ export const DetailsTab = ({ item }: TabProps) => {
           value: <PulpLabels labels={item?.pulp_labels} />,
         },
         {
+          label: t`Private`,
+          value: item?.private ? t`Yes` : t`No`,
+        },
+        {
           label: t`Remote`,
           value: remote ? (
             <Link


### PR DESCRIPTION
> You don’t need to add the “approved for use” label on the repo screen. The pipeline labels are all we need
> informational boxes/descriptions would be helpful on all the fields on the new forms to let people know what they do (this is especially important with private, pipeline etc on the repo page)
> Having something on the retained versions to let users know to leave it blank to retain all versions would be good

Follows #3144 

This removes the "approved_for_use" label logic, replaced by the Pipelines section.

And adds help text to the fields in AnsibleRepositoryForm:

![20230327232234](https://user-images.githubusercontent.com/289743/228088778-eb7933f7-e4c3-4b6c-b4ea-cf43e4756564.png)
![20230327232244](https://user-images.githubusercontent.com/289743/228088784-c730db94-3c24-41a3-b997-89e8e2242ff5.png)
![20230327232254](https://user-images.githubusercontent.com/289743/228088785-cd8d95a6-cef8-47ac-943d-5ff7e956f36c.png)
![20230327232304](https://user-images.githubusercontent.com/289743/228088787-bd8e1f86-d98d-4d7f-b364-b2c44d07dd85.png)
![20230327232310](https://user-images.githubusercontent.com/289743/228088789-fdcd4bf6-8c81-46d6-abcd-4197630de4b1.png)
