### PR TITLE
fix extra "You don't have permission to display users." when deleting groups

### DIFF
--- a/CHANGES/2283.fix
+++ b/CHANGES/2283.fix
@@ -1,0 +1,1 @@
+fix extra "You don't have permission to display users." when deleting groups

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -374,7 +374,7 @@ class GroupDetail extends React.Component<RouteProps, IState> {
         });
     };
     const { hasPermission } = this.context;
-    const { view_user } = hasPermission('galaxy.view_user');
+    const view_user = hasPermission('galaxy.view_user');
 
     if (!users && view_user) {
       this.queryUsers();

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -268,7 +268,7 @@ class GroupList extends React.Component<RouteProps, IState> {
     const name = this.state.selectedGroup && this.state.selectedGroup.name;
     const { deleteModalUsers: users, deleteModalCount: count } = this.state;
     const { hasPermission } = this.context;
-    const { view_user } = hasPermission('galaxy.view_user');
+    const view_user = hasPermission('galaxy.view_user');
 
     if (!users && view_user) {
       this.queryUsers();


### PR DESCRIPTION
Issue: AAH-2283

This used to read from list of permissions, the destructuring no longer makes sense with `hasParmission`.
Fixes wrong "You don't have permission to display users." when deleting groups