### PR TITLE
Use antsibull-docs-ts to render semantic markup

### DIFF
--- a/CHANGES/2156.feature
+++ b/CHANGES/2156.feature
@@ -1,0 +1,1 @@
+Collection documentation: support semantic markup.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "@types/node": "^16.18.16",
                 "@types/react": "^17.0.2",
                 "@types/react-dom": "^17.0.2",
+                "antsibull-docs": "^1.0.0",
                 "axios": "~1.4.0",
                 "classnames": "^2.3.2",
                 "csstype": "^3.1.2",
@@ -4183,14 +4184,14 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.58.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.58.0.tgz",
-            "integrity": "sha512-ixaM3gRtlfrKzP8N6lRhBbjTow1t6ztfBvQNGuRM8qH1bjFFXIJ35XY+FC0RRBKn3C6cT+7VW1y8tNm7DwPHDQ==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.0.tgz",
+            "integrity": "sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.58.0",
-                "@typescript-eslint/types": "5.58.0",
-                "@typescript-eslint/typescript-estree": "5.58.0",
+                "@typescript-eslint/scope-manager": "5.59.0",
+                "@typescript-eslint/types": "5.59.0",
+                "@typescript-eslint/typescript-estree": "5.59.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -4210,13 +4211,13 @@
             }
         },
         "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.58.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.58.0.tgz",
-            "integrity": "sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
+            "integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.58.0",
-                "@typescript-eslint/visitor-keys": "5.58.0"
+                "@typescript-eslint/types": "5.59.0",
+                "@typescript-eslint/visitor-keys": "5.59.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4227,9 +4228,9 @@
             }
         },
         "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-            "version": "5.58.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
-            "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
+            "integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4240,13 +4241,13 @@
             }
         },
         "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.58.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
-            "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
+            "integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.58.0",
-                "@typescript-eslint/visitor-keys": "5.58.0",
+                "@typescript-eslint/types": "5.59.0",
+                "@typescript-eslint/visitor-keys": "5.59.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -4267,12 +4268,12 @@
             }
         },
         "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.58.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
-            "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
+            "integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "5.58.0",
+                "@typescript-eslint/types": "5.59.0",
                 "eslint-visitor-keys": "^3.3.0"
             },
             "engines": {
@@ -4313,9 +4314,9 @@
             }
         },
         "node_modules/@typescript-eslint/parser/node_modules/semver": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-            "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+            "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -4617,155 +4618,155 @@
             "peer": true
         },
         "node_modules/@webassemblyjs/ast": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.5.tgz",
-            "integrity": "sha512-LHY/GSAZZRpsNQH+/oHqhRQ5FT7eoULcBqgfyTB5nQHogFnK3/7QoN7dLnwSE/JkUAF0SrRuclT7ODqMFtWxxQ==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
+            "integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/helper-numbers": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5"
+                "@webassemblyjs/helper-numbers": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
             }
         },
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.5.tgz",
-            "integrity": "sha512-1j1zTIC5EZOtCplMBG/IEwLtUojtwFVwdyVMbL/hwWqbzlQoJsWCOavrdnLkemwNoC/EOwtUFch3fuo+cbcXYQ==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+            "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.5.tgz",
-            "integrity": "sha512-L65bDPmfpY0+yFrsgz8b6LhXmbbs38OnwDCf6NpnMUYqa+ENfE5Dq9E42ny0qz/PdR0LJyq/T5YijPnU8AXEpA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+            "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.5.tgz",
-            "integrity": "sha512-fDKo1gstwFFSfacIeH5KfwzjykIE6ldh1iH9Y/8YkAZrhmu4TctqYjSh7t0K2VyDSXOZJ1MLhht/k9IvYGcIxg==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
+            "integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.5.tgz",
-            "integrity": "sha512-DhykHXM0ZABqfIGYNv93A5KKDw/+ywBFnuWybZZWcuzWHfbp21wUfRkbtz7dMGwGgT4iXjWuhRMA2Mzod6W4WA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+            "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/floating-point-hex-parser": "1.11.5",
-                "@webassemblyjs/helper-api-error": "1.11.5",
+                "@webassemblyjs/floating-point-hex-parser": "1.11.6",
+                "@webassemblyjs/helper-api-error": "1.11.6",
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.5.tgz",
-            "integrity": "sha512-oC4Qa0bNcqnjAowFn7MPCETQgDYytpsfvz4ujZz63Zu/a/v71HeCAAmZsgZ3YVKec3zSPYytG3/PrRCqbtcAvA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+            "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.5.tgz",
-            "integrity": "sha512-uEoThA1LN2NA+K3B9wDo3yKlBfVtC6rh0i4/6hvbz071E8gTNZD/pT0MsBf7MeD6KbApMSkaAK0XeKyOZC7CIA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
+            "integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-buffer": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5",
-                "@webassemblyjs/wasm-gen": "1.11.5"
+                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/helper-buffer": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/wasm-gen": "1.11.6"
             }
         },
         "node_modules/@webassemblyjs/ieee754": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.5.tgz",
-            "integrity": "sha512-37aGq6qVL8A8oPbPrSGMBcp38YZFXcHfiROflJn9jxSdSMMM5dS5P/9e2/TpaJuhE+wFrbukN2WI6Hw9MH5acg==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+            "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
             "dev": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
         },
         "node_modules/@webassemblyjs/leb128": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.5.tgz",
-            "integrity": "sha512-ajqrRSXaTJoPW+xmkfYN6l8VIeNnR4vBOTQO9HzR7IygoCcKWkICbKFbVTNMjMgMREqXEr0+2M6zukzM47ZUfQ==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+            "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
             "dev": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/utf8": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.5.tgz",
-            "integrity": "sha512-WiOhulHKTZU5UPlRl53gHR8OxdGsSOxqfpqWeA2FmcwBMaoEdz6b2x2si3IwC9/fSPLfe8pBMRTHVMk5nlwnFQ==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+            "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
             "dev": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.5.tgz",
-            "integrity": "sha512-C0p9D2fAu3Twwqvygvf42iGCQ4av8MFBLiTb+08SZ4cEdwzWx9QeAHDo1E2k+9s/0w1DM40oflJOpkZ8jW4HCQ==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
+            "integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-buffer": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5",
-                "@webassemblyjs/helper-wasm-section": "1.11.5",
-                "@webassemblyjs/wasm-gen": "1.11.5",
-                "@webassemblyjs/wasm-opt": "1.11.5",
-                "@webassemblyjs/wasm-parser": "1.11.5",
-                "@webassemblyjs/wast-printer": "1.11.5"
+                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/helper-buffer": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/helper-wasm-section": "1.11.6",
+                "@webassemblyjs/wasm-gen": "1.11.6",
+                "@webassemblyjs/wasm-opt": "1.11.6",
+                "@webassemblyjs/wasm-parser": "1.11.6",
+                "@webassemblyjs/wast-printer": "1.11.6"
             }
         },
         "node_modules/@webassemblyjs/wasm-gen": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.5.tgz",
-            "integrity": "sha512-14vteRlRjxLK9eSyYFvw1K8Vv+iPdZU0Aebk3j6oB8TQiQYuO6hj9s4d7qf6f2HJr2khzvNldAFG13CgdkAIfA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
+            "integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5",
-                "@webassemblyjs/ieee754": "1.11.5",
-                "@webassemblyjs/leb128": "1.11.5",
-                "@webassemblyjs/utf8": "1.11.5"
+                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/ieee754": "1.11.6",
+                "@webassemblyjs/leb128": "1.11.6",
+                "@webassemblyjs/utf8": "1.11.6"
             }
         },
         "node_modules/@webassemblyjs/wasm-opt": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.5.tgz",
-            "integrity": "sha512-tcKwlIXstBQgbKy1MlbDMlXaxpucn42eb17H29rawYLxm5+MsEmgPzeCP8B1Cl69hCice8LeKgZpRUAPtqYPgw==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
+            "integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-buffer": "1.11.5",
-                "@webassemblyjs/wasm-gen": "1.11.5",
-                "@webassemblyjs/wasm-parser": "1.11.5"
+                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/helper-buffer": "1.11.6",
+                "@webassemblyjs/wasm-gen": "1.11.6",
+                "@webassemblyjs/wasm-parser": "1.11.6"
             }
         },
         "node_modules/@webassemblyjs/wasm-parser": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.5.tgz",
-            "integrity": "sha512-SVXUIwsLQlc8srSD7jejsfTU83g7pIGr2YYNb9oHdtldSxaOhvA5xwvIiWIfcX8PlSakgqMXsLpLfbbJ4cBYew==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
+            "integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-api-error": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5",
-                "@webassemblyjs/ieee754": "1.11.5",
-                "@webassemblyjs/leb128": "1.11.5",
-                "@webassemblyjs/utf8": "1.11.5"
+                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/helper-api-error": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/ieee754": "1.11.6",
+                "@webassemblyjs/leb128": "1.11.6",
+                "@webassemblyjs/utf8": "1.11.6"
             }
         },
         "node_modules/@webassemblyjs/wast-printer": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.5.tgz",
-            "integrity": "sha512-f7Pq3wvg3GSPUPzR0F6bmI89Hdb+u9WXrSKc4v+N0aV0q6r42WoF92Jp2jEorBEBRoRNXgjp53nBniDXcqZYPA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
+            "integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
             "dev": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.11.5",
+                "@webassemblyjs/ast": "1.11.6",
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webpack-cli/configtest": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.0.1.tgz",
-            "integrity": "sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.0.tgz",
+            "integrity": "sha512-K/vuv72vpfSEZoo5KIU0a2FsEoYdW0DUMtMpB5X3LlUwshetMZRZRxB7sCsVji/lFaSxtQQ3aM9O4eMolXkU9w==",
             "dev": true,
             "engines": {
                 "node": ">=14.15.0"
@@ -4789,9 +4790,9 @@
             }
         },
         "node_modules/@webpack-cli/serve": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.2.tgz",
-            "integrity": "sha512-S9h3GmOmzUseyeFW3tYNnWS7gNUuwxZ3mmMq0JyW78Vx1SGKPSkt5bT4pB0rUnVfHjP0EL9gW2bOzmtiTfQt0A==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.4.tgz",
+            "integrity": "sha512-0xRgjgDLdz6G7+vvDLlaRpFatJaJ69uTalZLRSMX5B3VUrDmXcrVA3+6fXXQgmYz7bY9AAgs348XQdmtLsK41A==",
             "dev": true,
             "engines": {
                 "node": ">=14.15.0"
@@ -5024,6 +5025,11 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/antsibull-docs": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/antsibull-docs/-/antsibull-docs-1.0.0.tgz",
+            "integrity": "sha512-OqrXCQkKeqTTuFBmQc9RJnXPcjUtRnMq0rfmT3zlp6UHJWTwq1SLffwOEw1I5jC7FNLMoabUjPb8wxCNB3RaZw=="
         },
         "node_modules/anymatch": {
             "version": "3.1.2",
@@ -13012,9 +13018,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.0.11",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-            "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+            "version": "6.0.12",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.12.tgz",
+            "integrity": "sha512-NdxGCAZdRrwVI1sy59+Wzrh+pMMHxapGnpfenDVlMEXoOcvt4pGE0JLK9YY2F5dLxcFYA/YbVQKhcGU+FtSYQg==",
             "dev": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -14840,9 +14846,9 @@
             }
         },
         "node_modules/stylelint": {
-            "version": "15.6.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.6.0.tgz",
-            "integrity": "sha512-Cqzpc8tvJm77KaM8qUbhpJ/UYK55Ia0whQXj4b9IId9dlPICO7J8Lyo15SZWiHxKjlvy3p5FQor/3n6i8ignXg==",
+            "version": "15.6.1",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.6.1.tgz",
+            "integrity": "sha512-d8icFBlVl93Elf3Z5ABQNOCe4nx69is3D/NZhDLAie1eyYnpxfeKe7pCfqzT5W4F8vxHCLSDfV8nKNJzogvV2Q==",
             "dev": true,
             "dependencies": {
                 "@csstools/css-parser-algorithms": "^2.1.1",
@@ -14872,11 +14878,11 @@
                 "micromatch": "^4.0.5",
                 "normalize-path": "^3.0.0",
                 "picocolors": "^1.0.0",
-                "postcss": "^8.4.22",
+                "postcss": "^8.4.23",
                 "postcss-media-query-parser": "^0.2.3",
                 "postcss-resolve-nested-selector": "^0.1.1",
                 "postcss-safe-parser": "^6.0.0",
-                "postcss-selector-parser": "^6.0.11",
+                "postcss-selector-parser": "^6.0.12",
                 "postcss-value-parser": "^4.2.0",
                 "resolve-from": "^5.0.0",
                 "string-width": "^4.2.3",
@@ -14886,7 +14892,7 @@
                 "svg-tags": "^1.0.0",
                 "table": "^6.8.1",
                 "v8-compile-cache": "^2.3.0",
-                "write-file-atomic": "^5.0.0"
+                "write-file-atomic": "^5.0.1"
             },
             "bin": {
                 "stylelint": "bin/stylelint.js"
@@ -15167,9 +15173,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.17.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
-            "integrity": "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==",
+            "version": "5.17.3",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.3.tgz",
+            "integrity": "sha512-AudpAZKmZHkG9jueayypz4duuCFJMMNGRMwaPvQKWfxKedh8Z2x3OCoDqIIi1xx5+iwx1u6Au8XQcc9Lke65Yg==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.2",
@@ -15185,16 +15191,16 @@
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
-            "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
+            "version": "5.3.8",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.8.tgz",
+            "integrity": "sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.1",
-                "terser": "^5.16.5"
+                "terser": "^5.16.8"
             },
             "engines": {
                 "node": ">= 10.13.0"
@@ -16061,9 +16067,9 @@
             "dev": true
         },
         "node_modules/webpack": {
-            "version": "5.81.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.81.0.tgz",
-            "integrity": "sha512-AAjaJ9S4hYCVODKLQTgG5p5e11hiMawBwV2v8MYLE0C/6UAGLuAF4n1qa9GOwdxnicaP+5k6M5HrLmD4+gIB8Q==",
+            "version": "5.82.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.82.1.tgz",
+            "integrity": "sha512-C6uiGQJ+Gt4RyHXXYt+v9f+SN1v83x68URwgxNQ98cvH8kxiuywWGP4XeNZ1paOzZ63aY3cTciCEQJNFUljlLw==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
@@ -16075,7 +16081,7 @@
                 "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.13.0",
+                "enhanced-resolve": "^5.14.0",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -16108,15 +16114,15 @@
             }
         },
         "node_modules/webpack-cli": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.2.tgz",
-            "integrity": "sha512-4y3W5Dawri5+8dXm3+diW6Mn1Ya+Dei6eEVAdIduAmYNLzv1koKVAqsfgrrc9P2mhrYHQphx5htnGkcNwtubyQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.1.tgz",
+            "integrity": "sha512-OLJwVMoXnXYH2ncNGU8gxVpUtm3ybvdioiTvHgUyBuyMLKiVvWy+QObzBsMtp5pH7qQoEuWgeEUQ/sU3ZJFzAw==",
             "dev": true,
             "dependencies": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^2.0.1",
+                "@webpack-cli/configtest": "^2.1.0",
                 "@webpack-cli/info": "^2.0.1",
-                "@webpack-cli/serve": "^2.0.2",
+                "@webpack-cli/serve": "^2.0.4",
                 "colorette": "^2.0.14",
                 "commander": "^10.0.1",
                 "cross-spawn": "^7.0.3",
@@ -16392,9 +16398,9 @@
             }
         },
         "node_modules/webpack/node_modules/enhanced-resolve": {
-            "version": "5.13.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.13.0.tgz",
-            "integrity": "sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==",
+            "version": "5.14.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.0.tgz",
+            "integrity": "sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw==",
             "dev": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -16563,16 +16569,28 @@
             "license": "ISC"
         },
         "node_modules/write-file-atomic": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
-            "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+            "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
             "dev": true,
             "dependencies": {
                 "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.7"
+                "signal-exit": "^4.0.1"
             },
             "engines": {
                 "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/write-file-atomic/node_modules/signal-exit": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+            "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+            "dev": true,
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/ws": {
@@ -19675,41 +19693,41 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.58.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.58.0.tgz",
-            "integrity": "sha512-ixaM3gRtlfrKzP8N6lRhBbjTow1t6ztfBvQNGuRM8qH1bjFFXIJ35XY+FC0RRBKn3C6cT+7VW1y8tNm7DwPHDQ==",
+            "version": "5.59.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.59.0.tgz",
+            "integrity": "sha512-qK9TZ70eJtjojSUMrrEwA9ZDQ4N0e/AuoOIgXuNBorXYcBDk397D2r5MIe1B3cok/oCtdNC5j+lUUpVB+Dpb+w==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.58.0",
-                "@typescript-eslint/types": "5.58.0",
-                "@typescript-eslint/typescript-estree": "5.58.0",
+                "@typescript-eslint/scope-manager": "5.59.0",
+                "@typescript-eslint/types": "5.59.0",
+                "@typescript-eslint/typescript-estree": "5.59.0",
                 "debug": "^4.3.4"
             },
             "dependencies": {
                 "@typescript-eslint/scope-manager": {
-                    "version": "5.58.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.58.0.tgz",
-                    "integrity": "sha512-b+w8ypN5CFvrXWQb9Ow9T4/6LC2MikNf1viLkYTiTbkQl46CnR69w7lajz1icW0TBsYmlpg+mRzFJ4LEJ8X9NA==",
+                    "version": "5.59.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.59.0.tgz",
+                    "integrity": "sha512-tsoldKaMh7izN6BvkK6zRMINj4Z2d6gGhO2UsI8zGZY3XhLq1DndP3Ycjhi1JwdwPRwtLMW4EFPgpuKhbCGOvQ==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "5.58.0",
-                        "@typescript-eslint/visitor-keys": "5.58.0"
+                        "@typescript-eslint/types": "5.59.0",
+                        "@typescript-eslint/visitor-keys": "5.59.0"
                     }
                 },
                 "@typescript-eslint/types": {
-                    "version": "5.58.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.58.0.tgz",
-                    "integrity": "sha512-JYV4eITHPzVQMnHZcYJXl2ZloC7thuUHrcUmxtzvItyKPvQ50kb9QXBkgNAt90OYMqwaodQh2kHutWZl1fc+1g==",
+                    "version": "5.59.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.59.0.tgz",
+                    "integrity": "sha512-yR2h1NotF23xFFYKHZs17QJnB51J/s+ud4PYU4MqdZbzeNxpgUr05+dNeCN/bb6raslHvGdd6BFCkVhpPk/ZeA==",
                     "dev": true
                 },
                 "@typescript-eslint/typescript-estree": {
-                    "version": "5.58.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.58.0.tgz",
-                    "integrity": "sha512-cRACvGTodA+UxnYM2uwA2KCwRL7VAzo45syNysqlMyNyjw0Z35Icc9ihPJZjIYuA5bXJYiJ2YGUB59BqlOZT1Q==",
+                    "version": "5.59.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.59.0.tgz",
+                    "integrity": "sha512-sUNnktjmI8DyGzPdZ8dRwW741zopGxltGs/SAPgGL/AAgDpiLsCFLcMNSpbfXfmnNeHmK9h3wGmCkGRGAoUZAg==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "5.58.0",
-                        "@typescript-eslint/visitor-keys": "5.58.0",
+                        "@typescript-eslint/types": "5.59.0",
+                        "@typescript-eslint/visitor-keys": "5.59.0",
                         "debug": "^4.3.4",
                         "globby": "^11.1.0",
                         "is-glob": "^4.0.3",
@@ -19718,12 +19736,12 @@
                     }
                 },
                 "@typescript-eslint/visitor-keys": {
-                    "version": "5.58.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.58.0.tgz",
-                    "integrity": "sha512-/fBraTlPj0jwdyTwLyrRTxv/3lnU2H96pNTVM6z3esTWLtA5MZ9ghSMJ7Rb+TtUAdtEw9EyJzJ0EydIMKxQ9gA==",
+                    "version": "5.59.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.59.0.tgz",
+                    "integrity": "sha512-qZ3iXxQhanchCeaExlKPV3gDQFxMUmU35xfd5eCXB6+kUw1TUAbIy2n7QIrwz9s98DQLzNWyHp61fY0da4ZcbA==",
                     "dev": true,
                     "requires": {
-                        "@typescript-eslint/types": "5.58.0",
+                        "@typescript-eslint/types": "5.59.0",
                         "eslint-visitor-keys": "^3.3.0"
                     }
                 },
@@ -19748,9 +19766,9 @@
                     }
                 },
                 "semver": {
-                    "version": "7.4.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
-                    "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
+                    "version": "7.5.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+                    "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
@@ -19971,155 +19989,155 @@
             "peer": true
         },
         "@webassemblyjs/ast": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.5.tgz",
-            "integrity": "sha512-LHY/GSAZZRpsNQH+/oHqhRQ5FT7eoULcBqgfyTB5nQHogFnK3/7QoN7dLnwSE/JkUAF0SrRuclT7ODqMFtWxxQ==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
+            "integrity": "sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/helper-numbers": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5"
+                "@webassemblyjs/helper-numbers": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
             }
         },
         "@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.5.tgz",
-            "integrity": "sha512-1j1zTIC5EZOtCplMBG/IEwLtUojtwFVwdyVMbL/hwWqbzlQoJsWCOavrdnLkemwNoC/EOwtUFch3fuo+cbcXYQ==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+            "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
             "dev": true
         },
         "@webassemblyjs/helper-api-error": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.5.tgz",
-            "integrity": "sha512-L65bDPmfpY0+yFrsgz8b6LhXmbbs38OnwDCf6NpnMUYqa+ENfE5Dq9E42ny0qz/PdR0LJyq/T5YijPnU8AXEpA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+            "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
             "dev": true
         },
         "@webassemblyjs/helper-buffer": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.5.tgz",
-            "integrity": "sha512-fDKo1gstwFFSfacIeH5KfwzjykIE6ldh1iH9Y/8YkAZrhmu4TctqYjSh7t0K2VyDSXOZJ1MLhht/k9IvYGcIxg==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.6.tgz",
+            "integrity": "sha512-z3nFzdcp1mb8nEOFFk8DrYLpHvhKC3grJD2ardfKOzmbmJvEf/tPIqCY+sNcwZIY8ZD7IkB2l7/pqhUhqm7hLA==",
             "dev": true
         },
         "@webassemblyjs/helper-numbers": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.5.tgz",
-            "integrity": "sha512-DhykHXM0ZABqfIGYNv93A5KKDw/+ywBFnuWybZZWcuzWHfbp21wUfRkbtz7dMGwGgT4iXjWuhRMA2Mzod6W4WA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+            "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/floating-point-hex-parser": "1.11.5",
-                "@webassemblyjs/helper-api-error": "1.11.5",
+                "@webassemblyjs/floating-point-hex-parser": "1.11.6",
+                "@webassemblyjs/helper-api-error": "1.11.6",
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.5.tgz",
-            "integrity": "sha512-oC4Qa0bNcqnjAowFn7MPCETQgDYytpsfvz4ujZz63Zu/a/v71HeCAAmZsgZ3YVKec3zSPYytG3/PrRCqbtcAvA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+            "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
             "dev": true
         },
         "@webassemblyjs/helper-wasm-section": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.5.tgz",
-            "integrity": "sha512-uEoThA1LN2NA+K3B9wDo3yKlBfVtC6rh0i4/6hvbz071E8gTNZD/pT0MsBf7MeD6KbApMSkaAK0XeKyOZC7CIA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.6.tgz",
+            "integrity": "sha512-LPpZbSOwTpEC2cgn4hTydySy1Ke+XEu+ETXuoyvuyezHO3Kjdu90KK95Sh9xTbmjrCsUwvWwCOQQNta37VrS9g==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-buffer": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5",
-                "@webassemblyjs/wasm-gen": "1.11.5"
+                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/helper-buffer": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/wasm-gen": "1.11.6"
             }
         },
         "@webassemblyjs/ieee754": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.5.tgz",
-            "integrity": "sha512-37aGq6qVL8A8oPbPrSGMBcp38YZFXcHfiROflJn9jxSdSMMM5dS5P/9e2/TpaJuhE+wFrbukN2WI6Hw9MH5acg==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+            "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
             "dev": true,
             "requires": {
                 "@xtuc/ieee754": "^1.2.0"
             }
         },
         "@webassemblyjs/leb128": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.5.tgz",
-            "integrity": "sha512-ajqrRSXaTJoPW+xmkfYN6l8VIeNnR4vBOTQO9HzR7IygoCcKWkICbKFbVTNMjMgMREqXEr0+2M6zukzM47ZUfQ==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+            "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
             "dev": true,
             "requires": {
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webassemblyjs/utf8": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.5.tgz",
-            "integrity": "sha512-WiOhulHKTZU5UPlRl53gHR8OxdGsSOxqfpqWeA2FmcwBMaoEdz6b2x2si3IwC9/fSPLfe8pBMRTHVMk5nlwnFQ==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+            "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
             "dev": true
         },
         "@webassemblyjs/wasm-edit": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.5.tgz",
-            "integrity": "sha512-C0p9D2fAu3Twwqvygvf42iGCQ4av8MFBLiTb+08SZ4cEdwzWx9QeAHDo1E2k+9s/0w1DM40oflJOpkZ8jW4HCQ==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.6.tgz",
+            "integrity": "sha512-Ybn2I6fnfIGuCR+Faaz7YcvtBKxvoLV3Lebn1tM4o/IAJzmi9AWYIPWpyBfU8cC+JxAO57bk4+zdsTjJR+VTOw==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-buffer": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5",
-                "@webassemblyjs/helper-wasm-section": "1.11.5",
-                "@webassemblyjs/wasm-gen": "1.11.5",
-                "@webassemblyjs/wasm-opt": "1.11.5",
-                "@webassemblyjs/wasm-parser": "1.11.5",
-                "@webassemblyjs/wast-printer": "1.11.5"
+                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/helper-buffer": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/helper-wasm-section": "1.11.6",
+                "@webassemblyjs/wasm-gen": "1.11.6",
+                "@webassemblyjs/wasm-opt": "1.11.6",
+                "@webassemblyjs/wasm-parser": "1.11.6",
+                "@webassemblyjs/wast-printer": "1.11.6"
             }
         },
         "@webassemblyjs/wasm-gen": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.5.tgz",
-            "integrity": "sha512-14vteRlRjxLK9eSyYFvw1K8Vv+iPdZU0Aebk3j6oB8TQiQYuO6hj9s4d7qf6f2HJr2khzvNldAFG13CgdkAIfA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.6.tgz",
+            "integrity": "sha512-3XOqkZP/y6B4F0PBAXvI1/bky7GryoogUtfwExeP/v7Nzwo1QLcq5oQmpKlftZLbT+ERUOAZVQjuNVak6UXjPA==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5",
-                "@webassemblyjs/ieee754": "1.11.5",
-                "@webassemblyjs/leb128": "1.11.5",
-                "@webassemblyjs/utf8": "1.11.5"
+                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/ieee754": "1.11.6",
+                "@webassemblyjs/leb128": "1.11.6",
+                "@webassemblyjs/utf8": "1.11.6"
             }
         },
         "@webassemblyjs/wasm-opt": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.5.tgz",
-            "integrity": "sha512-tcKwlIXstBQgbKy1MlbDMlXaxpucn42eb17H29rawYLxm5+MsEmgPzeCP8B1Cl69hCice8LeKgZpRUAPtqYPgw==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.6.tgz",
+            "integrity": "sha512-cOrKuLRE7PCe6AsOVl7WasYf3wbSo4CeOk6PkrjS7g57MFfVUF9u6ysQBBODX0LdgSvQqRiGz3CXvIDKcPNy4g==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-buffer": "1.11.5",
-                "@webassemblyjs/wasm-gen": "1.11.5",
-                "@webassemblyjs/wasm-parser": "1.11.5"
+                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/helper-buffer": "1.11.6",
+                "@webassemblyjs/wasm-gen": "1.11.6",
+                "@webassemblyjs/wasm-parser": "1.11.6"
             }
         },
         "@webassemblyjs/wasm-parser": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.5.tgz",
-            "integrity": "sha512-SVXUIwsLQlc8srSD7jejsfTU83g7pIGr2YYNb9oHdtldSxaOhvA5xwvIiWIfcX8PlSakgqMXsLpLfbbJ4cBYew==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.6.tgz",
+            "integrity": "sha512-6ZwPeGzMJM3Dqp3hCsLgESxBGtT/OeCvCZ4TA1JUPYgmhAx38tTPR9JaKy0S5H3evQpO/h2uWs2j6Yc/fjkpTQ==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.5",
-                "@webassemblyjs/helper-api-error": "1.11.5",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.5",
-                "@webassemblyjs/ieee754": "1.11.5",
-                "@webassemblyjs/leb128": "1.11.5",
-                "@webassemblyjs/utf8": "1.11.5"
+                "@webassemblyjs/ast": "1.11.6",
+                "@webassemblyjs/helper-api-error": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/ieee754": "1.11.6",
+                "@webassemblyjs/leb128": "1.11.6",
+                "@webassemblyjs/utf8": "1.11.6"
             }
         },
         "@webassemblyjs/wast-printer": {
-            "version": "1.11.5",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.5.tgz",
-            "integrity": "sha512-f7Pq3wvg3GSPUPzR0F6bmI89Hdb+u9WXrSKc4v+N0aV0q6r42WoF92Jp2jEorBEBRoRNXgjp53nBniDXcqZYPA==",
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.6.tgz",
+            "integrity": "sha512-JM7AhRcE+yW2GWYaKeHL5vt4xqee5N2WcezptmgyhNS+ScggqcT1OtXykhAb13Sn5Yas0j2uv9tHgrjwvzAP4A==",
             "dev": true,
             "requires": {
-                "@webassemblyjs/ast": "1.11.5",
+                "@webassemblyjs/ast": "1.11.6",
                 "@xtuc/long": "4.2.2"
             }
         },
         "@webpack-cli/configtest": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.0.1.tgz",
-            "integrity": "sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.0.tgz",
+            "integrity": "sha512-K/vuv72vpfSEZoo5KIU0a2FsEoYdW0DUMtMpB5X3LlUwshetMZRZRxB7sCsVji/lFaSxtQQ3aM9O4eMolXkU9w==",
             "dev": true,
             "requires": {}
         },
@@ -20131,9 +20149,9 @@
             "requires": {}
         },
         "@webpack-cli/serve": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.2.tgz",
-            "integrity": "sha512-S9h3GmOmzUseyeFW3tYNnWS7gNUuwxZ3mmMq0JyW78Vx1SGKPSkt5bT4pB0rUnVfHjP0EL9gW2bOzmtiTfQt0A==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.4.tgz",
+            "integrity": "sha512-0xRgjgDLdz6G7+vvDLlaRpFatJaJ69uTalZLRSMX5B3VUrDmXcrVA3+6fXXQgmYz7bY9AAgs348XQdmtLsK41A==",
             "dev": true,
             "requires": {}
         },
@@ -20285,6 +20303,11 @@
             "requires": {
                 "color-convert": "^1.9.0"
             }
+        },
+        "antsibull-docs": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/antsibull-docs/-/antsibull-docs-1.0.0.tgz",
+            "integrity": "sha512-OqrXCQkKeqTTuFBmQc9RJnXPcjUtRnMq0rfmT3zlp6UHJWTwq1SLffwOEw1I5jC7FNLMoabUjPb8wxCNB3RaZw=="
         },
         "anymatch": {
             "version": "3.1.2",
@@ -25693,9 +25716,9 @@
             "requires": {}
         },
         "postcss-selector-parser": {
-            "version": "6.0.11",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-            "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+            "version": "6.0.12",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.12.tgz",
+            "integrity": "sha512-NdxGCAZdRrwVI1sy59+Wzrh+pMMHxapGnpfenDVlMEXoOcvt4pGE0JLK9YY2F5dLxcFYA/YbVQKhcGU+FtSYQg==",
             "dev": true,
             "requires": {
                 "cssesc": "^3.0.0",
@@ -26972,9 +26995,9 @@
             }
         },
         "stylelint": {
-            "version": "15.6.0",
-            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.6.0.tgz",
-            "integrity": "sha512-Cqzpc8tvJm77KaM8qUbhpJ/UYK55Ia0whQXj4b9IId9dlPICO7J8Lyo15SZWiHxKjlvy3p5FQor/3n6i8ignXg==",
+            "version": "15.6.1",
+            "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-15.6.1.tgz",
+            "integrity": "sha512-d8icFBlVl93Elf3Z5ABQNOCe4nx69is3D/NZhDLAie1eyYnpxfeKe7pCfqzT5W4F8vxHCLSDfV8nKNJzogvV2Q==",
             "dev": true,
             "requires": {
                 "@csstools/css-parser-algorithms": "^2.1.1",
@@ -27004,11 +27027,11 @@
                 "micromatch": "^4.0.5",
                 "normalize-path": "^3.0.0",
                 "picocolors": "^1.0.0",
-                "postcss": "^8.4.22",
+                "postcss": "^8.4.23",
                 "postcss-media-query-parser": "^0.2.3",
                 "postcss-resolve-nested-selector": "^0.1.1",
                 "postcss-safe-parser": "^6.0.0",
-                "postcss-selector-parser": "^6.0.11",
+                "postcss-selector-parser": "^6.0.12",
                 "postcss-value-parser": "^4.2.0",
                 "resolve-from": "^5.0.0",
                 "string-width": "^4.2.3",
@@ -27018,7 +27041,7 @@
                 "svg-tags": "^1.0.0",
                 "table": "^6.8.1",
                 "v8-compile-cache": "^2.3.0",
-                "write-file-atomic": "^5.0.0"
+                "write-file-atomic": "^5.0.1"
             },
             "dependencies": {
                 "array-union": {
@@ -27221,9 +27244,9 @@
             "dev": true
         },
         "terser": {
-            "version": "5.17.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.1.tgz",
-            "integrity": "sha512-hVl35zClmpisy6oaoKALOpS0rDYLxRFLHhRuDlEGTKey9qHjS1w9GMORjuwIMt70Wan4lwsLYyWDVnWgF+KUEw==",
+            "version": "5.17.3",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.3.tgz",
+            "integrity": "sha512-AudpAZKmZHkG9jueayypz4duuCFJMMNGRMwaPvQKWfxKedh8Z2x3OCoDqIIi1xx5+iwx1u6Au8XQcc9Lke65Yg==",
             "dev": true,
             "requires": {
                 "@jridgewell/source-map": "^0.3.2",
@@ -27253,16 +27276,16 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.3.7",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.7.tgz",
-            "integrity": "sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==",
+            "version": "5.3.8",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.8.tgz",
+            "integrity": "sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==",
             "dev": true,
             "requires": {
                 "@jridgewell/trace-mapping": "^0.3.17",
                 "jest-worker": "^27.4.5",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.1",
-                "terser": "^5.16.5"
+                "terser": "^5.16.8"
             }
         },
         "text-table": {
@@ -27840,9 +27863,9 @@
             "dev": true
         },
         "webpack": {
-            "version": "5.81.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.81.0.tgz",
-            "integrity": "sha512-AAjaJ9S4hYCVODKLQTgG5p5e11hiMawBwV2v8MYLE0C/6UAGLuAF4n1qa9GOwdxnicaP+5k6M5HrLmD4+gIB8Q==",
+            "version": "5.82.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.82.1.tgz",
+            "integrity": "sha512-C6uiGQJ+Gt4RyHXXYt+v9f+SN1v83x68URwgxNQ98cvH8kxiuywWGP4XeNZ1paOzZ63aY3cTciCEQJNFUljlLw==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",
@@ -27854,7 +27877,7 @@
                 "acorn-import-assertions": "^1.7.6",
                 "browserslist": "^4.14.5",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.13.0",
+                "enhanced-resolve": "^5.14.0",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -27872,9 +27895,9 @@
             },
             "dependencies": {
                 "enhanced-resolve": {
-                    "version": "5.13.0",
-                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.13.0.tgz",
-                    "integrity": "sha512-eyV8f0y1+bzyfh8xAwW/WTSZpLbjhqc4ne9eGSH4Zo2ejdyiNG9pU6mf9DG8a7+Auk6MFTlNOT4Y2y/9k8GKVg==",
+                    "version": "5.14.0",
+                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.0.tgz",
+                    "integrity": "sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw==",
                     "dev": true,
                     "requires": {
                         "graceful-fs": "^4.2.4",
@@ -27888,15 +27911,15 @@
             }
         },
         "webpack-cli": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.0.2.tgz",
-            "integrity": "sha512-4y3W5Dawri5+8dXm3+diW6Mn1Ya+Dei6eEVAdIduAmYNLzv1koKVAqsfgrrc9P2mhrYHQphx5htnGkcNwtubyQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.1.tgz",
+            "integrity": "sha512-OLJwVMoXnXYH2ncNGU8gxVpUtm3ybvdioiTvHgUyBuyMLKiVvWy+QObzBsMtp5pH7qQoEuWgeEUQ/sU3ZJFzAw==",
             "dev": true,
             "requires": {
                 "@discoveryjs/json-ext": "^0.5.0",
-                "@webpack-cli/configtest": "^2.0.1",
+                "@webpack-cli/configtest": "^2.1.0",
                 "@webpack-cli/info": "^2.0.1",
-                "@webpack-cli/serve": "^2.0.2",
+                "@webpack-cli/serve": "^2.0.4",
                 "colorette": "^2.0.14",
                 "commander": "^10.0.1",
                 "cross-spawn": "^7.0.3",
@@ -28190,13 +28213,21 @@
             "version": "1.0.2"
         },
         "write-file-atomic": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.0.tgz",
-            "integrity": "sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+            "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
             "dev": true,
             "requires": {
                 "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.7"
+                "signal-exit": "^4.0.1"
+            },
+            "dependencies": {
+                "signal-exit": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.0.2.tgz",
+                    "integrity": "sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==",
+                    "dev": true
+                }
             }
         },
         "ws": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "@types/node": "^16.18.16",
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.2",
+        "antsibull-docs": "^1.0.0",
         "axios": "~1.4.0",
         "classnames": "^2.3.2",
         "csstype": "^3.1.2",

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -171,9 +171,11 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
                   // if plugin data is set render it
                   <RenderPluginDoc
                     plugin={pluginData}
-                    renderModuleLink={(moduleName) =>
-                      this.renderModuleLink(
-                        moduleName,
+                    renderPluginLink={(pluginName, pluginType, text) =>
+                      this.renderPluginLink(
+                        pluginName,
+                        pluginType,
+                        text ?? pluginName,
                         collection,
                         params,
                         content.contents,
@@ -243,9 +245,16 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
     }
   }
 
-  private renderModuleLink(moduleName, collection, params, allContent) {
+  private renderPluginLink(
+    pluginName,
+    pluginType,
+    text,
+    collection,
+    params,
+    allContent,
+  ) {
     const module = allContent.find(
-      (x) => x.content_type === 'module' && x.name === moduleName,
+      (x) => x.content_type === pluginType && x.name === pluginName,
     );
 
     if (module) {
@@ -256,18 +265,18 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
             {
               namespace: collection.collection_version.namespace,
               collection: collection.collection_version.name,
-              type: 'module',
-              name: moduleName,
+              type: pluginType,
+              name: pluginName,
               repo: this.props.routeParams.repo,
             },
             params,
           )}
         >
-          {moduleName}
+          {text}
         </Link>
       );
     } else {
-      return moduleName;
+      return text;
     }
   }
 


### PR DESCRIPTION
Uses the TypeScript library [antsibull-docs](https://www.npmjs.com/package/antsibull-docs) (https://github.com/ansible-community/antsibull-docs-ts) to render Ansible markup, including the new semantic markup.

(I marked this as a draft since I want to wait a bit until antsibull-docs-ts reaches 1.0.0 before making this ready.)

FYI, I haven't managed to test this locally, so no idea how the output actually looks...