### PR TITLE
Namespace detail - fix Sign all

### DIFF
--- a/CHANGES/2308.bug
+++ b/CHANGES/2308.bug
@@ -1,0 +1,1 @@
+Namespace detail: sign all collections only signs current repo now

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -19,7 +19,8 @@ export function findDistroBasePathByRepo(distributions, repository) {
   const distro = distributions.find(
     (distro) => distro.name === repository.name,
   );
-  return distro ? distro.base_path : distro[0].base_path;
+
+  return distro ? distro.base_path : distributions[0].base_path;
 }
 
 function filterContents(contents) {

--- a/src/api/sign-collections.ts
+++ b/src/api/sign-collections.ts
@@ -30,6 +30,12 @@ class API extends HubAPI {
     if (!repository && repository_name) {
       repository = (await AnsibleRepositoryAPI.list({ name: repository_name }))
         ?.data?.results?.[0];
+
+      if (!repository) {
+        return Promise.reject({
+          response: { status: t`Failed to find repository` },
+        });
+      }
     }
 
     const distribution = (

--- a/src/api/sign-collections.ts
+++ b/src/api/sign-collections.ts
@@ -26,14 +26,14 @@ type SignProps = SignNamespace | SignCollection | SignVersion;
 class API extends HubAPI {
   apiPath = this.getUIPath('collection_signing/');
 
-  async sign({ repository, repository_name, ...args }: SignProps) {
-    if (!repository && repository_name) {
-      repository = (await AnsibleRepositoryAPI.list({ name: repository_name }))
-        ?.data?.results?.[0];
+  async sign({ repository, repository_name: name, ...args }: SignProps) {
+    if (!repository && name) {
+      repository = (await AnsibleRepositoryAPI.list({ name }))?.data
+        ?.results?.[0];
 
       if (!repository) {
         return Promise.reject({
-          response: { status: t`Failed to find repository` },
+          response: { status: t`Failed to find repository ${name}` },
         });
       }
     }
@@ -45,8 +45,11 @@ class API extends HubAPI {
     )?.data?.results?.[0];
 
     if (!distribution) {
+      const name = repository.name;
       return Promise.reject({
-        response: { status: t`Failed to find a distribution` },
+        response: {
+          status: t`Failed to find a distribution for repository ${name}`,
+        },
       });
     }
 

--- a/src/api/sign-collections.ts
+++ b/src/api/sign-collections.ts
@@ -1,13 +1,15 @@
+import { t } from '@lingui/macro';
 import {
   AnsibleDistributionAPI,
+  AnsibleRepositoryAPI,
   CollectionVersionSearch,
-  findDistroBasePathByRepo,
 } from 'src/api';
 import { HubAPI } from './hub';
 
 interface SignNamespace {
   signing_service?: string;
-  repository: CollectionVersionSearch['repository'];
+  repository?: CollectionVersionSearch['repository'];
+  repository_name?: string;
   namespace: string;
 }
 
@@ -24,19 +26,26 @@ type SignProps = SignNamespace | SignCollection | SignVersion;
 class API extends HubAPI {
   apiPath = this.getUIPath('collection_signing/');
 
-  async sign(data: SignProps) {
-    const { repository, ...args } = data;
-    const distros = await AnsibleDistributionAPI.list({
-      repository: repository.pulp_href,
-    });
+  async sign({ repository, repository_name, ...args }: SignProps) {
+    if (!repository && repository_name) {
+      repository = (await AnsibleRepositoryAPI.list({ name: repository_name }))
+        ?.data?.results?.[0];
+    }
 
-    const distroBasePath = findDistroBasePathByRepo(
-      distros.data.results,
-      repository,
-    );
+    const distribution = (
+      await AnsibleDistributionAPI.list({
+        repository: repository?.pulp_href,
+      })
+    )?.data?.results?.[0];
+
+    if (!distribution) {
+      return Promise.reject({
+        response: { status: t`Failed to find a distribution` },
+      });
+    }
 
     const updatedData = {
-      distro_base_path: distroBasePath,
+      distro_base_path: distribution.base_path,
       ...args,
     };
 

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -124,11 +124,11 @@ export const CollectionFilter = (props: IProps) => {
             <ToolbarItem>
               <AppliedFilters
                 niceNames={{
-                  is_signed: t`sign state`,
-                  tags: t`tags`,
-                  keywords: t`keywords`,
-                  repository_name: t`repository`,
-                  namespace: t`namespace`,
+                  is_signed: t`Sign state`,
+                  tags: t`Tags`,
+                  keywords: t`Keywords`,
+                  repository_name: t`Repository`,
+                  namespace: t`Namespace`,
                 }}
                 niceValues={{
                   is_signed: {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -108,6 +108,9 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     ]);
 
     params['namespace'] = props.routeParams.namespace;
+    if (props.routeParams.repo && !params['repository_name']) {
+      params['repository_name'] = props.routeParams.repo;
+    }
 
     this.state = {
       canSign: false,
@@ -147,18 +150,28 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
   }
 
   componentDidUpdate(prevProps) {
-    if (prevProps.location.search !== this.props.location.search) {
-      const params = ParamHelper.parseParamString(this.props.location.search, [
-        'page',
-        'page_size',
-      ]);
+    const params = ParamHelper.parseParamString(this.props.location.search, [
+      'page',
+      'page_size',
+    ]);
 
+    if (prevProps.location.search !== this.props.location.search) {
       params['namespace'] = this.props.routeParams.namespace;
 
       this.setState({
         params,
         group: this.filterGroup(params['group'], this.state.namespace.groups),
       });
+    }
+
+    if (
+      prevProps.routeParams.repo !== this.props.routeParams.repo &&
+      this.props.routeParams.repo &&
+      (!params['repository_name'] ||
+        params['repository_name'] === prevProps.routeParams.repo)
+    ) {
+      params['repository_name'] = this.props.routeParams.repo;
+      this.setState({ params });
     }
   }
 
@@ -275,7 +288,6 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
 
     const ignoredParams = [
       'namespace',
-      'repository__name',
       'page',
       'page_size',
       'sort',


### PR DESCRIPTION
Issue: AAH-2308

Before: "sign all" would only sign collections in the repository of the first collection of the currently displayed list.

After: "sign all" only works when a repository is selected

![20230425235133](https://user-images.githubusercontent.com/289743/234432540-dfc98f8a-62f0-4c25-a8ef-c43d1a7d6bee.png)
![20230425235205](https://user-images.githubusercontent.com/289743/234432544-11d2aa0d-23ff-4a99-9996-735878dd075e.png)

Also updates `findDistroBasePathByRepo` to fix fallback,
allows SignCollectionAPI.sign to find repository by name,
and when using the `myCollectionsByRepo` route, use the repo to preset the repository filter