### PR TITLE
Namespace list refactor

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -5,6 +5,7 @@ export {
   NamespaceListType,
   NamespaceLinkType,
 } from './response-types/namespace';
+export { LatestMetadataType } from './response-types/latest-metadata';
 export {
   CollectionDetailType,
   CollectionListType,

--- a/src/api/my-namespace.ts
+++ b/src/api/my-namespace.ts
@@ -1,7 +1,7 @@
-import { HubAPI } from './hub';
+import { PulpAPI } from './pulp';
 
-class API extends HubAPI {
-  apiPath = this.getUIPath('my-namespaces/');
+class API extends PulpAPI {
+  apiPath = 'pulp_ansible/namespaces/';
 
   get(id: string, params = {}) {
     return this.http.get(this.apiPath + id + '/', { params });

--- a/src/api/namespace.ts
+++ b/src/api/namespace.ts
@@ -4,7 +4,11 @@ class API extends HubAPI {
   apiPath = this.getUIPath('namespaces/');
 
   get(id: string, params = {}) {
-    return this.http.get(this.apiPath + id + '/', { params });
+    // return this.http.get(this.apiPath + id + '/', { params });
+    return this.http.get(
+      'http://localhost:8002/api/automation-hub/pulp/api/v3/content/ansible/namespaces/',
+      { params },
+    );
   }
 }
 

--- a/src/api/namespace.ts
+++ b/src/api/namespace.ts
@@ -1,8 +1,8 @@
 import { HubAPI } from './hub';
 
 class API extends HubAPI {
-  // apiPath = this.getUIPath('namespaces/');
-  apiPath = '/pulp/api/v3/pulp_ansible/namespaces/';
+  apiPath =
+    'http://localhost:8002/api/automation-hub/pulp/api/v3/pulp_ansible/namespaces/';
 
   get(id: string, params = {}) {
     return this.http.get(this.apiPath + id + '/', { params });

--- a/src/api/namespace.ts
+++ b/src/api/namespace.ts
@@ -1,8 +1,7 @@
-import { HubAPI } from './hub';
+import { PulpAPI } from './pulp';
 
-class API extends HubAPI {
-  apiPath =
-    'http://localhost:8002/api/automation-hub/pulp/api/v3/pulp_ansible/namespaces/';
+class API extends PulpAPI {
+  apiPath = 'pulp_ansible/namespaces/';
 
   get(id: string, params = {}) {
     return this.http.get(this.apiPath + id + '/', { params });

--- a/src/api/namespace.ts
+++ b/src/api/namespace.ts
@@ -1,14 +1,12 @@
 import { HubAPI } from './hub';
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('namespaces/');
+  // apiPath = this.getUIPath('namespaces/');
+  apiPath =
+    'http://localhost:8002/api/automation-hub/pulp/api/v3/content/ansible/namespaces/';
 
   get(id: string, params = {}) {
-    // return this.http.get(this.apiPath + id + '/', { params });
-    return this.http.get(
-      'http://localhost:8002/api/automation-hub/pulp/api/v3/content/ansible/namespaces/',
-      { params },
-    );
+    return this.http.get(this.apiPath + id + '/', { params });
   }
 }
 

--- a/src/api/namespace.ts
+++ b/src/api/namespace.ts
@@ -2,8 +2,7 @@ import { HubAPI } from './hub';
 
 class API extends HubAPI {
   // apiPath = this.getUIPath('namespaces/');
-  apiPath =
-    'http://localhost:8002/api/automation-hub/pulp/api/v3/content/ansible/namespaces/';
+  apiPath = '/pulp/api/v3/content/ansible/namespaces/';
 
   get(id: string, params = {}) {
     return this.http.get(this.apiPath + id + '/', { params });

--- a/src/api/namespace.ts
+++ b/src/api/namespace.ts
@@ -2,7 +2,7 @@ import { HubAPI } from './hub';
 
 class API extends HubAPI {
   // apiPath = this.getUIPath('namespaces/');
-  apiPath = '/pulp/api/v3/content/ansible/namespaces/';
+  apiPath = '/pulp/api/v3/pulp_ansible/namespaces/';
 
   get(id: string, params = {}) {
     return this.http.get(this.apiPath + id + '/', { params });

--- a/src/api/response-types/latest-metadata.ts
+++ b/src/api/response-types/latest-metadata.ts
@@ -1,0 +1,19 @@
+export class LinksType {
+  url: string;
+  name: string;
+}
+
+export class LatestMetadataType {
+  pulp_href: string;
+  name: string;
+  company: string;
+  email: string;
+  description: string;
+  resources: string;
+  links: LinksType[];
+  avatar_sha256: string | null;
+  avatar_url: string | null;
+  metadata_sha256: string;
+  groups: string[];
+  task: string | null;
+}

--- a/src/api/response-types/namespace.ts
+++ b/src/api/response-types/namespace.ts
@@ -13,6 +13,7 @@ export class NamespaceListType {
   avatar_url: string;
   description: string;
   num_collections: number;
+  pulp_href: string;
 }
 
 export class NamespaceType extends NamespaceListType {
@@ -20,5 +21,5 @@ export class NamespaceType extends NamespaceListType {
   resources: string;
   owners: string[];
   links: NamespaceLinkType[];
-  related_fields: { my_permissions?: string[] };
+  my_permissions: string[];
 }

--- a/src/api/response-types/namespace.ts
+++ b/src/api/response-types/namespace.ts
@@ -1,3 +1,4 @@
+import { LatestMetadataType } from './latest-metadata';
 import { GroupObjectPermissionType } from './permissions';
 
 export class NamespaceLinkType {
@@ -13,7 +14,6 @@ export class NamespaceListType {
   avatar_url: string;
   description: string;
   num_collections: number;
-  pulp_href: string;
 }
 
 export class NamespaceType extends NamespaceListType {
@@ -22,4 +22,5 @@ export class NamespaceType extends NamespaceListType {
   owners: string[];
   links: NamespaceLinkType[];
   my_permissions: string[];
+  latest_metadata: LatestMetadataType;
 }

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -66,12 +66,12 @@ export class PartnerHeader extends React.Component<IProps> {
               updateParams={(p) => updateParams(p)}
             />
           </div>
-          {namespace?.links?.length > 0 ? (
+          {namespace?.latest_metadata?.links?.length > 0 ? (
             <div className='links'>
               <div>
                 <ExternalLinkAltIcon />
               </div>
-              {namespace.links.map((x, i) => {
+              {namespace.latest_metadata.links.map((x, i) => {
                 return (
                   <div className='link' key={i}>
                     <a href={x.url} target='blank'>

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -66,7 +66,7 @@ export class PartnerHeader extends React.Component<IProps> {
               updateParams={(p) => updateParams(p)}
             />
           </div>
-          {namespace.links.length > 0 ? (
+          {namespace?.links?.length > 0 ? (
             <div className='links'>
               <div>
                 <ExternalLinkAltIcon />

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -64,7 +64,6 @@ export class NamespaceModal extends React.Component<IProps, IState> {
   private handleSubmit = () => {
     const data = {
       name: this.state.newNamespaceName,
-      groups: [],
     };
     NamespaceAPI.create(data)
       .then(() => {

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -189,6 +189,7 @@ class EditNamespace extends React.Component<RouteProps, IState> {
   private loadNamespace() {
     NamespaceAPI.list({
       name: this.props.routeParams.namespace,
+      my_permissions: 'ansible.change_ansiblenamespace',
     })
       .then((response) => {
         // Add an empty link to the end of the links array to create an empty field

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -2,7 +2,7 @@ import { Trans, t } from '@lingui/macro';
 import { ActionGroup, Button, Form, Spinner } from '@patternfly/react-core';
 import React from 'react';
 import { Navigate } from 'react-router-dom';
-import { MyNamespaceAPI, NamespaceLinkType, NamespaceType } from 'src/api';
+import { NamespaceAPI, NamespaceLinkType, NamespaceType } from 'src/api';
 import {
   AlertList,
   AlertType,
@@ -187,13 +187,15 @@ class EditNamespace extends React.Component<RouteProps, IState> {
   }
 
   private loadNamespace() {
-    MyNamespaceAPI.get(this.props.routeParams.namespace)
+    NamespaceAPI.list({
+      name: this.props.routeParams.namespace,
+    })
       .then((response) => {
         // Add an empty link to the end of the links array to create an empty field
         // on the link edit form for adding new links
         const emptyLink: NamespaceLinkType = { name: '', url: '' };
         response.data.links.push(emptyLink);
-        this.setState({ loading: false, namespace: response.data });
+        this.setState({ loading: false, namespace: response.data.results[0] });
       })
       .catch(() => {
         this.setState({ unauthorized: true, loading: false });
@@ -214,7 +216,7 @@ class EditNamespace extends React.Component<RouteProps, IState> {
 
       namespace.links = setLinks;
 
-      MyNamespaceAPI.update(this.state.namespace.name, namespace)
+      NamespaceAPI.update(this.state.namespace.name, namespace)
         .then((result) => {
           this.setState(
             {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -709,11 +709,8 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
         namespace: this.props.routeParams.namespace,
         is_highest: true,
       }),
-      NamespaceAPI.get(this.props.routeParams.namespace, {
-        // include_related: 'my_permissions',
-      }),
-      MyNamespaceAPI.get(this.props.routeParams.namespace, {
-        // include_related: 'my_permissions',
+      NamespaceAPI.list({
+        name: this.props.routeParams.namespace,
       }).catch((e) => {
         // TODO this needs fixing on backend to return nothing in these cases with 200 status
         // if view only mode is enabled disregard errors and hope

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -730,9 +730,9 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
         this.setState({
           collections: val[0].data.data,
           itemCount: val[0].data.meta.count,
-          namespace: val[1].data,
-          showControls: !!val[2],
-          canSign: canSignNamespace(this.context, val[2]?.data),
+          namespace: val[1].data.results[0],
+          showControls: !!val[1].data.results[0],
+          canSign: canSignNamespace(this.context, val[1]?.data.results[0]),
           group: this.filterGroup(
             this.state.params['group'],
             val[1].data['groups'],

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -299,9 +299,9 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     const { hasPermission } = this.context;
 
     const canEditOwners =
-      this.state.namespace.related_fields.my_permissions?.includes(
-        'galaxy.change_namespace',
-      ) || hasPermission('galaxy.change_namespace');
+      this.state.namespace.my_permissions?.includes(
+        'ansible.change_ansiblenamespace',
+      ) || hasPermission('ansible.change_ansiblenamespace');
 
     // remove ?group (access tab) when switching tabs
     const tabParams = { ...params };
@@ -710,10 +710,10 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
         is_highest: true,
       }),
       NamespaceAPI.get(this.props.routeParams.namespace, {
-        include_related: 'my_permissions',
+        // include_related: 'my_permissions',
       }),
       MyNamespaceAPI.get(this.props.routeParams.namespace, {
-        include_related: 'my_permissions',
+        // include_related: 'my_permissions',
       }).catch((e) => {
         // TODO this needs fixing on backend to return nothing in these cases with 200 status
         // if view only mode is enabled disregard errors and hope

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -301,7 +301,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     const canEditOwners =
       this.state.namespace.my_permissions?.includes(
         'ansible.change_ansiblenamespace',
-      ) || hasPermission('ansible.change_ansiblenamespace');
+      ) || hasPermission('galaxy.change_namespace');
 
     // remove ?group (access tab) when switching tabs
     const tabParams = { ...params };

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -326,7 +326,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
           <div key={i} className='card-wrapper'>
             <NamespaceCard
               namespaceURL={formatPath(namespacePath, {
-                namespace: ns.pulp_href.split('/').at(-2),
+                namespace: ns.name,
               })}
               key={i}
               {...ns}

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -105,7 +105,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
       // if the user can edit namespaces
       MyNamespaceAPI.list({})
         .then((results) => {
-          if (results.data.meta.count !== 0) {
+          if (results.data.count !== 0) {
             this.loadNamespaces();
           } else {
             this.setState({
@@ -319,7 +319,6 @@ export class NamespaceList extends React.Component<IProps, IState> {
         </section>
       );
     }
-
     return (
       <section className='card-layout'>
         {namespaces.map((ns, i) => (

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -46,6 +46,7 @@ interface IState {
     page_size?: number;
     tenant?: string;
     keywords?: string;
+    my_permissions?: string;
   };
   hasPermission: boolean;
   isModalOpen: boolean;
@@ -68,15 +69,16 @@ export class NamespaceList extends React.Component<IProps, IState> {
     const params = ParamHelper.parseParamString(props.location.search, [
       'page',
       'page_size',
+      'my_permissions',
     ]);
 
     if (!params['page_size']) {
       params['page_size'] = 20;
     }
 
-    if (!params['sort']) {
-      params['sort'] = 'name';
-    }
+    // if (!params['sort']) {
+    //   params['sort'] = 'name';
+    // }
 
     this.state = {
       alerts: [],
@@ -99,11 +101,10 @@ export class NamespaceList extends React.Component<IProps, IState> {
   componentDidMount() {
     this.setState({ alerts: this.context.alerts || [] });
     this.context.setAlerts([]);
-
     if (this.props.filterOwner) {
       // Make a query with no params and see if it returns results to tell
       // if the user can edit namespaces
-      MyNamespaceAPI.list({})
+      MyNamespaceAPI.list({ my_permissions: 'ansible.change_ansiblenamespace' })
         .then((results) => {
           if (results.data.count !== 0) {
             this.loadNamespaces();
@@ -290,7 +291,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
       ? t`Namespaces will appear once created`
       : t`This account is not set up to manage any namespaces`;
 
-    const noDataButton = hasPermission('galaxy.add_namespace') ? (
+    const noDataButton = hasPermission('ansible.add_ansiblenamespace') ? (
       <Button variant='primary' onClick={() => this.handleModalToggle()}>
         {t`Create`}
       </Button>
@@ -325,7 +326,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
           <div key={i} className='card-wrapper'>
             <NamespaceCard
               namespaceURL={formatPath(namespacePath, {
-                namespace: ns.name,
+                namespace: ns.pulp_href.split('/').at(-2),
               })}
               key={i}
               {...ns}

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -104,7 +104,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
     if (this.props.filterOwner) {
       // Make a query with no params and see if it returns results to tell
       // if the user can edit namespaces
-      MyNamespaceAPI.list({ my_permissions: 'ansible.change_ansiblenamespace' })
+      NamespaceAPI.list({ my_permissions: 'ansible.change_ansiblenamespace' })
         .then((results) => {
           if (results.data.count !== 0) {
             this.loadNamespaces();

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -346,8 +346,8 @@ export class NamespaceList extends React.Component<IProps, IState> {
         .list(this.state.params)
         .then((results) => {
           this.setState({
-            namespaces: results.data.data,
-            itemCount: results.data.meta.count,
+            namespaces: results.data.results,
+            itemCount: results.data.count,
             loading: false,
           });
         })

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -454,9 +454,7 @@ class Search extends React.Component<RouteProps, IState> {
       });
     };
 
-    MyNamespaceAPI.get(collection.collection_version.namespace, {
-      include_related: 'my_permissions',
-    })
+    MyNamespaceAPI.get(collection.collection_version.namespace, {})
       .then((value) => {
         if (
           value.data.related_fields.my_permissions.includes(


### PR DESCRIPTION
The pr uses the the new v3/namespaces endpoint to populate the namespaces list view using the following environment: 

 https://github.com/pulp/pulp_ansible/pull/1437 (galaxy_ng)
 https://github.com/ansible/galaxy_ng/pull/1705 (pulp_ansible)

The MyNamespaceAPI  `my-namespace.ts` has been removed and replaced with calling the NamespaceAPI with a { my_permssions : ansible.change_ansiblenamespace} param. 


This is in draft form. Thank you for your review. 
