### PR TITLE
Fix version modal - load data on pagination

### DIFF
--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -84,6 +84,8 @@ export function loadCollection({
     .then(({ data: { results } }) => results[0])
     .catch(() => navigate(formatPath(Paths.notFound)));
 
+  // Note: this only provides the first page - containing the latest version, and all items for the version *selector*,
+  // but the version *modal* is using a separate call, in CollectionHeader updatePaginationParams
   const versions = CollectionVersionAPI.list({
     ...requestParams,
     order_by: '-version',


### PR DESCRIPTION
Follows #3595,
open a collection detail when the collection has more than 10 versions available.
Open version selector, more versions, go to page 2, :boom: 

the version selector modal still operates under the assumption that collections contains all the versions, not just the first page

making the modal query the api on pagination, have a loading spinner, default page size to 10, not 20 to match the loadCollections request

Cc @jctanner , thanks for finding this! :)

---

Before:
![image (1)](https://user-images.githubusercontent.com/289743/234099441-d0b7498f-f1ef-4503-b432-af98f1898bda.png)

After:
![20230424194042](https://user-images.githubusercontent.com/289743/234099123-4a6bda76-50a7-4f1a-88ad-6c546a41354c.png)
![20230424194049](https://user-images.githubusercontent.com/289743/234099127-769a657b-afd7-49e4-8c7e-5f37a8f2ddb6.png)
![20230424194059](https://user-images.githubusercontent.com/289743/234099132-9d673112-2ff7-4550-9f9b-70e81c1903d6.png)

