### PR TITLE
Disable checkbox for adding collection if collection is already assigned to repository

### DIFF
--- a/CHANGES/2323.feature
+++ b/CHANGES/2323.feature
@@ -1,0 +1,1 @@
+Disable checkbox for adding collection if collection is already assigned to repository

--- a/src/actions/ansible-repository-collection-version-add.tsx
+++ b/src/actions/ansible-repository-collection-version-add.tsx
@@ -3,6 +3,7 @@ import { Button, Checkbox, Modal } from '@patternfly/react-core';
 import React, { useState } from 'react';
 import {
   AnsibleRepositoryAPI,
+  AnsibleRepositoryType,
   CollectionVersionAPI,
   CollectionVersionSearch,
 } from 'src/api';
@@ -55,9 +56,11 @@ const add = (
 const AddCollectionVersionModal = ({
   addAction,
   closeAction,
+  sourceRepository,
 }: {
   addAction: (selected) => void;
   closeAction: () => void;
+  sourceRepository: AnsibleRepositoryType;
 }) => {
   const [alerts, setAlerts] = useState([]);
   const [selected, setSelected] = useState<CollectionVersionSearch[]>([]);
@@ -93,6 +96,9 @@ const AddCollectionVersionModal = ({
       repository,
     } = item;
 
+    const isCollectionInRepo =
+      sourceRepository.pulp_href === repository.pulp_href;
+
     return (
       <tr
         onClick={() =>
@@ -106,8 +112,9 @@ const AddCollectionVersionModal = ({
           <Checkbox
             aria-label={`${namespace}.${name} v${version}`}
             id={`collection-${index}`}
-            isChecked={selected.includes(item)}
+            isChecked={isCollectionInRepo || selected.includes(item)}
             name={`collection-${index}`}
+            isDisabled={isCollectionInRepo}
           />
         </td>
         <td>
@@ -221,6 +228,7 @@ export const ansibleRepositoryCollectionVersionAddAction = Action({
         closeAction={() =>
           setState((ms) => ({ ...ms, addCollectionVersionModal: null }))
         }
+        sourceRepository={state.repository}
       />
     ) : null,
   onClick: (

--- a/src/utilities/repositories.ts
+++ b/src/utilities/repositories.ts
@@ -90,11 +90,9 @@ export class RepositoriesUtils {
   ): CollectionVersionSearch[] {
     // check if collection is already selected
     const selectedItem = collections.find(
-      ({ collection_version: { name, namespace, version }, repository }) =>
-        name === selectedCollection.collection_version.name &&
-        namespace === selectedCollection.collection_version.namespace &&
-        version === selectedCollection.collection_version.version &&
-        repository.name === selectedCollection.repository.name,
+      ({ collection_version: cv, repository }) =>
+        cv.pulp_href === selectedCollection.collection_version.pulp_href &&
+        repository.pulp_href === selectedCollection.repository.pulp_href,
     );
 
     // if collection is not selected, add it to selected items
@@ -104,14 +102,9 @@ export class RepositoriesUtils {
 
     // unselect collection
     return collections.filter(
-      ({ collection_version, repository }) =>
-        collection_version.name !==
-          selectedCollection.collection_version.name ||
-        collection_version.namespace !==
-          selectedCollection.collection_version.namespace ||
-        collection_version.version !==
-          selectedCollection.collection_version.version ||
-        repository.name !== selectedCollection.repository.name,
+      ({ collection_version: cv, repository }) =>
+        cv.pulp_href !== selectedCollection.collection_version.pulp_href ||
+        repository.pulp_href !== selectedCollection.repository.pulp_href,
     );
   }
 }


### PR DESCRIPTION
Issue: AAH-2323

User experience improvement, but for performance cost. It could be a little inefficient to fetch collections from the collection versions list again and match them with modal collection versions. So I think we need to think this through if we want to include this. :)

before:
![Screenshot from 2023-04-27 13-49-31](https://user-images.githubusercontent.com/19647757/234853485-245dd349-50d9-4ff7-953e-60cb12b2bdc8.png)


after:
![Screenshot from 2023-04-27 13-41-55](https://user-images.githubusercontent.com/19647757/234853477-2bc6270b-f095-46a9-a81c-c67662733e9d.png)
