### PR TITLE
[stable-4.7] Unify routing to collection detail (#3541)

### DIFF
--- a/CHANGES/2231.bug
+++ b/CHANGES/2231.bug
@@ -1,0 +1,1 @@
+Fix and unify collection detail routing to `/ui/repo/<repository>/<namespace>/<collection>`

--- a/src/containers/ansible-repository/tab-collection-versions.tsx
+++ b/src/containers/ansible-repository/tab-collection-versions.tsx
@@ -59,6 +59,7 @@ export const CollectionVersionsTab = ({
   ) => {
     const {
       collection_version: { name, namespace, version, description },
+      repository,
     } = item;
 
     const kebabItems = listItemActions.map((action) =>
@@ -70,8 +71,9 @@ export const CollectionVersionsTab = ({
         <td>
           <Link
             to={formatPath(
-              Paths.collection,
+              Paths.collectionByRepo,
               {
+                repo: repository.name,
                 namespace,
                 collection: name,
               },

--- a/src/containers/ansible-repository/tab-repository-versions.tsx
+++ b/src/containers/ansible-repository/tab-repository-versions.tsx
@@ -38,10 +38,12 @@ const VersionContent = ({
   href,
   addAlert,
   hasPermission,
+  repositoryName,
 }: {
   href: string;
   addAlert: (alert) => void;
   hasPermission: (string) => boolean;
+  repositoryName: string;
 }) => {
   const [state, setState] = useState({});
   if (!href) {
@@ -60,8 +62,9 @@ const VersionContent = ({
       <td>
         <Link
           to={formatPath(
-            Paths.collection,
+            Paths.collectionByRepo,
             {
+              repo: repositoryName,
               namespace,
               collection: name,
             },
@@ -273,6 +276,7 @@ export const RepositoryVersionsTab = ({
         />
         <VersionContent
           {...version.content_summary.present['ansible.collection_version']}
+          repositoryName={repositoryName}
         />
       </>
     ) : (

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -285,7 +285,6 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
       { component: CollectionContent, path: Paths.collectionContentList },
       { component: CollectionImportLog, path: Paths.collectionImportLog },
       { component: MyImports, path: Paths.myImports },
-      { component: CollectionDetail, path: Paths.collection },
       { component: NamespaceDetail, path: Paths.namespace },
       { component: Search, path: Paths.collections },
       { component: Search, path: Paths.search },

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -100,7 +100,6 @@ export enum Paths {
   collectionDependenciesByRepo = '/repo/:repo/:namespace/:collection/dependencies',
   collectionDistributionsByRepo = '/repo/:repo/:namespace/:collection/distributions',
   namespaceByRepo = '/repo/:repo/:namespace',
-  collection = '/:namespace/:collection',
   namespace = '/:namespace',
   namespaceDetail = '/namespaces/:namespace',
   namespaces = '/namespaces',


### PR DESCRIPTION
Manual backport of #3541 

(conflicts because no insights routes in 4.7)

---

* fix routing to collection detail
* remove unusued collection detail path Issue: AAH-2231

(cherry picked from commit 837315eb6c09f26adb4e200a544f858d0b6c8bdb)
