### PR TITLE
Prevent deleting protected repositories

### DIFF
--- a/src/actions/ansible-repository-delete.tsx
+++ b/src/actions/ansible-repository-delete.tsx
@@ -2,6 +2,7 @@ import { t } from '@lingui/macro';
 import React from 'react';
 import { AnsibleRepositoryAPI } from 'src/api';
 import { DeleteAnsibleRepositoryModal } from 'src/components';
+import { Constants } from 'src/constants';
 import { canDeleteAnsibleRepository } from 'src/permissions';
 import { handleHttpError, parsePulpIDFromURL, taskAlert } from 'src/utilities';
 import { Action } from './action';
@@ -26,6 +27,13 @@ export const ansibleRepositoryDeleteAction = Action({
     setState({
       deleteModalOpen: { pulpId: id || parsePulpIDFromURL(pulp_href), name },
     }),
+  disabled: ({ name }) => {
+    if (Constants.PROTECTED_REPOSITORIES.includes(name)) {
+      return t`Protected repositories cannot be deleted.`;
+    }
+
+    return null;
+  },
 });
 
 function deleteRepository({ name, pulpId }, { addAlert, setState, query }) {
@@ -39,7 +47,7 @@ function deleteRepository({ name, pulpId }, { addAlert, setState, query }) {
     .catch(
       handleHttpError(
         t`Failed to remove repository ${name}`,
-        () => null,
+        () => setState({ deleteModalOpen: null }),
         addAlert,
       ),
     );

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -35,6 +35,15 @@ export class Constants {
     validated: defineMessage({ message: `Validated` }),
   };
 
+  static PROTECTED_REPOSITORIES = [
+    'rh-certified',
+    'validated',
+    'community',
+    'published',
+    'staging',
+    'rejected',
+  ];
+
   static COLLECTION_FILTER_TAGS = [
     'application',
     'cloud',


### PR DESCRIPTION
Issue: AAH-2300

- close modal if the repository deletion fails 
- Disable delete button if the repository is protected (default) 
![Screenshot from 2023-04-13 11-08-06](https://user-images.githubusercontent.com/19647757/231712697-75d97e52-8b31-4d04-98a3-ba6290c5a121.png)

Protected repositories: https://github.com/ansible/galaxy_ng/blob/master/galaxy_ng/app/access_control/access_policy.py#L465 (https://github.com/ansible/galaxy_ng/pull/1671)