### PR TITLE
Delete repository distributions when deleting a repository

### DIFF
--- a/CHANGES/2254.fix
+++ b/CHANGES/2254.fix
@@ -1,0 +1,1 @@
+Delete repository distributions when deleting a repository

--- a/CHANGES/2278.fix
+++ b/CHANGES/2278.fix
@@ -1,0 +1,1 @@
+Delete repository distributions when deleting a repository

--- a/src/api/ansible-distribution.ts
+++ b/src/api/ansible-distribution.ts
@@ -5,6 +5,7 @@ class API extends PulpAPI {
   useOrdering = true;
 
   // list(params?)
+  // delete(pk)
 }
 
 export const AnsibleDistributionAPI = new API();


### PR DESCRIPTION
Issue: AAH-2254
Issue: AAH-2278

When deleting a repository with distributions, delete the distribution as well.

(The list distributions request has to happen before deleting the repo, otherwise the distributions get null repository,
but failure to list/delete distributions doesn't stop the repo deletion.)