### PR TITLE
Fix manual approve/reject when repository name is different from distribution base_path

### DIFF
--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -4,25 +4,25 @@ import { HubAPI } from './hub';
 export class API extends HubAPI {
   apiPath = 'v3/plugin/ansible/search/collection-versions/';
 
-  setRepository(
+  move(
     namespace: string,
     name: string,
     version: string,
-    originalRepo: string,
-    destinationRepo: string,
+    source_base_path: string,
+    destination_base_path: string,
   ) {
-    const path = `v3/collections/${namespace}/${name}/versions/${version}/move/${originalRepo}/${destinationRepo}/`;
+    const path = `v3/collections/${namespace}/${name}/versions/${version}/move/${source_base_path}/${destination_base_path}/`;
     return this.create({}, path);
   }
 
-  copyToRepository(
+  copy(
     namespace: string,
     name: string,
     version: string,
-    originalRepo: string,
-    destinationRepo: string,
+    source_base_path: string,
+    destination_base_path: string,
   ) {
-    const path = `v3/collections/${namespace}/${name}/versions/${version}/copy/${originalRepo}/${destinationRepo}/`;
+    const path = `v3/collections/${namespace}/${name}/versions/${version}/copy/${source_base_path}/${destination_base_path}/`;
     return this.create({}, path);
   }
 

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -18,6 +18,8 @@ import {
 import * as React from 'react';
 import { Link } from 'react-router-dom';
 import {
+  AnsibleDistributionAPI,
+  AnsibleRepositoryAPI,
   CertificateUploadAPI,
   CollectionAPI,
   CollectionVersionAPI,
@@ -772,14 +774,41 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
       });
   }
 
+  private async distributionByRepoName(name) {
+    const repository = (await AnsibleRepositoryAPI.list({ name }))?.data
+      ?.results?.[0];
+    if (!repository) {
+      return Promise.reject(t`Failed to find repository ${name}`);
+    }
+
+    const distribution = (
+      await AnsibleDistributionAPI.list({ repository: repository.pulp_href })
+    )?.data?.results?.[0];
+    if (!distribution) {
+      return Promise.reject(
+        t`Failed to find a distribution for repository ${name}`,
+      );
+    }
+
+    return distribution;
+  }
+
   private updateCertification(version, originalRepo, destinationRepo) {
-    return CollectionVersionAPI.setRepository(
-      version.namespace,
-      version.name,
-      version.version,
-      originalRepo,
-      destinationRepo,
-    )
+    // galaxy_ng CollectionRepositoryMixing.get_repos uses the distribution base path to look up repository pk
+    // there ..may be room for simplification since we already know the repo; OTOH also compatibility concerns
+    return Promise.all([
+      this.distributionByRepoName(originalRepo),
+      this.distributionByRepoName(destinationRepo),
+    ])
+      .then(([source, destination]) =>
+        CollectionVersionAPI.move(
+          version.namespace,
+          version.name,
+          version.version,
+          source.base_path,
+          destination.base_path,
+        ),
+      )
       .then((result) =>
         waitForTask(result.data.remove_task_id, { waitMs: 500 }),
       )


### PR DESCRIPTION
when calling the collection version copy/move API, the endpoint accepts source base path and destination base path, those are usually identical to repository name, but not always .. any repo with spaces in the name will have a different base path

This ensures we call the endpoint with actual distribution base paths, not repository names.

(There may be room for improvement, the first thing the API does with the base path is look up the repository ([galaxy_ng/app/api/v3/viewsets/collection.py:239](https://github.com/ansible/galaxy_ng/blob/master/galaxy_ng/app/api/v3/viewsets/collection.py#L239)), but not sure that would be backportable.)

Cc @MilanPospisil good catch finding this :)