### PR TITLE
remove nav links for repositories and remotes for insights users

### DIFF
--- a/CHANGES/2334.misc
+++ b/CHANGES/2334.misc
@@ -1,0 +1,1 @@
+Remove repositories and remotes nav links in insights mode.

--- a/src/loaders/insights/routes.tsx
+++ b/src/loaders/insights/routes.tsx
@@ -3,25 +3,6 @@ import { Route, Routes } from 'react-router-dom';
 import { LoadingPageWithHeader } from 'src/components';
 import { Paths } from 'src/paths';
 
-const AnsibleRemoteDetail = lazy(
-  () => import('src/containers/ansible-remote/detail'),
-);
-const AnsibleRemoteEdit = lazy(
-  () => import('src/containers/ansible-remote/edit'),
-);
-const AnsibleRemoteList = lazy(
-  () => import('src/containers/ansible-remote/list'),
-);
-const AnsibleRepositoryDetail = lazy(
-  () => import('src/containers/ansible-repository/detail'),
-);
-const AnsibleRepositoryEdit = lazy(
-  () => import('src/containers/ansible-repository/edit'),
-);
-const AnsibleRepositoryList = lazy(
-  () => import('src/containers/ansible-repository/list'),
-);
-
 const CertificationDashboard = lazy(
   () =>
     import('src/containers/certification-dashboard/certification-dashboard'),
@@ -86,12 +67,6 @@ const TaskListView = lazy(
 const TokenInsights = lazy(() => import('src/containers/token/token-insights'));
 
 const routes = [
-  { path: Paths.ansibleRemoteDetail, component: AnsibleRemoteDetail },
-  { path: Paths.ansibleRemoteEdit, component: AnsibleRemoteEdit },
-  { path: Paths.ansibleRemotes, component: AnsibleRemoteList },
-  { path: Paths.ansibleRepositories, component: AnsibleRepositoryList },
-  { path: Paths.ansibleRepositoryDetail, component: AnsibleRepositoryDetail },
-  { path: Paths.ansibleRepositoryEdit, component: AnsibleRepositoryEdit },
   {
     path: Paths.approvalDashboard,
     component: CertificationDashboard,


### PR DESCRIPTION
Issue: AAH-2334

Removing the repositories and remotes nav links for insights CRC users. 

As for https://issues.redhat.com/browse/AAH-2133 for removing/disabling repositories:
Feature flag `PULP_GALAXY_FEATURE_FLAGS__display_repositories=false)` should be added to the oci-env/compose.env / galaxy_ng/.compose.env in dev mode; for actual [console.redhat.com](http://console.redhat.com/), it `probably` lives somewhere in the deploy config . 

