### PR TITLE
[stable-4.6] Bump frontend-components-config, use HtmlWebpackPlugin directly

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -1,6 +1,7 @@
 const { resolve } = require('path'); // node:path
 const config = require('@redhat-cloud-services/frontend-components-config');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { execSync } = require('child_process'); // node:child_process
 
 const isBuild = process.env.NODE_ENV === 'production';
@@ -58,31 +59,17 @@ module.exports = (inputConfigs) => {
     customConfigs.API_BASE_PATH + 'pulp/api/v3/',
   );
 
-  // config for HtmlWebpackPlugin
-  const htmlPluginConfig = {
-    // used by src/index.html
-    applicationName: customConfigs.APPLICATION_NAME,
-
-    favicon: 'static/images/favicon.ico',
-
-    // standalone needs injecting js and css into dist/index.html
-    inject: true,
-  };
-
   const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
     definePlugin: globals,
-    htmlPlugin: htmlPluginConfig,
     debug: customConfigs.UI_DEBUG,
     https: customConfigs.UI_USE_HTTPS,
+
     // defines port for dev server
     port: customConfigs.UI_PORT,
 
     // frontend-components-config 4.5.0+: don't remove patternfly from builds
     bundlePfModules: true,
-
-    // frontend-components-config 4.6.9+: keep HtmlWebpackPlugin for standalone
-    useChromeTemplate: false,
 
     // frontend-components-config 4.6.25-29+: ensure hashed filenames
     useFileHash: true,
@@ -156,6 +143,15 @@ module.exports = (inputConfigs) => {
   newWebpackConfig.entry.App = newEntry;
 
   // ForkTsCheckerWebpackPlugin is part of default config since @redhat-cloud-services/frontend-components-config 4.6.24
+
+  // keep HtmlWebpackPlugin for standalone, inject src/index.html
+  plugins.push(
+    new HtmlWebpackPlugin({
+      applicationName: customConfigs.APPLICATION_NAME,
+      favicon: 'static/images/favicon.ico',
+      template: resolve(__dirname, '../src/index.html'),
+    }),
+  );
 
   return {
     ...newWebpackConfig,

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
                 "eslint": "^8.35.0",
                 "eslint-config-prettier": "^8.7.0",
                 "eslint-plugin-react": "^7.32.2",
+                "html-webpack-plugin": "^5.5.0",
                 "npm-run-all": "^4.1.5",
                 "postcss": "^8.4.21",
                 "prettier": "^2.8.7",
@@ -7844,8 +7845,9 @@
         },
         "node_modules/html-webpack-plugin": {
             "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
+            "integrity": "sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==",
             "dev": true,
-            "license": "MIT",
             "dependencies": {
                 "@types/html-minifier-terser": "^6.0.0",
                 "html-minifier-terser": "^6.0.2",
@@ -20053,6 +20055,8 @@
         },
         "html-webpack-plugin": {
             "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-5.5.0.tgz",
+            "integrity": "sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==",
             "dev": true,
             "requires": {
                 "@types/html-minifier-terser": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
         "eslint": "^8.35.0",
         "eslint-config-prettier": "^8.7.0",
         "eslint-plugin-react": "^7.32.2",
+        "html-webpack-plugin": "^5.5.0",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.21",
         "prettier": "^2.8.7",


### PR DESCRIPTION
Backports #3325 & #3405

And syncs shared webpack config with later releases (https://github.com/ansible/ansible-hub-ui/pull/3535).