### PR TITLE
Repair approval process and modal

### DIFF
--- a/src/api/repositories.ts
+++ b/src/api/repositories.ts
@@ -21,14 +21,6 @@ class API extends PulpAPI {
     return this.http.get(`${this.apiPath}?name=${data.name}`);
   }
 
-  listApproved(): Promise<ReturnRepository> {
-    return this.http.get(
-      `${this.apiPath}?pulp_label_select=${encodeURIComponent(
-        'pipeline=approved',
-      )}`,
-    );
-  }
-
   list(params?) {
     return super.list(params, this.apiPath);
   }

--- a/src/api/response-types/repositories.ts
+++ b/src/api/response-types/repositories.ts
@@ -5,4 +5,5 @@ export interface Repository {
   pulp_created: string;
   versions_href: string;
   pulp_labels: { pipeline?: string };
+  latest_version_href: string;
 }

--- a/src/components/approve-modal/all-repos-selector.tsx
+++ b/src/components/approve-modal/all-repos-selector.tsx
@@ -1,0 +1,52 @@
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownSeparator,
+  DropdownToggle,
+  DropdownToggleCheckbox,
+} from '@patternfly/react-core';
+import React from 'react';
+
+export const AllReposSelector: React.FunctionComponent = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const onToggle = (isOpen: boolean) => {
+    setIsOpen(isOpen);
+  };
+
+  const onFocus = () => {
+    const element = document.getElementById('toggle-split-button');
+    element.focus();
+  };
+
+  const onSelect = () => {
+    setIsOpen(false);
+    onFocus();
+  };
+
+  const dropdownItems = [
+    <DropdownItem key='link'>Link</DropdownItem>,
+    <DropdownSeparator key='separator' />,
+  ];
+
+  return (
+    <Dropdown
+      onSelect={onSelect}
+      toggle={
+        <DropdownToggle
+          splitButtonItems={[
+            <DropdownToggleCheckbox
+              id='split-button-toggle-checkbox'
+              key='split-checkbox'
+              aria-label='Select all'
+            />,
+          ]}
+          onToggle={onToggle}
+          id='toggle-split-button'
+        />
+      }
+      isOpen={isOpen}
+      dropdownItems={dropdownItems}
+    />
+  );
+};

--- a/src/components/approve-modal/approve-modal.tsx
+++ b/src/components/approve-modal/approve-modal.tsx
@@ -278,7 +278,7 @@ export const ApproveModal = (props: IProps) => {
     }
 
     function selectPage() {
-      let newRepos = [...selectedRepos];
+      const newRepos = [...selectedRepos];
 
       repositoryList.forEach((repo) => {
         if (!selectedRepos.includes(repo.name)) {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -126,3 +126,4 @@ export { LegacyRoleListItem } from './legacy-role-list/legacy-role-item';
 export { LegacyNamespaceListItem } from './legacy-namespace-list/legacy-namespace-item';
 export { WisdomModal } from './wisdom-modal/wisdom-modal';
 export { ApproveModal } from './approve-modal/approve-modal';
+export { AllReposSelector } from './approve-modal/all-repos-selector';

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -53,6 +53,7 @@ import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import {
   ParamHelper,
+  RepositoriesUtils,
   RouteProps,
   errorMessage,
   filterIsSet,
@@ -76,15 +77,17 @@ interface IState {
   versions: CollectionVersionSearch[];
   itemCount: number;
   loading: boolean;
-  updatingVersions: CollectionVersionSearch['collection_version'][];
+  updatingVersions: CollectionVersionSearch[];
   unauthorized: boolean;
   inputText: string;
   uploadCertificateModalOpen: boolean;
   versionToUploadCertificate?: CollectionVersionSearch;
   approveModalInfo: {
-    collectionVersion: CollectionVersion;
+    collectionVersion;
   };
   approvedRepositoryList: Repository[];
+  stagingRepoNames: string[];
+  rejectedRepoName: string;
 }
 
 class CertificationDashboard extends React.Component<RouteProps, IState> {
@@ -121,6 +124,8 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
       versionToUploadCertificate: null,
       approveModalInfo: null,
       approvedRepositoryList: [],
+      rejectedRepoName: null,
+      stagingRepoNames: [],
     };
   }
 
@@ -137,10 +142,13 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
 
       const promises = [];
 
+      promises.push(this.loadRepo('staging'));
+      promises.push(this.loadRepo('rejected'));
+
       promises.push(
-        Repositories.listApproved()
+        RepositoriesUtils.listApproved()
           .then((data) => {
-            this.setState({ approvedRepositoryList: data.data.results });
+            this.setState({ approvedRepositoryList: data });
           })
           .catch(({ response: { status, statusText } }) => {
             this.addAlertObj({
@@ -158,6 +166,30 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
         this.setState({ updatingVersions: [] });
       });
     }
+  }
+
+  private loadRepo(pipeline) {
+    return Repositories.list({ pulp_label_select: `pipeline=${pipeline}` })
+      .then((data) => {
+        if (data.data.results.length > 0) {
+          if (pipeline == 'staging') {
+            this.setState({
+              stagingRepoNames: data.data.results.map((res) => res.name),
+            });
+          }
+
+          if (pipeline == 'rejected') {
+            this.setState({ rejectedRepoName: data.data.results[0].name });
+          }
+        }
+      })
+      .catch((error) => {
+        this.addAlert(
+          t`Error loading repository with label ${pipeline}.`,
+          'danger',
+          error?.message,
+        );
+      });
   }
 
   render() {
@@ -291,6 +323,8 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
                 }
                 addAlert={(alert) => this.addAlertObj(alert)}
                 allRepositories={this.state.approvedRepositoryList}
+                stagingRepoNames={this.state.stagingRepoNames}
+                rejectedRepoName={this.state.rejectedRepoName}
               />
             )}
           </Main>
@@ -333,7 +367,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
           id: 'pulp_created',
         },
         {
-          title: t`Repositories`,
+          title: t`Repository`,
           type: 'none',
           id: '',
         },
@@ -369,13 +403,20 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
     );
   }
 
+  private isVersionUpdating(collection: CollectionVersionSearch) {
+    return this.state.updatingVersions.find((v) => {
+      return v == collection;
+    });
+  }
+
   private renderStatus(collectionData: CollectionVersionSearch) {
     const { collection_version: version, repository } = collectionData;
     const repoStatus = repository.pulp_labels?.pipeline;
 
-    if (this.state.updatingVersions.includes(version)) {
+    if (this.isVersionUpdating(collectionData)) {
       return <span className='fa fa-lg fa-spin fa-spinner' />;
     }
+
     if (this.isApproved(collectionData)) {
       const { display_signatures } = this.context.featureFlags;
       return (
@@ -468,7 +509,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
       collection_auto_sign,
       require_upload_signatures,
     } = this.context.featureFlags;
-    if (this.state.updatingVersions.includes(version)) {
+    if (this.isVersionUpdating(collectionData)) {
       return <ListItemActions />; // empty td;
     }
 
@@ -675,26 +716,63 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
   }
 
   private reject(collection) {
-    if (!collection) {
-      // I hope that this may not occure ever, but to be sure...
-      this.addAlert(
-        t`Rejection failed.`,
-        'danger',
-        t`Collection not found in any repository.`,
-      );
-      return;
-    }
+    const originalRepo = collection.repository.name;
+    const version = collection.collection_version;
 
-    this.updateCertification(
-      collection.collection_version,
-      collection.repository.name,
-      Constants.NOTCERTIFIED,
-    );
+    this.transformToCollectionVersion(collection)
+      .then((versionWithRepos: any) => {
+        this.setState({ updatingVersions: [collection] });
+        if (
+          versionWithRepos.repository_list.includes(this.state.rejectedRepoName)
+        ) {
+          // collection already in rejected repository, so remove it from aproved repo
+
+          RepositoriesUtils.deleteCollection(originalRepo, version.pulp_href)
+            .then(() => {
+              this.addAlert(
+                t`Certification status for collection "${version.namespace} ${version.name} v${version.version}" has been successfully updated.`,
+                'success',
+              );
+              this.queryCollections(true);
+            })
+            .catch((error) => {
+              this.setState({ updatingVersions: [] });
+              const description = !error.response
+                ? error
+                : errorMessage(
+                    error.response.status,
+                    error.response.statusText,
+                  );
+
+              this.addAlert(
+                t`Changes to certification status for collection "${version.namespace} ${version.name} v${version.version}" could not be saved.`,
+                'danger',
+                description,
+              );
+            });
+        } else {
+          // collection is not in rejected state, move it there
+          this.updateCertification(
+            version,
+            originalRepo,
+            this.state.rejectedRepoName,
+          );
+        }
+      })
+      .catch((error) => {
+        const description = !error.response
+          ? error
+          : errorMessage(error.response.status, error.response.statusText);
+
+        this.addAlert(
+          t`Changes to certification status for collection "${version.namespace} ${version.name} v${version.version}" could not be saved.`,
+          'danger',
+          description,
+        );
+      });
   }
 
   private updateCertification(version, originalRepo, destinationRepo) {
-    this.setState({ updatingVersions: [version] });
-
     return CollectionVersionAPI.setRepository(
       version.namespace,
       version.name,
@@ -828,20 +906,12 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
 
     const { collection_version, is_signed } = collection;
     const id = parsePulpIDFromURL(collection_version.pulp_href);
-    const collectionVersion: CollectionVersion = {
+    const collectionVersion = {
       id,
       version: collection_version.version,
-      metadata: {
-        contents: collection_version.contents,
-        description: collection_version.description,
-        tags: collection_version.tags.map((tag) => tag.name),
-        dependencies: [collection_version.dependencies],
-      },
-      created_at: collection_version.pulp_created,
       namespace: collection_version.namespace,
       name: collection_version.name,
       repository_list: repoList,
-      sign_state: is_signed ? 'signed' : 'unsigned',
     };
 
     return collectionVersion;

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -719,7 +719,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
     const version = collection.collection_version;
 
     this.transformToCollectionVersion(collection)
-      .then((versionWithRepos: any) => {
+      .then((versionWithRepos) => {
         this.setState({ updatingVersions: [collection] });
         if (
           versionWithRepos.repository_list.includes(this.state.rejectedRepoName)

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -20,7 +20,6 @@ import { Link } from 'react-router-dom';
 import {
   CertificateUploadAPI,
   CollectionAPI,
-  CollectionVersion,
   CollectionVersionAPI,
   CollectionVersionSearch,
   Repositories,
@@ -410,7 +409,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
   }
 
   private renderStatus(collectionData: CollectionVersionSearch) {
-    const { collection_version: version, repository } = collectionData;
+    const { repository } = collectionData;
     const repoStatus = repository.pulp_labels?.pipeline;
 
     if (this.isVersionUpdating(collectionData)) {
@@ -904,7 +903,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
   async transformToCollectionVersion(collection: CollectionVersionSearch) {
     const repoList = await this.getCollectionRepoList(collection);
 
-    const { collection_version, is_signed } = collection;
+    const { collection_version } = collection;
     const id = parsePulpIDFromURL(collection_version.pulp_href);
     const collectionVersion = {
       id,

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -32,3 +32,4 @@ export { RepoSigningUtils } from './repo-signing';
 export { translateLockedRolesDescription } from './translate-locked-roles-desc';
 export { RouteProps, withRouter } from './with-router';
 export { mapNetworkErrors, validateInput } from './map-role-errors';
+export { RepositoriesUtils } from './repositories';

--- a/src/utilities/repositories.ts
+++ b/src/utilities/repositories.ts
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-import { CollectionVersionAPI } from 'src/api/collection-version';
 import { Repositories } from 'src/api/repositories';
 import { Repository } from 'src/api/response-types/repositories';
 import { waitForTaskUrl } from 'src/utilities';

--- a/src/utilities/repositories.ts
+++ b/src/utilities/repositories.ts
@@ -1,0 +1,86 @@
+import { t } from '@lingui/macro';
+import { CollectionVersionAPI } from 'src/api/collection-version';
+import { Repositories } from 'src/api/repositories';
+import { Repository } from 'src/api/response-types/repositories';
+import { waitForTaskUrl } from 'src/utilities';
+import { parsePulpIDFromURL } from 'src/utilities/parse-pulp-id';
+
+export class RepositoriesUtils {
+  public static listApproved(): Promise<Repository[]> {
+    async function getAll() {
+      let list = [];
+
+      let page = 0;
+      const pageSize = 100;
+      // watchdog, in case something terrible happened, loop maximum of 10 times. I hope 1000 repos limit is enough
+      // otherwise, doing more than 10 API calls is not acceptable either
+      for (let i = 0; i < 10; i++) {
+        const result = await Repositories.http.get(
+          `${
+            Repositories.apiPath
+          }?offset=${page}&limit=${pageSize}&pulp_label_select=${encodeURIComponent(
+            'pipeline=approved',
+          )}`,
+        );
+
+        list = list.concat(result.data.results);
+        if (list.length >= result.data.count) {
+          return list;
+        }
+
+        page += pageSize;
+      }
+    }
+
+    return getAll();
+  }
+
+  public static async deleteOrAddCollection(
+    repoName,
+    collectionVersion_pulp_href,
+    add,
+  ) {
+    let data = await Repositories.getRepository({ name: repoName });
+
+    if (data.data.results.length == 0) {
+      return Promise.reject({ error: t`Repository ${repoName} not found.` });
+    }
+
+    const repo = data.data.results[0];
+    const pulp_id = parsePulpIDFromURL(repo.pulp_href);
+
+    const addList = [];
+    const removeList = [];
+
+    if (add) {
+      addList.push(collectionVersion_pulp_href);
+    } else {
+      removeList.push(collectionVersion_pulp_href);
+    }
+
+    data = await Repositories.modify(
+      pulp_id,
+      addList,
+      removeList,
+      repo.latest_version_href,
+    );
+
+    data = await waitForTaskUrl(data.data['task']);
+  }
+
+  public static async deleteCollection(repoName, collectionVersion_pulp_href) {
+    return RepositoriesUtils.deleteOrAddCollection(
+      repoName,
+      collectionVersion_pulp_href,
+      false,
+    );
+  }
+
+  public static async addCollection(repoName, collectionVersion_pulp_href) {
+    return RepositoriesUtils.deleteOrAddCollection(
+      repoName,
+      collectionVersion_pulp_href,
+      true,
+    );
+  }
+}


### PR DESCRIPTION
No-Issue

After merging of new CollectionAPISearch, Approval modal has now different philosophy. Each row now represents tuple Collection and repo. So for one collection in multiple repos, there will be one row for each repo.

Approve modal not affected, data for it was transformed in master. However this PR is adding ability to select/deselect all/on page.

Certification dashboard now contains those changes:

Rejected repo being loaded using pipeline:rejected filter, no longer contains hardwired 'rejected' repo. However, it reads first rejected repo, completely ignoring another if there are more. But user cant still create rejected repos, so this is probably ok.

Staging repos loaded, so it now supports multiple staging repos.

Rejection process reworked - it now rejecting only one collection from one approved repo into rejected repo. If collection is already in rejected repo (it can be both in rejected and in approved repos), collection is deleted from that approved repo, rather than moved to rejected repo (this will fail if collection is already in rejected repo).
 