### PR TITLE
CollectionDetail: use routeParams.repo, not routeParams.published

### DIFF
--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -83,7 +83,7 @@ class CollectionDetail extends React.Component<
           }
           breadcrumbs={breadcrumbs}
           activeTab='install'
-          repo={this.props.routeParams.published}
+          repo={this.props.routeParams.repo}
         />
         <Main>
           <section className='body'>


### PR DESCRIPTION
Fixes typo from #3467 

there's no `:published` param, there is a `:repo` param .. use that one :)
