### PR TITLE
Creating a distribution - transform base_path, rename on failure

### DIFF
--- a/CHANGES/2253.fix
+++ b/CHANGES/2253.fix
@@ -1,0 +1,1 @@
+Creating a distribution - transform base_path, rename on failure

--- a/CHANGES/2277.fix
+++ b/CHANGES/2277.fix
@@ -1,0 +1,1 @@
+Creating a distribution - transform base_path, rename on failure


### PR DESCRIPTION
retry distribution with a numeric suffix on failure, and transform anything other than / - _ a-zA-Z0-9 to _ in base_path

Issue: AAH-2253
Issue: AAH-2277

![20230413001620](https://user-images.githubusercontent.com/289743/231613934-6efc903c-b820-42db-be85-3b4872214ce4.png)
![20230413001705](https://user-images.githubusercontent.com/289743/231613937-27bec8be-94ab-43e0-b8a3-053a217dbc57.png)
