### PR TITLE
Details: break words when needed for wrapping

### DIFF
--- a/CHANGES/2285.bug
+++ b/CHANGES/2285.bug
@@ -1,0 +1,1 @@
+Details: break words when needed for wrapping

--- a/src/components/shared/details.tsx
+++ b/src/components/shared/details.tsx
@@ -11,7 +11,7 @@ interface IProps {
 export const Details = ({ item, fields = [] }: IProps) => (
   <>
     {fields.map(({ label, value }) => (
-      <div key={label}>
+      <div key={label} style={{ overflowWrap: 'break-word' }}>
         <div>
           <b>{label}</b>
         </div>


### PR DESCRIPTION
Issue: AAH-2285

![20230411003130](https://user-images.githubusercontent.com/289743/231025287-da45836c-9b07-4e86-9371-3547cbe77e26.png)

(before, it would only wrap on whitespace)