### PR TITLE
Collection documentation: do not wrongly interpret plugins/modules whose name starts with `_` as deprecated

### DIFF
--- a/CHANGES/3715.bug
+++ b/CHANGES/3715.bug
@@ -1,0 +1,1 @@
+Collection documentation: do not wrongly interpret plugins/modules whose name starts with `_` as deprecated.

--- a/src/components/render-plugin-doc/render-plugin-doc.tsx
+++ b/src/components/render-plugin-doc/render-plugin-doc.tsx
@@ -316,8 +316,8 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
     }
   }
 
-  private renderDeprecated(doc: PluginDoc, pluginName: string) {
-    const isDeprecated = doc.deprecated || pluginName.startsWith('_');
+  private renderDeprecated(doc: PluginDoc, _pluginName: string) {
+    const isDeprecated = doc.deprecated;
 
     if (!isDeprecated) {
       return null;


### PR DESCRIPTION
I'm not sure whether an issue exists for this I can reference. I spotted this while working on #3607 and noticing that a plugin in a collection I was uploading for testing was wrongly marked as deprecated.

In ansible-core itself, an underscore was interpreted this way also in ansible-doc and the validate-modules sanity test (but nowhere else), but that was changed for 2.15.

Ref: https://github.com/ansible/ansible/pull/79362