### PR TITLE
Use mirror:true for repository syncs

### DIFF
--- a/CHANGES/2286.fix
+++ b/CHANGES/2286.fix
@@ -1,0 +1,1 @@
+Use mirror:true for repository syncs

--- a/src/actions/ansible-repository-sync.tsx
+++ b/src/actions/ansible-repository-sync.tsx
@@ -9,7 +9,7 @@ export const ansibleRepositorySyncAction = Action({
   title: t`Sync`,
   onClick: ({ name, pulp_href }, { addAlert, query }) => {
     const pulpId = parsePulpIDFromURL(pulp_href);
-    AnsibleRepositoryAPI.sync(pulpId)
+    AnsibleRepositoryAPI.sync(pulpId, { mirror: true })
       .then(({ data }) => {
         addAlert(
           taskAlert(data.task, t`Sync started for repository "${name}".`),

--- a/src/api/ansible-repository.ts
+++ b/src/api/ansible-repository.ts
@@ -12,8 +12,8 @@ class API extends PulpAPI {
 
   // delete(uuid)
 
-  sync(id) {
-    return this.http.post(this.apiPath + id + '/sync/', {});
+  sync(id, body = {}) {
+    return this.http.post(this.apiPath + id + '/sync/', body);
   }
 
   revert(id, version_href) {


### PR DESCRIPTION
Issue: AAH-2286

Use `{ mirror: true }` when calling the repository sync endpoint.

When enabled, all content that is not present in the remote repository will be removed from the local repository, otherwise sync will be add missing content.