### PR TITLE
Fix Add/Remove collection ignoring repository object permissions

### DIFF
--- a/CHANGES/2305.bug
+++ b/CHANGES/2305.bug
@@ -1,0 +1,1 @@
+Fix Add/Remove collection ignoring repository object permissions

--- a/src/containers/ansible-repository/tab-collection-versions.tsx
+++ b/src/containers/ansible-repository/tab-collection-versions.tsx
@@ -99,6 +99,8 @@ export const CollectionVersionsTab = ({
         setState: setModalState,
         query,
         hasPermission,
+        hasObjectPermission: (p: string): boolean =>
+          item?.my_permissions?.includes?.(p),
       }}
       defaultPageSize={10}
       defaultSort={'name'}


### PR DESCRIPTION
Issue: AAH-2305

Repository detail > Collection Versions

The permission check wasn't running on object permissions because it didn't know which object permissions to use, fixing.

![20230414190221](https://user-images.githubusercontent.com/289743/232133714-1c2286e5-92c9-470e-b1a5-43a8cb8e59ef.png)
