### PR TITLE
Cypress: disable video on CI when not debug logging

### DIFF
--- a/test/cypress.config.js
+++ b/test/cypress.config.js
@@ -20,4 +20,6 @@ module.exports = defineConfig({
     // Default is 0
     openMode: 0,
   },
+  // only record videos when running action in debug mode
+  video: !!process.env.RUNNER_DEBUG,
 });

--- a/test/scripts/ctn-run.sh
+++ b/test/scripts/ctn-run.sh
@@ -17,5 +17,6 @@ docker run \
 	-e HUB_ADMIN_GROUP \
 	-e HUB_REQUIRE_CERTIFY \
 	-e HUB_UPLOAD_TO_INBOUND \
+	-e RUNNER_DEBUG=1 \
 	--rm \
 	hubuitest


### PR DESCRIPTION
using debug logging just because it's already a toggle when rerunning an action and disabling video recording by default apparently saves quite some time
