### PR TITLE
Fix Delete collection version redirect when in multiple repos

### DIFF
--- a/CHANGES/2264.fix
+++ b/CHANGES/2264.fix
@@ -1,0 +1,1 @@
+Fix Delete collection version redirect when in multiple repos

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -870,12 +870,12 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         const name = deleteCollection.collection_version.name;
 
         waitForTask(taskId).then(() => {
-          if (collections.length > 1) {
-            const topVersion = collections.filter(
-              ({ collection_version }) =>
-                collection_version.version !== collectionVersion,
-            );
+          const topVersion = (collections || []).filter(
+            ({ collection_version }) =>
+              collection_version.version !== collectionVersion,
+          );
 
+          if (topVersion.length) {
             this.props.updateParams(
               ParamHelper.setParam(
                 this.props.params,


### PR DESCRIPTION
Issue: AAH-2264

Collection version deletion checks if deleting the last version (and thus redirect to list view), or not (thus redirect to latest version),
but the logic fails when the deleted version exists in multiple repos (looks like there are more than 1 versions, but we delete all of them, and then there are none).

Changed the logic to look for latest only when there are versions other than the current one.