### PR TITLE
[stable-4.7] webpack config - sync with other releases

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -65,10 +65,11 @@ module.exports = (inputConfigs) => {
     definePlugin: globals,
     debug: customConfigs.UI_DEBUG,
     https: customConfigs.UI_USE_HTTPS,
+
     // defines port for dev server
     port: customConfigs.UI_PORT,
 
-    // frontend-components-config 4.5.0+: don't remove patternfly from non-insights builds
+    // frontend-components-config 4.5.0+: don't remove patternfly from builds
     bundlePfModules: true,
 
     // frontend-components-config 4.6.25-29+: ensure hashed filenames


### PR DESCRIPTION
Only really syncs shared webpack config with other releases.

Together with https://github.com/ansible/ansible-hub-ui/pull/3536, https://github.com/ansible/ansible-hub-ui/pull/3537, https://github.com/ansible/ansible-hub-ui/pull/3538, https://github.com/ansible/ansible-hub-ui/pull/3539 which also backport https://github.com/ansible/ansible-hub-ui/pull/3325 & https://github.com/ansible/ansible-hub-ui/pull/3405,

And https://github.com/ansible/ansible-hub-ui/pull/3535