### PR TITLE
Legacy roles: fix l10n typo

### DIFF
--- a/src/components/legacy-role-list/legacy-role-item.tsx
+++ b/src/components/legacy-role-list/legacy-role-item.tsx
@@ -62,7 +62,7 @@ export class LegacyRoleListItem extends React.Component<LegacyRoleProps> {
       cells.push(
         <DataListCell isFilled={false} alignRight={false} key='ns'>
           <Logo
-            alt={t`role.github_user logo`}
+            alt={t`${role.github_user} logo`}
             image={role.summary_fields.namespace.avatar_url}
             size='70px'
             unlockWidth

--- a/src/containers/legacy-roles/legacy-role.tsx
+++ b/src/containers/legacy-roles/legacy-role.tsx
@@ -275,7 +275,7 @@ class LegacyRole extends React.Component<RouteProps, IProps> {
       header_cells.push(
         <DataListCell isFilled={false} alignRight={false} key='ns'>
           <Logo
-            alt={t`role.github_user logo`}
+            alt={t`${role.github_user} logo`}
             fallbackToDefault
             image={role.summary_fields.namespace.avatar_url}
             size='70px'


### PR DESCRIPTION
Instead of trying to translate "role.github_user logo", these should extract as "{role.github_user} logo"