### PR TITLE
Don't send my_permissions field when repository/remote is edited (fixes a 400 Bad request)

### DIFF
--- a/CHANGES/2233.bug
+++ b/CHANGES/2233.bug
@@ -1,0 +1,1 @@
+Don't send my_permissions field when repository/remote is edited (fixes a 400 Bad request)

--- a/src/containers/ansible-remote/edit.tsx
+++ b/src/containers/ansible-remote/edit.tsx
@@ -94,6 +94,8 @@ const AnsibleRemoteEdit = Page<AnsibleRemoteType>({
         delete data.hidden_fields;
       }
 
+      delete data.my_permissions;
+
       // api requires traling slash, fix the trivial case
       if (data.url && !data.url.includes('?') && !data.url.endsWith('/')) {
         data.url += '/';

--- a/src/containers/ansible-repository/edit.tsx
+++ b/src/containers/ansible-repository/edit.tsx
@@ -97,6 +97,8 @@ const AnsibleRepositoryEdit = Page<AnsibleRepositoryType>({
         delete data.versions_href;
       }
 
+      delete data.my_permissions;
+
       data.pulp_labels ||= {};
       if (hideFromSearch) {
         data.pulp_labels.hide_from_search = '';


### PR DESCRIPTION
Fixes: AAH-2233

delete `my_permissions` before saving the form.