### PR TITLE
[Cross Repo Search] Namespace detail, collection list and collection detail refactor

### DIFF
--- a/.github/workflows/cypress/cypress.env.json.insights
+++ b/.github/workflows/cypress/cypress.env.json.insights
@@ -5,6 +5,5 @@
   "username": "admin",
   "password": "admin",
   "galaxykit": "galaxykit --ignore-certs --auth-url 'http://localhost:8002/auth/realms/redhat-external/protocol/openid-connect/token'",
-  "insightsLogin": true,
-  "disableRepoSwitch" : true
+  "insightsLogin": true
 }

--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -1,6 +1,11 @@
+import axios from 'axios';
+import { CollectionVersionSearch } from '../api';
 import { HubAPI } from './hub';
 
 export class API extends HubAPI {
+  // contains collection versions
+  cachedCollection: CollectionVersionSearch[] = [];
+
   apiPath = 'v3/plugin/ansible/search/collection-versions/';
 
   setRepository(
@@ -27,6 +32,54 @@ export class API extends HubAPI {
 
   get(id: string) {
     return super.get(id, 'pulp/api/v3/content/ansible/collection_versions/');
+  }
+
+  // Caches the collection returned from the server.
+  // collection is array of collection versions
+  // If the requested collection matches the cache, return it,
+  // if it doesn't, query the API for the collection versions and
+  // replace the old cache with the new value.
+  // This allows the collection page to be broken into separate components
+  // and routed separately without fetching redundant data from the API
+  getCached(params, forceReload?: boolean) {
+    return new Promise((resolve, reject) => {
+      const { name, namespace, repository_name } = params;
+      const [collection] = this.cachedCollection;
+      if (
+        !forceReload &&
+        collection &&
+        collection.collection_version.name === name &&
+        collection.collection_version.namespace === namespace &&
+        collection.repository.name === repository_name
+      ) {
+        return resolve(this.cachedCollection);
+      }
+
+      super
+        .list(params)
+        .then((result) => {
+          const { data } = result.data;
+          this.cachedCollection = data;
+          return resolve(data);
+        })
+        .catch((err) => reject(err));
+    });
+  }
+
+  getUsedDependenciesByCollection(
+    namespace,
+    collection,
+    params = {},
+    cancelToken = undefined,
+  ) {
+    return this.http.get(
+      `${this.apiPath}?dependency=${namespace}.${collection}`,
+      { params: this.mapPageToOffset(params), cancelToken: cancelToken?.token },
+    );
+  }
+
+  getCancelToken() {
+    return axios.CancelToken.source();
   }
 }
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,4 +1,4 @@
-export { CollectionAPI } from './collection';
+export { CollectionAPI, findDistroBasePathByRepo } from './collection';
 export { NamespaceAPI } from './namespace';
 export {
   NamespaceType,
@@ -13,6 +13,7 @@ export {
   CollectionUsedByDependencies,
   CollectionVersion,
   CollectionVersionSearch,
+  CollectionVersionContentType,
   ContentSummaryType,
   DocsBlobType,
   PluginContentType,
@@ -43,7 +44,10 @@ export { ApplicationInfoAPI } from './application-info';
 export { RemoteType } from './response-types/remote';
 export { DistributionAPI } from './distribution';
 export { MyDistributionAPI } from './my-distribution';
-export { DistributionType } from './response-types/distribution';
+export {
+  DistributionType,
+  PulpAnsibleDistributionType,
+} from './response-types/distribution';
 export { ExecutionEnvironmentAPI } from './execution-environment';
 export { ExecutionEnvironmentRegistryAPI } from './execution-environment-registry';
 export {

--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -97,6 +97,21 @@ export class CollectionVersionSearch {
   repository_version: string;
 }
 
+export class CollectionVersionContentType {
+  contents: ContentSummaryType[];
+  description: string;
+  tags: string[];
+  authors: string[];
+  license: string[];
+  homepage: string;
+  documentation: string;
+  issues: string;
+  repository: string;
+  dependencies: DependencyType[];
+  docs_blob: DocsBlobType;
+  requires_ansible: string;
+}
+
 export class CollectionListType {
   id: string;
   name: string;

--- a/src/api/response-types/distribution.ts
+++ b/src/api/response-types/distribution.ts
@@ -10,3 +10,15 @@ export class DistributionType {
     content_count: number;
   };
 }
+
+export class PulpAnsibleDistributionType {
+  base_path: string;
+  client_url: string;
+  content_guard: string;
+  name: string;
+  pulp_created: string;
+  pulp_href: string;
+  pulp_labels: object;
+  repository: string;
+  repository_version: string;
+}

--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -22,6 +22,15 @@
     display: block;
   }
 
+  .card-badge-area {
+    display: flex;
+    justify-content: end;
+    gap: 5px;
+    flex-wrap: wrap;
+    align-content: stretch;
+    align-items: center;
+  }
+
   .name {
     font-weight: bold;
     text-overflow: ellipsis;
@@ -48,10 +57,6 @@
     .icon {
       color: var(--pf-global--info-color--100);
       margin-right: 3px;
-    }
-
-    .hub-signature-badge {
-      margin-left: 5px;
     }
   }
 

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -13,35 +13,33 @@ import {
 import cx from 'classnames';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { CollectionListType } from 'src/api';
+import { CollectionVersionSearch } from 'src/api';
 import { CollectionNumericLabel, Logo, SignatureBadge } from 'src/components';
 import { Constants } from 'src/constants';
 import { Paths, formatPath } from 'src/paths';
 import { convertContentSummaryCounts } from 'src/utilities';
 
-interface IProps extends CollectionListType {
+interface IProps extends CollectionVersionSearch {
   className?: string;
   displaySignatures: boolean;
   footer?: React.ReactNode;
-  repo?: string;
   menu?: React.ReactNode;
 }
 
 export const CollectionCard = ({
-  name,
-  latest_version,
-  namespace,
+  collection_version,
+  namespace_metadata: namespace,
+  repository,
+  is_signed,
   className,
   displaySignatures,
-  footer,
-  repo,
-  sign_state,
   menu,
+  footer,
 }: IProps) => {
   const MAX_DESCRIPTION_LENGTH = 60;
 
   const company = namespace.company || namespace.name;
-  const contentSummary = convertContentSummaryCounts(latest_version.metadata);
+  const contentSummary = convertContentSummaryCounts(collection_version);
 
   return (
     <Card className={cx('hub-c-card-collection-container ', className)}>
@@ -54,37 +52,65 @@ export const CollectionCard = ({
           unlockWidth
           flexGrow
         />
-        <TextContent>{getCertification(repo)}</TextContent>
-        {displaySignatures ? (
-          <SignatureBadge isCompact signState={sign_state} />
-        ) : null}
+        <div className='card-badge-area'>
+          <TextContent>
+            <Text component={TextVariants.small}>
+              <Badge isRead>
+                <Link
+                  to={formatPath(Paths.ansibleRepositoryDetail, {
+                    name: repository.name,
+                  })}
+                >
+                  {repository.name === Constants.CERTIFIED_REPO
+                    ? t`Certified`
+                    : repository.name}
+                </Link>
+              </Badge>
+            </Text>
+          </TextContent>
+          {displaySignatures ? (
+            <SignatureBadge
+              isCompact
+              signState={is_signed ? 'signed' : 'unsigned'}
+            />
+          ) : null}
+        </div>
         {menu}
       </CardHeader>
       <CardHeader>
         <div className='name'>
           <Link
             to={formatPath(Paths.collectionByRepo, {
-              collection: name,
+              collection: collection_version.name,
               namespace: namespace.name,
-              repo: repo,
+              repo: repository.name,
             })}
           >
-            {name}
+            {collection_version.name}
           </Link>
         </div>
         <div className='author'>
           <TextContent>
             <Text component={TextVariants.small}>
-              <Trans>Provided by {company}</Trans>
+              <Trans>
+                Provided by&nbsp;
+                <Link
+                  to={formatPath(Paths.namespaceDetail, {
+                    namespace: namespace.name,
+                  })}
+                >
+                  {company}
+                </Link>
+              </Trans>
             </Text>
           </TextContent>
         </div>
       </CardHeader>
       <CardBody>
-        <Tooltip content={<div>{latest_version.metadata.description}</div>}>
+        <Tooltip content={<div>{collection_version.description}</div>}>
           <div className='description'>
             {getDescription(
-              latest_version.metadata.description,
+              collection_version.description,
               MAX_DESCRIPTION_LENGTH,
             )}
           </div>
@@ -99,18 +125,6 @@ export const CollectionCard = ({
     </Card>
   );
 };
-
-function getCertification(repo) {
-  if (repo === Constants.CERTIFIED_REPO) {
-    return (
-      <Text component={TextVariants.small}>
-        <Badge isRead>{t`Certified`}</Badge>
-      </Text>
-    );
-  }
-
-  return null;
-}
 
 function getDescription(d: string, MAX_DESCRIPTION_LENGTH) {
   if (!d) {

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -38,7 +38,7 @@ export const CollectionCard = ({
 }: IProps) => {
   const MAX_DESCRIPTION_LENGTH = 60;
 
-  const company = namespace.company || namespace.name;
+  const company = namespace?.company || collection_version.namespace;
   const contentSummary = convertContentSummaryCounts(collection_version);
 
   return (
@@ -47,7 +47,7 @@ export const CollectionCard = ({
         <Logo
           alt={t`${company} logo`}
           fallbackToDefault
-          image={namespace.avatar_url}
+          image={namespace?.avatar_url}
           size='40px'
           unlockWidth
           flexGrow
@@ -82,7 +82,7 @@ export const CollectionCard = ({
           <Link
             to={formatPath(Paths.collectionByRepo, {
               collection: collection_version.name,
-              namespace: namespace.name,
+              namespace: collection_version.namespace,
               repo: repository.name,
             })}
           >
@@ -96,7 +96,7 @@ export const CollectionCard = ({
                 Provided by&nbsp;
                 <Link
                   to={formatPath(Paths.namespaceDetail, {
-                    namespace: namespace.name,
+                    namespace: collection_version.namespace,
                   })}
                 >
                   {company}

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -2,13 +2,13 @@ import { t } from '@lingui/macro';
 import { List, ListItem, ListVariant } from '@patternfly/react-core';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { CollectionDetailType, CollectionVersion } from 'src/api';
+import { CollectionVersion, CollectionVersionSearch } from 'src/api';
 import { EmptyStateNoData, HelperText } from 'src/components';
 import 'src/containers/collection-detail/collection-dependencies.scss';
 
 interface IProps {
-  collection: CollectionDetailType;
-  dependencies_repos: (CollectionVersion & {
+  collection: CollectionVersionSearch;
+  dependencies_repos?: (CollectionVersion & {
     path?: string;
   })[];
 }
@@ -17,7 +17,7 @@ export const CollectionDependenciesList = ({
   collection,
   dependencies_repos,
 }: IProps) => {
-  const { dependencies } = collection.latest_version.metadata;
+  const { dependencies } = collection.collection_version;
 
   if (!Object.keys(dependencies).length) {
     return (

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -22,12 +22,10 @@ import { ParamHelper, filterIsSet } from 'src/utilities';
 interface IProps {
   usedByDependencies: CollectionUsedByDependencies[];
   usedByDependenciesLoading: boolean;
-  repo: string;
   itemCount: number;
   params: {
     page?: number;
     page_size?: number;
-    collection?: string;
     sort?: string;
     version?: string;
     name__icontains?: string;

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -9,7 +9,7 @@ import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import cx from 'classnames';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { ContentSummaryType } from 'src/api';
+import { CollectionVersionSearch, ContentSummaryType } from 'src/api';
 import { EmptyStateCustom } from 'src/components';
 import { useContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
@@ -18,8 +18,7 @@ import './collection-content-list.scss';
 
 interface IProps {
   contents: ContentSummaryType[];
-  collection: string;
-  namespace: string;
+  collection: CollectionVersionSearch;
   params: {
     keywords?: string;
     showing?: string;
@@ -30,7 +29,6 @@ interface IProps {
 export const CollectionContentList = ({
   contents,
   collection,
-  namespace,
   params,
   updateParams,
 }: IProps) => {
@@ -59,6 +57,8 @@ export const CollectionContentList = ({
       toShow.push(c);
     }
   }
+
+  const { collection_version, repository } = collection;
 
   return (
     <div>
@@ -115,11 +115,11 @@ export const CollectionContentList = ({
                   to={formatPath(
                     Paths.collectionContentDocsByRepo,
                     {
-                      collection: collection,
-                      namespace: namespace,
+                      collection: collection_version.name,
+                      namespace: collection_version.namespace,
                       type: content.content_type,
                       name: content.name,
-                      repo: context.selectedRepo,
+                      repo: repository.name,
                     },
                     ParamHelper.getReduced(params, ignoredParams),
                   )}

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -11,7 +11,6 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { CollectionVersionSearch, ContentSummaryType } from 'src/api';
 import { EmptyStateCustom } from 'src/components';
-import { useContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import { ParamHelper } from 'src/utilities/param-helper';
 import './collection-content-list.scss';
@@ -33,7 +32,6 @@ export const CollectionContentList = ({
   updateParams,
 }: IProps) => {
   const ignoredParams = ['keywords', 'showing'];
-  const context = useContext();
 
   const toShow: ContentSummaryType[] = [];
   const summary = { all: 0 };
@@ -134,7 +132,7 @@ export const CollectionContentList = ({
         </tbody>
       </table>
       {summary.all <= 0 &&
-        context.selectedRepo === 'community' &&
+        repository.name === 'community' &&
         renderCommunityWarningMessage()}
     </div>
   );

--- a/src/components/collection-detail/collection-info.scss
+++ b/src/components/collection-detail/collection-info.scss
@@ -34,6 +34,10 @@
   padding: 8px;
 }
 
+.hub-collection-download-alert {
+  width: 100%;
+}
+
 .hub-collection-download-alert > h4 {
   margin-top: 0;
 }

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -7,60 +7,72 @@ import {
   Split,
   SplitItem,
 } from '@patternfly/react-core';
-import { DownloadIcon } from '@patternfly/react-icons';
+import { DownloadIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { CollectionAPI, CollectionDetailType } from 'src/api';
-import { ClipboardCopy, LoginLink, Tag } from 'src/components';
+import {
+  CollectionAPI,
+  CollectionVersionContentType,
+  CollectionVersionSearch,
+} from 'src/api';
+import {
+  ClipboardCopy,
+  LoadingPageSpinner,
+  LoginLink,
+  Tag,
+} from 'src/components';
 import { useContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import { errorMessage } from 'src/utilities';
 import './collection-info.scss';
 import { DownloadSignatureGridItem } from './download-signature-grid-item';
 
-interface IProps extends CollectionDetailType {
+interface IProps extends CollectionVersionSearch {
   params: {
     version?: string;
   };
   updateParams: (params) => void;
   addAlert?: (variant, title, description?) => void;
+  content?: CollectionVersionContentType;
 }
 
 export const CollectionInfo = ({
-  name,
-  latest_version,
-  namespace,
+  collection_version,
+  repository,
+  content,
   params,
   addAlert,
 }: IProps) => {
   const downloadLinkRef = React.useRef<HTMLAnchorElement>(null);
   const context = useContext();
 
-  let installCommand = `ansible-galaxy collection install ${namespace.name}.${name}`;
+  let installCommand = `ansible-galaxy collection install ${collection_version.namespace}.${collection_version.name}`;
 
   if (params.version) {
     installCommand += `:${params.version}`;
+  }
+
+  if (!content) {
+    return <LoadingPageSpinner />;
   }
 
   return (
     <div className='pf-c-content info-panel'>
       <h1>{t`Install`}</h1>
       <Grid hasGutter={true}>
-        <GridItem>{latest_version.metadata.description}</GridItem>
+        <GridItem>{collection_version.description}</GridItem>
         <GridItem>
-          {latest_version.metadata.tags.map((tag, i) => (
-            <Tag key={i}>{tag}</Tag>
+          {collection_version.tags.map((tag, i) => (
+            <Tag key={i}>{tag.name}</Tag>
           ))}
         </GridItem>
 
-        {latest_version?.metadata?.license?.length > 0 && (
+        {content.license?.length > 0 && (
           <GridItem>
             <Split hasGutter={true}>
               <SplitItem className='install-title'>{t`License`}</SplitItem>
               <SplitItem isFilled>
-                {latest_version.metadata.license
-                  ? latest_version.metadata.license.join(', ')
-                  : ''}
+                {content.license ? content.license.join(', ') : ''}
               </SplitItem>
             </Split>
           </GridItem>
@@ -76,67 +88,97 @@ export const CollectionInfo = ({
                   only supported in ansible 2.9+
                 </Trans>
               </div>
-              {context.user.is_anonymous &&
-              !context.settings
-                .GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD ? (
-                <Alert
-                  className={'hub-collection-download-alert'}
-                  isInline
-                  variant='warning'
-                  title={
-                    <React.Fragment>
-                      {t`You have to be logged in to be able to download the tarball.`}{' '}
-                      <LoginLink />
-                    </React.Fragment>
-                  }
-                />
-              ) : (
-                <div>
-                  <a ref={downloadLinkRef} style={{ display: 'none' }}></a>
-                  <Button
-                    className='download-button'
-                    variant='link'
-                    data-cy='download-collection-tarball-button'
-                    icon={<DownloadIcon />}
-                    onClick={() =>
-                      download(
-                        context.selectedRepo,
-                        namespace,
-                        name,
-                        latest_version,
-                        downloadLinkRef,
-                        addAlert,
-                      )
-                    }
-                  >
-                    {t`Download tarball`}
-                  </Button>
-                </div>
-              )}
             </SplitItem>
           </Split>
         </GridItem>
-        <DownloadSignatureGridItem version={latest_version} />
-        {latest_version.requires_ansible && (
+        <GridItem>
+          <Split hasGutter={true}>
+            <SplitItem className='install-title'>{t`Download`}</SplitItem>
+            {context.user.is_anonymous &&
+            !context.settings
+              .GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD ? (
+              <Alert
+                className={'hub-collection-download-alert'}
+                isInline
+                variant='warning'
+                title={
+                  <React.Fragment>
+                    {t`You have to be logged in to be able to download the tarball.`}{' '}
+                    <LoginLink />
+                  </React.Fragment>
+                }
+              />
+            ) : (
+              <SplitItem isFilled>
+                <div>
+                  <Trans>
+                    To download this collection, configure your client to
+                    connect to one of this repositories distributions.{' '}
+                    <Link
+                      to={formatPath(Paths.collectionDistributionsByRepo, {
+                        repo: repository.name,
+                        namespace: collection_version.namespace,
+                        collection: collection_version.name,
+                      })}
+                    >
+                      <ExternalLinkAltIcon />
+                    </Link>
+                  </Trans>
+                </div>
+                <a ref={downloadLinkRef} style={{ display: 'none' }}></a>
+                <Button
+                  className='download-button'
+                  variant='link'
+                  data-cy='download-collection-tarball-button'
+                  icon={<DownloadIcon />}
+                  onClick={() =>
+                    download(
+                      repository,
+                      collection_version.namespace,
+                      collection_version.name,
+                      collection_version.version,
+                      downloadLinkRef,
+                      addAlert,
+                    )
+                  }
+                >
+                  {t`Download tarball`}
+                </Button>
+              </SplitItem>
+            )}
+          </Split>
+        </GridItem>
+        <DownloadSignatureGridItem
+          collectionVersion={collection_version}
+          repository={repository}
+          addAlert={(status, statusText) =>
+            addAlert(
+              'danger',
+              t`Signatures could not be loaded.`,
+              errorMessage(status, statusText),
+            )
+          }
+        />
+        {content?.requires_ansible && (
           <GridItem>
             <Split hasGutter={true}>
               <SplitItem className='install-title'>
                 {t`Requires Ansible`}
               </SplitItem>
               <SplitItem isFilled data-cy='ansible-requirement'>
-                {latest_version.requires_ansible}
+                {content?.requires_ansible}
               </SplitItem>
             </Split>
           </GridItem>
         )}
 
-        {latest_version.docs_blob.collection_readme ? (
+        {content?.docs_blob?.collection_readme ? (
           <GridItem>
             <div className='hub-readme-container'>
               <div
                 className='pf-c-content'
                 dangerouslySetInnerHTML={{
-                  __html: latest_version.docs_blob.collection_readme.html,
+                  __html: content?.docs_blob?.collection_readme.html,
                 }}
               />
               <div className='hub-fade-out'></div>
@@ -145,9 +187,9 @@ export const CollectionInfo = ({
               to={formatPath(
                 Paths.collectionDocsIndexByRepo,
                 {
-                  collection: name,
-                  namespace: namespace.name,
-                  repo: context.selectedRepo,
+                  collection: collection_version.name,
+                  namespace: collection_version.namespace,
+                  repo: repository.name,
                 },
                 params,
               )}
@@ -162,19 +204,14 @@ export const CollectionInfo = ({
 };
 
 function download(
-  reponame,
-  namespace,
-  name,
-  latest_version,
+  repository: CollectionVersionSearch['repository'],
+  namespace: string,
+  name: string,
+  version: string,
   downloadLinkRef,
   addAlert,
 ) {
-  CollectionAPI.getDownloadURL(
-    reponame,
-    namespace.name,
-    name,
-    latest_version.version,
-  )
+  CollectionAPI.getDownloadURL(repository, namespace, name, version)
     .then((downloadURL: string) => {
       // By getting a reference to a hidden <a> tag, setting the href and
       // programmatically clicking it, we can hold off on making the api

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -7,7 +7,7 @@ import {
   Split,
   SplitItem,
 } from '@patternfly/react-core';
-import { DownloadIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
+import { DownloadIcon } from '@patternfly/react-icons';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -113,7 +113,7 @@ export const CollectionInfo = ({
                 <div>
                   <Trans>
                     To download this collection, configure your client to
-                    connect to one of this repositories distributions.{' '}
+                    connect to one of this repositories{' '}
                     <Link
                       to={formatPath(Paths.collectionDistributionsByRepo, {
                         repo: repository.name,
@@ -121,8 +121,9 @@ export const CollectionInfo = ({
                         collection: collection_version.name,
                       })}
                     >
-                      <ExternalLinkAltIcon />
+                      distributions
                     </Link>
+                    .
                   </Trans>
                 </div>
                 <a ref={downloadLinkRef} style={{ display: 'none' }}></a>

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -13,7 +13,6 @@ import { capitalize } from 'lodash';
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { DocsBlobType } from 'src/api';
-import { useContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import { ParamHelper, sanitizeDocsUrls } from 'src/utilities';
 
@@ -36,6 +35,7 @@ interface IProps {
   docs_blob: DocsBlobType;
   namespace: string;
   collection: string;
+  repository: string;
   params: { keywords?: string };
   selectedName?: string;
   selectedType?: string;
@@ -47,13 +47,12 @@ interface IProps {
 export const TableOfContents = (props: IProps) => {
   const [docsBlob, setDocsBlob] = useState<DocsBlobType>(null);
   const [table, setTable] = useState<Table>(null);
-  const context = useContext();
 
   const collapsedCategories = [];
   const { className, docs_blob, updateParams, params } = props;
 
   if (!table || docsBlob !== docs_blob) {
-    setTable(parseLinks(docs_blob, props, context));
+    setTable(parseLinks(docs_blob, props));
     setDocsBlob(docs_blob);
   }
 
@@ -97,13 +96,13 @@ export const TableOfContents = (props: IProps) => {
   );
 };
 
-function parseLinks(docs_blob: DocsBlobType, props, context): Table {
+function parseLinks(docs_blob: DocsBlobType, props): Table {
   const { namespace, collection } = props;
 
   const baseUrlParams = {
     namespace: namespace,
     collection: collection,
-    repo: context.selectedRepo,
+    repo: props.repository,
   };
 
   const table = {

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -7,6 +7,7 @@ import {
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { useEffect, useState } from 'react';
+import { Repositories } from 'src/api';
 import { AppliedFilters, CompoundFilter } from 'src/components';
 import { Constants } from 'src/constants';
 import { useContext } from 'src/loaders/app-context';
@@ -20,28 +21,68 @@ interface IProps {
     page_size?: number;
     tags?: string[];
     view_type?: string;
+    repository__name?: string;
   };
   updateParams: (p) => void;
 }
 
 export const CollectionFilter = (props: IProps) => {
   const context = useContext();
-  const [inputText, setInputText] = useState(props.params.keywords || '');
+  const [repositories, setRepositories] = useState([]);
+  const [inputText, setInputText] = useState('');
+
+  const loadRepos = () => {
+    Repositories.list({
+      name__icontains: inputText,
+    }).then((res) => {
+      const repos = res.data.results.map(({ name }) => ({
+        id: name,
+        title: name,
+      }));
+      setRepositories(repos);
+    });
+  };
+
+  useEffect(() => {
+    loadRepos();
+  }, []);
 
   useEffect(() => {
     setInputText(props.params['keywords'] || '');
   }, [props.params.keywords]);
 
+  useEffect(() => {
+    setInputText(props.params['repository__name'] || '');
+  }, [props.params.repository__name]);
+
+  useEffect(() => {
+    if (inputText != '') {
+      loadRepos();
+    }
+  }, [inputText]);
+
   const { ignoredParams, params, updateParams } = props;
   const { display_signatures } = context.featureFlags;
-  const display_tags = ignoredParams.includes('tags') === false;
+  const displayTags = ignoredParams.includes('tags') === false;
+  const displayRepos = ignoredParams.includes('repository__name') === false;
+  const displayNamespaces = ignoredParams.includes('namespace') === false;
 
   const filterConfig = [
     {
       id: 'keywords',
       title: t`Keywords`,
     },
-    display_tags && {
+    displayRepos && {
+      id: 'repository__name',
+      title: t`Repository`,
+      inputType: 'typeahead' as const,
+      options: repositories,
+    },
+    displayNamespaces && {
+      id: 'namespace',
+      title: t`Namespace`,
+    },
+    displayTags && {
       id: 'tags',
       title: t`Tag`,
       inputType: 'multiple' as const,
@@ -51,12 +92,12 @@ export const CollectionFilter = (props: IProps) => {
       })),
     },
     display_signatures && {
-      id: 'sign_state',
+      id: 'is_signed',
       title: t`Sign state`,
       inputType: 'select' as const,
       options: [
-        { id: 'signed', title: t`Signed` },
-        { id: 'unsigned', title: t`Unsigned` },
+        { id: 'true', title: t`Signed` },
+        { id: 'false', title: t`Unsigned` },
       ],
     },
   ].filter(Boolean);
@@ -76,9 +117,17 @@ export const CollectionFilter = (props: IProps) => {
             <ToolbarItem>
               <AppliedFilters
                 niceNames={{
-                  sign_state: t`sign state`,
+                  is_signed: t`sign state`,
                   tags: t`tags`,
                   keywords: t`keywords`,
+                  repository__name: t`repository`,
+                  namespace: t`namespace`,
+                }}
+                niceValues={{
+                  is_signed: {
+                    false: t`unsigned`,
+                    true: t`signed`,
+                  },
                 }}
                 style={{ marginTop: '16px' }}
                 updateParams={updateParams}

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -21,7 +21,7 @@ interface IProps {
     page_size?: number;
     tags?: string[];
     view_type?: string;
-    repository__name?: string;
+    repository_name?: string;
   };
   updateParams: (p) => void;
 }
@@ -30,6 +30,7 @@ export const CollectionFilter = (props: IProps) => {
   const context = useContext();
   const [repositories, setRepositories] = useState([]);
   const [inputText, setInputText] = useState('');
+  const [selectedFilter, setSelectedFilter] = useState(null);
 
   const loadRepos = () => {
     Repositories.list({
@@ -52,11 +53,11 @@ export const CollectionFilter = (props: IProps) => {
   }, [props.params.keywords]);
 
   useEffect(() => {
-    setInputText(props.params['repository__name'] || '');
-  }, [props.params.repository__name]);
+    setInputText(props.params['repository_name'] || '');
+  }, [props.params.repository_name]);
 
   useEffect(() => {
-    if (inputText != '') {
+    if (inputText != '' && selectedFilter === 'repository_name') {
       loadRepos();
     }
   }, [inputText]);
@@ -64,7 +65,7 @@ export const CollectionFilter = (props: IProps) => {
   const { ignoredParams, params, updateParams } = props;
   const { display_signatures } = context.featureFlags;
   const displayTags = ignoredParams.includes('tags') === false;
-  const displayRepos = ignoredParams.includes('repository__name') === false;
+  const displayRepos = ignoredParams.includes('repository_name') === false;
   const displayNamespaces = ignoredParams.includes('namespace') === false;
 
   const filterConfig = [
@@ -73,7 +74,7 @@ export const CollectionFilter = (props: IProps) => {
       title: t`Keywords`,
     },
     displayRepos && {
-      id: 'repository__name',
+      id: 'repository_name',
       title: t`Repository`,
       inputType: 'typeahead' as const,
       options: repositories,
@@ -113,6 +114,9 @@ export const CollectionFilter = (props: IProps) => {
               updateParams={updateParams}
               params={params}
               filterConfig={filterConfig}
+              selectFilter={(selected) => {
+                setSelectedFilter(selected);
+              }}
             />
             <ToolbarItem>
               <AppliedFilters
@@ -120,7 +124,7 @@ export const CollectionFilter = (props: IProps) => {
                   is_signed: t`sign state`,
                   tags: t`tags`,
                   keywords: t`keywords`,
-                  repository__name: t`repository`,
+                  repository_name: t`repository`,
                   namespace: t`namespace`,
                 }}
                 niceValues={{

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -45,8 +45,10 @@ export const CollectionFilter = (props: IProps) => {
   };
 
   useEffect(() => {
-    loadRepos();
-  }, []);
+    if (selectedFilter === 'repository_name') {
+      loadRepos();
+    }
+  }, [selectedFilter]);
 
   useEffect(() => {
     setInputText(props.params['keywords'] || '');

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -4,6 +4,7 @@ import {
   DataListItem,
   DataListItemCells,
   DataListItemRow,
+  Label,
   LabelGroup,
   Text,
   TextContent,
@@ -11,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { Link } from 'react-router-dom';
-import { CollectionListType } from 'src/api';
+import { CollectionVersionSearch } from 'src/api';
 import {
   CollectionNumericLabel,
   DateComponent,
@@ -24,26 +25,22 @@ import { chipGroupProps, convertContentSummaryCounts } from 'src/utilities';
 import { SignatureBadge } from '../signing';
 import './list-item.scss';
 
-interface IProps extends CollectionListType {
+interface IProps extends CollectionVersionSearch {
   showNamespace?: boolean;
   controls?: React.ReactNode;
   displaySignatures: boolean;
-  repo?: string;
 }
 
-export const CollectionListItem = (props: IProps) => {
-  const {
-    name,
-    latest_version,
-    namespace,
-    showNamespace,
-    controls,
-    deprecated,
-    displaySignatures,
-    repo,
-    sign_state,
-  } = props;
-
+export const CollectionListItem = ({
+  collection_version,
+  namespace_metadata: namespace,
+  repository,
+  is_signed,
+  is_deprecated,
+  displaySignatures,
+  showNamespace,
+  controls,
+}: IProps) => {
   const cells = [];
 
   const company = namespace.company || namespace.name;
@@ -63,31 +60,39 @@ export const CollectionListItem = (props: IProps) => {
     );
   }
 
-  const contentSummary = convertContentSummaryCounts(latest_version.metadata);
+  const contentSummary = convertContentSummaryCounts(collection_version);
 
   cells.push(
     <DataListCell key='content'>
       <div>
         <Link
           to={formatPath(Paths.collectionByRepo, {
-            collection: name,
+            collection: collection_version.name,
             namespace: namespace.name,
-            repo: repo,
+            repo: repository.name,
           })}
           data-cy='CollectionList-name'
         >
-          {name}
+          {collection_version.name}
         </Link>
-        {deprecated && <DeprecatedTag />}
+        {is_deprecated && <DeprecatedTag />}
         {showNamespace ? (
           <TextContent>
             <Text component={TextVariants.small}>
-              <Trans>Provided by {company}</Trans>
+              <Trans>
+                Provided by&nbsp;
+                <Link
+                  to={formatPath(Paths.namespaceDetail, {
+                    namespace: namespace.name,
+                  })}
+                >
+                  {company}
+                </Link>
+              </Trans>
             </Text>
           </TextContent>
         ) : null}
       </div>
-      <div className='hub-entry'>{latest_version.metadata.description}</div>
       <div className='hub-entry pf-l-flex pf-m-wrap'>
         {Object.keys(contentSummary.contents).map((type) => (
           <div key={type}>
@@ -100,8 +105,8 @@ export const CollectionListItem = (props: IProps) => {
       </div>
       <div className='hub-entry pf-l-flex pf-m-wrap'>
         <LabelGroup {...chipGroupProps()}>
-          {latest_version.metadata.tags.map((tag, index) => (
-            <Tag key={index}>{tag}</Tag>
+          {collection_version.tags.map((tag, index) => (
+            <Tag key={index}>{tag.name}</Tag>
           ))}
         </LabelGroup>
       </div>
@@ -113,12 +118,25 @@ export const CollectionListItem = (props: IProps) => {
       {controls ? <div className='hub-entry'>{controls}</div> : null}
       <div className='hub-right-col hub-entry'>
         <Trans>
-          Updated <DateComponent date={latest_version.created_at} />
+          Updated <DateComponent date={collection_version.pulp_created} />
         </Trans>
       </div>
-      <div className='hub-entry'>v{latest_version.version}</div>
+      <div className='hub-entry'>v{collection_version.version}</div>
+      <Label variant='outline' className='hub-repository-badge'>
+        <Link
+          to={formatPath(Paths.ansibleRepositoryDetail, {
+            name: repository.name,
+          })}
+        >
+          {repository.name}
+        </Link>
+      </Label>
       {displaySignatures ? (
-        <SignatureBadge className='hub-entry' signState={sign_state} />
+        <SignatureBadge
+          className='hub-entry'
+          variant='outline'
+          signState={is_signed ? 'signed' : 'unsigned'}
+        />
       ) : null}
     </DataListCell>,
   );

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -43,7 +43,7 @@ export const CollectionListItem = ({
 }: IProps) => {
   const cells = [];
 
-  const company = namespace.company || namespace.name;
+  const company = namespace?.company || collection_version.namespace;
 
   if (showNamespace) {
     cells.push(
@@ -51,7 +51,7 @@ export const CollectionListItem = ({
         <Logo
           alt={t`${company} logo`}
           fallbackToDefault
-          image={namespace.avatar_url}
+          image={namespace?.avatar_url}
           size='40px'
           unlockWidth
           width='97px'
@@ -68,7 +68,7 @@ export const CollectionListItem = ({
         <Link
           to={formatPath(Paths.collectionByRepo, {
             collection: collection_version.name,
-            namespace: namespace.name,
+            namespace: collection_version.namespace,
             repo: repository.name,
           })}
           data-cy='CollectionList-name'
@@ -83,7 +83,7 @@ export const CollectionListItem = ({
                 Provided by&nbsp;
                 <Link
                   to={formatPath(Paths.namespaceDetail, {
-                    namespace: namespace.name,
+                    namespace: collection_version.namespace,
                   })}
                 >
                   {company}

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { DataList } from '@patternfly/react-core';
 import * as React from 'react';
-import { CollectionListType } from 'src/api';
+import { CollectionVersionSearch } from 'src/api';
 import {
   CollectionListItem,
   EmptyStateFilter,
@@ -11,7 +11,7 @@ import { ParamHelper } from 'src/utilities/param-helper';
 import './list.scss';
 
 interface IProps {
-  collections: CollectionListType[];
+  collections: CollectionVersionSearch[];
   displaySignatures: boolean;
   params: {
     sort?: string;
@@ -22,7 +22,6 @@ interface IProps {
   itemCount: number;
   ignoredParams: string[];
   showControls?: boolean;
-  repo?: string;
   renderCollectionControls: (collection) => React.ReactNode;
 }
 
@@ -36,19 +35,17 @@ export const CollectionList = (props: IProps) => {
     ignoredParams,
     itemCount,
     showControls,
-    repo,
   } = props;
 
   return (
     <React.Fragment>
       <DataList aria-label={t`List of Collections`}>
         {collections.length > 0 ? (
-          collections.map((c) => (
+          collections.map((c, i) => (
             <CollectionListItem
               controls={showControls ? props.renderCollectionControls(c) : null}
-              key={c.id}
+              key={i}
               {...c}
-              repo={repo}
               displaySignatures={displaySignatures}
             />
           ))

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -47,6 +47,7 @@ export const CollectionList = (props: IProps) => {
               key={i}
               {...c}
               displaySignatures={displaySignatures}
+              showNamespace={true}
             />
           ))
         ) : (

--- a/src/components/collection-list/list-item.scss
+++ b/src/components/collection-list/list-item.scss
@@ -10,3 +10,7 @@
   font-size: var(--pf-global--FontSize--xs);
   color: var(--pf-global--color--200);
 }
+
+.hub-repository-badge {
+  margin-right: 5px;
+}

--- a/src/components/delete-modal/delete-collection-modal.tsx
+++ b/src/components/delete-modal/delete-collection-modal.tsx
@@ -1,11 +1,12 @@
 import { Trans, t } from '@lingui/macro';
 import { Checkbox, Text } from '@patternfly/react-core';
 import React from 'react';
-import { CollectionDetailType, CollectionListType } from 'src/api';
+import { CollectionVersionSearch } from 'src/api';
 import { DeleteModal } from 'src/components';
 
 interface IProps {
-  deleteCollection: CollectionDetailType | CollectionListType;
+  deleteCollection: CollectionVersionSearch;
+  collections: CollectionVersionSearch[];
   isDeletionPending: boolean;
   confirmDelete: boolean;
   collectionVersion?: string;
@@ -17,6 +18,7 @@ interface IProps {
 export const DeleteCollectionModal = (props: IProps) => {
   const {
     deleteCollection,
+    collections,
     isDeletionPending,
     confirmDelete,
     collectionVersion,
@@ -41,12 +43,12 @@ export const DeleteCollectionModal = (props: IProps) => {
         <Text style={{ paddingBottom: 'var(--pf-global--spacer--md)' }}>
           {collectionVersion ? (
             <>
-              {(deleteCollection as CollectionDetailType).all_versions
-                .length === 1 ? (
+              {(collections as CollectionVersionSearch[]).length === 1 ? (
                 <Trans>
                   Deleting{' '}
                   <b>
-                    {deleteCollection.name} v{collectionVersion}
+                    {deleteCollection.collection_version.name} v
+                    {collectionVersion}
                   </b>{' '}
                   and its data will be lost and this will cause the entire
                   collection to be deleted.
@@ -55,7 +57,8 @@ export const DeleteCollectionModal = (props: IProps) => {
                 <Trans>
                   Deleting{' '}
                   <b>
-                    {deleteCollection.name} v{collectionVersion}
+                    {deleteCollection.collection_version.name} v
+                    {collectionVersion}
                   </b>{' '}
                   and its data will be lost.
                 </Trans>
@@ -63,7 +66,8 @@ export const DeleteCollectionModal = (props: IProps) => {
             </>
           ) : (
             <Trans>
-              Deleting <b>{deleteCollection.name}</b> and its data will be lost.
+              Deleting <b>{deleteCollection.collection_version.name}</b> and its
+              data will be lost.
             </Trans>
           )}
         </Text>

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -254,9 +254,14 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           {t`Sign version ${version}`}
         </DropdownItem>
       ),
-      <DropdownItem onClick={() => this.deprecate(collection)} key='deprecate'>
-        {collection.is_deprecated ? t`Undeprecate` : t`Deprecate`}
-      </DropdownItem>,
+      hasPermission('galaxy.upload_to_namespace') && (
+        <DropdownItem
+          onClick={() => this.deprecate(collection)}
+          key='deprecate'
+        >
+          {collection.is_deprecated ? t`Undeprecate` : t`Deprecate`}
+        </DropdownItem>
+      ),
       <DropdownItem
         key='upload-collection-version'
         onClick={() => this.checkUploadPrivilleges(collection)}

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -20,11 +20,11 @@ import { Navigate } from 'react-router-dom';
 import {
   CertificateUploadAPI,
   CollectionAPI,
-  CollectionDetailType,
-  CollectionListType,
-  CollectionVersion,
+  CollectionVersionContentType,
+  CollectionVersionSearch,
   MyNamespaceAPI,
-  Repositories,
+  NamespaceAPI,
+  NamespaceType,
   SignCollectionAPI,
 } from 'src/api';
 import {
@@ -60,7 +60,9 @@ import { SignatureBadge } from '../signing';
 import './header.scss';
 
 interface IProps {
-  collection: CollectionDetailType;
+  collections: CollectionVersionSearch[];
+  collection: CollectionVersionSearch;
+  content: CollectionVersionContentType;
   params: {
     version?: string;
     latestVersion?: string;
@@ -82,17 +84,18 @@ interface IState {
     page: number;
     pageSize: number;
   };
-  deleteCollection: CollectionDetailType;
+  deleteCollection: CollectionVersionSearch;
   collectionVersion: string | null;
   confirmDelete: boolean;
   alerts: AlertType[];
   redirect: string;
   noDependencies: boolean;
   isDeletionPending: boolean;
-  updateCollection: CollectionListType;
+  updateCollection: CollectionVersionSearch;
   showImportModal: boolean;
   uploadCertificateModalOpen: boolean;
-  versionToUploadCertificate: CollectionVersion;
+  versionToUploadCertificate: CollectionVersionSearch;
+  namespace: NamespaceType;
 }
 
 export class CollectionHeader extends React.Component<IProps, IState> {
@@ -122,6 +125,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       showImportModal: false,
       uploadCertificateModalOpen: false,
       versionToUploadCertificate: undefined,
+      namespace: null,
     };
   }
 
@@ -130,11 +134,19 @@ export class CollectionHeader extends React.Component<IProps, IState> {
     DeleteCollectionUtils.getUsedbyDependencies(collection)
       .then((noDependencies) => this.setState({ noDependencies }))
       .catch((alert) => this.addAlert(alert));
+
+    NamespaceAPI.get(collection.collection_version.namespace, {
+      include_related: 'my_permissions',
+    }).then(({ data }) => {
+      this.setState({ namespace: data });
+    });
   }
 
   render() {
     const {
+      collections,
       collection,
+      content,
       params,
       updateParams,
       breadcrumbs,
@@ -158,53 +170,57 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     const numOfshownVersions = 10;
 
-    const all_versions = [...collection.all_versions];
-
-    const match = all_versions.find(
-      (x) => x.version === collection.latest_version.version,
-    );
-
-    if (!match) {
-      all_versions.push({
-        id: collection.latest_version.id,
-        version: collection.latest_version.version,
-        created: collection.latest_version.created_at,
-        sign_state: collection.latest_version.sign_state,
-      });
-    }
-
     const urlKeys = [
       { key: 'documentation', name: t`Docs site` },
       { key: 'homepage', name: t`Website` },
       { key: 'issues', name: t`Issue tracker` },
-      { key: 'repository', name: t`Repo` },
+      { key: 'origin_repository', name: t`Repo` },
     ];
 
-    const latestVersion = collection.latest_version.created_at;
+    const latestVersion = collection.collection_version.pulp_created;
 
     const { display_signatures, can_upload_signatures } =
       this.context.featureFlags;
 
-    const signedString = (v) => {
-      if (display_signatures && 'sign_state' in v) {
-        return v.sign_state === 'signed' ? t`(signed)` : t`(unsigned)`;
-      } else {
+    const signedString = () => {
+      if (!display_signatures) {
         return '';
       }
+
+      return collection.is_signed ? t`(signed)` : t`(unsigned)`;
     };
 
-    const isLatestVersion = (v) =>
-      `${moment(v.created).fromNow()} ${signedString(v)}
-      ${v.version === all_versions[0].version ? t`(latest)` : ''}`;
+    const isLatestVersion = (v) => {
+      return `${moment(v.pulp_created).fromNow()} ${signedString()}
+      ${
+        v.version === collections[0].collection_version.version
+          ? t`(latest)`
+          : ''
+      }`;
+    };
 
-    const { name: collectionName, namespace } = collection;
-    const company = namespace.company || namespace.name;
+    const { collection_version } = collection;
+    const { name: collectionName, version } = collection_version;
+
+    // FIXME: remove when API switch to AnsibleNamespaceMetadata
+    const mockNamespace = {
+      pulp_href: '',
+      name: collection_version.namespace,
+      company: 'xaz',
+      description: 'foo bar',
+      avatar: '',
+      avatar_url: '',
+      email: 'foo',
+    };
+    const namespace = mockNamespace;
+
+    const company = namespace?.company || namespace.name;
 
     if (redirect) {
       return <Navigate to={redirect} />;
     }
 
-    const canSign = canSignNamespace(this.context, namespace);
+    const canSign = canSignNamespace(this.context, this.state.namespace);
 
     const { hasPermission } = this.context;
 
@@ -218,11 +234,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         <DropdownItem
           data-cy='delete-version-dropdown'
           key='delete-collection-version'
-          onClick={() =>
-            this.openDeleteModalWithConfirm(collection.latest_version.version)
-          }
+          onClick={() => this.openDeleteModalWithConfirm(version)}
         >
-          {t`Delete version ${collection.latest_version.version}`}
+          {t`Delete version ${version}`}
         </DropdownItem>
       ),
       canSign && !can_upload_signatures && (
@@ -241,7 +255,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             if (can_upload_signatures) {
               this.setState({
                 uploadCertificateModalOpen: true,
-                versionToUploadCertificate: collection.latest_version,
+                versionToUploadCertificate: collection,
               });
             } else {
               this.setState({ isOpenSignModal: true });
@@ -249,11 +263,11 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           }}
           data-cy='sign-version-button'
         >
-          {t`Sign version ${collection.latest_version.version}`}
+          {t`Sign version ${version}`}
         </DropdownItem>
       ),
       <DropdownItem onClick={() => this.deprecate(collection)} key='deprecate'>
-        {collection.deprecated ? t`Undeprecate` : t`Deprecate`}
+        {collection.is_deprecated ? t`Undeprecate` : t`Deprecate`}
       </DropdownItem>,
       <DropdownItem
         key='upload-collection-version'
@@ -266,9 +280,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     const issueUrl =
       'https://access.redhat.com/support/cases/#/case/new/open-case/describe-issue/recommendations?caseCreate=true&product=Ansible%20Automation%20Hub&version=Online&summary=' +
-      encodeURIComponent(
-        `${namespace.name}-${collectionName}-${collection.latest_version.version}`,
-      );
+      encodeURIComponent(`${namespace.name}-${collectionName}-${version}`);
 
     return (
       <React.Fragment>
@@ -281,15 +293,15 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                   Paths.myImports,
                   {},
                   {
-                    namespace: updateCollection.namespace.name,
+                    namespace: updateCollection.collection_version.namespace,
                   },
                 ),
               })
             }
             // onCancel
             setOpen={(isOpen, warn) => this.toggleImportModal(isOpen, warn)}
-            collection={updateCollection}
-            namespace={updateCollection.namespace.name}
+            collection={updateCollection.collection_version}
+            namespace={updateCollection.collection_version.namespace}
           />
         )}
         {canSign && (
@@ -309,7 +321,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             />
             <SignSingleCertificateModal
               name={collectionName}
-              version={collection.latest_version.version}
+              version={version}
               isOpen={this.state.isOpenSignModal}
               onSubmit={this.signVersion}
               onCancel={() => this.setState({ isOpenSignModal: false })}
@@ -332,30 +344,32 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                   page_size: modalPagination.pageSize,
                 }}
                 updateParams={this.updatePaginationParams}
-                count={all_versions.length}
+                count={collections.length}
               />
             </div>
-            {this.paginateVersions(all_versions).map((v, i) => (
-              <ListItem key={i}>
-                <Button
-                  variant='link'
-                  isInline
-                  onClick={() => {
-                    updateParams(
-                      ParamHelper.setParam(
-                        params,
-                        'version',
-                        v.version.toString(),
-                      ),
-                    );
-                    this.setState({ isOpenVersionsModal: false });
-                  }}
-                >
-                  v{v.version}
-                </Button>{' '}
-                {t`updated ${isLatestVersion(v)}`}
-              </ListItem>
-            ))}
+            {this.paginateVersions(collections).map(
+              ({ collection_version }, i) => (
+                <ListItem key={i}>
+                  <Button
+                    variant='link'
+                    isInline
+                    onClick={() => {
+                      updateParams(
+                        ParamHelper.setParam(
+                          params,
+                          'version',
+                          collection_version.version.toString(),
+                        ),
+                      );
+                      this.setState({ isOpenVersionsModal: false });
+                    }}
+                  >
+                    v{collection_version.version}
+                  </Button>{' '}
+                  {t`updated ${isLatestVersion(collection_version)}`}
+                </ListItem>
+              ),
+            )}
           </List>
           <Pagination
             params={{
@@ -363,15 +377,16 @@ export class CollectionHeader extends React.Component<IProps, IState> {
               page_size: modalPagination.pageSize,
             }}
             updateParams={this.updatePaginationParams}
-            count={all_versions.length}
+            count={collections.length}
           />
         </Modal>
         <DeleteCollectionModal
           deleteCollection={deleteCollection}
+          collections={collections}
           isDeletionPending={isDeletionPending}
           confirmDelete={confirmDelete}
           setConfirmDelete={(confirmDelete) => this.setState({ confirmDelete })}
-          collectionVersion={collectionVersion}
+          collectionVersion={version}
           cancelAction={() => this.setState({ deleteCollection: null })}
           deleteAction={() =>
             this.setState({ isDeletionPending: true }, () => {
@@ -381,11 +396,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                     collection: deleteCollection,
                     setState: (state) => this.setState(state),
                     load: null,
-                    redirect: formatPath(Paths.namespaceByRepo, {
-                      repo: this.context.selectedRepo,
-                      namespace: deleteCollection.namespace.name,
+                    redirect: formatPath(Paths.namespaceDetail, {
+                      namespace: deleteCollection.collection_version.namespace,
                     }),
-                    selectedRepo: this.context.selectedRepo,
                     addAlert: (alert) => this.context.queueAlert(alert),
                   });
             })
@@ -393,14 +406,14 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         />
         <BaseHeader
           className={className}
-          title={collection.name}
+          title={collection_version.name}
           logo={
-            collection.namespace.avatar_url && (
+            namespace.avatar_url && (
               <Logo
                 alt={t`${company} logo`}
                 className='image'
                 fallbackToDefault
-                image={collection.namespace.avatar_url}
+                image={namespace.avatar_url}
                 size='40px'
                 unlockWidth
               />
@@ -408,8 +421,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           }
           contextSelector={
             <RepoSelector
-              path={Paths.searchByRepo}
-              selectedRepo={this.context.selectedRepo}
+              selectedRepo={collection.repository.name}
               isDisabled
             />
           }
@@ -427,10 +439,10 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                   onSelect={() =>
                     this.setState({ isOpenVersionsSelect: false })
                   }
-                  selections={`v${collection.latest_version.version}`}
+                  selections={`v${version}`}
                   aria-label={t`Select collection version`}
                   loadingVariant={
-                    numOfshownVersions < all_versions.length
+                    numOfshownVersions < collections.length
                       ? {
                           text: t`View more`,
                           onClick: () =>
@@ -443,7 +455,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                   }
                 >
                   {this.renderSelectVersions(
-                    all_versions,
+                    collections,
                     numOfshownVersions,
                   ).map((v) => (
                     <SelectOption
@@ -476,7 +488,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
               {display_signatures ? (
                 <SignatureBadge
                   isCompact
-                  signState={collection.latest_version.sign_state}
+                  signState={collection.is_signed ? 'signed' : 'unsigned'}
                 />
               ) : null}
             </div>
@@ -499,7 +511,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             </Flex>
           }
         >
-          {collection.deprecated && (
+          {collection.is_deprecated && (
             <Alert
               variant='danger'
               isInline
@@ -517,7 +529,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                 <ExternalLinkAltIcon />
               </div>
               {urlKeys.map((link) => {
-                const url = collection.latest_version.metadata[link.key];
+                const url = content[link.key];
                 if (!url) {
                   return null;
                 }
@@ -550,7 +562,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       });
     };
 
-    MyNamespaceAPI.get(collection.namespace.name, {
+    MyNamespaceAPI.get(collection.collection_version.namespace, {
       include_related: 'my_permissions',
     })
       .then((value) => {
@@ -573,12 +585,11 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   }
 
   private renderTabs(active) {
-    const { params, repo } = this.props;
-
+    const { params, collection } = this.props;
     const pathParams = {
-      namespace: this.props.collection.namespace.name,
-      collection: this.props.collection.name,
-      repo: repo,
+      namespace: collection.collection_version.namespace,
+      collection: collection.collection_version.name,
+      repo: collection.repository.name,
     };
     const reduced = ParamHelper.getReduced(params, this.ignoreParams);
 
@@ -616,21 +627,30 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           reduced,
         ),
       },
+      {
+        active: active === 'distributions',
+        title: t`Distributions`,
+        link: formatPath(
+          Paths.collectionDistributionsByRepo,
+          pathParams,
+          reduced,
+        ),
+      },
     ];
 
     return <LinkTabs tabs={tabs} />;
   }
 
   private renderSelectVersions(versions, count) {
-    return versions.slice(0, count);
+    return versions.slice(0, count).map((c) => c.collection_version);
   }
 
   private async submitCertificate(file: File) {
-    const version = this.state.versionToUploadCertificate;
-    const response = await Repositories.getRepository({
-      name: this.context.selectedRepo,
-    });
-    const signed_collection = `${PULP_API_BASE_PATH}content/ansible/collection_versions/${version.id}/`;
+    const { collection_version: version, repository } =
+      this.state.versionToUploadCertificate;
+
+    const signed_collection =
+      this.props.collection.collection_version.pulp_href;
 
     this.setState({
       alerts: this.state.alerts.concat({
@@ -644,7 +664,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     CertificateUploadAPI.upload({
       file,
-      repository: response.data.results[0].pulp_href,
+      repository: repository.pulp_href,
       signed_collection,
     })
       .then((result) => {
@@ -700,6 +720,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   };
 
   private signCollection = () => {
+    const { namespace, name } = this.props.collection.collection_version;
     const errorAlert = (status: string | number = 500): AlertType => ({
       variant: 'danger',
       title: t`Failed to sign all versions in the collection.`,
@@ -712,7 +733,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         {
           id: 'loading-signing',
           variant: 'success',
-          title: t`Signing started for all versions in collection "${this.props.collection.name}"`,
+          title: t`Signing started for all versions in collection "${name}"`,
         },
       ],
       isOpenSignAllModal: false,
@@ -720,9 +741,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
-      distro_base_path: this.context.selectedRepo,
-      namespace: this.props.collection.namespace.name,
-      collection: this.props.collection.name,
+      repository: this.props.collection.repository,
+      namespace: namespace,
+      collection: name,
     })
       .then((result) => {
         waitForTask(result.data.task_id)
@@ -751,6 +772,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   };
 
   private signVersion = () => {
+    const { name, version, namespace } =
+      this.props.collection.collection_version;
+
     const errorAlert = (status: string | number = 500): AlertType => ({
       variant: 'danger',
       title: t`Failed to sign the version.`,
@@ -763,7 +787,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         {
           id: 'loading-signing',
           variant: 'success',
-          title: t`Signing started for collection "${this.props.collection.name} v${this.props.collection.latest_version.version}".`,
+          title: t`Signing started for collection "${name} v${version}".`,
         },
       ],
       isOpenSignModal: false,
@@ -771,10 +795,10 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
-      distro_base_path: this.context.selectedRepo,
-      namespace: this.props.collection.namespace.name,
-      collection: this.props.collection.name,
-      version: this.props.collection.latest_version.version,
+      repository: this.props.collection.repository,
+      namespace: namespace,
+      collection: name,
+      version: version,
     })
       .then((result) => {
         waitForTask(result.data.task_id)
@@ -803,17 +827,13 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   };
 
   private deprecate(collection) {
-    CollectionAPI.setDeprecation(
-      collection,
-      !collection.deprecated,
-      this.context.selectedRepo,
-    )
+    CollectionAPI.setDeprecation(collection)
       .then((res) => {
         const taskId = parsePulpIDFromURL(res.data.task);
         return waitForTask(taskId).then(() => {
-          const title = !collection.deprecated
-            ? t`The collection "${collection.name}" has been successfully deprecated.`
-            : t`The collection "${collection.name}" has been successfully undeprecated.`;
+          const title = !collection.is_deprecated
+            ? t`The collection "${collection.collection_version.name}" has been successfully deprecated.`
+            : t`The collection "${collection.collection_version.name}" has been successfully undeprecated.`;
           this.setState({
             alerts: [
               ...this.state.alerts,
@@ -836,9 +856,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             ...this.state.alerts,
             {
               variant: 'danger',
-              title: !collection.deprecated
-                ? t`Collection "${collection.name}" could not be deprecated.`
-                : t`Collection "${collection.name}" could not be undeprecated.`,
+              title: !collection.is_deprecated
+                ? t`Collection "${collection.collection_version.name}" could not be deprecated.`
+                : t`Collection "${collection.collection_version.name}" could not be undeprecated.`,
               description: errorMessage(status, statusText),
             },
           ],
@@ -847,28 +867,25 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   }
 
   private deleteCollectionVersion = (collectionVersion) => {
-    const {
-      deleteCollection,
-      deleteCollection: { name },
-    } = this.state;
-    CollectionAPI.deleteCollectionVersion(
-      this.context.selectedRepo,
-      deleteCollection,
-    )
+    const { deleteCollection } = this.state;
+    const { collections } = this.props;
+    CollectionAPI.deleteCollectionVersion(deleteCollection)
       .then((res) => {
         const taskId = parsePulpIDFromURL(res.data.task);
-        const name = deleteCollection.name;
+        const name = deleteCollection.collection_version.name;
 
         waitForTask(taskId).then(() => {
-          if (deleteCollection.all_versions.length > 1) {
-            const topVersion = deleteCollection.all_versions.filter(
-              ({ version }) => version !== collectionVersion,
+          if (collections.length > 1) {
+            const topVersion = collections.filter(
+              ({ collection_version }) =>
+                collection_version.version !== collectionVersion,
             );
+
             this.props.updateParams(
               ParamHelper.setParam(
                 this.props.params,
                 'version',
-                topVersion[0].version,
+                topVersion[0].collection_version.version,
               ),
             );
 
@@ -901,9 +918,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
               ),
             });
             this.setState({
-              redirect: formatPath(Paths.namespaceByRepo, {
-                repo: this.context.selectedRepo,
-                namespace: deleteCollection.namespace.name,
+              redirect: formatPath(Paths.namespaceDetail, {
+                namespace: deleteCollection.collection_version.namespace,
               }),
             });
           }
@@ -949,7 +965,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
               ...this.state.alerts,
               {
                 variant: 'danger',
-                title: t`Collection "${name} v${collectionVersion}" could not be deleted.`,
+                title: t`Collection "${deleteCollection.collection_version.name} v${collectionVersion}" could not be deleted.`,
                 description: errorMessage(status, statusText),
               },
             ],

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -199,22 +199,10 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       }`;
     };
 
-    const { collection_version } = collection;
+    const { collection_version, namespace_metadata: namespace } = collection;
     const { name: collectionName, version } = collection_version;
 
-    // FIXME: remove when API switch to AnsibleNamespaceMetadata
-    const mockNamespace = {
-      pulp_href: '',
-      name: collection_version.namespace,
-      company: 'xaz',
-      description: 'foo bar',
-      avatar: '',
-      avatar_url: '',
-      email: 'foo',
-    };
-    const namespace = mockNamespace;
-
-    const company = namespace?.company || namespace.name;
+    const company = namespace?.company || collection_version.namespace;
 
     if (redirect) {
       return <Navigate to={redirect} />;
@@ -280,7 +268,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
 
     const issueUrl =
       'https://access.redhat.com/support/cases/#/case/new/open-case/describe-issue/recommendations?caseCreate=true&product=Ansible%20Automation%20Hub&version=Online&summary=' +
-      encodeURIComponent(`${namespace.name}-${collectionName}-${version}`);
+      encodeURIComponent(
+        `${collection_version.namespace}-${collectionName}-${version}`,
+      );
 
     return (
       <React.Fragment>
@@ -408,7 +398,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           className={className}
           title={collection_version.name}
           logo={
-            namespace.avatar_url && (
+            namespace?.avatar_url && (
               <Logo
                 alt={t`${company} logo`}
                 className='image'

--- a/src/components/import-modal/import-modal.tsx
+++ b/src/components/import-modal/import-modal.tsx
@@ -5,7 +5,6 @@ import axios from 'axios';
 import * as React from 'react';
 import {
   CollectionAPI,
-  CollectionListType,
   CollectionUploadType,
   CollectionVersionSearch,
 } from 'src/api';

--- a/src/components/import-modal/import-modal.tsx
+++ b/src/components/import-modal/import-modal.tsx
@@ -21,9 +21,7 @@ interface IProps {
   setOpen: (isOpen, warnings?) => void;
   onUploadSuccess: (result) => void;
 
-  collection?:
-    | CollectionVersionSearch['collection_version']
-    | CollectionListType;
+  collection?: CollectionVersionSearch['collection_version'];
   namespace: string;
 }
 

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -64,7 +64,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
   }
 
   render() {
-    const { filterConfig } = this.props;
+    const { filterConfig, selectFilter } = this.props;
     const { selectedFilter } = this.state;
 
     if (filterConfig.length === 0) {
@@ -76,7 +76,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
         onClick={() => {
           this.props.onChange('');
           this.setState({ selectedFilter: v });
-          this.props.selectFilter(v.id);
+          selectFilter && selectFilter(v.id);
         }}
         key={v.id}
       >

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -38,6 +38,8 @@ interface IProps {
   inputText: string;
 
   onChange: (inputText: string) => void;
+
+  selectFilter?: (filterId: string) => void;
 }
 
 interface IState {
@@ -74,6 +76,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
         onClick={() => {
           this.props.onChange('');
           this.setState({ selectedFilter: v });
+          this.props.selectFilter(v.id);
         }}
         key={v.id}
       >

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -12,14 +12,14 @@ import {
 } from '@patternfly/react-core';
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
 import * as React from 'react';
-import { StatefulDropdown } from 'src/components';
+import { APISearchTypeAhead, StatefulDropdown } from 'src/components';
 import { ParamHelper } from 'src/utilities';
 
 export class FilterOption {
   id: string;
   title: string;
   placeholder?: string;
-  inputType?: 'text-field' | 'select' | 'multiple';
+  inputType?: 'text-field' | 'select' | 'multiple' | 'typeahead';
   options?: { id: string; title: string }[];
 }
 
@@ -162,6 +162,30 @@ export class CompoundFilter extends React.Component<IProps, IState> {
             ))}
           />
         );
+      case 'typeahead': {
+        const typeAheadResults = this.props.filterConfig
+          .find(({ id }) => id === selectedFilter.id)
+          .options.map(({ id, title }) => ({ id, name: title }));
+        return (
+          <APISearchTypeAhead
+            multiple={false}
+            loadResults={(name) => {
+              this.props.onChange(name);
+            }}
+            onClear={() => {
+              this.props.onChange('');
+            }}
+            onSelect={(event, value) => {
+              this.submitFilter(value);
+            }}
+            placeholderText={
+              selectedFilter?.placeholder ||
+              t`Filter by ${selectedFilter.title.toLowerCase()}`
+            }
+            results={typeAheadResults}
+          />
+        );
+      }
       default:
         return (
           <TextInput

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -18,7 +18,7 @@ interface IProps {
   selectedRepo: string;
   // Path of the component that's using the component. This is required so that
   // the url for the repo can be updated correctly.
-  path: Paths;
+  path?: Paths;
   pathParams?: Record<string, string>;
   isDisabled?: boolean;
 }
@@ -48,11 +48,11 @@ export const RepoSelector = ({
             variant='plain'
             className='hub-input-group-text-no-wrap'
           >
-            {t`Filter by repository`}
+            {t`Repository`}
           </InputGroupText>
           <Select
             className='nav-select'
-            isDisabled={isDisabled}
+            isDisabled={!path || isDisabled}
             isOpen={selectExpanded}
             isPlain={false}
             onSelect={(event: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/signing/upload-sign-certificate-modal.tsx
+++ b/src/components/signing/upload-sign-certificate-modal.tsx
@@ -55,7 +55,7 @@ export const UploadSingCertificateModal: React.FC<Props> = ({
       <FileUpload
         id='certificate-file'
         filename={filename}
-        filenamePlaceholder={t`Drag and drop a file or upload one'`}
+        filenamePlaceholder={t`Drag and drop a file or upload one.`}
         browseButtonText={t`Select file`}
         onFileInputChange={handleFileInputChange}
         onClearClick={() => setFilename('')}

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -23,38 +23,41 @@ class CollectionContent extends React.Component<
     const params = ParamHelper.parseParamString(props.location.search);
 
     this.state = {
-      collection: undefined,
+      collections: [],
+      collection: null,
+      content: null,
       params: params,
     };
   }
 
   componentDidMount() {
-    this.loadCollection(false);
+    this.loadCollections(false);
   }
 
   render() {
-    const { collection, params } = this.state;
+    const { collections, collection, params, content } = this.state;
 
-    if (!collection) {
+    if (collections.length <= 0) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
+
+    const { collection_version, repository } = collection;
 
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
-        url: formatPath(Paths.namespaceByRepo, {
-          namespace: collection.namespace.name,
-          repo: this.context.selectedRepo,
+        url: formatPath(Paths.namespaceDetail, {
+          namespace: collection_version.namespace,
         }),
-        name: collection.namespace.name,
+        name: collection_version.namespace,
       },
       {
         url: formatPath(Paths.collectionByRepo, {
-          namespace: collection.namespace.name,
-          collection: collection.name,
-          repo: this.context.selectedRepo,
+          namespace: collection_version.namespace,
+          collection: collection_version.name,
+          repo: repository.name,
         }),
-        name: collection.name,
+        name: collection_version.name,
       },
       { name: t`Content` },
     ];
@@ -62,22 +65,22 @@ class CollectionContent extends React.Component<
     return (
       <React.Fragment>
         <CollectionHeader
-          reload={() => this.loadCollection(true)}
+          reload={() => this.loadCollections(true)}
+          collections={collections}
           collection={collection}
+          content={content}
           params={params}
           updateParams={(params) =>
-            this.updateParams(params, () => this.loadCollection(true))
+            this.updateParams(params, () => this.loadCollections(true))
           }
           breadcrumbs={breadcrumbs}
           activeTab='contents'
-          repo={this.context.selectedRepo}
         />
         <Main>
           <section className='body'>
             <CollectionContentList
-              contents={collection.latest_version.metadata.contents}
-              collection={collection.name}
-              namespace={collection.namespace.name}
+              contents={content.contents}
+              collection={collection}
               params={params}
               updateParams={(p) => this.updateParams(p)}
             ></CollectionContentList>
@@ -87,13 +90,14 @@ class CollectionContent extends React.Component<
     );
   }
 
-  private loadCollection(forceReload) {
+  private loadCollections(forceReload) {
     loadCollection({
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      selectedRepo: this.context.selectedRepo,
-      setCollection: (collection) => this.setState({ collection }),
+      setCollection: (collections, collection, content) => {
+        this.setState({ collections, collection, content });
+      },
       stateParams: this.state.params,
     });
   }

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -25,40 +25,44 @@ class CollectionDetail extends React.Component<
     const params = ParamHelper.parseParamString(props.location.search);
 
     this.state = {
-      collection: undefined,
+      collections: [],
+      collection: null,
+      content: null,
+      distroBasePath: null,
       params: params,
       alerts: [],
     };
   }
 
   componentDidMount() {
-    this.loadCollection(true);
+    this.loadCollections(true);
   }
 
   componentDidUpdate(prevProps) {
     if (!isEqual(prevProps.location, this.props.location)) {
-      this.loadCollection(false);
+      this.loadCollections(false);
     }
   }
 
   render() {
-    const { collection, params, alerts } = this.state;
+    const { collections, collection, content, params, alerts } = this.state;
 
-    if (!collection) {
+    if (collections.length <= 0) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
+
+    const { collection_version: version } = collection;
 
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
-        url: formatPath(Paths.namespaceByRepo, {
-          namespace: collection.namespace.name,
-          repo: this.context.selectedRepo,
+        url: formatPath(Paths.namespaceDetail, {
+          namespace: version.namespace,
         }),
-        name: collection.namespace.name,
+        name: version.namespace,
       },
       {
-        name: collection.name,
+        name: version.name,
       },
     ];
 
@@ -69,20 +73,23 @@ class CollectionDetail extends React.Component<
           closeAlert={(i) => this.closeAlert(i)}
         ></AlertList>
         <CollectionHeader
-          reload={() => this.loadCollection(true)}
+          reload={() => this.loadCollections(true)}
+          collections={collections}
           collection={collection}
+          content={content}
           params={params}
           updateParams={(p) =>
-            this.updateParams(p, () => this.loadCollection(true))
+            this.updateParams(p, () => this.loadCollections(true))
           }
           breadcrumbs={breadcrumbs}
           activeTab='install'
-          repo={this.context.selectedRepo}
+          repo={this.props.routeParams.published}
         />
         <Main>
           <section className='body'>
             <CollectionInfo
               {...collection}
+              content={content}
               updateParams={(p) => this.updateParams(p)}
               params={this.state.params}
               addAlert={(variant, title, description) =>
@@ -104,13 +111,18 @@ class CollectionDetail extends React.Component<
     );
   }
 
-  private loadCollection(forceReload) {
+  private loadCollections(forceReload) {
     loadCollection({
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      selectedRepo: this.context.selectedRepo,
-      setCollection: (collection) => this.setState({ collection }),
+      setCollection: (collections, collection, content) => {
+        this.setState({
+          collections,
+          collection,
+          content,
+        });
+      },
       stateParams: this.state.params,
     });
   }

--- a/src/containers/collection-detail/collection-distributions.tsx
+++ b/src/containers/collection-detail/collection-distributions.tsx
@@ -1,0 +1,285 @@
+import { t } from '@lingui/macro';
+import { Toolbar, ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
+import React, { useEffect, useState } from 'react';
+import { AnsibleDistributionAPI } from 'src/api';
+import {
+  AppliedFilters,
+  ClipboardCopy,
+  CollectionHeader,
+  CompoundFilter,
+  DateComponent,
+  EmptyStateFilter,
+  EmptyStateNoData,
+  LoadingPageSpinner,
+  LoadingPageWithHeader,
+  Main,
+  Pagination,
+  SortTable,
+} from 'src/components';
+import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import {
+  ParamHelper,
+  RouteProps,
+  filterIsSet,
+  getRepoUrl,
+  withRouter,
+} from 'src/utilities';
+import { loadCollection } from './base';
+
+const CollectionDistributions = (props: RouteProps) => {
+  const routeParams = ParamHelper.parseParamString(props.location.search);
+
+  const [collections, setCollections] = useState([]);
+  const [collection, setCollection] = useState(null);
+  const [content, setContent] = useState(null);
+  const [inputText, setInputText] = useState('');
+
+  const [distributions, setDistributions] = useState(null);
+  const [count, setCount] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  const [params, setParams] = useState(
+    Object.keys(routeParams).length
+      ? routeParams
+      : {
+          sort: '-pulp_created',
+        },
+  );
+  const loadCollections = (forceReload) => {
+    loadCollection({
+      forceReload,
+      matchParams: props.routeParams,
+      navigate: props.navigate,
+      setCollection: (collections, collection, content) => {
+        setCollections(collections);
+        setCollection(collection);
+        setContent(content);
+
+        loadDistributions(collection.repository.pulp_href);
+      },
+      stateParams: params,
+    });
+  };
+
+  const loadDistributions = async (repositoryHref: string) => {
+    setLoading(true);
+    const distroList = await AnsibleDistributionAPI.list({
+      repository: repositoryHref,
+      ...ParamHelper.getReduced(params, ['version']),
+    });
+
+    setDistributions(distroList.data.results);
+    setCount(distroList.data.count);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    loadCollections(false);
+  }, []);
+
+  useEffect(() => {
+    loadCollections(false);
+  }, [params]);
+
+  if (!collection || !content || collections.length <= 0) {
+    return <LoadingPageWithHeader></LoadingPageWithHeader>;
+  }
+
+  const { collection_version, repository } = collection;
+
+  const breadcrumbs = [
+    namespaceBreadcrumb,
+    {
+      url: formatPath(Paths.namespaceDetail, {
+        namespace: collection_version.namespace,
+      }),
+      name: collection_version.namespace,
+    },
+    {
+      url: formatPath(Paths.collectionByRepo, {
+        namespace: collection_version.namespace,
+        collection: collection_version.name,
+        repo: repository.name,
+      }),
+      name: collection_version.name,
+    },
+    { name: t`Distributions` },
+  ];
+
+  const cliConfig = (distribution) =>
+    [
+      '[galaxy]',
+      `server_list = ${distribution.base_path}`,
+      '',
+      `[galaxy_server.${distribution.base_path}]`,
+      `url=${getRepoUrl()}`,
+      'token=<put your token here>',
+    ].join('\n');
+
+  const updateParamsMixin = (params) => {
+    props.navigate({
+      search: '?' + ParamHelper.getQueryString(params || []),
+    });
+
+    setParams(params);
+  };
+
+  const renderTable = (distributions, params) => {
+    if (distributions.length === 0) {
+      return filterIsSet(params, [
+        'name__icontains',
+        'base_path__icontains',
+      ]) ? (
+        <EmptyStateFilter />
+      ) : (
+        <EmptyStateNoData
+          title={t`No distributions yet`}
+          description={t`Collection doesn't have any distribution assigned.`}
+        />
+      );
+    }
+
+    const sortTableOptions = {
+      headers: [
+        {
+          title: t`Name`,
+          type: 'alpha',
+          id: 'name',
+        },
+        {
+          title: t`Base path`,
+          type: 'alpha',
+          id: 'base_path',
+        },
+        {
+          title: t`Created`,
+          type: 'alpha',
+          id: 'pulp_created',
+        },
+        {
+          title: t`CLI configuration`,
+          type: 'none',
+          id: '',
+        },
+      ],
+    };
+
+    return (
+      <table
+        aria-label={t`Collection distributions`}
+        className='hub-c-table-content pf-c-table'
+      >
+        <SortTable
+          options={sortTableOptions}
+          params={params}
+          updateParams={(params) => {
+            updateParamsMixin(params);
+          }}
+        />
+        <tbody>
+          {distributions.map((distribution, i) => (
+            <tr key={i}>
+              <td>{distribution.name}</td>
+              <td>{distribution.base_path}</td>
+              <td>
+                <DateComponent date={distribution.pulp_created} />
+              </td>
+              <td>
+                <ClipboardCopy isCode isReadOnly variant={'expansion'} key={i}>
+                  {cliConfig(distribution)}
+                </ClipboardCopy>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    );
+  };
+
+  return (
+    <React.Fragment>
+      <CollectionHeader
+        reload={() => loadCollections(true)}
+        collections={collections}
+        collection={collection}
+        content={content}
+        params={params}
+        updateParams={(params) => {
+          updateParamsMixin(
+            ParamHelper.setParam(params, 'version', params.version),
+          );
+        }}
+        breadcrumbs={breadcrumbs}
+        activeTab='distributions'
+      />
+      <Main>
+        <section className='body'>
+          <div className='toolbar hub-toolbar'>
+            <Toolbar>
+              <ToolbarGroup>
+                <ToolbarItem>
+                  <CompoundFilter
+                    inputText={inputText}
+                    onChange={(text) => {
+                      setInputText(text);
+                    }}
+                    updateParams={(p) => {
+                      updateParamsMixin(p);
+                    }}
+                    params={params}
+                    filterConfig={[
+                      {
+                        id: 'name__icontains',
+                        title: t`Name`,
+                      },
+                      {
+                        id: 'base_path__icontains',
+                        title: t`Base path`,
+                      },
+                    ]}
+                  />
+                </ToolbarItem>
+              </ToolbarGroup>
+            </Toolbar>
+
+            <Pagination
+              params={params}
+              updateParams={(p) => {
+                updateParamsMixin(p);
+              }}
+              count={count}
+              isTop
+            />
+          </div>
+
+          <AppliedFilters
+            updateParams={(p) => {
+              updateParamsMixin(p);
+              setInputText('');
+            }}
+            params={params}
+            ignoredParams={['page_size', 'page', 'sort']}
+            niceNames={{
+              base_path__icontains: t`Base path`,
+              name__icontains: t`Name`,
+            }}
+          />
+          {loading ? (
+            <LoadingPageSpinner />
+          ) : (
+            renderTable(distributions, params)
+          )}
+          <Pagination
+            params={params}
+            updateParams={(p) => {
+              updateParamsMixin(p);
+            }}
+            count={count}
+          />
+        </section>
+      </Main>
+    </React.Fragment>
+  );
+};
+
+export default withRouter(CollectionDistributions);

--- a/src/containers/collection-detail/collection-distributions.tsx
+++ b/src/containers/collection-detail/collection-distributions.tsx
@@ -258,7 +258,7 @@ const CollectionDistributions = (props: RouteProps) => {
               setInputText('');
             }}
             params={params}
-            ignoredParams={['page_size', 'page', 'sort']}
+            ignoredParams={['page_size', 'page', 'sort', 'version']}
             niceNames={{
               base_path__icontains: t`Base path`,
               name__icontains: t`Name`,

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -7,6 +7,7 @@ import {
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
+import { CollectionVersionSearch } from 'src/api';
 import {
   CollectionHeader,
   EmptyStateCustom,
@@ -32,7 +33,9 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
     const params = ParamHelper.parseParamString(props.location.search);
 
     this.state = {
-      collection: undefined,
+      collections: [],
+      collection: null,
+      content: null,
       params: params,
     };
     this.docsRef = React.createRef();
@@ -44,10 +47,10 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
   }
 
   render() {
-    const { params, collection } = this.state;
+    const { params, collection, collections, content } = this.state;
     const urlFields = this.props.routeParams;
 
-    if (!collection) {
+    if (!collection || !content) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
@@ -60,11 +63,10 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
     const contentName = urlFields['name'] || urlFields['page'] || null;
 
     if (contentType === 'docs' && contentName) {
-      if (collection.latest_version.docs_blob.documentation_files) {
-        const file =
-          collection.latest_version.docs_blob.documentation_files.find(
-            (x) => sanitizeDocsUrls(x.name) === urlFields['page'],
-          );
+      if (content.docs_blob.documentation_files) {
+        const file = content.docs_blob.documentation_files.find(
+          (x) => sanitizeDocsUrls(x.name) === urlFields['page'],
+        );
 
         if (file) {
           displayHTML = file.html;
@@ -72,43 +74,43 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
       }
     } else if (contentName) {
       // check if contents exists
-      if (collection.latest_version.docs_blob.contents) {
-        const content = collection.latest_version.docs_blob.contents.find(
+      if (content.docs_blob.contents) {
+        const selectedContent = content.docs_blob.contents.find(
           (x) =>
             x.content_type === contentType && x.content_name === contentName,
         );
 
-        if (content) {
+        if (selectedContent) {
           if (contentType === 'role') {
-            displayHTML = content['readme_html'];
+            displayHTML = selectedContent['readme_html'];
           } else {
-            pluginData = content;
+            pluginData = selectedContent;
           }
         }
       }
     } else {
-      if (collection.latest_version.docs_blob.collection_readme) {
-        displayHTML =
-          collection.latest_version.docs_blob.collection_readme.html;
+      if (content.docs_blob.collection_readme) {
+        displayHTML = content.docs_blob.collection_readme.html;
       }
     }
+
+    const { collection_version, repository } = collection;
 
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
-        url: formatPath(Paths.namespaceByRepo, {
-          namespace: collection.namespace.name,
-          repo: this.context.selectedRepo,
+        url: formatPath(Paths.namespaceDetail, {
+          namespace: collection_version.namespace,
         }),
-        name: collection.namespace.name,
+        name: collection.collection_version.namespace,
       },
       {
         url: formatPath(Paths.collectionByRepo, {
-          namespace: collection.namespace.name,
-          collection: collection.name,
-          repo: this.context.selectedRepo,
+          namespace: collection_version.namespace,
+          collection: collection_version.name,
+          repo: repository.name,
         }),
-        name: collection.name,
+        name: collection_version.name,
       },
       { name: t`Documentation` },
     ];
@@ -127,6 +129,8 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
         <CollectionHeader
           reload={() => this.loadCollection(true)}
           collection={collection}
+          collections={collections}
+          content={content}
           params={params}
           updateParams={(p) =>
             this.updateParams(p, () => this.loadCollection(true))
@@ -134,15 +138,14 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
           breadcrumbs={breadcrumbs}
           activeTab='documentation'
           className='header'
-          repo={this.context.selectedRepo}
         />
         <Main className='main'>
           <section className='docs-container'>
             <TableOfContents
               className='sidebar'
-              namespace={collection.namespace.name}
-              collection={collection.name}
-              docs_blob={collection.latest_version.docs_blob}
+              namespace={collection.collection_version.namespace}
+              collection={collection.collection_version.name}
+              docs_blob={content.docs_blob}
               selectedName={contentName}
               selectedType={contentType}
               params={params}
@@ -169,7 +172,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
                         moduleName,
                         collection,
                         params,
-                        collection.latest_version.metadata.contents,
+                        content.contents,
                       )
                     }
                     renderDocLink={(name, href) =>
@@ -183,11 +186,11 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
                     )}
                   />
                 )
-              ) : this.context.selectedRepo === 'community' &&
-                !collection.latest_version.docs_blob.contents ? (
+              ) : collection.repository.name === 'community' &&
+                !content.docs_blob.contents ? (
                 this.renderCommunityWarningMessage()
               ) : (
-                this.renderNotFound(collection.name)
+                this.renderNotFound(collection.collection_version.name)
               )}
             </div>
           </section>
@@ -196,7 +199,12 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
     );
   }
 
-  private renderDocLink(name, href, collection, params) {
+  private renderDocLink(
+    name,
+    href,
+    collection: CollectionVersionSearch,
+    params,
+  ) {
     if (!!href && href.startsWith('http')) {
       return (
         <a href={href} target='_blank' rel='noreferrer'>
@@ -207,15 +215,18 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
       // TODO: right now this will break if people put
       // ../ at the front of their urls. Need to find a
       // way to document this
+
+      const { collection_version, repository } = collection;
+
       return (
         <Link
           to={formatPath(
             Paths.collectionDocsPageByRepo,
             {
-              namespace: collection.namespace.name,
-              collection: collection.name,
+              namespace: collection_version.namespace,
+              collection: collection_version.name,
               page: sanitizeDocsUrls(href),
-              repo: this.context.selectedRepo,
+              repo: repository.name,
             },
             params,
           )}
@@ -243,7 +254,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
               collection: collection.name,
               type: 'module',
               name: moduleName,
-              repo: this.context.selectedRepo,
+              repo: this.props.routeParams.repo,
             },
             params,
           )}
@@ -281,8 +292,9 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      selectedRepo: this.context.selectedRepo,
-      setCollection: (collection) => this.setState({ collection }),
+      setCollection: (collections, collection, content) => {
+        this.setState({ collections, collection, content });
+      },
       stateParams: this.state.params,
     });
   }

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -102,7 +102,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
         url: formatPath(Paths.namespaceDetail, {
           namespace: collection_version.namespace,
         }),
-        name: collection.collection_version.namespace,
+        name: collection_version.namespace,
       },
       {
         url: formatPath(Paths.collectionByRepo, {
@@ -145,6 +145,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
               className='sidebar'
               namespace={collection.collection_version.namespace}
               collection={collection.collection_version.name}
+              repository={collection.repository.name}
               docs_blob={content.docs_blob}
               selectedName={contentName}
               selectedType={contentType}
@@ -250,8 +251,8 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
           to={formatPath(
             Paths.collectionContentDocsByRepo,
             {
-              namespace: collection.namespace.name,
-              collection: collection.name,
+              namespace: collection.collection_version.namespace,
+              collection: collection.collection_version.name,
               type: 'module',
               name: moduleName,
               repo: this.props.routeParams.repo,

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -27,7 +27,9 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
     const params = ParamHelper.parseParamString(props.location.search);
 
     this.state = {
-      collection: undefined,
+      collection: null,
+      collections: [],
+      content: null,
       params: params,
       loadingImports: true,
       selectedImportDetail: undefined,
@@ -43,33 +45,36 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
   render() {
     const {
       collection,
+      collections,
       params,
       loadingImports,
       selectedImportDetail,
       selectedImport,
       apiError,
+      content,
     } = this.state;
 
     if (!collection) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
     }
 
+    const { collection_version, repository } = collection;
+
     const breadcrumbs = [
       namespaceBreadcrumb,
       {
-        url: formatPath(Paths.namespaceByRepo, {
-          namespace: collection.namespace.name,
-          repo: this.context.selectedRepo,
+        url: formatPath(Paths.namespaceDetail, {
+          namespace: collection_version.namespace,
         }),
-        name: collection.namespace.name,
+        name: collection_version.namespace,
       },
       {
         url: formatPath(Paths.collectionByRepo, {
-          namespace: collection.namespace.name,
-          collection: collection.name,
-          repo: this.context.selectedRepo,
+          namespace: collection_version.namespace,
+          collection: collection_version.name,
+          repo: repository.name,
         }),
-        name: collection.name,
+        name: collection_version.name,
       },
       { name: t`Import log` },
     ];
@@ -78,14 +83,15 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
       <React.Fragment>
         <CollectionHeader
           reload={() => this.loadData(true)}
+          collections={collections}
           collection={collection}
+          content={content}
           params={params}
           updateParams={(params) =>
             this.updateParams(params, () => this.loadData(true))
           }
           breadcrumbs={breadcrumbs}
           activeTab='import-log'
-          repo={this.context.selectedRepo}
         />
         <Main>
           <section className='body'>
@@ -110,9 +116,9 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
     this.setState({ loadingImports: true }, () => {
       this.loadCollection(forceReload, () => {
         ImportAPI.list({
-          namespace: this.state.collection.namespace.name,
-          name: this.state.collection.name,
-          version: this.state.collection.latest_version.version,
+          namespace: this.state.collection.collection_version.namespace,
+          name: this.state.collection.collection_version.name,
+          version: this.state.collection.collection_version.version,
           sort: '-created',
         })
           .then((importListResult) => {
@@ -148,8 +154,8 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      selectedRepo: this.context.selectedRepo,
-      setCollection: (collection) => this.setState({ collection }, callback),
+      setCollection: (collections, collection, content) =>
+        this.setState({ collections, collection, content }, callback),
       stateParams: this.state.params,
     });
   }

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -113,8 +113,7 @@ class EditNamespace extends React.Component<RouteProps, IState> {
             namespaceBreadcrumb,
             {
               name: namespace.name,
-              url: formatPath(Paths.namespaceByRepo, {
-                repo: this.context.selectedRepo,
+              url: formatPath(Paths.namespaceDetail, {
                 namespace: namespace.name,
               }),
             },
@@ -223,8 +222,7 @@ class EditNamespace extends React.Component<RouteProps, IState> {
               errorMessages: {},
               saving: false,
               unsavedData: false,
-              redirect: formatPath(Paths.namespaceByRepo, {
-                repo: this.context.selectedRepo,
+              redirect: formatPath(Paths.namespaceDetail, {
                 namespace: this.state.namespace.name,
               }),
             },
@@ -267,8 +265,7 @@ class EditNamespace extends React.Component<RouteProps, IState> {
 
   private cancel() {
     this.setState({
-      redirect: formatPath(Paths.namespaceByRepo, {
-        repo: this.context.selectedRepo,
+      redirect: formatPath(Paths.namespaceDetail, {
         namespace: this.state.namespace.name,
       }),
     });

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -10,6 +10,7 @@ export { default as CollectionDetail } from './collection-detail/collection-deta
 export { default as CollectionDocs } from './collection-detail/collection-docs';
 export { default as CollectionImportLog } from './collection-detail/collection-import-log';
 export { default as CollectionDependencies } from './collection-detail/collection-dependencies';
+export { default as CollectionDistributions } from './collection-detail/collection-distributions';
 export { default as EditNamespace } from './edit-namespace/edit-namespace';
 export { default as LoginPage } from './login/login';
 export { default as MyImports } from './my-imports/my-imports';

--- a/src/containers/legacy-namespaces/legacy-namespaces.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespaces.tsx
@@ -90,6 +90,7 @@ class LegacyNamespaces extends React.Component<
   render() {
     const ignoredParams = [
       'namespace',
+      'repository__name',
       'page',
       'page_size',
       'sort',

--- a/src/containers/legacy-roles/legacy-roles.tsx
+++ b/src/containers/legacy-roles/legacy-roles.tsx
@@ -98,6 +98,7 @@ class LegacyRoles extends React.Component<RouteProps, IProps> {
     const ignoredParams = [
       'order_by',
       'namespace',
+      'repository__name',
       'page',
       'page_size',
       'sort',

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -61,6 +61,7 @@ import './namespace-detail.scss';
 interface IState {
   canSign: boolean;
   collections: CollectionVersionSearch[];
+  allCollections: CollectionVersionSearch[];
   namespace: NamespaceType;
   params: {
     sort?: string;
@@ -111,6 +112,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     this.state = {
       canSign: false,
       collections: [],
+      allCollections: [],
       namespace: null,
       params: params,
       redirect: null,
@@ -137,6 +139,8 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
 
   componentDidMount() {
     this.load();
+
+    this.loadAllCollections();
 
     this.setState({ alerts: this.context.alerts || [] });
     this.context.setAlerts([]);
@@ -732,6 +736,17 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
       });
   }
 
+  private loadAllCollections() {
+    CollectionVersionAPI.list({
+      ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
+      namespace: this.props.routeParams.namespace,
+    }).then((result) => {
+      this.setState({
+        allCollections: result.data.data,
+      });
+    });
+  }
+
   private get updateParams() {
     return ParamHelper.updateParamsMixin(this.nonQueryStringParams);
   }
@@ -757,7 +772,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
       />,
       hasPermission('galaxy.delete_namespace') && (
         <React.Fragment key={'2'}>
-          {this.state.collections.length === 0 ? (
+          {this.state.allCollections.length === 0 ? (
             <DropdownItem
               onClick={() => this.setState({ isOpenNamespaceModal: true })}
             >

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -14,7 +14,8 @@ import ReactMarkdown from 'react-markdown';
 import { Link, Navigate } from 'react-router-dom';
 import {
   CollectionAPI,
-  CollectionListType,
+  CollectionVersionAPI,
+  CollectionVersionSearch,
   GroupType,
   MyNamespaceAPI,
   NamespaceAPI,
@@ -37,13 +38,11 @@ import {
   Main,
   Pagination,
   PartnerHeader,
-  RepoSelector,
   SignAllCertificatesModal,
   StatefulDropdown,
   WisdomModal,
   closeAlertMixin,
 } from 'src/components';
-import { Constants } from 'src/constants';
 import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
@@ -61,7 +60,7 @@ import './namespace-detail.scss';
 
 interface IState {
   canSign: boolean;
-  collections: CollectionListType[];
+  collections: CollectionVersionSearch[];
   namespace: NamespaceType;
   params: {
     sort?: string;
@@ -76,16 +75,15 @@ interface IState {
   itemCount: number;
   showImportModal: boolean;
   warning: string;
-  updateCollection: CollectionListType;
+  updateCollection: CollectionVersionSearch;
   showControls: boolean;
   isOpenNamespaceModal: boolean;
   isOpenSignModal: boolean;
   isOpenWisdomModal: boolean;
-  isNamespaceEmpty: boolean;
   confirmDelete: boolean;
   isNamespacePending: boolean;
   alerts: AlertType[];
-  deleteCollection: CollectionListType;
+  deleteCollection: CollectionVersionSearch;
   isDeletionPending: boolean;
   showGroupRemoveModal?: GroupType;
   showGroupSelectWizard?: { group?: GroupType; roles?: RoleType[] };
@@ -94,11 +92,7 @@ interface IState {
   group: GroupType;
 }
 
-interface IProps extends RouteProps {
-  selectedRepo: string;
-}
-
-export class NamespaceDetail extends React.Component<IProps, IState> {
+export class NamespaceDetail extends React.Component<RouteProps, IState> {
   nonAPIParams = ['tab', 'group'];
 
   // namespace is a positional url argument, so don't include it in the
@@ -128,7 +122,6 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       isOpenNamespaceModal: false,
       isOpenSignModal: false,
       isOpenWisdomModal: false,
-      isNamespaceEmpty: false,
       confirmDelete: false,
       isNamespacePending: false,
       alerts: [],
@@ -238,8 +231,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
         name: namespace.name,
         url:
           tab === 'access'
-            ? formatPath(Paths.namespaceByRepo, {
-                repo: this.context.selectedRepo,
+            ? formatPath(Paths.namespaceDetail, {
                 namespace: namespace.name,
               })
             : null,
@@ -249,9 +241,8 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             name: t`Access`,
             url: params.group
               ? formatPath(
-                  Paths.namespaceByRepo,
+                  Paths.namespaceDetail,
                   {
-                    repo: this.context.selectedRepo,
                     namespace: namespace.name,
                   },
                   { tab: 'access' },
@@ -273,6 +264,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
     const ignoredParams = [
       'namespace',
+      'repository__name',
       'page',
       'page_size',
       'sort',
@@ -310,11 +302,12 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           }
           // onCancel
           setOpen={(isOpen, warn) => this.toggleImportModal(isOpen, warn)}
-          collection={updateCollection}
+          collection={updateCollection?.collection_version}
           namespace={namespace.name}
         />
         <DeleteCollectionModal
           deleteCollection={deleteCollection}
+          collections={collections}
           isDeletionPending={isDeletionPending}
           confirmDelete={confirmDelete}
           setConfirmDelete={(confirmDelete) => this.setState({ confirmDelete })}
@@ -326,7 +319,6 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                 setState: (state) => this.setState(state),
                 load: () => this.load(),
                 redirect: false,
-                selectedRepo: this.context.selectedRepo,
                 addAlert: (alert) => this.addAlert(alert),
               }),
             )
@@ -382,13 +374,6 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           params={tabParams}
           updateParams={(p) => this.updateParams(p)}
           pageControls={this.renderPageControls()}
-          contextSelector={
-            <RepoSelector
-              path={this.props.routePath}
-              pathParams={{ namespace: namespace.name }}
-              selectedRepo={this.context.selectedRepo}
-            />
-          }
           filters={
             tab === 'collections' ? (
               <div className='hub-toolbar-wrapper namespace-detail'>
@@ -437,7 +422,6 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                   collections={collections}
                   itemCount={itemCount}
                   showControls={this.state.showControls}
-                  repo={this.context.selectedRepo}
                   renderCollectionControls={(collection) =>
                     this.renderCollectionControls(collection)
                   }
@@ -551,8 +535,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
                   stateUpdate: { showRoleRemoveModal: null },
                 });
               }}
-              urlPrefix={formatPath(Paths.namespaceByRepo, {
-                repo: this.context.selectedRepo,
+              urlPrefix={formatPath(Paths.namespaceDetail, {
                 namespace: namespace.name,
               })}
             />
@@ -574,8 +557,11 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
     );
   }
 
-  private handleCollectionAction(id, action) {
-    const collection = this.state.collections.find((x) => x.id === id);
+  private handleCollectionAction(pulp_href, action) {
+    const collection = this.state.collections.find(
+      (c) => c.collection_version.pulp_href === pulp_href,
+    );
+    const { name } = collection.collection_version;
 
     switch (action) {
       case 'upload':
@@ -590,21 +576,17 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             ...this.state.alerts,
             {
               variant: 'info',
-              title: t`Deprecation status update starting for collection "${collection.name}".`,
+              title: t`Deprecation status update starting for collection "${name}".`,
             },
           ],
         });
-        CollectionAPI.setDeprecation(
-          collection,
-          !collection.deprecated,
-          this.context.selectedRepo,
-        )
+        CollectionAPI.setDeprecation(collection)
           .then((result) => {
             const taskId = parsePulpIDFromURL(result.data.task);
             return waitForTask(taskId).then(() => {
-              const title = collection.deprecated
-                ? t`Collection "${collection.name}" has been successfully undeprecated.`
-                : t`Collection "${collection.name}" has been successfully deprecated.`;
+              const title = collection.is_deprecated
+                ? t`Collection "${name}" has been successfully undeprecated.`
+                : t`Collection "${name}" has been successfully deprecated.`;
               this.setState({
                 alerts: [
                   ...this.state.alerts,
@@ -635,6 +617,10 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
   }
 
   private signAllCertificates(namespace: NamespaceType) {
+    // get the repository from first collection
+    // all collections are in same repo, so this should be fine.
+    const [collection] = this.state.collections;
+
     const errorAlert = (status: string | number = 500): AlertType => ({
       variant: 'danger',
       title: t`Failed to sign all collections.`,
@@ -653,10 +639,13 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       isOpenSignModal: false,
     });
 
+    const { name } = collection.collection_version;
+
     SignCollectionAPI.sign({
       signing_service: this.context.settings.GALAXY_COLLECTION_SIGNING_SERVICE,
-      distro_base_path: this.context.selectedRepo,
+      repository: collection.repository,
       namespace: namespace.name,
+      collection: name,
     })
       .then((result) => {
         waitForTask(result.data.task_id)
@@ -685,12 +674,11 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
   }
 
   private loadCollections() {
-    CollectionAPI.list(
-      {
-        ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
-      },
-      this.context.selectedRepo,
-    ).then((result) => {
+    CollectionVersionAPI.list({
+      ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
+      // repository_label: '!hide_from_search',
+      namespace: this.props.routeParams.namespace,
+    }).then((result) => {
       this.setState({
         collections: result.data.data,
         itemCount: result.data.meta.count,
@@ -700,12 +688,12 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
 
   private load() {
     Promise.all([
-      CollectionAPI.list(
-        {
-          ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
-        },
-        this.context.selectedRepo,
-      ),
+      CollectionVersionAPI.list({
+        ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
+        // repository_label: '!hide_from_search',
+        namespace: this.props.routeParams.namespace,
+        is_highest: true,
+      }),
       NamespaceAPI.get(this.props.routeParams.namespace, {
         include_related: 'my_permissions',
       }),
@@ -738,46 +726,9 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             val[1].data['groups'],
           ),
         });
-
-        this.loadAllRepos(val[0].data.meta.count);
       })
       .catch(() => {
         this.setState({ redirect: formatPath(Paths.notFound) });
-      });
-  }
-
-  private loadAllRepos(currentRepoCount) {
-    // get collections in namespace from each repo
-    // except the one we already have
-    const repoPromises = Object.keys(Constants.REPOSITORYNAMES)
-      .filter((repo) => repo !== this.context.selectedRepo)
-      .map((repo) =>
-        CollectionAPI.list(
-          { namespace: this.props.routeParams.namespace },
-          repo,
-        ),
-      );
-
-    Promise.all(repoPromises)
-      .then((results) =>
-        this.setState({
-          isNamespaceEmpty:
-            results.every((val) => val.data.meta.count === 0) &&
-            currentRepoCount === 0,
-        }),
-      )
-      .catch((err) => {
-        const { status, statusText } = err.response;
-        this.setState({
-          alerts: [
-            ...this.state.alerts,
-            {
-              variant: 'danger',
-              title: t`Collection repositories could not be displayed.`,
-              description: errorMessage(status, statusText),
-            },
-          ],
-        });
       });
   }
 
@@ -806,7 +757,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       />,
       hasPermission('galaxy.delete_namespace') && (
         <React.Fragment key={'2'}>
-          {this.state.isNamespaceEmpty ? (
+          {this.state.collections.length === 0 ? (
             <DropdownItem
               onClick={() => this.setState({ isOpenNamespaceModal: true })}
             >
@@ -845,15 +796,17 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
           </Link>
         }
       />,
-      canSign && !can_upload_signatures && (
-        <DropdownItem
-          key='sign-collections'
-          data-cy='sign-all-collections-button'
-          onClick={() => this.setState({ isOpenSignModal: true })}
-        >
-          {t`Sign all collections`}
-        </DropdownItem>
-      ),
+      canSign &&
+        !can_upload_signatures &&
+        this.state.collections.length >= 1 && (
+          <DropdownItem
+            key='sign-collections'
+            data-cy='sign-all-collections-button'
+            onClick={() => this.setState({ isOpenSignModal: true })}
+          >
+            {t`Sign all collections`}
+          </DropdownItem>
+        ),
       ai_deny_index && (
         <DropdownItem
           key='wisdom-settings'
@@ -956,12 +909,17 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
     return closeAlertMixin('alerts');
   }
 
-  private renderCollectionControls(collection: CollectionListType) {
+  private renderCollectionControls(collection: CollectionVersionSearch) {
     const { hasPermission } = this.context;
     return (
       <div style={{ display: 'flex', alignItems: 'center' }}>
         <Button
-          onClick={() => this.handleCollectionAction(collection.id, 'upload')}
+          onClick={() =>
+            this.handleCollectionAction(
+              collection.collection_version.pulp_href,
+              'upload',
+            )
+          }
           variant='secondary'
         >
           {t`Upload new version`}
@@ -980,11 +938,14 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
             }),
             <DropdownItem
               onClick={() =>
-                this.handleCollectionAction(collection.id, 'deprecate')
+                this.handleCollectionAction(
+                  collection.collection_version.pulp_href,
+                  'deprecate',
+                )
               }
               key='deprecate'
             >
-              {collection.deprecated ? t`Undeprecate` : t`Deprecate`}
+              {collection.is_deprecated ? t`Undeprecate` : t`Deprecate`}
             </DropdownItem>,
           ].filter(Boolean)}
           ariaLabel='collection-kebab'

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -676,7 +676,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
   private loadCollections() {
     CollectionVersionAPI.list({
       ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
-      // repository_label: '!hide_from_search',
+      repository_label: '!hide_from_search',
       namespace: this.props.routeParams.namespace,
     }).then((result) => {
       this.setState({
@@ -690,7 +690,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     Promise.all([
       CollectionVersionAPI.list({
         ...ParamHelper.getReduced(this.state.params, this.nonAPIParams),
-        // repository_label: '!hide_from_search',
+        repository_label: '!hide_from_search',
         namespace: this.props.routeParams.namespace,
         is_highest: true,
       }),

--- a/src/containers/namespace-list/my-namespaces.tsx
+++ b/src/containers/namespace-list/my-namespaces.tsx
@@ -13,7 +13,7 @@ class MyNamespaces extends React.Component<RouteProps> {
     return (
       <NamespaceList
         {...this.props}
-        namespacePath={Paths.myCollectionsByRepo}
+        namespacePath={Paths.namespaceDetail}
         filterOwner={true}
       />
     );

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -166,9 +166,8 @@ export class NamespaceList extends React.Component<IProps, IState> {
           onCreateSuccess={(result) =>
             this.setState({
               redirect: formatPath(
-                Paths.namespaceByRepo,
+                Paths.namespaceDetail,
                 {
-                  repo: 'published',
                   namespace: result.name,
                 },
                 { tab: 'collections' },
@@ -328,7 +327,6 @@ export class NamespaceList extends React.Component<IProps, IState> {
             <NamespaceCard
               namespaceURL={formatPath(namespacePath, {
                 namespace: ns.name,
-                repo: this.context.selectedRepo,
               })}
               key={i}
               {...ns}

--- a/src/containers/namespace-list/partners.tsx
+++ b/src/containers/namespace-list/partners.tsx
@@ -8,7 +8,7 @@ class Partners extends React.Component<RouteProps> {
     return (
       <NamespaceList
         {...this.props}
-        namespacePath={Paths.namespaceByRepo}
+        namespacePath={Paths.namespaceDetail}
         filterOwner={false}
       />
     );

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -4,7 +4,8 @@ import * as React from 'react';
 import { Navigate } from 'react-router-dom';
 import {
   CollectionAPI,
-  CollectionListType,
+  CollectionVersionAPI,
+  CollectionVersionSearch,
   MyNamespaceAPI,
   MySyncListAPI,
   SyncListType,
@@ -23,7 +24,6 @@ import {
   ImportModal,
   LoadingPageSpinner,
   Pagination,
-  RepoSelector,
   StatefulDropdown,
   closeAlertMixin,
 } from 'src/components';
@@ -43,7 +43,7 @@ import { ParamHelper } from 'src/utilities/param-helper';
 import './search.scss';
 
 interface IState {
-  collections: CollectionListType[];
+  collections: CollectionVersionSearch[];
   numberOfResults: number;
   params: {
     page?: number;
@@ -51,15 +51,17 @@ interface IState {
     keywords?: string;
     tags?: string[];
     view_type?: string;
+    repository__name?: string;
+    namespace?: string;
   };
   loading: boolean;
   synclist: SyncListType;
   alerts: AlertType[];
-  updateCollection: CollectionListType;
+  updateCollection: CollectionVersionSearch;
   showImportModal: boolean;
   redirect: string;
   noDependencies: boolean;
-  deleteCollection: CollectionListType;
+  deleteCollection: CollectionVersionSearch;
   confirmDelete: boolean;
   isDeletionPending: boolean;
 }
@@ -144,7 +146,13 @@ class Search extends React.Component<RouteProps, IState> {
     } = this.state;
     const noData =
       collections.length === 0 &&
-      !filterIsSet(params, ['keywords', 'tags', 'sign_state']);
+      !filterIsSet(params, [
+        'keywords',
+        'tags',
+        'is_signed',
+        'repository__name',
+        'namespace',
+      ]);
 
     const updateParams = (p) =>
       this.updateParams(p, () => this.queryCollections());
@@ -157,6 +165,7 @@ class Search extends React.Component<RouteProps, IState> {
         />
         <DeleteCollectionModal
           deleteCollection={deleteCollection}
+          collections={collections}
           isDeletionPending={isDeletionPending}
           confirmDelete={confirmDelete}
           setConfirmDelete={(confirmDelete) => this.setState({ confirmDelete })}
@@ -168,7 +177,6 @@ class Search extends React.Component<RouteProps, IState> {
                 setState: (state) => this.setState(state),
                 load: () => this.load(),
                 redirect: false,
-                selectedRepo: this.context.selectedRepo,
                 addAlert: (alert) => this.addAlert(alert),
               }),
             )
@@ -184,27 +192,18 @@ class Search extends React.Component<RouteProps, IState> {
                   Paths.myImports,
                   {},
                   {
-                    namespace: updateCollection.namespace.name,
+                    namespace: updateCollection.collection_version.namespace,
                   },
                 ),
               })
             }
             // onCancel
             setOpen={(isOpen, warn) => this.toggleImportModal(isOpen, warn)}
-            collection={updateCollection}
-            namespace={updateCollection.namespace.name}
+            collection={updateCollection.collection_version}
+            namespace={updateCollection.collection_version.namespace}
           />
         )}
-        <BaseHeader
-          className='header'
-          title={t`Collections`}
-          contextSelector={
-            <RepoSelector
-              path={Paths.searchByRepo}
-              selectedRepo={this.context.selectedRepo}
-            />
-          }
-        >
+        <BaseHeader className='header' title={t`Collections`}>
           {!noData && (
             <div className='hub-toolbar-wrapper'>
               <div className='toolbar'>
@@ -308,14 +307,16 @@ class Search extends React.Component<RouteProps, IState> {
   private renderCards(collections) {
     return (
       <div className='hub-cards'>
-        {collections.map((c) => {
+        {collections.map((c, i) => {
           return (
             <CollectionCard
               className='card'
-              key={c.id}
+              key={i}
               {...c}
-              footer={this.renderSyncToogle(c.name, c.namespace.name)}
-              repo={this.context.selectedRepo}
+              footer={this.renderSyncToogle(
+                c.collection_version.name,
+                c.collection_version.namespace.name,
+              )}
               menu={this.renderMenu(false, c)}
               displaySignatures={this.context.featureFlags.display_signatures}
             />
@@ -326,17 +327,14 @@ class Search extends React.Component<RouteProps, IState> {
   }
 
   private handleControlClick(collection) {
-    CollectionAPI.setDeprecation(
-      collection,
-      !collection.deprecated,
-      this.context.selectedRepo,
-    )
+    const { name } = collection.collection_version;
+    CollectionAPI.setDeprecation(collection)
       .then((res) => {
         const taskId = parsePulpIDFromURL(res.data.task);
         return waitForTask(taskId).then(() => {
           const title = !collection.deprecated
-            ? t`The collection "${collection.name}" has been successfully deprecated.`
-            : t`The collection "${collection.name}" has been successfully undeprecated.`;
+            ? t`The collection "${name}" has been successfully deprecated.`
+            : t`The collection "${name}" has been successfully undeprecated.`;
           this.setState({
             alerts: [
               ...this.state.alerts,
@@ -357,8 +355,8 @@ class Search extends React.Component<RouteProps, IState> {
             {
               variant: 'danger',
               title: !collection.deprecated
-                ? t`Collection "${collection.name}" could not be deprecated.`
-                : t`Collection "${collection.name}" could not be undeprecated.`,
+                ? t`Collection "${name}" could not be deprecated.`
+                : t`Collection "${name}" could not be undeprecated.`,
               description: errorMessage(status, statusText),
             },
           ],
@@ -383,7 +381,7 @@ class Search extends React.Component<RouteProps, IState> {
         onClick={() => this.handleControlClick(collection)}
         key='deprecate'
       >
-        {collection.deprecated ? t`Undeprecate` : t`Deprecate`}
+        {collection.is_deprecated ? t`Undeprecate` : t`Deprecate`}
       </DropdownItem>,
     ];
 
@@ -506,18 +504,20 @@ class Search extends React.Component<RouteProps, IState> {
       <div className='list-container'>
         <div className='hub-list'>
           <DataList className='data-list' aria-label={t`List of Collections`}>
-            {collections.map((c) => (
+            {collections.map((c, i) => (
               <CollectionListItem
                 showNamespace={true}
-                key={c.id}
+                key={i}
                 {...c}
                 controls={
                   <>
-                    {this.renderSyncToogle(c.name, c.namespace.name)}
+                    {this.renderSyncToogle(
+                      c.collection_version.name,
+                      c.collection_version.namespace,
+                    )}
                     {this.renderMenu(true, c)}
                   </>
                 }
-                repo={this.context.selectedRepo}
                 displaySignatures={this.context.featureFlags.display_signatures}
               />
             ))}
@@ -543,13 +543,12 @@ class Search extends React.Component<RouteProps, IState> {
 
   private queryCollections() {
     this.setState({ loading: true }, () => {
-      CollectionAPI.list(
-        {
-          ...ParamHelper.getReduced(this.state.params, ['view_type']),
-          deprecated: false,
-        },
-        this.context.selectedRepo,
-      ).then((result) => {
+      CollectionVersionAPI.list({
+        ...ParamHelper.getReduced(this.state.params, ['view_type']),
+        is_deprecated: false,
+        repository_label: '!hide_from_search',
+        is_highest: true,
+      }).then((result) => {
         this.setState({
           collections: result.data.data,
           numberOfResults: result.data.meta.count,

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -377,12 +377,14 @@ class Search extends React.Component<RouteProps, IState> {
             collection,
           }),
       }),
-      <DropdownItem
-        onClick={() => this.handleControlClick(collection)}
-        key='deprecate'
-      >
-        {collection.is_deprecated ? t`Undeprecate` : t`Deprecate`}
-      </DropdownItem>,
+      hasPermission('galaxy.upload_to_namespace') && (
+        <DropdownItem
+          onClick={() => this.handleControlClick(collection)}
+          key='deprecate'
+        >
+          {collection.is_deprecated ? t`Undeprecate` : t`Deprecate`}
+        </DropdownItem>
+      ),
     ];
 
     if (!list) {

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -51,7 +51,7 @@ interface IState {
     keywords?: string;
     tags?: string[];
     view_type?: string;
-    repository__name?: string;
+    repository_name?: string;
     namespace?: string;
   };
   loading: boolean;
@@ -150,7 +150,7 @@ class Search extends React.Component<RouteProps, IState> {
         'keywords',
         'tags',
         'is_signed',
-        'repository__name',
+        'repository_name',
         'namespace',
       ]);
 
@@ -315,7 +315,7 @@ class Search extends React.Component<RouteProps, IState> {
               {...c}
               footer={this.renderSyncToogle(
                 c.collection_version.name,
-                c.collection_version.namespace.name,
+                c.collection_version.namespace,
               )}
               menu={this.renderMenu(false, c)}
               displaySignatures={this.context.featureFlags.display_signatures}
@@ -445,7 +445,7 @@ class Search extends React.Component<RouteProps, IState> {
       });
     };
 
-    MyNamespaceAPI.get(collection.namespace.name, {
+    MyNamespaceAPI.get(collection.collection_version.namespace, {
       include_related: 'my_permissions',
     })
       .then((value) => {

--- a/src/loaders/insights/loader.tsx
+++ b/src/loaders/insights/loader.tsx
@@ -3,27 +3,16 @@ import { t } from '@lingui/macro';
 import { Alert } from '@patternfly/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import React, { useEffect, useState } from 'react';
-import { matchPath, useLocation } from 'react-router-dom';
 import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { AlertType, UIVersion } from 'src/components';
-import { Paths, formatPath } from 'src/paths';
 import { hasPermission } from 'src/utilities';
 import { AppContext } from '../app-context';
 import { loadContext } from '../load-context';
 import { InsightsRoutes } from './routes';
 
-const DEFAULT_REPO = 'published';
-
-const isRepoURL = (pathname) =>
-  matchPath({ path: formatPath(Paths.searchByRepo) + '*' }, pathname);
-
 const App = (_props) => {
-  const location = useLocation();
-  const match = isRepoURL(location.pathname);
-
   const [alerts, setAlerts] = useState<AlertType[]>([]);
   const [featureFlags, setFeatureFlags] = useState<FeatureFlagsType>(null);
-  const [selectedRepo, setSelectedRepo] = useState<string>(DEFAULT_REPO);
   const [settings, setSettings] = useState<SettingsType>(null);
   const [user, setUser] = useState<UserType>(null);
 
@@ -42,31 +31,6 @@ const App = (_props) => {
     });
   }, []);
 
-  // componentDidUpdate
-  useEffect(() => {
-    // This is sort of a dirty hack to make it so that collection details can view repositories other than "published", but all other views are locked to "published"
-    // We do this because there is not currently a way to toggle repositories in automation hub on console.redhat.com, so it's important to ensure the user always lands on the published repo
-
-    // check if the URL matches the base path for the collection detail page
-    if (match) {
-      // if the URL matches, allow the repo to be switched to the repo defined in the url
-      if (match.params.repo !== selectedRepo) {
-        setSelectedRepo(match.params.repo);
-      }
-    } else {
-      // For all other URLs, switch the global state back to the "publised" repo if the repo is set to anything else.
-      if (selectedRepo !== DEFAULT_REPO) {
-        setSelectedRepo(DEFAULT_REPO);
-      }
-    }
-  });
-
-  // block the page from rendering if we're on a repo route and the repo in the url doesn't match the current state
-  // This gives componentDidUpdate a chance to recognize that route has changed and update the internal state to match the route before any pages can redirect the URL to a 404 state.
-  if (match && match.params.repo !== selectedRepo) {
-    return null;
-  }
-
   // Wait for the user data to load before any of the child components are rendered. This will prevent API calls from happening before the app can authenticate
   if (!user) {
     return null;
@@ -80,7 +44,6 @@ const App = (_props) => {
         alerts,
         featureFlags,
         queueAlert,
-        selectedRepo,
         setAlerts,
         setUser,
         settings,

--- a/src/loaders/insights/routes.tsx
+++ b/src/loaders/insights/routes.tsx
@@ -28,6 +28,10 @@ const CollectionImportLog = lazy(
   () => import('src/containers/collection-detail/collection-import-log'),
 );
 
+const CollectionDistributions = lazy(
+  () => import('src/containers/collection-detail/collection-distributions'),
+);
+
 const EditNamespace = lazy(
   () => import('src/containers/edit-namespace/edit-namespace'),
 );
@@ -106,9 +110,13 @@ const routes = [
     path: Paths.collectionDependenciesByRepo,
     component: CollectionDependencies,
   },
+  {
+    component: CollectionDistributions,
+    path: Paths.collectionDistributionsByRepo,
+  },
   { path: Paths.collectionByRepo, component: CollectionDetail },
-  { path: Paths.namespaceByRepo, component: NamespaceDetail },
-  { path: Paths.searchByRepo, component: Search },
+  { path: Paths.namespaceDetail, component: NamespaceDetail },
+  { path: Paths.collections, component: Search },
   { path: Paths.collectionDocsPage, component: CollectionDocs },
   { path: Paths.collectionDocsIndex, component: CollectionDocs },
   {
@@ -126,6 +134,7 @@ const routes = [
   { path: Paths.myImports, component: MyImports },
   { path: Paths.collection, component: CollectionDetail },
   { path: Paths.namespace, component: NamespaceDetail },
+  { path: Paths.collections, component: Search },
   { path: Paths.search, component: Search },
 ];
 

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -32,7 +32,6 @@ import { StandaloneMenu } from './menu';
 interface IProps {
   children: React.ReactNode;
   featureFlags: FeatureFlagsType;
-  selectedRepo: string;
   setUser: (user) => void;
   settings: SettingsType;
   user: UserType;
@@ -41,7 +40,6 @@ interface IProps {
 export const StandaloneLayout = ({
   children,
   featureFlags,
-  selectedRepo,
   setUser,
   settings,
   user,
@@ -127,13 +125,7 @@ export const StandaloneLayout = ({
     <PageHeader
       logo={<SmallLogo alt={APPLICATION_NAME}></SmallLogo>}
       logoComponent={({ children }) => (
-        <Link
-          to={formatPath(Paths.searchByRepo, {
-            repo: selectedRepo,
-          })}
-        >
-          {children}
-        </Link>
+        <Link to={formatPath(Paths.collections)}>{children}</Link>
       )}
       headerTools={
         <PageHeaderTools>
@@ -164,12 +156,7 @@ export const StandaloneLayout = ({
   const Sidebar = (
     <PageSidebar
       theme='dark'
-      nav={
-        <StandaloneMenu
-          repository={selectedRepo}
-          context={{ user, settings, featureFlags }}
-        />
-      }
+      nav={<StandaloneMenu context={{ user, settings, featureFlags }} />}
     />
   );
 

--- a/src/loaders/standalone/loader.tsx
+++ b/src/loaders/standalone/loader.tsx
@@ -1,7 +1,7 @@
 import '../app.scss';
 import '@patternfly/patternfly/patternfly.scss';
-import React, { useEffect, useState } from 'react';
-import { matchPath, useLocation } from 'react-router-dom';
+import React, { useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { AlertType, UIVersion } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
@@ -10,33 +10,13 @@ import { AppContext } from '../app-context';
 import { StandaloneLayout } from './layout';
 import { StandaloneRoutes } from './routes';
 
-const isRepoURL = (pathname) =>
-  matchPath({ path: formatPath(Paths.searchByRepo) + '*' }, pathname);
-
 const App = (_props) => {
   const location = useLocation();
-  const match = isRepoURL(location.pathname);
 
   const [alerts, setAlerts] = useState<AlertType[]>([]);
   const [featureFlags, setFeatureFlags] = useState<FeatureFlagsType>(null);
-  const [selectedRepo, setSelectedRepo] = useState<string>('published');
   const [settings, setSettings] = useState<SettingsType>(null);
   const [user, setUser] = useState<UserType>(null);
-
-  useEffect(() => {
-    if (match && match.params.repo !== selectedRepo) {
-      setSelectedRepo(match.params.repo);
-    }
-  }, [location]);
-
-  // block the page from rendering if we're on a repo route and the repo in the
-  // url doesn't match the current state
-  // This gives componentDidUpdate a chance to recognize that route has chnaged
-  // and update the internal state to match the route before any pages can
-  // redirect the URL to a 404 state.
-  if (match && match.params.repo !== selectedRepo) {
-    return null;
-  }
 
   const updateInitialData = ({ alerts, featureFlags, settings, user }) => {
     setAlerts(alerts);
@@ -54,7 +34,6 @@ const App = (_props) => {
     component = (
       <StandaloneLayout
         featureFlags={featureFlags}
-        selectedRepo={selectedRepo}
         settings={settings}
         user={user}
         setUser={setUser}
@@ -72,7 +51,6 @@ const App = (_props) => {
         alerts,
         featureFlags,
         queueAlert,
-        selectedRepo,
         setAlerts,
         setUser,
         settings,

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -32,13 +32,11 @@ const menuSection = (name, options = {}, items = []) => ({
   items,
 });
 
-function standaloneMenu({ repository }) {
+function standaloneMenu() {
   return [
     menuSection(t`Collections`, {}, [
       menuItem(t`Collections`, {
-        url: formatPath(Paths.searchByRepo, {
-          repo: repository || 'published',
-        }),
+        url: formatPath(Paths.collections),
         condition: ({ settings, user }) =>
           settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
           !user.is_anonymous,
@@ -224,16 +222,15 @@ function Menu({ items, context, expandedSections }) {
   );
 }
 
-export const StandaloneMenu = ({ repository, context }) => {
+export const StandaloneMenu = ({ context }) => {
   const [expandedSections, setExpandedSections] = useState([]);
 
   const location = useLocation();
   const [menu, setMenu] = useState([]);
 
   useEffect(() => {
-    setMenu(standaloneMenu({ repository }));
-  }, [repository]);
-
+    setMenu(standaloneMenu());
+  }, []);
   useEffect(() => {
     activateMenu(menu, location.pathname);
     setExpandedSections(

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -13,6 +13,7 @@ import {
   CollectionContent,
   CollectionDependencies,
   CollectionDetail,
+  CollectionDistributions,
   CollectionDocs,
   CollectionImportLog,
   EditNamespace,
@@ -270,12 +271,16 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
       { component: CollectionContent, path: Paths.collectionContentListByRepo },
       { component: CollectionImportLog, path: Paths.collectionImportLogByRepo },
       {
+        component: CollectionDistributions,
+        path: Paths.collectionDistributionsByRepo,
+      },
+      {
         component: CollectionDependencies,
         path: Paths.collectionDependenciesByRepo,
       },
       { component: CollectionDetail, path: Paths.collectionByRepo },
-      { component: NamespaceDetail, path: Paths.namespaceByRepo },
-      { component: Search, path: Paths.searchByRepo },
+      { component: NamespaceDetail, path: Paths.namespaceDetail },
+      { component: Search, path: Paths.collections },
       { component: CollectionDocs, path: Paths.collectionDocsPage },
       { component: CollectionDocs, path: Paths.collectionDocsIndex },
       { component: CollectionDocs, path: Paths.collectionContentDocs },
@@ -284,6 +289,7 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
       { component: MyImports, path: Paths.myImports },
       { component: CollectionDetail, path: Paths.collection },
       { component: NamespaceDetail, path: Paths.namespace },
+      { component: Search, path: Paths.collections },
       { component: Search, path: Paths.search },
     ];
   }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -103,9 +103,11 @@ export enum Paths {
   collectionContentListByRepo = '/repo/:repo/:namespace/:collection/content',
   collectionImportLogByRepo = '/repo/:repo/:namespace/:collection/import-log',
   collectionDependenciesByRepo = '/repo/:repo/:namespace/:collection/dependencies',
+  collectionDistributionsByRepo = '/repo/:repo/:namespace/:collection/distributions',
   namespaceByRepo = '/repo/:repo/:namespace',
   collection = '/:namespace/:collection',
   namespace = '/:namespace',
+  namespaceDetail = '/namespaces/:namespace',
   partners = '/partners',
   namespaces = '/namespaces',
   notFound = '/not-found',
@@ -119,6 +121,7 @@ export enum Paths {
   repositories = '/repositories',
   taskList = '/tasks',
   signatureKeys = '/signature-keys',
+  collections = '/collections',
 }
 
 export const namespaceBreadcrumb = {

--- a/src/utilities/content-summary.ts
+++ b/src/utilities/content-summary.ts
@@ -1,4 +1,4 @@
-import { CollectionVersion } from 'src/api';
+import { CollectionVersionSearch } from 'src/api';
 
 class Summary {
   total_count: number;
@@ -11,10 +11,10 @@ class Summary {
   };
 }
 
-export function convertContentSummaryCounts(
-  metadata: CollectionVersion['metadata'],
-): Summary {
-  const { contents: content, dependencies } = metadata;
+export function convertContentSummaryCounts({
+  contents: content,
+  dependencies,
+}: CollectionVersionSearch['collection_version']): Summary {
   const summary: Summary = {
     total_count: content.length,
     contents: {

--- a/src/utilities/delete-collection.tsx
+++ b/src/utilities/delete-collection.tsx
@@ -1,13 +1,17 @@
 import { Trans, t } from '@lingui/macro';
 import { DropdownItem, Tooltip } from '@patternfly/react-core';
 import React from 'react';
-import { CollectionAPI } from 'src/api';
+import {
+  CollectionAPI,
+  CollectionVersionAPI,
+  CollectionVersionSearch,
+} from 'src/api';
 import { errorMessage, parsePulpIDFromURL, waitForTask } from 'src/utilities';
 
 export class DeleteCollectionUtils {
-  public static getUsedbyDependencies(collection) {
-    const { name, namespace } = collection;
-    return CollectionAPI.getUsedDependenciesByCollection(namespace.name, name)
+  public static getUsedbyDependencies(collection: CollectionVersionSearch) {
+    const { name, namespace } = collection.collection_version;
+    return CollectionVersionAPI.getUsedDependenciesByCollection(namespace, name)
       .then(({ data }) => data.data.length === 0)
       .catch((err) => {
         const { status, statusText } = err.response;
@@ -109,13 +113,12 @@ export class DeleteCollectionUtils {
     setState,
     load,
     redirect,
-    selectedRepo,
     addAlert,
   }) {
-    CollectionAPI.deleteCollection(selectedRepo, collection)
+    CollectionAPI.deleteCollection(collection)
       .then((res) => {
         const taskId = parsePulpIDFromURL(res.data.task);
-        const name = collection.name;
+        const name = collection.collection_version.name;
 
         waitForTask(taskId).then(() => {
           addAlert({
@@ -142,7 +145,7 @@ export class DeleteCollectionUtils {
 
         addAlert({
           variant: 'danger',
-          title: t`Collection "${name}" could not be deleted.`,
+          title: t`Collection "${collection.collection_version.name}" could not be deleted.`,
           description: errorMessage(status, statusText),
         });
       })

--- a/test/cypress.env.json.template
+++ b/test/cypress.env.json.template
@@ -19,6 +19,5 @@
   "username": "admin",
   "password": "admin",
   "galaxykit": "galaxykit --ignore-certs --auth-url 'http://localhost:8002/auth/realms/redhat-external/protocol/openid-connect/token'",
-  "disableRepoSwitch" : true,
   "insightsLogin" : true
 }

--- a/test/cypress/e2e/approval/approval_process.js
+++ b/test/cypress/e2e/approval/approval_process.js
@@ -16,7 +16,7 @@ describe('Approval Dashboard process', () => {
   });
 
   it('should test the whole approval process.', () => {
-    cy.visit(`${uiPrefix}repo/published`);
+    cy.visit(`${uiPrefix}collections`);
     cy.contains('No collections yet');
 
     // should approve
@@ -35,7 +35,7 @@ describe('Approval Dashboard process', () => {
     );
 
     // should see item in collections
-    cy.visit(`${uiPrefix}repo/published?page_size=100`);
+    cy.visit(`${uiPrefix}collections?page_size=100`);
     cy.contains('.collection-container', 'appp_c_test1');
 
     // should reject
@@ -48,7 +48,7 @@ describe('Approval Dashboard process', () => {
     cy.contains('[data-cy="CertificationDashboard-row"]', 'Rejected');
 
     // should not see items in collections
-    cy.visit(`${uiPrefix}repo/published`);
+    cy.visit(`${uiPrefix}collections`);
     cy.contains('No collections yet');
   });
 });

--- a/test/cypress/e2e/approval/signing.js
+++ b/test/cypress/e2e/approval/signing.js
@@ -37,7 +37,7 @@ describe('signing versions - auto sign on approval', () => {
     cy.wait(10000);
 
     // Go and check if it is signed in the collections
-    cy.visit(`${uiPrefix}repo/published`);
+    cy.visit(`${uiPrefix}collections`);
     cy.get('[data-cy="signature-badge"]', { timeout: 20000 }).should(
       'have.length',
       1,

--- a/test/cypress/e2e/collections/collection.js
+++ b/test/cypress/e2e/collections/collection.js
@@ -38,6 +38,7 @@ describe('collection tests', () => {
     cy.get('input[id=delete_confirm]').click();
     cy.get('button').contains('Delete').click();
     cy.wait('@reload', { timeout: 50000 });
+    cy.wait(5000);
     cy.get('[data-cy="AlertList"] h4[class=pf-c-alert__title]').should(
       'have.text',
       'Success alert:Collection "my_collection v1.0.0" has been successfully deleted.',

--- a/test/cypress/e2e/collections/collection.js
+++ b/test/cypress/e2e/collections/collection.js
@@ -25,7 +25,7 @@ describe('collection tests', () => {
   it('deletes a collection version', () => {
     cy.createApprovedCollection('my_namespace', 'my_collection');
 
-    cy.visit(`${uiPrefix}repo/published`);
+    cy.visit(`${uiPrefix}collections`);
 
     cy.intercept('GET', `${apiPrefix}_ui/v1/namespaces/my_namespace/?*`).as(
       'reload',

--- a/test/cypress/e2e/collections/collection_upload.js
+++ b/test/cypress/e2e/collections/collection_upload.js
@@ -22,7 +22,7 @@ describe('Collection Upload Tests', () => {
     it('should not upload new collection version in collection list when user does not have permissions', () => {
       cy.login(userName, userPassword);
       cy.visit(
-        `${uiPrefix}repo/published?page_size=10&view_type=list&keywords=testcollection`,
+        `${uiPrefix}collections?page_size=10&view_type=list&keywords=testcollection`,
       );
       cy.contains('testcollection');
       cy.contains('Upload new version').click();
@@ -32,7 +32,7 @@ describe('Collection Upload Tests', () => {
     it('should not upload new collection version in collection list/cards when user does not have permissions', () => {
       cy.login(userName, userPassword);
       cy.visit(
-        `${uiPrefix}repo/published?page_size=10&view_type=card&keywords=testcollection`,
+        `${uiPrefix}collections?page_size=10&view_type=card&keywords=testcollection`,
       );
       cy.contains('testcollection');
       cy.get('[aria-label="Actions"]').click();
@@ -52,14 +52,14 @@ describe('Collection Upload Tests', () => {
     it('should see upload new collection version in collection list when user does have permissions', () => {
       cy.login();
       cy.visit(
-        `${uiPrefix}repo/published?page_size=10&view_type=list&keywords=testcollection`,
+        `${uiPrefix}collections?page_size=10&view_type=list&keywords=testcollection`,
       );
       cy.contains('testcollection');
       cy.contains('Upload new version').click();
       cy.contains('New version of testcollection');
 
       cy.visit(
-        `${uiPrefix}repo/published?page_size=10&view_type=card&keywords=testcollection`,
+        `${uiPrefix}collections?page_size=10&view_type=card&keywords=testcollection`,
       );
       cy.contains('testcollection');
       cy.get('button[aria-label="Actions"]').click();
@@ -90,7 +90,7 @@ describe('Collection Upload Tests', () => {
         'namespaces',
       );
 
-      cy.get(`a[href="${uiPrefix}repo/published/ansible/"]`).click();
+      cy.get(`a[href="${uiPrefix}namespaces/ansible/"]`).click();
       cy.wait('@namespaces');
       cy.contains('Upload collection').should('not.exist');
     });
@@ -106,7 +106,7 @@ describe('Collection Upload Tests', () => {
     cy.goToNamespaces();
     cy.intercept('GET', `${apiPrefix}_ui/v1/repo/published/*`).as('namespaces');
 
-    cy.get(`a[href="${uiPrefix}repo/published/ansible/"]`).click();
+    cy.get(`a[href="${uiPrefix}namespaces/ansible/"]`).click();
     cy.wait('@namespaces');
     cy.contains('Upload collection').click();
     cy.fixture('collections/ansible-posix-1.4.0.tar.gz', 'binary')
@@ -130,7 +130,7 @@ describe('Collection Upload Tests', () => {
   if (!insightsLogin) {
     it('should not upload new collection version when user does not have permissions', () => {
       cy.login(userName, userPassword);
-      cy.visit(`${uiPrefix}repo/published/testspace`);
+      cy.visit(`${uiPrefix}namespaces/testspace`);
 
       cy.get('[data-cy="CollectionList-name"]').contains('testcollection');
       cy.contains('Upload new version').should('not.exist');
@@ -139,16 +139,16 @@ describe('Collection Upload Tests', () => {
 
   it('should deprecate let user deprecate and undeprecate collections', () => {
     cy.login();
-    cy.visit(`${uiPrefix}repo/published/testspace`);
+    cy.visit(`${uiPrefix}namespaces/testspace`);
     cy.get('[aria-label=collection-kebab]').first().click();
     cy.contains('Deprecate').click();
-    cy.visit(`${uiPrefix}repo/published/testspace`);
+    cy.visit(`${uiPrefix}namespaces/testspace`);
     cy.contains('DEPRECATED');
 
-    cy.visit(`${uiPrefix}repo/published/testspace`);
+    cy.visit(`${uiPrefix}namespaces/testspace`);
     cy.get('[aria-label=collection-kebab]').first().click();
     cy.contains('Undeprecate').click();
-    cy.visit(`${uiPrefix}repo/published/testspace`);
+    cy.visit(`${uiPrefix}namespaces/testspace`);
     cy.contains('DEPRECATED').should('not.exist');
   });
 });

--- a/test/cypress/e2e/collections/collection_upload.js
+++ b/test/cypress/e2e/collections/collection_upload.js
@@ -82,7 +82,7 @@ describe('Collection Upload Tests', () => {
       cy.login(userName, userPassword);
       cy.intercept(
         'GET',
-        `${apiPrefix}_ui/v1/collection-versions/?namespace=*`,
+        `${apiPrefix}v3/plugin/ansible/search/collection-versions/?namespace=*`,
       ).as('upload');
       cy.galaxykit('-i namespace create', 'ansible');
       cy.menuGo('Collections > Namespaces');

--- a/test/cypress/e2e/collections/collection_upload.js
+++ b/test/cypress/e2e/collections/collection_upload.js
@@ -86,12 +86,8 @@ describe('Collection Upload Tests', () => {
       ).as('upload');
       cy.galaxykit('-i namespace create', 'ansible');
       cy.menuGo('Collections > Namespaces');
-      cy.intercept('GET', `${apiPrefix}_ui/v1/repo/published/*`).as(
-        'namespaces',
-      );
 
       cy.get(`a[href="${uiPrefix}namespaces/ansible/"]`).click();
-      cy.wait('@namespaces');
       cy.contains('Upload collection').should('not.exist');
     });
   }
@@ -104,10 +100,8 @@ describe('Collection Upload Tests', () => {
     ).as('upload');
     cy.galaxykit('-i namespace create', 'ansible');
     cy.goToNamespaces();
-    cy.intercept('GET', `${apiPrefix}_ui/v1/repo/published/*`).as('namespaces');
 
     cy.get(`a[href="${uiPrefix}namespaces/ansible/"]`).click();
-    cy.wait('@namespaces');
     cy.contains('Upload collection').click();
     cy.fixture('collections/ansible-posix-1.4.0.tar.gz', 'binary')
       .then(Cypress.Blob.binaryStringToBlob)
@@ -123,6 +117,7 @@ describe('Collection Upload Tests', () => {
     cy.contains('My imports');
     cy.get('.pf-c-label__content').contains('Running').should('exist');
     cy.wait('@upload', { timeout: 10000 });
+    cy.wait(5000);
     cy.get('.pf-c-label__content').contains('Failed').should('not.exist');
     cy.get('.pf-c-label__content').contains('Completed').should('exist');
   });

--- a/test/cypress/e2e/collections/collection_upload.js
+++ b/test/cypress/e2e/collections/collection_upload.js
@@ -114,6 +114,7 @@ describe('Collection Upload Tests', () => {
       });
     cy.get('[data-cy="confirm-upload"]').click();
     cy.wait('@upload');
+    cy.wait(10000);
     cy.contains('My imports');
     cy.get('.pf-c-label__content').contains('Running').should('exist');
     cy.wait('@upload', { timeout: 10000 });

--- a/test/cypress/e2e/collections/collections_list.js
+++ b/test/cypress/e2e/collections/collections_list.js
@@ -2,7 +2,6 @@ import { range } from 'lodash';
 
 const apiPrefix = Cypress.env('apiPrefix');
 const uiPrefix = Cypress.env('uiPrefix');
-const disableRepoSwitch = Cypress.env('disableRepoSwitch');
 const insightsLogin = Cypress.env('insightsLogin');
 
 describe('Collections list Tests', () => {
@@ -120,23 +119,6 @@ describe('Collections list Tests', () => {
 
     cy.get('[data-cy="CollectionListItem"]').should('have.length', 10);
   });
-
-  if (!disableRepoSwitch) {
-    it('should switch repos when clicking on the dropdown', () => {
-      cy.get('button[aria-label="Options menu"]:first').click();
-      cy.get('button[name="rh-certified"]:first').click();
-      cy.get('.hub-cards .card').should('have.length', 0);
-
-      // Switch back (to have data again)
-      cy.get('button[aria-label="Options menu"]:first').click();
-      cy.get('button[name="published"]:first').click();
-      cy.get('.hub-cards .card').should('have.length', 10);
-
-      cy.get('button[aria-label="Options menu"]:first').click();
-      cy.get('button[name="community"]:first').click();
-      cy.get('.hub-cards .card').should('have.length', 0);
-    });
-  }
 
   it('Can delete collection in collection list', () => {
     cy.get('[data-cy="view_type_list"] svg').click();

--- a/test/cypress/e2e/collections/collections_list.js
+++ b/test/cypress/e2e/collections/collections_list.js
@@ -60,7 +60,7 @@ describe('Collections list Tests', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit(`${uiPrefix}repo/published`);
+    cy.visit(`${uiPrefix}collections`);
     cy.contains('Collections');
   });
 
@@ -158,7 +158,7 @@ describe('Collections list Tests', () => {
   });
 
   it('Can delete collection in namespace collection list', () => {
-    cy.visit(`${uiPrefix}repo/published/my_namespace`);
+    cy.visit(`${uiPrefix}namespaces/my_namespace`);
     cy.get('.toolbar')
       .get('[aria-label="keywords"]:first')
       .type('my_collection1{enter}');

--- a/test/cypress/e2e/misc/rbac.js
+++ b/test/cypress/e2e/misc/rbac.js
@@ -51,7 +51,7 @@ describe('RBAC test for user without permissions', () => {
     cy.contains('Create').should('not.exist');
 
     cy.galaxykit('-i namespace create', 'testspace');
-    cy.visit(`${uiPrefix}repo/published/testspace`);
+    cy.visit(`${uiPrefix}namespaces/testspace`);
 
     // cannot Change namespace and Delete namespace
     cy.get('[data-cy=kebab-toggle]').should('not.exist');
@@ -268,7 +268,7 @@ describe('RBAC test for user with permissions', () => {
     cy.contains('Create').should('exist');
     cy.galaxykit('-i namespace create', 'testspace');
 
-    cy.visit(`${uiPrefix}repo/published/testspace`);
+    cy.visit(`${uiPrefix}namespaces/testspace`);
     cy.get('[data-cy="ns-kebab-toggle"]').should('exist').click();
     cy.contains('Edit namespace');
     cy.contains('Delete namespace');

--- a/test/cypress/e2e/misc/rbac_access.js
+++ b/test/cypress/e2e/misc/rbac_access.js
@@ -13,7 +13,7 @@ describe('Namespace Access tab', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit(`${uiPrefix}repo/published/rbac_access_${num}`);
+    cy.visit(`${uiPrefix}namespaces/rbac_access_${num}`);
     cy.get('.pf-c-tabs__item-text').contains('Access').click();
   });
 

--- a/test/cypress/e2e/misc/wisdom_modal.js
+++ b/test/cypress/e2e/misc/wisdom_modal.js
@@ -29,7 +29,7 @@ describe('Wisdom Modal Test', () => {
 
   it('can opt in or opt out of namespace.', () => {
     cy.login();
-    cy.visit(`${uiPrefix}repo/published/testns1`);
+    cy.visit(`${uiPrefix}namespaces/testns1`);
     optOut();
     optIn();
     clickWisdomSettings();
@@ -46,7 +46,7 @@ describe('Wisdom Modal Test', () => {
     // namespace was removed from wisdom, now delete it and it should be in wisdom again after recreation
     cy.deleteNamespacesAndCollections();
     cy.galaxykit('-i namespace create', 'testns1');
-    cy.visit(`${uiPrefix}repo/published/testns1`);
+    cy.visit(`${uiPrefix}namespaces/testns1`);
 
     // it should be again in wisdom
     clickWisdomSettings();

--- a/test/cypress/e2e/namespaces/namespace_delete.js
+++ b/test/cypress/e2e/namespaces/namespace_delete.js
@@ -17,7 +17,7 @@ describe('Delete a namespace', () => {
     cy.intercept('GET', `${apiPrefix}_ui/v1/namespaces/?sort=name*`).as(
       'reload',
     );
-    cy.get(`a[href*="${uiPrefix}repo/published/testns1"]`).click();
+    cy.get(`a[href*="${uiPrefix}namespaces/testns1"]`).click();
     cy.get('[data-cy="ns-kebab-toggle"]').click();
     cy.contains('Delete namespace').click();
     cy.get('input[id=delete_confirm]').click();
@@ -35,7 +35,7 @@ describe('Delete a namespace', () => {
     cy.goToNamespaces();
     cy.wait('@reload');
 
-    cy.get(`a[href*="${uiPrefix}repo/published/ansible"]`).click();
+    cy.get(`a[href*="${uiPrefix}namespaces/ansible"]`).click();
 
     //upload a collection
     cy.createApprovedCollection('ansible', 'network');

--- a/test/cypress/e2e/namespaces/namespace_detail.js
+++ b/test/cypress/e2e/namespaces/namespace_detail.js
@@ -1,6 +1,5 @@
 const uiPrefix = Cypress.env('uiPrefix');
 const apiPrefix = Cypress.env('apiPrefix');
-// const disableRepoSwitch = Cypress.env('disableRepoSwitch');
 
 describe('Namespace detail screen', () => {
   before(() => {
@@ -77,31 +76,4 @@ describe('Namespace detail screen', () => {
 
     // The test for success are impmeneted in the collection_upload file
   });
-
-  // if (!disableRepoSwitch) {
-  //   it('should filter by repositories', () => {
-  //     const namespace = 'coolestnamespace';
-  //     cy.galaxykit('-i namespace create', namespace);
-  //     cy.visit(`${uiPrefix}namespaces/${namespace}`);
-
-  //     cy.get('.nav-select').contains('Published').click();
-  //     cy.contains('Red Hat Certified').click();
-
-  //     cy.get('.nav-select').contains('Red Hat Certified');
-  //     cy.url().should('include', `/repo/rh-certified/${namespace}`);
-
-  //     cy.visit(`${uiPrefix}repo/community/${namespace}`);
-  //     cy.get('.nav-select').contains('Community');
-  //   });
-
-  //   it('repo selector should be disabled in collection detail ', () => {
-  //     const namespace = 'coolestnamespace';
-  //     const collection = 'coolestcollection';
-  //     cy.galaxykit('-i namespace create', namespace);
-  //     cy.createApprovedCollection(namespace, collection);
-
-  //     cy.visit(`${uiPrefix}repo/published/${namespace}/${collection}`);
-  //     cy.get('.nav-select').contains('Published').should('be.disabled');
-  //   });
-  // }
 });

--- a/test/cypress/e2e/namespaces/namespace_detail.js
+++ b/test/cypress/e2e/namespaces/namespace_detail.js
@@ -1,6 +1,6 @@
 const uiPrefix = Cypress.env('uiPrefix');
 const apiPrefix = Cypress.env('apiPrefix');
-const disableRepoSwitch = Cypress.env('disableRepoSwitch');
+// const disableRepoSwitch = Cypress.env('disableRepoSwitch');
 
 describe('Namespace detail screen', () => {
   before(() => {
@@ -16,7 +16,7 @@ describe('Namespace detail screen', () => {
 
   beforeEach(() => {
     cy.login();
-    cy.visit(`${uiPrefix}repo/published/namespace_detail_test`);
+    cy.visit(`${uiPrefix}namespaces/namespace_detail_test`);
   });
 
   it('should display the collections belonging to the namespace', () => {
@@ -32,7 +32,7 @@ describe('Namespace detail screen', () => {
     cy.contains('.body ul a', 'Deprecate').click();
 
     // Reload the page
-    cy.visit(`${uiPrefix}repo/published/namespace_detail_test`);
+    cy.visit(`${uiPrefix}namespaces/namespace_detail_test`);
 
     cy.get('[data-cy="CollectionListItem"]:first').contains('DEPRECATED');
   });
@@ -78,30 +78,30 @@ describe('Namespace detail screen', () => {
     // The test for success are impmeneted in the collection_upload file
   });
 
-  if (!disableRepoSwitch) {
-    it('should filter by repositories', () => {
-      const namespace = 'coolestnamespace';
-      cy.galaxykit('-i namespace create', namespace);
-      cy.visit(`${uiPrefix}repo/published/${namespace}`);
+  // if (!disableRepoSwitch) {
+  //   it('should filter by repositories', () => {
+  //     const namespace = 'coolestnamespace';
+  //     cy.galaxykit('-i namespace create', namespace);
+  //     cy.visit(`${uiPrefix}namespaces/${namespace}`);
 
-      cy.get('.nav-select').contains('Published').click();
-      cy.contains('Red Hat Certified').click();
+  //     cy.get('.nav-select').contains('Published').click();
+  //     cy.contains('Red Hat Certified').click();
 
-      cy.get('.nav-select').contains('Red Hat Certified');
-      cy.url().should('include', `/repo/rh-certified/${namespace}`);
+  //     cy.get('.nav-select').contains('Red Hat Certified');
+  //     cy.url().should('include', `/repo/rh-certified/${namespace}`);
 
-      cy.visit(`${uiPrefix}repo/community/${namespace}`);
-      cy.get('.nav-select').contains('Community');
-    });
+  //     cy.visit(`${uiPrefix}repo/community/${namespace}`);
+  //     cy.get('.nav-select').contains('Community');
+  //   });
 
-    it('repo selector should be disabled in collection detail ', () => {
-      const namespace = 'coolestnamespace';
-      const collection = 'coolestcollection';
-      cy.galaxykit('-i namespace create', namespace);
-      cy.createApprovedCollection(namespace, collection);
+  //   it('repo selector should be disabled in collection detail ', () => {
+  //     const namespace = 'coolestnamespace';
+  //     const collection = 'coolestcollection';
+  //     cy.galaxykit('-i namespace create', namespace);
+  //     cy.createApprovedCollection(namespace, collection);
 
-      cy.visit(`${uiPrefix}repo/published/${namespace}/${collection}`);
-      cy.get('.nav-select').contains('Published').should('be.disabled');
-    });
-  }
+  //     cy.visit(`${uiPrefix}repo/published/${namespace}/${collection}`);
+  //     cy.get('.nav-select').contains('Published').should('be.disabled');
+  //   });
+  // }
 });

--- a/test/cypress/e2e/namespaces/namespace_edit.js
+++ b/test/cypress/e2e/namespaces/namespace_edit.js
@@ -46,7 +46,7 @@ describe('Edit a namespace', () => {
     cy.login();
     cy.galaxykit('-i namespace create', 'testns1');
     cy.goToNamespaces();
-    cy.get(`a[href*="${uiPrefix}repo/published/testns1"]`).click();
+    cy.get(`a[href*="${uiPrefix}namespaces/testns1"]`).click();
     cy.contains('No collections yet');
     kebabToggle();
     cy.contains('Edit namespace').click();
@@ -73,7 +73,7 @@ describe('Edit a namespace', () => {
   it('saves a new company name', () => {
     cy.get('#company').clear().type('Company name');
     saveButton().click();
-    cy.url().should('match', new RegExp(`${uiPrefix}repo/published/testns1`));
+    cy.url().should('match', new RegExp(`${uiPrefix}namespaces/testns1`));
     cy.get('.pf-c-title').should('contain', 'Company name');
   });
 

--- a/test/cypress/e2e/namespaces/namespace_edit.js
+++ b/test/cypress/e2e/namespaces/namespace_edit.js
@@ -2,7 +2,9 @@ const uiPrefix = Cypress.env('uiPrefix');
 
 describe('Edit a namespace', () => {
   let kebabToggle = () => {
-    cy.get('[data-cy="ns-kebab-toggle"] button[aria-label="Actions"]').click();
+    cy.get('[data-cy="ns-kebab-toggle"] button[aria-label="Actions"]').click({
+      force: true,
+    });
   };
 
   let saveButton = () => {

--- a/test/cypress/e2e/namespaces/namespace_form.js
+++ b/test/cypress/e2e/namespaces/namespace_form.js
@@ -85,6 +85,6 @@ describe('A namespace form', () => {
     let id = parseInt(Math.random() * 1000000);
     getInputBox().type(`testns_${id}`);
     getCreateButton().click();
-    cy.url().should('match', new RegExp(`${uiPrefix}repo/published/testns_`));
+    cy.url().should('match', new RegExp(`${uiPrefix}namespaces/testns_`));
   });
 });

--- a/test/cypress/e2e/screenshots/screenshots.js
+++ b/test/cypress/e2e/screenshots/screenshots.js
@@ -30,7 +30,7 @@ describe('screenshots', () => {
     };
 
     screenshot('/');
-    screenshot('/repo/published');
+    screenshot('/collections');
     screenshot('/namespaces');
     // TODO - problems - repositories are showing minutes, so text may quickly change and generate diff
     //screenshot('/repositories');


### PR DESCRIPTION
Issue: AAH-767

Requires:
- https://github.com/ansible/galaxy_ng/pull/1649 
- ~https://github.com/ansible/galaxy_ng/pull/1642~
- ~https://github.com/ansible/galaxy_ng/pull/1658~
- ~https://github.com/pulp/pulp_ansible/pull/1395~
- ~https://github.com/ansible/galaxy_ng/pull/1652~
- ~https://github.com/pulp/pulp_ansible/pull/1357~

Use new cross repo search for.
- Namespace detail
- Collection list (search)
- Collection detail (install, documentation, contents, import log, dependencies)

Changes: 
- new distributions tab in collection detail ![Screenshot from 2023-03-28 00-49-02](https://user-images.githubusercontent.com/19647757/228084206-50e18eaa-6354-4985-874c-c93a88587baa.png)
![Screenshot from 2023-03-27 12-19-28](https://user-images.githubusercontent.com/19647757/227914399-a803e0ba-b60c-4346-9469-07d032f83ebb.png)
- removed repo selector for namespace detail
- changed URL for namespace detail to /ui/namespaces/<namespace>
- changed URL for collection list (search.tsx) to /ui/collections
- repository badge in collection card and list item
![Screenshot from 2023-03-27 11-58-03](https://user-images.githubusercontent.com/19647757/227910080-72afa8fc-c435-4728-9e11-c129661b8d5b.png)
![Screenshot from 2023-03-27 11-37-14](https://user-images.githubusercontent.com/19647757/227910124-93f4b918-4211-475d-90b4-5239a8ede1cf.png)


