### PR TITLE
[stable-4.7] Repository edit: respect object permissions (#3628)

### DIFF
--- a/CHANGES/2305.bug
+++ b/CHANGES/2305.bug
@@ -1,0 +1,1 @@
+Fix Edit collection ignoring repository object permissions


### PR DESCRIPTION
Backports #3628 , conflict in CHANGES/

---

previously the permission check for rendering the edit form would happen before loading the repository, so we only used the global permissions .. postponing check until item has been loaded

Issue: AAH-2305
(cherry picked from commit 9610edb86a28bfef79b4fa43170262e3a870ddb7)