### PR TITLE
Fix collection version selector

### DIFF
--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -1,11 +1,7 @@
 import axios from 'axios';
-import { CollectionVersionSearch } from 'src/api';
 import { HubAPI } from './hub';
 
 export class API extends HubAPI {
-  // contains collection versions
-  cachedCollection: CollectionVersionSearch[] = [];
-
   apiPath = 'v3/plugin/ansible/search/collection-versions/';
 
   setRepository(
@@ -34,38 +30,6 @@ export class API extends HubAPI {
     return super.get(id, 'pulp/api/v3/content/ansible/collection_versions/');
   }
 
-  // Caches the collection returned from the server.
-  // collection is array of collection versions
-  // If the requested collection matches the cache, return it,
-  // if it doesn't, query the API for the collection versions and
-  // replace the old cache with the new value.
-  // This allows the collection page to be broken into separate components
-  // and routed separately without fetching redundant data from the API
-  getCached(params, forceReload?: boolean) {
-    return new Promise((resolve, reject) => {
-      const { name, namespace, repository_name } = params;
-      const [collection] = this.cachedCollection;
-      if (
-        !forceReload &&
-        collection &&
-        collection.collection_version.name === name &&
-        collection.collection_version.namespace === namespace &&
-        collection.repository.name === repository_name
-      ) {
-        return resolve(this.cachedCollection);
-      }
-
-      super
-        .list(params)
-        .then((result) => {
-          const { data } = result.data;
-          this.cachedCollection = data;
-          return resolve(data);
-        })
-        .catch((err) => reject(err));
-    });
-  }
-
   getUsedDependenciesByCollection(
     namespace,
     collection,
@@ -81,6 +45,8 @@ export class API extends HubAPI {
   getCancelToken() {
     return axios.CancelToken.source();
   }
+
+  // list(params?)
 }
 
 export const CollectionVersionAPI = new API();

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -61,6 +61,7 @@ import './header.scss';
 
 interface IProps {
   collections: CollectionVersionSearch[];
+  collectionsCount: number;
   collection: CollectionVersionSearch;
   content: CollectionVersionContentType;
   params: {
@@ -145,6 +146,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
   render() {
     const {
       collections,
+      collectionsCount,
       collection,
       content,
       params,
@@ -167,8 +169,6 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       showImportModal,
       updateCollection,
     } = this.state;
-
-    const numOfshownVersions = 10;
 
     const urlKeys = [
       { key: 'documentation', name: t`Docs site` },
@@ -339,7 +339,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                   page_size: modalPagination.pageSize,
                 }}
                 updateParams={this.updatePaginationParams}
-                count={collections.length}
+                count={collectionsCount}
               />
             </div>
             {this.paginateVersions(collections).map(
@@ -372,7 +372,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
               page_size: modalPagination.pageSize,
             }}
             updateParams={this.updatePaginationParams}
-            count={collections.length}
+            count={collectionsCount}
           />
         </Modal>
         <DeleteCollectionModal
@@ -437,7 +437,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                   selections={`v${version}`}
                   aria-label={t`Select collection version`}
                   loadingVariant={
-                    numOfshownVersions < collections.length
+                    collections.length < collectionsCount
                       ? {
                           text: t`View more`,
                           onClick: () =>
@@ -449,28 +449,27 @@ export class CollectionHeader extends React.Component<IProps, IState> {
                       : null
                   }
                 >
-                  {this.renderSelectVersions(
-                    collections,
-                    numOfshownVersions,
-                  ).map((v) => (
-                    <SelectOption
-                      key={v.version}
-                      value={`v${v.version}`}
-                      onClick={() =>
-                        updateParams(
-                          ParamHelper.setParam(
-                            params,
-                            'version',
-                            v.version.toString(),
-                          ),
-                        )
-                      }
-                    >
-                      <Trans>
-                        {v.version} updated {isLatestVersion(v)}
-                      </Trans>
-                    </SelectOption>
-                  ))}
+                  {collections
+                    .map((c) => c.collection_version)
+                    .map((v) => (
+                      <SelectOption
+                        key={v.version}
+                        value={`v${v.version}`}
+                        onClick={() =>
+                          updateParams(
+                            ParamHelper.setParam(
+                              params,
+                              'version',
+                              v.version.toString(),
+                            ),
+                          )
+                        }
+                      >
+                        <Trans>
+                          {v.version} updated {isLatestVersion(v)}
+                        </Trans>
+                      </SelectOption>
+                    ))}
                 </Select>
               </div>
               {latestVersion ? (
@@ -634,10 +633,6 @@ export class CollectionHeader extends React.Component<IProps, IState> {
     ];
 
     return <LinkTabs tabs={tabs} />;
-  }
-
-  private renderSelectVersions(versions, count) {
-    return versions.slice(0, count).map((c) => c.collection_version);
   }
 
   private async submitCertificate(file: File) {

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -14,6 +14,7 @@ export interface IBaseCollectionState {
     keywords?: string;
   };
   collections?: CollectionVersionSearch[];
+  collectionsCount?: number;
   collection?: CollectionVersionSearch;
   content?: CollectionVersionContentType;
   alerts?: AlertType[];
@@ -55,6 +56,7 @@ export function loadCollection({
       cache.collections,
       cache.collection,
       cache.content,
+      cache.collectionsCount,
     );
     return;
   }
@@ -99,7 +101,7 @@ export function loadCollection({
       collection,
       content,
     ]) => {
-      setCollection(collections, collection, content);
+      setCollection(collections, collection, content, collectionsCount);
 
       cache.repository = repo;
       cache.namespace = namespace;

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -20,6 +20,19 @@ export interface IBaseCollectionState {
   distroBasePath?: string;
 }
 
+// Caches the collection data when matching, prevents redundant fetches between collection detail tabs
+const cache = {
+  repository: null,
+  namespace: null,
+  name: null,
+  version: null,
+
+  collections: [],
+  collectionsCount: 0,
+  collection: null,
+  content: null,
+};
+
 export function loadCollection({
   forceReload,
   matchParams,
@@ -30,32 +43,73 @@ export function loadCollection({
   const { version } = stateParams;
   const { collection: name, namespace, repo } = matchParams;
 
-  CollectionVersionAPI.getCached(
-    {
-      ...(repo ? { repository_name: repo } : {}),
-      namespace,
-      name,
-      order_by: '-version',
-    },
-    forceReload,
-  )
-    .then((collections: CollectionVersionSearch[]) => {
-      const collection = version
-        ? collections.find(
-            ({ collection_version }) => collection_version.version == version,
-          )
-        : collections.find((cv) => cv.is_highest);
+  // try loading from cache
+  if (
+    !forceReload &&
+    cache.repository === repo &&
+    cache.namespace === namespace &&
+    cache.name === name &&
+    cache.version === version
+  ) {
+    setCollection(
+      cache.collections,
+      cache.collection,
+      cache.content,
+    );
+    return;
+  }
 
+  const requestParams = {
+    ...(repo ? { repository_name: repo } : {}),
+    namespace,
+    name,
+  };
+
+  const currentVersion = (
+    version
+      ? CollectionVersionAPI.list({ ...requestParams, version })
+      : CollectionVersionAPI.list({ ...requestParams, is_highest: true })
+  ).then(({ data }) => data.data[0]);
+
+  const content = currentVersion
+    .then((collection) =>
       CollectionAPI.getContent(
         namespace,
         name,
         collection.collection_version.version,
-      ).then((res) => {
-        const [content] = res.data.results;
-        setCollection(collections, collection, content);
-      });
-    })
-    .catch(() => {
-      navigate(formatPath(Paths.notFound));
-    });
+      ),
+    )
+    .then(({ data: { results } }) => results[0])
+    .catch(() => navigate(formatPath(Paths.notFound)));
+
+  const versions = CollectionVersionAPI.list({
+    ...requestParams,
+    order_by: '-version',
+    page_size: 10,
+  })
+    .then(({ data }) => data)
+    .catch(() => ({ data: [], meta: { count: 0 } }));
+
+  return Promise.all([versions, currentVersion, content]).then(
+    ([
+      {
+        data: collections,
+        meta: { count: collectionsCount },
+      },
+      collection,
+      content,
+    ]) => {
+      setCollection(collections, collection, content);
+
+      cache.repository = repo;
+      cache.namespace = namespace;
+      cache.name = name;
+      cache.version = version;
+
+      cache.collections = collections;
+      cache.collectionsCount = collectionsCount;
+      cache.collection = collection;
+      cache.content = content;
+    },
+  );
 }

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -24,6 +24,7 @@ class CollectionContent extends React.Component<
 
     this.state = {
       collections: [],
+      collectionsCount: 0,
       collection: null,
       content: null,
       params: params,
@@ -35,7 +36,8 @@ class CollectionContent extends React.Component<
   }
 
   render() {
-    const { collections, collection, params, content } = this.state;
+    const { collections, collectionsCount, collection, params, content } =
+      this.state;
 
     if (collections.length <= 0) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
@@ -67,6 +69,7 @@ class CollectionContent extends React.Component<
         <CollectionHeader
           reload={() => this.loadCollections(true)}
           collections={collections}
+          collectionsCount={collectionsCount}
           collection={collection}
           content={content}
           params={params}
@@ -95,9 +98,8 @@ class CollectionContent extends React.Component<
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      setCollection: (collections, collection, content) => {
-        this.setState({ collections, collection, content });
-      },
+      setCollection: (collections, collection, content, collectionsCount) =>
+        this.setState({ collections, collection, content, collectionsCount }),
       stateParams: this.state.params,
     });
   }

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -5,12 +5,9 @@ import {
   CollectionUsedByDependencies,
   CollectionVersion,
   CollectionVersionAPI,
-  CollectionVersionContentType,
-  CollectionVersionSearch,
 } from 'src/api';
 import {
   AlertList,
-  AlertType,
   CollectionDependenciesList,
   CollectionHeader,
   CollectionUsedbyDependenciesList,
@@ -23,13 +20,10 @@ import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
 import { ParamHelper, errorMessage, filterIsSet } from 'src/utilities';
-import { loadCollection } from './base';
+import { IBaseCollectionState, loadCollection } from './base';
 import './collection-dependencies.scss';
 
-interface IState {
-  collections: CollectionVersionSearch[];
-  collection: CollectionVersionSearch;
-  content: CollectionVersionContentType;
+interface IState extends IBaseCollectionState {
   dependencies_repos: CollectionVersion[];
   params: {
     page?: number;
@@ -41,7 +35,6 @@ interface IState {
   usedByDependencies: CollectionUsedByDependencies[];
   usedByDependenciesCount: number;
   usedByDependenciesLoading: boolean;
-  alerts: AlertType[];
 }
 
 class CollectionDependencies extends React.Component<RouteProps, IState> {
@@ -60,6 +53,7 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
 
     this.state = {
       collections: [],
+      collectionsCount: 0,
       collection: null,
       content: null,
       dependencies_repos: [],
@@ -78,6 +72,7 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
   render() {
     const {
       collections,
+      collectionsCount,
       collection,
       content,
       params,
@@ -124,6 +119,7 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
         <CollectionHeader
           reload={() => this.loadData(true)}
           collections={collections}
+          collectionsCount={collectionsCount}
           collection={collection}
           content={content}
           params={headerParams}
@@ -295,8 +291,11 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      setCollection: (collections, collection, content) =>
-        this.setState({ collections, collection, content }, callback),
+      setCollection: (collections, collection, content, collectionsCount) =>
+        this.setState(
+          { collections, collection, content, collectionsCount },
+          callback,
+        ),
       stateParams: this.state.params.version
         ? { version: this.state.params.version }
         : {},

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -26,6 +26,7 @@ class CollectionDetail extends React.Component<
 
     this.state = {
       collections: [],
+      collectionsCount: 0,
       collection: null,
       content: null,
       distroBasePath: null,
@@ -45,7 +46,14 @@ class CollectionDetail extends React.Component<
   }
 
   render() {
-    const { collections, collection, content, params, alerts } = this.state;
+    const {
+      collections,
+      collectionsCount,
+      collection,
+      content,
+      params,
+      alerts,
+    } = this.state;
 
     if (collections.length <= 0) {
       return <LoadingPageWithHeader></LoadingPageWithHeader>;
@@ -75,6 +83,7 @@ class CollectionDetail extends React.Component<
         <CollectionHeader
           reload={() => this.loadCollections(true)}
           collections={collections}
+          collectionsCount={collectionsCount}
           collection={collection}
           content={content}
           params={params}
@@ -116,13 +125,13 @@ class CollectionDetail extends React.Component<
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      setCollection: (collections, collection, content) => {
+      setCollection: (collections, collection, content, collectionsCount) =>
         this.setState({
           collections,
           collection,
           content,
-        });
-      },
+          collectionsCount,
+        }),
       stateParams: this.state.params,
     });
   }

--- a/src/containers/collection-detail/collection-distributions.tsx
+++ b/src/containers/collection-detail/collection-distributions.tsx
@@ -30,6 +30,7 @@ const CollectionDistributions = (props: RouteProps) => {
   const routeParams = ParamHelper.parseParamString(props.location.search);
 
   const [collections, setCollections] = useState([]);
+  const [collectionsCount, setCollectionsCount] = useState(0);
   const [collection, setCollection] = useState(null);
   const [content, setContent] = useState(null);
   const [inputText, setInputText] = useState('');
@@ -50,8 +51,9 @@ const CollectionDistributions = (props: RouteProps) => {
       forceReload,
       matchParams: props.routeParams,
       navigate: props.navigate,
-      setCollection: (collections, collection, content) => {
+      setCollection: (collections, collection, content, collectionsCount) => {
         setCollections(collections);
+        setCollectionsCount(collectionsCount);
         setCollection(collection);
         setContent(content);
 
@@ -201,6 +203,7 @@ const CollectionDistributions = (props: RouteProps) => {
       <CollectionHeader
         reload={() => loadCollections(true)}
         collections={collections}
+        collectionsCount={collectionsCount}
         collection={collection}
         content={content}
         params={params}

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -34,6 +34,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
 
     this.state = {
       collections: [],
+      collectionsCount: 0,
       collection: null,
       content: null,
       params: params,
@@ -47,7 +48,8 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
   }
 
   render() {
-    const { params, collection, collections, content } = this.state;
+    const { params, collection, collections, collectionsCount, content } =
+      this.state;
     const urlFields = this.props.routeParams;
 
     if (!collection || !content) {
@@ -128,8 +130,9 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
       <React.Fragment>
         <CollectionHeader
           reload={() => this.loadCollection(true)}
-          collection={collection}
           collections={collections}
+          collectionsCount={collectionsCount}
+          collection={collection}
           content={content}
           params={params}
           updateParams={(p) =>
@@ -293,9 +296,8 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      setCollection: (collections, collection, content) => {
-        this.setState({ collections, collection, content });
-      },
+      setCollection: (collections, collection, content, collectionsCount) =>
+        this.setState({ collections, collection, content, collectionsCount }),
       stateParams: this.state.params,
     });
   }

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -29,6 +29,7 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
     this.state = {
       collection: null,
       collections: [],
+      collectionsCount: 0,
       content: null,
       params: params,
       loadingImports: true,
@@ -46,6 +47,7 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
     const {
       collection,
       collections,
+      collectionsCount,
       params,
       loadingImports,
       selectedImportDetail,
@@ -84,6 +86,7 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
         <CollectionHeader
           reload={() => this.loadData(true)}
           collections={collections}
+          collectionsCount={collectionsCount}
           collection={collection}
           content={content}
           params={params}
@@ -154,8 +157,11 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
       forceReload,
       matchParams: this.props.routeParams,
       navigate: this.props.navigate,
-      setCollection: (collections, collection, content) =>
-        this.setState({ collections, collection, content }, callback),
+      setCollection: (collections, collection, content, collectionsCount) =>
+        this.setState(
+          { collections, collection, content, collectionsCount },
+          callback,
+        ),
       stateParams: this.state.params,
     });
   }


### PR DESCRIPTION
When a collection has more than 10 versions, accessing http://localhost:8002/ui/repo/comu_yaml/ansible/netcommon/?version=0.0.3-dev8 gives a 404 when the requested version is not in the top 10 (by latest) version results.

=> changing `loadCollection` to load the requested version (by `version` or `is_highest`) separately from the list of versions

but then it either works and the version loads, but there are no other versions in the version selector,
or it 404s and there would be .. because `getCached` will only return the value from one request for both .. caching works :)

=> moving `getCached` logic to `loadCollection`, caching current collection, collection versions and content separately.

And version picker (when more than 10 versions) stopped working, because we're only ever getting 10 results per page.
=> wiring in a separate `collectionsCount` variable with the full version count, and basing the versions modal logic on that.

![20230414025135](https://user-images.githubusercontent.com/289743/231929423-cafb21fc-57d7-43b0-a7b1-726b66bc4e30.png)
![20230414025148](https://user-images.githubusercontent.com/289743/231929427-2edee618-d9b0-46d2-8a09-f5cc02c22138.png)
