### PR TITLE
Fix EmptyStateFilter not appearing in Namespace detail when filtering by repo/tags/sign state

### DIFF
--- a/CHANGES/2304.bug
+++ b/CHANGES/2304.bug
@@ -1,0 +1,1 @@
+Fix EmptyStateFilter not appearing in Namespace detail when filtering by repo

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -242,8 +242,16 @@ export class CompoundFilter extends React.Component<IProps, IState> {
 
   private onSelectMultiple = (event) => {
     let newParams = this.props.params[this.state.selectedFilter.id];
+
+    // no tags => falsy
+    // 1 tag => "foo"
+    // 2+ tags => ["foo", "bar"]
+    // convert all to an array
     if (!newParams) {
       newParams = [];
+    }
+    if (!Array.isArray(newParams)) {
+      newParams = [newParams];
     }
 
     // TODO: Remove this replace after patternfly fixes the pf-random-id issue
@@ -256,6 +264,7 @@ export class CompoundFilter extends React.Component<IProps, IState> {
     } else {
       newParams.push(selectedID);
     }
+
     this.submitMultiple(newParams);
   };
 

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -261,7 +261,14 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
 
     const repositoryUrl = getRepoUrl();
 
-    const noData = itemCount === 0 && !filterIsSet(params, ['keywords']);
+    const noData =
+      itemCount === 0 &&
+      !filterIsSet(params, [
+        'is_signed',
+        'keywords',
+        'repository_name',
+        'tags',
+      ]);
 
     const updateParams = (params) =>
       this.updateParams(params, () => this.loadCollections());


### PR DESCRIPTION
Issue: AAH-2304

![20230414040224](https://user-images.githubusercontent.com/289743/231938627-2ed90099-97ab-4de1-8f1d-2a27a3fc2749.png)

Previously `EmptyStateFilter` would only render when no data and filtering by keywords, adding the rest of `CollectionFilter` params.