### PR TITLE
Insights smoke test: nav-toggle no longer exists

### DIFF
--- a/test/cypress/e2e/insights/smoke.js
+++ b/test/cypress/e2e/insights/smoke.js
@@ -27,7 +27,7 @@ describe('cloud smoketest', () => {
      * **************************************************/
 
     // wait for navbar to appear
-    cy.get('#nav-toggle').should('be.visible');
+    cy.get('.pf-c-page__sidebar').should('be.visible');
     // wait for the automation-hub button to appear and then click on it
     cy.get('[data-quickstart-id="Automation-Hub"]').click();
     // wait for the collections button to appear and then click on it


### PR DESCRIPTION
..the sidebar still does, check that does, check that instead.

Should fix https://github.com/ansible/ansible-hub-ui/actions/runs/4682109624/jobs/8299457032?pr=3574
