### PR TITLE
basic landing page

### DIFF
--- a/CHANGES/2172.feature
+++ b/CHANGES/2172.feature
@@ -1,0 +1,1 @@
+Add a landing page to our UI.

--- a/developer_guidelines.md
+++ b/developer_guidelines.md
@@ -82,7 +82,7 @@ Example:
 
 ```
 // Static route
-<Link to={formatPath(Paths.search)} />
+<Link to={formatPath(Paths.collections)} />
 
 // Dynamic route
 <Link to={formatPath(Paths.editNamespace, { namespace: "NSname" })} />

--- a/src/components/cards/landing-page-card.tsx
+++ b/src/components/cards/landing-page-card.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import { Card, CardBody, CardHeader, Title } from '@patternfly/react-core';
 import * as React from 'react';
 
 interface IProps {
@@ -10,12 +10,26 @@ export const LandingPageCard = ({ title, body }: IProps) => {
   return (
     <Card
       className='landing-page-card'
-      style={{ margin: '0 0 24px 24px', flex: '30%' }}
+      style={{
+        margin: '0 0 24px 24px',
+        flex: '30%',
+        borderTop: '3px solid #39a5dc',
+      }}
     >
-      <CardHeader>
-        <CardTitle>{title}</CardTitle>
-      </CardHeader>
-      <CardBody>{body}</CardBody>
+      {' '}
+      <div
+        style={{
+          border: 0,
+          borderBottom: '1px solid #d1d1d1',
+        }}
+      >
+        <CardHeader>
+          <Title headingLevel='h1' size='2xl'>
+            {title}
+          </Title>
+        </CardHeader>
+      </div>
+      <CardBody style={{ marginTop: '24px' }}>{body}</CardBody>
     </Card>
   );
 };

--- a/src/components/cards/landing-page-card.tsx
+++ b/src/components/cards/landing-page-card.tsx
@@ -9,7 +9,7 @@ interface IProps {
 export const LandingPageCard = ({ title, body }: IProps) => {
   return (
     <React.Fragment>
-      <Card className='landing-page-card'>
+      <Card className='landing-page-card' style={{ marginBottom: '20px' }}>
         <CardHeader>
           <CardTitle>{title}</CardTitle>
         </CardHeader>

--- a/src/components/cards/landing-page-card.tsx
+++ b/src/components/cards/landing-page-card.tsx
@@ -1,0 +1,20 @@
+import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core';
+import * as React from 'react';
+
+interface IProps {
+  title: string;
+  body: string;
+}
+
+export const LandingPageCard = ({ title, body }: IProps) => {
+  return (
+    <React.Fragment>
+      <Card className='landing-page-card'>
+        <CardHeader>
+          <CardTitle>{title}</CardTitle>
+        </CardHeader>
+        <CardBody>{body}</CardBody>
+      </Card>
+    </React.Fragment>
+  );
+};

--- a/src/components/cards/landing-page-card.tsx
+++ b/src/components/cards/landing-page-card.tsx
@@ -8,13 +8,14 @@ interface IProps {
 
 export const LandingPageCard = ({ title, body }: IProps) => {
   return (
-    <React.Fragment>
-      <Card className='landing-page-card' style={{ marginBottom: '20px' }}>
-        <CardHeader>
-          <CardTitle>{title}</CardTitle>
-        </CardHeader>
-        <CardBody>{body}</CardBody>
-      </Card>
-    </React.Fragment>
+    <Card
+      className='landing-page-card'
+      style={{ margin: '0 0 24px 24px', flex: '30%' }}
+    >
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+      </CardHeader>
+      <CardBody>{body}</CardBody>
+    </Card>
   );
 };

--- a/src/components/cards/landing-page-card.tsx
+++ b/src/components/cards/landing-page-card.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 interface IProps {
   title: string;
-  body: string;
+  body: React.ReactNode;
 }
 
 export const LandingPageCard = ({ title, body }: IProps) => {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -61,6 +61,7 @@ export { LoadingPageSpinner } from './loading/loading-page-spinner';
 export { LoadingPageWithHeader } from './loading/loading-with-header';
 export { LoginLink } from './shared/login-link';
 export { Logo } from './logo/logo';
+export { LandingPageCard } from './cards/landing-page-card';
 export { Main } from './patternfly-wrappers/main';
 export { MarkdownEditor } from './markdown-editor/markdown-editor';
 export { NamespaceCard } from './cards/namespace-card';

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -11,6 +11,7 @@ export { default as CollectionDocs } from './collection-detail/collection-docs';
 export { default as CollectionImportLog } from './collection-detail/collection-import-log';
 export { default as CollectionDependencies } from './collection-detail/collection-dependencies';
 export { default as CollectionDistributions } from './collection-detail/collection-distributions';
+export { default as LandingPage } from './landing/landing-page';
 export { default as EditNamespace } from './edit-namespace/edit-namespace';
 export { default as LoginPage } from './login/login';
 export { default as MyImports } from './my-imports/my-imports';

--- a/src/containers/landing/landing-page.scss
+++ b/src/containers/landing/landing-page.scss
@@ -1,0 +1,3 @@
+.footer-link {
+  padding-right: 16px;
+}

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -74,7 +74,11 @@ export class LandingPage extends React.Component<RouteProps, IState> {
                   <p>
                     <Trans>
                       Use the{' '}
-                      <a href='https://galaxy.ansible.com/search?deprecated=false&keywords=&order_by=-relevance'>
+                      <a
+                        href='https://galaxy.ansible.com/search?deprecated=false&keywords=&order_by=-relevance'
+                        target='_blank'
+                        rel='noreferrer'
+                      >
                         Search page
                       </a>{' '}
                       to find content for your project, then download them onto
@@ -134,7 +138,11 @@ export class LandingPage extends React.Component<RouteProps, IState> {
                   </b>
                   <br />
                   <p>
-                    <a href='https://www.redhat.com/en/summit/ansiblefest?intcmp=7013a0000034lvmAAA'>
+                    <a
+                      href='https://www.redhat.com/en/summit/ansiblefest?intcmp=7013a0000034lvmAAA'
+                      target='_blank'
+                      rel='noreferrer'
+                    >
                       <img
                         width='100%'
                         alt='Ansible Fest at Red Hat Summit May 23rd to 25th 2023'
@@ -179,24 +187,32 @@ export class LandingPage extends React.Component<RouteProps, IState> {
                       <a
                         className='footer-link'
                         href='https://www.redhat.com/en/about/privacy-policy'
+                        target='_blank'
+                        rel='noreferrer'
                       >{t`Privacy statement`}</a>
                     </span>
                     <span>
                       <a
                         className='footer-link'
                         href='https://www.redhat.com/en/about/terms-use'
+                        target='_blank'
+                        rel='noreferrer'
                       >{t`Terms of use`}</a>
                     </span>
                     <span>
                       <a
                         className='footer-link'
                         href='https://www.redhat.com/en/about/all-policies-guidelines'
+                        target='_blank'
+                        rel='noreferrer'
                       >{t`All policies and guidelines`}</a>
                     </span>
                     <span>
                       <a
                         className='footer-link'
                         href='https://www.redhat.com/en/about/digital-accessibility'
+                        target='_blank'
+                        rel='noreferrer'
                       >{t`Digital accessibility`}</a>
                     </span>
                   </div>

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -1,17 +1,17 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import { SigningServiceAPI, SigningServiceType } from 'src/api';
+import { SigningServiceType } from 'src/api';
 import {
   AlertList,
   AlertType,
   BaseHeader,
-  LoadingPageSpinner,
+  LandingPageCard,
   Main,
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
 import { RouteProps, withRouter } from 'src/utilities';
-import { ParamHelper, errorMessage } from 'src/utilities';
+import { ParamHelper } from 'src/utilities';
 
 interface IState {
   params: {
@@ -50,16 +50,8 @@ export class LandingPage extends React.Component<RouteProps, IState> {
     };
   }
 
-  componentDidMount() {
-    if (!this.context.user || this.context.user.is_anonymous) {
-      this.setState({ loading: false, unauthorised: true });
-    } else {
-      this.query();
-    }
-  }
-
   render() {
-    const { loading, alerts } = this.state;
+    const { alerts } = this.state;
 
     return (
       <React.Fragment>
@@ -67,15 +59,24 @@ export class LandingPage extends React.Component<RouteProps, IState> {
           alerts={alerts}
           closeAlert={(i) => this.closeAlert(i)}
         ></AlertList>
-        <BaseHeader title={t`Landing Page`} />
+        <BaseHeader title={t`Home`} />
         <Main>
-          {loading ? (
-            <LoadingPageSpinner />
-          ) : (
-            <section className='body'>
-              <div className='hub-list-toolbar'></div>
-            </section>
-          )}
+          <LandingPageCard
+            title={t`Lorem Ipsum`}
+            body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
+          />
+          <LandingPageCard
+            title={t`Lorem Ipsum`}
+            body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
+          />
+          <LandingPageCard
+            title={t`Lorem Ipsum`}
+            body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
+          />
+          <LandingPageCard
+            title={t`Lorem Ipsum`}
+            body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
+          />
         </Main>
       </React.Fragment>
     );
@@ -83,32 +84,6 @@ export class LandingPage extends React.Component<RouteProps, IState> {
 
   private get closeAlert() {
     return closeAlertMixin('alerts');
-  }
-
-  private query() {
-    this.setState({ loading: true }, () => {
-      SigningServiceAPI.list(this.state.params)
-        .then((result) => {
-          this.setState({
-            items: result.data.results,
-            itemCount: result.data.count,
-            loading: false,
-          });
-        })
-        .catch((e) => {
-          const { status, statusText } = e.response;
-          this.setState({
-            loading: false,
-            items: [],
-            itemCount: 0,
-          });
-          this.addAlert({
-            title: t`Signature keys could not be displayed.`,
-            variant: 'danger',
-            description: errorMessage(status, statusText),
-          });
-        });
-    });
   }
 
   private addAlert(alert: AlertType) {

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -12,6 +12,8 @@ import {
 import { AppContext } from 'src/loaders/app-context';
 import { RouteProps, withRouter } from 'src/utilities';
 
+
+
 interface IState {
   alerts: AlertType[];
 }
@@ -34,13 +36,8 @@ export class LandingPage extends React.Component<RouteProps, IState> {
           alerts={alerts}
           closeAlert={(i) => this.closeAlert(i)}
         ></AlertList>
-        <BaseHeader title={t`Home`} />
+        <BaseHeader title={t`Welcome to Beta Galaxy`} />
         <Main>
-          <Title
-            style={{ margin: '8px 0 24px 0' }}
-            headingLevel='h1'
-            size='2xl'
-          >{t`Welcome to Beta Galaxy`}</Title>
           <div
             style={{
               display: 'flex',
@@ -145,10 +142,15 @@ export class LandingPage extends React.Component<RouteProps, IState> {
               title={t`Terms of Use`}
               body={
                 <React.Fragment>
-                  <p>
-                    {t`Please see our`}{' '}
-                    <a href='https://www.redhat.com/en/about/terms-use'>{t`Terms of Use`}</a>
+                  <div style={{ display: 'flex',}}>
+                  <p style={{paddingRight: '16px'}}>
+                    <a href='https://www.redhat.com/en/about/privacy-policy'>{t`Privacy statement`}</a>
                   </p>
+                  <p style={{paddingRight: '16px'}}><a href='https://www.redhat.com/en/about/terms-use'>{t`Terms of use`}</a></p>
+                  <p style={{paddingRight: '16px'}}><a href='https://www.redhat.com/en/about/all-policies-guidelines'>{t`All policies and guidelines`}</a></p>
+                  <p style={{paddingRight: '16px'}}><a href='https://www.redhat.com/en/about/digital-accessibility'>{t`Digital accessibility`}</a></p>
+                  <p style={{paddingRight: '16px'}}><a href="#">{t`Cookie preferences`}</a></p>
+                  </div>
                 </React.Fragment>
               }
             />

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -1,6 +1,5 @@
 import { t } from '@lingui/macro';
 import * as React from 'react';
-import { SigningServiceType } from 'src/api';
 import {
   AlertList,
   AlertType,
@@ -11,42 +10,17 @@ import {
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
 import { RouteProps, withRouter } from 'src/utilities';
-import { ParamHelper } from 'src/utilities';
 
 interface IState {
-  params: {
-    page?: number;
-    page_size?: number;
-  };
-  loading: boolean;
-  items: SigningServiceType[];
-  itemCount: number;
   alerts: AlertType[];
-  unauthorised: boolean;
-  inputText: string;
 }
 
 export class LandingPage extends React.Component<RouteProps, IState> {
   constructor(props) {
     super(props);
 
-    const params = ParamHelper.parseParamString(props.location.search, [
-      'page',
-      'page_size',
-    ]);
-
-    if (!params['page_size']) {
-      params['page_size'] = 100;
-    }
-
     this.state = {
-      params: params,
-      items: [],
-      loading: true,
-      itemCount: 0,
       alerts: [],
-      unauthorised: false,
-      inputText: '',
     };
   }
 
@@ -61,22 +35,31 @@ export class LandingPage extends React.Component<RouteProps, IState> {
         ></AlertList>
         <BaseHeader title={t`Home`} />
         <Main>
-          <LandingPageCard
-            title={t`Lorem Ipsum`}
-            body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
-          />
-          <LandingPageCard
-            title={t`Lorem Ipsum`}
-            body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
-          />
-          <LandingPageCard
-            title={t`Lorem Ipsum`}
-            body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
-          />
-          <LandingPageCard
-            title={t`Lorem Ipsum`}
-            body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
-          />
+          <div
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              alignContent: 'flex-start',
+              marginLeft: '-24px',
+            }}
+          >
+            <LandingPageCard
+              title={t`Lorem Ipsum`}
+              body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
+            />
+            <LandingPageCard
+              title={t`Lorem Ipsum`}
+              body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
+            />
+            <LandingPageCard
+              title={t`Lorem Ipsum`}
+              body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
+            />
+            <LandingPageCard
+              title={t`Lorem Ipsum`}
+              body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
+            />
+          </div>
         </Main>
       </React.Fragment>
     );
@@ -90,10 +73,6 @@ export class LandingPage extends React.Component<RouteProps, IState> {
     this.setState({
       alerts: [...this.state.alerts, alert],
     });
-  }
-
-  private get updateParams() {
-    return ParamHelper.updateParamsMixin();
   }
 }
 

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -1,5 +1,4 @@
 import { t } from '@lingui/macro';
-
 import * as React from 'react';
 import { SigningServiceAPI, SigningServiceType } from 'src/api';
 import {
@@ -74,8 +73,7 @@ export class LandingPage extends React.Component<RouteProps, IState> {
             <LoadingPageSpinner />
           ) : (
             <section className='body'>
-              <div className='hub-list-toolbar'>
-              </div>
+              <div className='hub-list-toolbar'></div>
             </section>
           )}
         </Main>

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -1,5 +1,4 @@
-import { t } from '@lingui/macro';
-import { Title } from '@patternfly/react-core';
+import { Trans, t } from '@lingui/macro';
 import * as React from 'react';
 import {
   AlertList,
@@ -11,8 +10,7 @@ import {
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
 import { RouteProps, withRouter } from 'src/utilities';
-
-
+import './landing-page.scss';
 
 interface IState {
   alerts: AlertType[];
@@ -59,14 +57,21 @@ export class LandingPage extends React.Component<RouteProps, IState> {
                   <br />
 
                   <p>
-                    {t`Use the`}{' '}
-                    <a href='https://galaxy.ansible.com/search?deprecated=false&keywords=&order_by=-relevance'>{t`Search page`}</a>{' '}
-                    {t`to find content for your project, then download them onto your Ansible host using`}{' '}
-                    <a
-                      href='https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html#the-command-line-tool'
-                      target='_blanck'
-                    >{t`ansible-galaxy`}</a>
-                    {t`, the command line tool that comes bundled with Ansible.`}
+                    <Trans>
+                      Use the{' '}
+                      <a href='https://galaxy.ansible.com/search?deprecated=false&keywords=&order_by=-relevance'>
+                        Search page
+                      </a>{' '}
+                      to find content for your project, then download them onto
+                      your Ansible host using{' '}
+                      <a
+                        href='https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html#the-command-line-tool'
+                        target='_blanck'
+                      >
+                        ansible-galaxy
+                      </a>
+                      , the command line tool that comes bundled with Ansible.
+                    </Trans>
                   </p>
                 </React.Fragment>
               }
@@ -81,14 +86,25 @@ export class LandingPage extends React.Component<RouteProps, IState> {
                   <br />
 
                   <p>
-                    {t`Red Hat is working on exciting new Ansible content development capabilities within the context of`}{' '}
-                    <a
-                      href='https://www.redhat.com/en/engage/project-wisdom?extIdCarryOver=true&sc_cid=701f2000001OH6uAAG'
-                      target='_blank'
-                      rel='noopener noreferrer'
-                    >{t`Project Wisdom`}</a>{' '}
-                    {t`to help other automators build Ansible content. Your roles and collections may be used as training data for a machine learning model that provides Ansible automation content recommendations. If you have concerns, please contact the Ansible team at`}{' '}
-                    <a href='mailto:ansible-content-ai@redhat.com'>{t`ansible-content-ai@redhat.com`}</a>
+                    <Trans>
+                      Red Hat is working on exciting new Ansible content
+                      development capabilities within the context of{' '}
+                      <a
+                        href='https://www.redhat.com/en/engage/project-wisdom?extIdCarryOver=true&sc_cid=701f2000001OH6uAAG'
+                        target='_blank'
+                        rel='noopener noreferrer'
+                      >
+                        Project Wisdom
+                      </a>{' '}
+                      to help other automators build Ansible content. Your roles
+                      and collections may be used as training data for a machine
+                      learning model that provides Ansible automation content
+                      recommendations. If you have concerns, please contact the
+                      Ansible team at{' '}
+                      <a href='mailto:ansible-content-ai@redhat.com'>
+                        ansible-content-ai@redhat.com
+                      </a>
+                    </Trans>
                   </p>
                 </React.Fragment>
               }
@@ -142,14 +158,37 @@ export class LandingPage extends React.Component<RouteProps, IState> {
               title={t`Terms of Use`}
               body={
                 <React.Fragment>
-                  <div style={{ display: 'flex',}}>
-                  <p style={{paddingRight: '16px'}}>
-                    <a href='https://www.redhat.com/en/about/privacy-policy'>{t`Privacy statement`}</a>
-                  </p>
-                  <p style={{paddingRight: '16px'}}><a href='https://www.redhat.com/en/about/terms-use'>{t`Terms of use`}</a></p>
-                  <p style={{paddingRight: '16px'}}><a href='https://www.redhat.com/en/about/all-policies-guidelines'>{t`All policies and guidelines`}</a></p>
-                  <p style={{paddingRight: '16px'}}><a href='https://www.redhat.com/en/about/digital-accessibility'>{t`Digital accessibility`}</a></p>
-                  <p style={{paddingRight: '16px'}}><a href="#">{t`Cookie preferences`}</a></p>
+                  <div className='footer-parent-links'>
+                    <span>
+                      <a
+                        className='footer-link'
+                        href='https://www.redhat.com/en/about/privacy-policy'
+                      >{t`Privacy statement`}</a>
+                    </span>
+                    <span>
+                      <a
+                        className='footer-link'
+                        href='https://www.redhat.com/en/about/terms-use'
+                      >{t`Terms of use`}</a>
+                    </span>
+                    <span>
+                      <a
+                        className='footer-link'
+                        href='https://www.redhat.com/en/about/all-policies-guidelines'
+                      >{t`All policies and guidelines`}</a>
+                    </span>
+                    <span>
+                      <a
+                        className='footer-link'
+                        href='https://www.redhat.com/en/about/digital-accessibility'
+                      >{t`Digital accessibility`}</a>
+                    </span>
+                    <span>
+                      <a
+                        className='footer-link'
+                        href='#'
+                      >{t`Cookie preferences`}</a>
+                    </span>
                   </div>
                 </React.Fragment>
               }

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -44,20 +44,31 @@ export class LandingPage extends React.Component<RouteProps, IState> {
             }}
           >
             <LandingPageCard
-              title={t`Lorem Ipsum`}
-              body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
+              title={t`Download`}
+              body={<React.Fragment><p>{t`Jump-start your automation project with great content from the Ansible community. Galaxy provides pre-packaged units of work known to Ansible as roles and collections.`}</p><br/>
+
+<p>{t`Content from roles and collections can be referenced in Ansible PlayBooks and immediately put to work. You'll find content for provisioning infrastructure, deploying applications, and all of the tasks you do everyday.`} </p><br/>
+
+<p>{t`Use the <Search page> to find content for your project, then download them onto your Ansible host using <ansible-galaxy>, the command line tool that comes bundled with Ansible.`}</p></React.Fragment>}
+
+
             />
-            <LandingPageCard
-              title={t`Lorem Ipsum`}
-              body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
+             <LandingPageCard
+              title={t`Share`}
+              body={<React.Fragment><p>{t`Help other Ansible users by sharing the awesome roles and collections you create.`}</p><br/>
+              <p>{t`Maybe you have automation for installing and configuring a popular software package, or for deploying software built by your company. Whatever it is, use Galaxy to share it with the community.`}</p><br/>
+
+
+<p>{t`Red Hat is working on exciting new Ansible content development capabilities within the context of <Project Wisdom> to help other automators build Ansible content. Your roles and collections may be used as training data for a machine learning model that provides Ansible automation content recommendations. If you have concerns, please contact the Ansible team at <ansible-content-ai@redhat.com>.`}</p></React.Fragment>}
+
+
             />
-            <LandingPageCard
-              title={t`Lorem Ipsum`}
-              body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
-            />
-            <LandingPageCard
-              title={t`Lorem Ipsum`}
-              body={t`Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam nibh odio, semper non ex vitae, semper convallis tellus. Praesent et ipsum erat. Praesent hendrerit urna eget mattis vestibulum. Maecenas dictum orci vitae nisl sagittis laoreet id et mauris. Sed pharetra accumsan nibh a viverra. Duis tincidunt eros at maximus sodales. Fusce gravida tellus ligula eu posuere lorem placerat ut.`}
+             <LandingPageCard
+              title={t`Featured`}
+              body={<React.Fragment><p>{t`Jump-start your automation project with great content from the Ansible community. Galaxy provides pre-packaged units of work known to Ansible as roles and collections.`}</p><br/>
+
+<p>{t`Content from roles and collections can be referenced in Ansible PlayBooks and immediately put to work. You'll find content for provisioning infrastructure, deploying applications, and all of the tasks you do everyday.`} </p><br/>
+<p>{t`Use the Search page to find content for your project, then download them onto your Ansible host using ansible-galaxy, the command line tool that comes bundled with Ansible.`}</p></React.Fragment>}
             />
           </div>
         </Main>

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -1,21 +1,13 @@
 import { t } from '@lingui/macro';
-import {
-  Toolbar,
-  ToolbarContent,
-  ToolbarGroup,
-  ToolbarItem,
-} from '@patternfly/react-core';
+
 import * as React from 'react';
 import { SigningServiceAPI, SigningServiceType } from 'src/api';
 import {
   AlertList,
   AlertType,
-  AppliedFilters,
   BaseHeader,
-  CompoundFilter,
   LoadingPageSpinner,
   Main,
-  Pagination,
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
@@ -68,7 +60,7 @@ export class LandingPage extends React.Component<RouteProps, IState> {
   }
 
   render() {
-    const { params, itemCount, loading, alerts } = this.state;
+    const { loading, alerts } = this.state;
 
     return (
       <React.Fragment>
@@ -83,57 +75,7 @@ export class LandingPage extends React.Component<RouteProps, IState> {
           ) : (
             <section className='body'>
               <div className='hub-list-toolbar'>
-                <Toolbar>
-                  <ToolbarContent>
-                    <ToolbarGroup>
-                      <ToolbarItem>
-                        <CompoundFilter
-                          inputText={this.state.inputText}
-                          onChange={(text) =>
-                            this.setState({ inputText: text })
-                          }
-                          updateParams={(p) => {
-                            p['page'] = 1;
-                            this.updateParams(p, () => this.query());
-                          }}
-                          params={params}
-                          filterConfig={[
-                            {
-                              id: 'name',
-                              title: t`Name`,
-                            },
-                          ]}
-                        />
-                      </ToolbarItem>
-                    </ToolbarGroup>
-                  </ToolbarContent>
-                </Toolbar>
-                <Pagination
-                  params={params}
-                  updateParams={(p) => this.updateParams(p, () => this.query())}
-                  count={itemCount}
-                  isTop
-                />
               </div>
-              <div>
-                <AppliedFilters
-                  updateParams={(p) => {
-                    this.updateParams(p, () => this.query());
-                    this.setState({ inputText: '' });
-                  }}
-                  params={params}
-                  ignoredParams={['page_size', 'page', 'sort', 'ordering']}
-                  niceNames={{
-                    name: t`Name`,
-                  }}
-                />
-              </div>
-
-              <Pagination
-                params={params}
-                updateParams={(p) => this.updateParams(p, () => this.query())}
-                count={itemCount}
-              />
             </section>
           )}
         </Main>

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -1,4 +1,5 @@
 import { t } from '@lingui/macro';
+import { Title } from '@patternfly/react-core';
 import * as React from 'react';
 import {
   AlertList,
@@ -35,6 +36,11 @@ export class LandingPage extends React.Component<RouteProps, IState> {
         ></AlertList>
         <BaseHeader title={t`Home`} />
         <Main>
+          <Title
+            style={{ margin: '8px 0 24px 0' }}
+            headingLevel='h1'
+            size='2xl'
+          >{t`Welcome to Beta Galaxy`}</Title>
           <div
             style={{
               display: 'flex',
@@ -45,30 +51,106 @@ export class LandingPage extends React.Component<RouteProps, IState> {
           >
             <LandingPageCard
               title={t`Download`}
-              body={<React.Fragment><p>{t`Jump-start your automation project with great content from the Ansible community. Galaxy provides pre-packaged units of work known to Ansible as roles and collections.`}</p><br/>
+              body={
+                <React.Fragment>
+                  <p>{t`Jump-start your automation project with great content from the Ansible community. Galaxy provides pre-packaged units of work known to Ansible as roles and collections.`}</p>
+                  <br />
 
-<p>{t`Content from roles and collections can be referenced in Ansible PlayBooks and immediately put to work. You'll find content for provisioning infrastructure, deploying applications, and all of the tasks you do everyday.`} </p><br/>
+                  <p>
+                    {t`Content from roles and collections can be referenced in Ansible PlayBooks and immediately put to work. You'll find content for provisioning infrastructure, deploying applications, and all of the tasks you do everyday.`}{' '}
+                  </p>
+                  <br />
 
-<p>{t`Use the <Search page> to find content for your project, then download them onto your Ansible host using <ansible-galaxy>, the command line tool that comes bundled with Ansible.`}</p></React.Fragment>}
-
-
+                  <p>
+                    {t`Use the`}{' '}
+                    <a href='https://galaxy.ansible.com/search?deprecated=false&keywords=&order_by=-relevance'>{t`Search page`}</a>{' '}
+                    {t`to find content for your project, then download them onto your Ansible host using`}{' '}
+                    <a
+                      href='https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html#the-command-line-tool'
+                      target='_blanck'
+                    >{t`ansible-galaxy`}</a>
+                    {t`, the command line tool that comes bundled with Ansible.`}
+                  </p>
+                </React.Fragment>
+              }
             />
-             <LandingPageCard
+            <LandingPageCard
               title={t`Share`}
-              body={<React.Fragment><p>{t`Help other Ansible users by sharing the awesome roles and collections you create.`}</p><br/>
-              <p>{t`Maybe you have automation for installing and configuring a popular software package, or for deploying software built by your company. Whatever it is, use Galaxy to share it with the community.`}</p><br/>
+              body={
+                <React.Fragment>
+                  <p>{t`Help other Ansible users by sharing the awesome roles and collections you create.`}</p>
+                  <br />
+                  <p>{t`Maybe you have automation for installing and configuring a popular software package, or for deploying software built by your company. Whatever it is, use Galaxy to share it with the community.`}</p>
+                  <br />
 
-
-<p>{t`Red Hat is working on exciting new Ansible content development capabilities within the context of <Project Wisdom> to help other automators build Ansible content. Your roles and collections may be used as training data for a machine learning model that provides Ansible automation content recommendations. If you have concerns, please contact the Ansible team at <ansible-content-ai@redhat.com>.`}</p></React.Fragment>}
-
-
+                  <p>
+                    {t`Red Hat is working on exciting new Ansible content development capabilities within the context of`}{' '}
+                    <a
+                      href='https://www.redhat.com/en/engage/project-wisdom?extIdCarryOver=true&sc_cid=701f2000001OH6uAAG'
+                      target='_blank'
+                      rel='noopener noreferrer'
+                    >{t`Project Wisdom`}</a>{' '}
+                    {t`to help other automators build Ansible content. Your roles and collections may be used as training data for a machine learning model that provides Ansible automation content recommendations. If you have concerns, please contact the Ansible team at`}{' '}
+                    <a href='mailto:ansible-content-ai@redhat.com'>{t`ansible-content-ai@redhat.com`}</a>
+                  </p>
+                </React.Fragment>
+              }
             />
-             <LandingPageCard
+            <LandingPageCard
               title={t`Featured`}
-              body={<React.Fragment><p>{t`Jump-start your automation project with great content from the Ansible community. Galaxy provides pre-packaged units of work known to Ansible as roles and collections.`}</p><br/>
-
-<p>{t`Content from roles and collections can be referenced in Ansible PlayBooks and immediately put to work. You'll find content for provisioning infrastructure, deploying applications, and all of the tasks you do everyday.`} </p><br/>
-<p>{t`Use the Search page to find content for your project, then download them onto your Ansible host using ansible-galaxy, the command line tool that comes bundled with Ansible.`}</p></React.Fragment>}
+              body={
+                <React.Fragment>
+                  <b>
+                    <p>{t`AnsibleFest`}</p>
+                  </b>
+                  <br />
+                  <p>
+                    <a href='https://www.redhat.com/en/summit/ansiblefest?intcmp=7013a0000034lvmAAA'>
+                      <img
+                        width='100%'
+                        alt='Ansible Fest at Red Hat Summit May 23rd to 25th 2023'
+                        src='https://www.ansible.com/hubfs/rh-2023-summit-ansiblefest-ansible-galaxy-site-200x200.png'
+                      />
+                    </a>
+                  </p>
+                  <hr
+                    style={{
+                      boxSizing: 'content-box',
+                      height: 0,
+                      marginTop: 20,
+                      marginBottom: 20,
+                      border: 0,
+                      borderTop: '1px solid #f1f1f1',
+                    }}
+                  />
+                  <p>
+                    <b>
+                      {t`Extend the power of Ansible to your entire team.`}{' '}
+                    </b>
+                  </p>
+                  <br />
+                  <p>{t`Try Red Hat Ansible Automation Platform`}</p>
+                  <br />
+                  <p>
+                    <a
+                      href='https://www.redhat.com/en/technologies/management/ansible/try-it?sc_cid=7013a0000030vCCAAY'
+                      target='_blank'
+                      rel='noreferrer'
+                    >{t`Get the trial`}</a>
+                  </p>
+                </React.Fragment>
+              }
+            />
+            <LandingPageCard
+              title={t`Terms of Use`}
+              body={
+                <React.Fragment>
+                  <p>
+                    {t`Please see our`}{' '}
+                    <a href='https://www.redhat.com/en/about/terms-use'>{t`Terms of Use`}</a>
+                  </p>
+                </React.Fragment>
+              }
             />
           </div>
         </Main>

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -1,0 +1,187 @@
+import { t } from '@lingui/macro';
+import {
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import * as React from 'react';
+import { SigningServiceAPI, SigningServiceType } from 'src/api';
+import {
+  AlertList,
+  AlertType,
+  AppliedFilters,
+  BaseHeader,
+  CompoundFilter,
+  LoadingPageSpinner,
+  Main,
+  Pagination,
+  closeAlertMixin,
+} from 'src/components';
+import { AppContext } from 'src/loaders/app-context';
+import { RouteProps, withRouter } from 'src/utilities';
+import { ParamHelper, errorMessage } from 'src/utilities';
+
+interface IState {
+  params: {
+    page?: number;
+    page_size?: number;
+  };
+  loading: boolean;
+  items: SigningServiceType[];
+  itemCount: number;
+  alerts: AlertType[];
+  unauthorised: boolean;
+  inputText: string;
+}
+
+export class LandingPage extends React.Component<RouteProps, IState> {
+  constructor(props) {
+    super(props);
+
+    const params = ParamHelper.parseParamString(props.location.search, [
+      'page',
+      'page_size',
+    ]);
+
+    if (!params['page_size']) {
+      params['page_size'] = 100;
+    }
+
+    this.state = {
+      params: params,
+      items: [],
+      loading: true,
+      itemCount: 0,
+      alerts: [],
+      unauthorised: false,
+      inputText: '',
+    };
+  }
+
+  componentDidMount() {
+    if (!this.context.user || this.context.user.is_anonymous) {
+      this.setState({ loading: false, unauthorised: true });
+    } else {
+      this.query();
+    }
+  }
+
+  render() {
+    const { params, itemCount, loading, alerts } = this.state;
+
+    return (
+      <React.Fragment>
+        <AlertList
+          alerts={alerts}
+          closeAlert={(i) => this.closeAlert(i)}
+        ></AlertList>
+        <BaseHeader title={t`Landing Page`} />
+        <Main>
+          {loading ? (
+            <LoadingPageSpinner />
+          ) : (
+            <section className='body'>
+              <div className='hub-list-toolbar'>
+                <Toolbar>
+                  <ToolbarContent>
+                    <ToolbarGroup>
+                      <ToolbarItem>
+                        <CompoundFilter
+                          inputText={this.state.inputText}
+                          onChange={(text) =>
+                            this.setState({ inputText: text })
+                          }
+                          updateParams={(p) => {
+                            p['page'] = 1;
+                            this.updateParams(p, () => this.query());
+                          }}
+                          params={params}
+                          filterConfig={[
+                            {
+                              id: 'name',
+                              title: t`Name`,
+                            },
+                          ]}
+                        />
+                      </ToolbarItem>
+                    </ToolbarGroup>
+                  </ToolbarContent>
+                </Toolbar>
+                <Pagination
+                  params={params}
+                  updateParams={(p) => this.updateParams(p, () => this.query())}
+                  count={itemCount}
+                  isTop
+                />
+              </div>
+              <div>
+                <AppliedFilters
+                  updateParams={(p) => {
+                    this.updateParams(p, () => this.query());
+                    this.setState({ inputText: '' });
+                  }}
+                  params={params}
+                  ignoredParams={['page_size', 'page', 'sort', 'ordering']}
+                  niceNames={{
+                    name: t`Name`,
+                  }}
+                />
+              </div>
+
+              <Pagination
+                params={params}
+                updateParams={(p) => this.updateParams(p, () => this.query())}
+                count={itemCount}
+              />
+            </section>
+          )}
+        </Main>
+      </React.Fragment>
+    );
+  }
+
+  private get closeAlert() {
+    return closeAlertMixin('alerts');
+  }
+
+  private query() {
+    this.setState({ loading: true }, () => {
+      SigningServiceAPI.list(this.state.params)
+        .then((result) => {
+          this.setState({
+            items: result.data.results,
+            itemCount: result.data.count,
+            loading: false,
+          });
+        })
+        .catch((e) => {
+          const { status, statusText } = e.response;
+          this.setState({
+            loading: false,
+            items: [],
+            itemCount: 0,
+          });
+          this.addAlert({
+            title: t`Signature keys could not be displayed.`,
+            variant: 'danger',
+            description: errorMessage(status, statusText),
+          });
+        });
+    });
+  }
+
+  private addAlert(alert: AlertType) {
+    this.setState({
+      alerts: [...this.state.alerts, alert],
+    });
+  }
+
+  private get updateParams() {
+    return ParamHelper.updateParamsMixin();
+  }
+}
+
+export default withRouter(LandingPage);
+
+LandingPage.contextType = AppContext;

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -199,12 +199,6 @@ export class LandingPage extends React.Component<RouteProps, IState> {
                         href='https://www.redhat.com/en/about/digital-accessibility'
                       >{t`Digital accessibility`}</a>
                     </span>
-                    <span>
-                      <a
-                        className='footer-link'
-                        href='#'
-                      >{t`Cookie preferences`}</a>
-                    </span>
                   </div>
                 </React.Fragment>
               }

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -1,5 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import * as React from 'react';
+import { Link } from 'react-router-dom';
 import {
   AlertList,
   AlertType,
@@ -74,13 +75,9 @@ export class LandingPage extends React.Component<RouteProps, IState> {
                   <p>
                     <Trans>
                       Use the{' '}
-                      <a
-                        href='https://galaxy.ansible.com/search?deprecated=false&keywords=&order_by=-relevance'
-                        target='_blank'
-                        rel='noreferrer'
-                      >
-                        Search page
-                      </a>{' '}
+                      <Link to={formatPath(Paths.collections)}>
+                        Search page{' '}
+                      </Link>
                       to find content for your project, then download them onto
                       your Ansible host using{' '}
                       <a

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -9,11 +9,13 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
+import { Paths, formatPath } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
 import './landing-page.scss';
 
 interface IState {
   alerts: AlertType[];
+  redirect: boolean;
 }
 
 export class LandingPage extends React.Component<RouteProps, IState> {
@@ -22,11 +24,24 @@ export class LandingPage extends React.Component<RouteProps, IState> {
 
     this.state = {
       alerts: [],
+      redirect: false,
     };
   }
 
+  componentDidMount() {
+    const { ai_deny_index } = this.context.featureFlags;
+    if (!ai_deny_index) {
+      this.setState({ redirect: true });
+    }
+  }
+
   render() {
-    const { alerts } = this.state;
+    const { alerts, redirect } = this.state;
+
+    if (redirect) {
+      setTimeout(() => this.props.navigate(formatPath(Paths.collections)));
+      return null;
+    }
 
     return (
       <React.Fragment>
@@ -66,7 +81,8 @@ export class LandingPage extends React.Component<RouteProps, IState> {
                       your Ansible host using{' '}
                       <a
                         href='https://docs.ansible.com/ansible/latest/reference_appendices/galaxy.html#the-command-line-tool'
-                        target='_blanck'
+                        target='_blank'
+                        rel='noreferrer'
                       >
                         ansible-galaxy
                       </a>
@@ -94,7 +110,7 @@ export class LandingPage extends React.Component<RouteProps, IState> {
                         target='_blank'
                         rel='noopener noreferrer'
                       >
-                        Project Wisdom
+                        Ansible Lightspeed
                       </a>{' '}
                       to help other automators build Ansible content. Your roles
                       and collections may be used as training data for a machine

--- a/src/containers/login/login.tsx
+++ b/src/containers/login/login.tsx
@@ -29,7 +29,7 @@ class LoginPage extends React.Component<RouteProps, IState> {
     };
 
     const params = ParamHelper.parseParamString(this.props.location.search);
-    this.redirectPage = params['next'] || formatPath(Paths.collections);
+    this.redirectPage = params['next'] || formatPath(Paths.landingPage);
   }
 
   render() {

--- a/src/containers/login/login.tsx
+++ b/src/containers/login/login.tsx
@@ -29,7 +29,7 @@ class LoginPage extends React.Component<RouteProps, IState> {
     };
 
     const params = ParamHelper.parseParamString(this.props.location.search);
-    this.redirectPage = params['next'] || formatPath(Paths.search);
+    this.redirectPage = params['next'] || formatPath(Paths.collections);
   }
 
   render() {

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -103,9 +103,9 @@ class TokenInsights extends React.Component<RouteProps, IState> {
                 page to sync collections curated by your organization to the Red
                 Hat Certified repository in your private Automation Hub. Users
                 with the correct permissions can use the sync toggles on the{' '}
-                <Link to={formatPath(Paths.collections)}>Collections</Link> page to
-                control which collections are added to their organization&apos;s
-                sync repository.
+                <Link to={formatPath(Paths.collections)}>Collections</Link> page
+                to control which collections are added to their
+                organization&apos;s sync repository.
               </Trans>
             </p>
           </section>

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -103,7 +103,7 @@ class TokenInsights extends React.Component<RouteProps, IState> {
                 page to sync collections curated by your organization to the Red
                 Hat Certified repository in your private Automation Hub. Users
                 with the correct permissions can use the sync toggles on the{' '}
-                <Link to={formatPath(Paths.search)}>Collections</Link> page to
+                <Link to={formatPath(Paths.collections)}>Collections</Link> page to
                 control which collections are added to their organization&apos;s
                 sync repository.
               </Trans>

--- a/src/loaders/insights/routes.tsx
+++ b/src/loaders/insights/routes.tsx
@@ -154,6 +154,7 @@ const routes = [
   { path: Paths.myImports, component: MyImports },
   { path: Paths.namespace, component: NamespaceDetail },
   { path: Paths.collections, component: Search },
+  { path: '/', component: Search },
 ];
 
 /**

--- a/src/loaders/insights/routes.tsx
+++ b/src/loaders/insights/routes.tsx
@@ -154,7 +154,6 @@ const routes = [
   { path: Paths.myImports, component: MyImports },
   { path: Paths.namespace, component: NamespaceDetail },
   { path: Paths.collections, component: Search },
-  { path: Paths.search, component: Search },
 ];
 
 /**

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -127,7 +127,7 @@ export const StandaloneLayout = ({
     <PageHeader
       logo={<SmallLogo alt={APPLICATION_NAME}></SmallLogo>}
       logoComponent={({ children }) => (
-        <Link to={formatPath(Paths.collections)}>{children}</Link>
+        <Link to={formatPath(Paths.landingPage)}>{children}</Link>
       )}
       headerTools={
         <PageHeaderTools>

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -38,10 +38,6 @@ const menuSection = (name, options = {}, items = []) => ({
 
 function standaloneMenu() {
   return [
-    menuItem(t`Landing Page`, {
-      url: formatPath(Paths.landingPage),
-      condition: isLoggedIn,
-    }),
     menuSection(t`Collections`, {}, [
       menuItem(t`Collections`, {
         url: formatPath(Paths.collections),

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -38,6 +38,10 @@ const menuSection = (name, options = {}, items = []) => ({
 
 function standaloneMenu() {
   return [
+    menuItem(t`Landing Page`, {
+      url: formatPath(Paths.landingPage),
+      condition: isLoggedIn,
+    }),
     menuSection(t`Collections`, {}, [
       menuItem(t`Collections`, {
         url: formatPath(Paths.collections),

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -288,7 +288,6 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
       { component: MyImports, path: Paths.myImports },
       { component: NamespaceDetail, path: Paths.namespace },
       { component: Search, path: Paths.collections },
-      { component: Search, path: Paths.search },
       { component: LandingPage, path: Paths.landingPage },
     ];
   }

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -28,6 +28,7 @@ import {
   ExecutionEnvironmentRegistryList,
   GroupDetail,
   GroupList,
+  LandingPage,
   LegacyNamespace,
   LegacyNamespaces,
   LegacyRole,
@@ -288,6 +289,7 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
       { component: NamespaceDetail, path: Paths.namespace },
       { component: Search, path: Paths.collections },
       { component: Search, path: Paths.search },
+      { component: LandingPage, path: Paths.landingPage },
     ];
   }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -122,6 +122,7 @@ export enum Paths {
   taskList = '/tasks',
   signatureKeys = '/signature-keys',
   collections = '/collections',
+  landingPage = '/landing-page',
 }
 
 export const namespaceBreadcrumb = {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -86,7 +86,7 @@ export enum Paths {
   myImports = '/my-imports',
   login = '/login',
   logout = '/logout',
-  search = '/',
+  landingPage = '',
   legacyRole = '/legacy/roles/:username/:name',
   legacyRoles = '/legacy/roles/',
   legacyNamespace = '/legacy/namespaces/:namespaceid',
@@ -122,7 +122,6 @@ export enum Paths {
   taskList = '/tasks',
   signatureKeys = '/signature-keys',
   collections = '/collections',
-  landingPage = '/landing-page',
 }
 
 export const namespaceBreadcrumb = {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -86,7 +86,7 @@ export enum Paths {
   myImports = '/my-imports',
   login = '/login',
   logout = '/logout',
-  landingPage = '',
+  landingPage = '/',
   legacyRole = '/legacy/roles/:username/:name',
   legacyRoles = '/legacy/roles/',
   legacyNamespace = '/legacy/namespaces/:namespaceid',

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -11,6 +11,7 @@ export function formatPath(path: Paths, data = {}, params?: ParamType) {
           .replace(/\/$/, '')
       : '';
   url += (path as string) + '/';
+  url = url.replaceAll('//', '/');
 
   for (const k of Object.keys(data)) {
     url = url.replace(':' + k, encodeURIComponent(data[k]));

--- a/test/cypress/e2e/execution_environments/execution_environments_edit.js
+++ b/test/cypress/e2e/execution_environments/execution_environments_edit.js
@@ -3,7 +3,6 @@ describe('execution environments', () => {
 
   before(() => {
     cy.login();
-
     cy.deleteRegistriesManual();
     cy.deleteContainersManual();
 
@@ -23,6 +22,7 @@ describe('execution environments', () => {
 
   beforeEach(() => {
     cy.login();
+    cy.wait(10000);
     cy.menuGo('Execution Environments > Execution Environments');
   });
 


### PR DESCRIPTION
Issue: AAH-2172

This work is the first version of the Beta Galaxy landing page dashboard with footer. The design follows and adds to the mockups created by Anastasia Ratti. 

The 'Cookie preferences' link on the footer (seen on redhat.com) is NOT included in this pr. 

Screenshots

Body: 
<img width="1017" alt="Screenshot 2023-04-24 at 11 15 05 AM" src="https://user-images.githubusercontent.com/64337863/234041053-c9fda02f-b5c8-4e0f-b760-86528ab4a0f7.png">

Footer:
<img width="818" alt="Screenshot 2023-04-28 at 12 18 14 PM" src="https://user-images.githubusercontent.com/64337863/235200842-3d8e6520-d7a4-42a1-8f35-a65c1291e797.png">




