### PR TITLE
Restyle collection list item controls to keep alignment

### DIFF
--- a/CHANGES/2303.bug
+++ b/CHANGES/2303.bug
@@ -1,0 +1,1 @@
+Restyle collection list item controls to keep alignment despite varying repository name lengths

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -4,6 +4,8 @@ import {
   DataListItem,
   DataListItemCells,
   DataListItemRow,
+  Flex,
+  FlexItem,
   Label,
   LabelGroup,
   Text,
@@ -25,21 +27,28 @@ import { chipGroupProps, convertContentSummaryCounts } from 'src/utilities';
 import { SignatureBadge } from '../signing';
 import './list-item.scss';
 
-interface IProps extends CollectionVersionSearch {
-  showNamespace?: boolean;
-  controls?: React.ReactNode;
+interface IProps {
+  collection: CollectionVersionSearch;
   displaySignatures: boolean;
+  dropdownMenu?: React.ReactNode | null;
+  showNamespace?: boolean;
+  synclistSwitch?: React.ReactNode | null;
+  uploadButton?: React.ReactNode | null;
 }
 
 export const CollectionListItem = ({
-  collection_version,
-  namespace_metadata: namespace,
-  repository,
-  is_signed,
-  is_deprecated,
+  collection: {
+    collection_version,
+    namespace_metadata: namespace,
+    repository,
+    is_signed,
+    is_deprecated,
+  },
   displaySignatures,
+  dropdownMenu,
   showNamespace,
-  controls,
+  synclistSwitch,
+  uploadButton,
 }: IProps) => {
   const cells = [];
 
@@ -115,29 +124,55 @@ export const CollectionListItem = ({
 
   cells.push(
     <DataListCell isFilled={false} alignRight key='stats'>
-      {controls ? <div className='hub-entry'>{controls}</div> : null}
-      <div className='hub-right-col hub-entry'>
-        <Trans>
-          Updated <DateComponent date={collection_version.pulp_created} />
-        </Trans>
-      </div>
-      <div className='hub-entry'>v{collection_version.version}</div>
-      <Label variant='outline' className='hub-repository-badge'>
-        <Link
-          to={formatPath(Paths.ansibleRepositoryDetail, {
-            name: repository.name,
-          })}
+      <Flex
+        direction={{ default: 'column' }}
+        alignItems={{ default: 'alignItemsFlexEnd' }}
+      >
+        <Flex
+          direction={{ default: 'column' }}
+          alignItems={{ default: 'alignItemsFlexStart' }}
         >
-          {repository.name}
-        </Link>
-      </Label>
-      {displaySignatures ? (
-        <SignatureBadge
-          className='hub-entry'
-          variant='outline'
-          signState={is_signed ? 'signed' : 'unsigned'}
-        />
-      ) : null}
+          {synclistSwitch && <FlexItem>{synclistSwitch}</FlexItem>}
+          {uploadButton || dropdownMenu ? (
+            <FlexItem>
+              {uploadButton}
+              {dropdownMenu || <span className='hidden-menu-space'></span>}
+            </FlexItem>
+          ) : null}
+          <FlexItem>
+            <div>
+              <Trans>
+                Updated <DateComponent date={collection_version.pulp_created} />
+              </Trans>
+            </div>
+            <div>v{collection_version.version}</div>
+          </FlexItem>
+        </Flex>
+        <Flex
+          direction={{ default: 'row' }}
+          alignSelf={{ default: 'alignSelfFlexStart' }}
+        >
+          <FlexItem>
+            <Label variant='outline'>
+              <Link
+                to={formatPath(Paths.ansibleRepositoryDetail, {
+                  name: repository.name,
+                })}
+              >
+                {repository.name}
+              </Link>
+            </Label>
+          </FlexItem>
+          {displaySignatures ? (
+            <FlexItem>
+              <SignatureBadge
+                variant='outline'
+                signState={is_signed ? 'signed' : 'unsigned'}
+              />
+            </FlexItem>
+          ) : null}
+        </Flex>
+      </Flex>
     </DataListCell>,
   );
 

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -21,20 +21,23 @@ interface IProps {
   updateParams: (params) => void;
   itemCount: number;
   ignoredParams: string[];
-  showControls?: boolean;
-  renderCollectionControls: (collection) => React.ReactNode;
+  collectionControls: (collection) => {
+    dropdownMenu?: React.ReactNode | null;
+    synclistSwitch?: React.ReactNode | null;
+    uploadButton?: React.ReactNode | null;
+  };
 }
 
 // only used in namespace detail, collections uses individual items
 export const CollectionList = (props: IProps) => {
   const {
     collections,
+    collectionControls,
     displaySignatures,
     params,
     updateParams,
     ignoredParams,
     itemCount,
-    showControls,
   } = props;
 
   return (
@@ -43,11 +46,11 @@ export const CollectionList = (props: IProps) => {
         {collections.length > 0 ? (
           collections.map((c, i) => (
             <CollectionListItem
-              controls={showControls ? props.renderCollectionControls(c) : null}
               key={i}
-              {...c}
+              collection={c}
               displaySignatures={displaySignatures}
-              showNamespace={true}
+              showNamespace
+              {...collectionControls(c)}
             />
           ))
         ) : (

--- a/src/components/collection-list/list-item.scss
+++ b/src/components/collection-list/list-item.scss
@@ -10,7 +10,3 @@
   font-size: var(--pf-global--FontSize--xs);
   color: var(--pf-global--color--200);
 }
-
-.hub-repository-badge {
-  margin-right: 5px;
-}

--- a/src/components/legacy-namespace-list/legacy-namespace-item.scss
+++ b/src/components/legacy-namespace-list/legacy-namespace-item.scss
@@ -5,13 +5,3 @@
 .hub-right-col {
   width: 200px;
 }
-
-.content {
-  text-transform: capitalize;
-}
-
-.hub-numeric-label-capitalize-text {
-  font-size: var(--pf-global--FontSize--xs);
-  color: var(--pf-global--color--200);
-  text-transform: capitalize;
-}

--- a/src/components/legacy-role-list/legacy-role-item.scss
+++ b/src/components/legacy-role-list/legacy-role-item.scss
@@ -1,17 +1,3 @@
 .hub-entry {
   margin-top: 5px;
 }
-
-.hub-right-col {
-  // width: 200px;
-}
-
-.content {
-  text-transform: capitalize;
-}
-
-.hub-numeric-label-capitalize-text {
-  font-size: var(--pf-global--FontSize--xs);
-  color: var(--pf-global--color--200);
-  text-transform: capitalize;
-}

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -425,12 +425,11 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
                   ignoredParams={ignoredParams}
                   collections={collections}
                   itemCount={itemCount}
-                  showControls={this.state.showControls}
-                  renderCollectionControls={(collection) =>
-                    this.renderCollectionControls(collection)
-                  }
                   displaySignatures={
                     this.context.featureFlags.display_signatures
+                  }
+                  collectionControls={(collection) =>
+                    this.renderCollectionControls(collection)
                   }
                 />
               </section>
@@ -926,8 +925,14 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
 
   private renderCollectionControls(collection: CollectionVersionSearch) {
     const { hasPermission } = this.context;
-    return (
-      <div style={{ display: 'flex', alignItems: 'center' }}>
+    const { showControls } = this.state;
+
+    if (!showControls) {
+      return;
+    }
+
+    return {
+      uploadButton: (
         <Button
           onClick={() =>
             this.handleCollectionAction(
@@ -939,6 +944,8 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
         >
           {t`Upload new version`}
         </Button>
+      ),
+      dropdownMenu: (
         <StatefulDropdown
           items={[
             DeleteCollectionUtils.deleteMenuOption({
@@ -965,8 +972,8 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
           ].filter(Boolean)}
           ariaLabel='collection-kebab'
         />
-      </div>
-    );
+      ),
+    };
   }
 }
 

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -398,22 +398,28 @@ class Search extends React.Component<RouteProps, IState> {
 
     const displayMenu = menuItems.length > 0;
 
-    return (
-      <React.Fragment>
-        {list && hasPermission('galaxy.upload_to_namespace') && (
+    if (list) {
+      return {
+        uploadButton: hasPermission('galaxy.upload_to_namespace') ? (
           <Button
             onClick={() => this.checkUploadPrivilleges(collection)}
             variant='secondary'
           >
             {t`Upload new version`}
           </Button>
+        ) : null,
+        dropdownMenu: displayMenu ? (
+          <StatefulDropdown items={menuItems} ariaLabel='collection-kebab' />
+        ) : null,
+      };
+    }
+
+    return (
+      <span className={cx(!displayMenu && 'hidden-menu-space')}>
+        {displayMenu && (
+          <StatefulDropdown items={menuItems} ariaLabel='collection-kebab' />
         )}
-        <span className={cx(!displayMenu && 'hidden-menu-space')}>
-          {displayMenu && (
-            <StatefulDropdown items={menuItems} ariaLabel='collection-kebab' />
-          )}
-        </span>
-      </React.Fragment>
+      </span>
     );
   }
 
@@ -495,11 +501,7 @@ class Search extends React.Component<RouteProps, IState> {
       (el) => el.name === name && el.namespace === namespace,
     );
 
-    if (synclist.policy === 'include') {
-      return !(found === undefined);
-    } else {
-      return found === undefined;
-    }
+    return synclist.policy === 'include' ? !!found : !found;
   }
 
   private renderList(collections) {
@@ -509,19 +511,15 @@ class Search extends React.Component<RouteProps, IState> {
           <DataList className='data-list' aria-label={t`List of Collections`}>
             {collections.map((c, i) => (
               <CollectionListItem
-                showNamespace={true}
                 key={i}
-                {...c}
-                controls={
-                  <>
-                    {this.renderSyncToogle(
-                      c.collection_version.name,
-                      c.collection_version.namespace,
-                    )}
-                    {this.renderMenu(true, c)}
-                  </>
-                }
+                collection={c}
                 displaySignatures={this.context.featureFlags.display_signatures}
+                showNamespace
+                synclistSwitch={this.renderSyncToogle(
+                  c.collection_version.name,
+                  c.collection_version.namespace,
+                )}
+                {...this.renderMenu(true, c)}
               />
             ))}
           </DataList>


### PR DESCRIPTION
Issue: AAH-2303

When repository names vary in length, collection list items (both in namespace detail and in collection list view (but not cards view)) end up with misaligned controls:

#### Namespace detail
##### before
![20230414214655](https://user-images.githubusercontent.com/289743/232160997-89eb377f-2e50-445d-ba83-10fb1ee1e6e9.png)
##### after
![20230415010104](https://user-images.githubusercontent.com/289743/232175433-53700ca1-8d43-4ad9-b36c-4cf5ecd98ce1.png)

#### Collection list
##### before
![20230414214718](https://user-images.githubusercontent.com/289743/232161005-49f0fa12-3d12-4e96-b7df-7b92d9d14efd.png)
##### after
![20230415010140](https://user-images.githubusercontent.com/289743/232175442-aa20731d-79ba-40b5-9480-c5736418f849.png)


Fixing by unifying the rendering between the two, and rendering as a right-aligned block of column flex items, aligned to the right, with text inside aligned to the left.

* `flex-direction: column` `align-items: flex-end`
  * `flex-direction: column` `align-items: flex-start`
    * synclist switch
    * upload button + dropdown menu
    * 2 lines of text
  * `flex-direction: row` `align-self: flex-start`
    * repository
    * signature badge