### PR TITLE
Repository URL - always use distro base_path, show in detail screen

### DIFF
--- a/src/actions/ansible-repository-copy.tsx
+++ b/src/actions/ansible-repository-copy.tsx
@@ -1,25 +1,60 @@
 import { t } from '@lingui/macro';
 import React from 'react';
-import { getRepoUrl } from 'src/utilities';
+import { AnsibleDistributionAPI } from 'src/api';
+import { getRepoURL } from 'src/utilities';
 import { Action } from './action';
 
 export const ansibleRepositoryCopyAction = Action({
   title: t`Copy CLI configuration`,
-  onClick: (item, { addAlert }) => {
+  onClick: async (item, { addAlert }) => {
+    let distribution = null;
+    if (!item.distributions) {
+      addAlert({
+        id: 'copy-cli-config',
+        title: t`Loading distribution...`,
+        variant: 'info',
+      });
+
+      distribution = (
+        await AnsibleDistributionAPI.list({
+          repository: item.pulp_href,
+        })
+      )?.data?.results?.[0];
+    } else {
+      distribution = item.distributions?.[0];
+    }
+
+    if (!distribution) {
+      addAlert({
+        id: 'copy-cli-config',
+        title: t`There are no distributions associated with this repository.`,
+        variant: 'danger',
+      });
+      return;
+    }
+
     const cliConfig = [
       '[galaxy]',
-      `server_list = ${item.name}_repo`,
+      `server_list = ${distribution.base_path}`,
       '',
-      `[galaxy_server.${item.name}_repo]`,
-      `url=${getRepoUrl(item.name)}`,
+      `[galaxy_server.${distribution.base_path}]`,
+      `url=${getRepoURL(distribution.base_path)}`,
       'token=<put your token here>',
     ].join('\n');
 
     navigator.clipboard.writeText(cliConfig);
     addAlert({
+      description: <pre>{cliConfig}</pre>,
+      id: 'copy-cli-config',
       title: t`Successfully copied to clipboard`,
       variant: 'success',
-      description: <pre>{cliConfig}</pre>,
     });
+  },
+  disabled: ({ distributions }) => {
+    if (distributions && !distributions.length) {
+      return t`There are no distributions associated with this repository.`;
+    }
+
+    return null;
   },
 });

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -54,7 +54,10 @@ export {
 export { PageWithTabs } from './page/page-with-tabs';
 export { Page } from './page/page';
 export { PulpLabels } from './repositories/pulp-labels';
-export { LazyDistributions } from './repositories/lazy-distributions';
+export {
+  NonLazyDistributions,
+  LazyDistributions,
+} from './repositories/lazy-distributions';
 export { LazyRepositories } from './repositories/lazy-repositories';
 export { LinkTabs } from './patternfly-wrappers/link-tabs';
 export { LoadingPageSpinner } from './loading/loading-page-spinner';

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -347,8 +347,13 @@ export const ListPage = function <T, ExtraState = Record<string, never>>({
     }
 
     private addAlert(alert: AlertType) {
+      let alerts = this.state.alerts;
+      if (alert.id) {
+        alerts = alerts.filter(({ id }) => id !== alert.id);
+      }
+
       this.setState({
-        alerts: [...this.state.alerts, alert],
+        alerts: [...alerts, alert],
       });
     }
 

--- a/src/components/page/page-with-tabs.tsx
+++ b/src/components/page/page-with-tabs.tsx
@@ -283,8 +283,13 @@ export const PageWithTabs = function <
     }
 
     private addAlert(alert: AlertType) {
+      let alerts = this.state.alerts;
+      if (alert.id) {
+        alerts = alerts.filter(({ id }) => id !== alert.id);
+      }
+
       this.setState({
-        alerts: [...this.state.alerts, alert],
+        alerts: [...alerts, alert],
       });
     }
 

--- a/src/components/page/page.tsx
+++ b/src/components/page/page.tsx
@@ -230,8 +230,13 @@ export const Page = function <
     }
 
     private addAlert(alert: AlertType) {
+      let alerts = this.state.alerts;
+      if (alert.id) {
+        alerts = alerts.filter(({ id }) => id !== alert.id);
+      }
+
       this.setState({
-        alerts: [...this.state.alerts, alert],
+        alerts: [...alerts, alert],
       });
     }
 

--- a/src/components/repositories/lazy-distributions.tsx
+++ b/src/components/repositories/lazy-distributions.tsx
@@ -5,6 +5,19 @@ import React, { useEffect, useState } from 'react';
 import { AnsibleDistributionAPI } from 'src/api';
 import { errorMessage } from 'src/utilities';
 
+export const NonLazyDistributions = ({
+  distributions,
+  emptyText,
+}: {
+  distributions: { name: string }[];
+  emptyText?: string;
+}) => (
+  <>
+    {distributions?.map?.(({ name }) => name)?.join?.(', ') ||
+      (emptyText ?? '---')}
+  </>
+);
+
 export const LazyDistributions = ({
   emptyText,
   onLoad,
@@ -60,9 +73,6 @@ export const LazyDistributions = ({
   ) : error ? (
     errorElement
   ) : (
-    <>
-      {distributions?.map?.(({ name }) => name)?.join?.(', ') ||
-        (emptyText ?? '---')}
-    </>
+    <NonLazyDistributions distributions={distributions} emptyText={emptyText} />
   );
 };

--- a/src/containers/ansible-repository/tab-details.tsx
+++ b/src/containers/ansible-repository/tab-details.tsx
@@ -6,7 +6,12 @@ import {
   AnsibleRemoteType,
   AnsibleRepositoryType,
 } from 'src/api';
-import { Details, NonLazyDistributions, PulpLabels } from 'src/components';
+import {
+  CopyURL,
+  Details,
+  NonLazyDistributions,
+  PulpLabels,
+} from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { getRepoURL, parsePulpIDFromURL } from 'src/utilities';
 
@@ -44,9 +49,11 @@ export const DetailsTab = ({ item }: TabProps) => {
         },
         {
           label: t`Repository URL`,
-          value: item.distributions?.length
-            ? getRepoURL(item.distributions[0].base_path)
-            : '---',
+          value: item.distributions?.length ? (
+            <CopyURL url={getRepoURL(item.distributions[0].base_path)} />
+          ) : (
+            '---'
+          ),
         },
         {
           label: t`Labels`,

--- a/src/containers/ansible-repository/tab-details.tsx
+++ b/src/containers/ansible-repository/tab-details.tsx
@@ -6,12 +6,14 @@ import {
   AnsibleRemoteType,
   AnsibleRepositoryType,
 } from 'src/api';
-import { Details, LazyDistributions, PulpLabels } from 'src/components';
+import { Details, NonLazyDistributions, PulpLabels } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
-import { parsePulpIDFromURL } from 'src/utilities';
+import { getRepoURL, parsePulpIDFromURL } from 'src/utilities';
 
 interface TabProps {
-  item: AnsibleRepositoryType;
+  item: AnsibleRepositoryType & {
+    distributions: { name: string; base_path: string }[];
+  };
   actionContext: { addAlert: (alert) => void; state: { params } };
 }
 
@@ -38,7 +40,13 @@ export const DetailsTab = ({ item }: TabProps) => {
         },
         {
           label: t`Distribution`,
-          value: <LazyDistributions repositoryHref={item.pulp_href} />,
+          value: <NonLazyDistributions distributions={item.distributions} />,
+        },
+        {
+          label: t`Repository URL`,
+          value: item.distributions?.length
+            ? getRepoURL(item.distributions[0].base_path)
+            : '---',
         },
         {
           label: t`Labels`,

--- a/src/containers/collection-detail/collection-distributions.tsx
+++ b/src/containers/collection-detail/collection-distributions.tsx
@@ -21,7 +21,7 @@ import {
   ParamHelper,
   RouteProps,
   filterIsSet,
-  getRepoUrl,
+  getRepoURL,
   withRouter,
 } from 'src/utilities';
 import { loadCollection } from './base';
@@ -114,7 +114,7 @@ const CollectionDistributions = (props: RouteProps) => {
       `server_list = ${distribution.base_path}`,
       '',
       `[galaxy_server.${distribution.base_path}]`,
-      `url=${getRepoUrl(distribution.base_path)}`,
+      `url=${getRepoURL(distribution.base_path)}`,
       'token=<put your token here>',
     ].join('\n');
 

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -52,7 +52,7 @@ import {
   canSignNamespace,
   errorMessage,
   filterIsSet,
-  getRepoUrl,
+  getRepoURL,
   waitForTask,
 } from 'src/utilities';
 import { parsePulpIDFromURL } from 'src/utilities/parse-pulp-id';
@@ -272,7 +272,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
         : null,
     ].filter(Boolean);
 
-    const repositoryUrl = getRepoUrl('published');
+    const repositoryUrl = getRepoURL('published');
 
     const noData =
       itemCount === 0 &&

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -14,7 +14,7 @@ import {
 import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
-import { errorMessage, getRepoUrl } from 'src/utilities';
+import { errorMessage, getRepoURL } from 'src/utilities';
 
 interface IState {
   tokenData: {
@@ -186,7 +186,7 @@ class TokenInsights extends React.Component<RouteProps, IState> {
                 download content from Automation Hub.
               </Trans>
             </p>
-            <ClipboardCopy isReadOnly>{getRepoUrl('published')}</ClipboardCopy>
+            <ClipboardCopy isReadOnly>{getRepoURL('published')}</ClipboardCopy>
           </section>
           <section className='body pf-c-content'>
             <h2>{t`SSO URL`}</h2>

--- a/src/utilities/get-repo-url.ts
+++ b/src/utilities/get-repo-url.ts
@@ -1,13 +1,15 @@
 // Returns the API path for a specific repository
-export function getRepoUrl(reponame) {
+export function getRepoURL(distribution_base_path) {
   // If the api is hosted on another URL, use API_HOST as the host part of the URL.
   // Otherwise use the host that the UI is served from
   const host = API_HOST ? API_HOST : window.location.origin;
 
-  if (reponame === 'published') {
+  // repo/distro "published" is special; not related to repo pipeline type
+  if (distribution_base_path === 'published') {
     return `${host}${API_BASE_PATH}`;
   }
-  return `${host}${API_BASE_PATH}content/${reponame}/`;
+
+  return `${host}${API_BASE_PATH}content/${distribution_base_path}/`;
 }
 
 // returns the server name for (protocol-less) container urls

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -10,7 +10,7 @@ export {
   isFormValid,
   mapErrorMessages,
 } from './map-error-messages';
-export { getContainersURL, getRepoUrl } from './get-repo-url';
+export { getContainersURL, getRepoURL } from './get-repo-url';
 export {
   clearSetFieldsFromRequest,
   isFieldSet,


### PR DESCRIPTION
The `getRepoUrl` helper went through some changes recently, #3346 & #3691,
but it only works when repository.name === distribution.base_path now.

That's not true for repositories without a distributions, repositories with spaces in name, or any repository where there was a distribution name clash and we created a new name.

=> make Repository Copy CLI configuration query the distribution api and use the actual base_path / fail when no distribution.
=> move loading distributions on the repo detail screen from a LazyDistributions component in DetailTab to the query method, allowing Copy CLI to be disabled on detail screen when no distributions,
=> change page addAlert to support alert ids - used to replace a "loading" alert with an "error"/"success" alert

And start showing the repository URL on the detail screen.

![20230518232547](https://github.com/ansible/ansible-hub-ui/assets/289743/f8595461-3ca7-4ca1-8615-a1a65afdf4d9)
![20230518232605](https://github.com/ansible/ansible-hub-ui/assets/289743/e824f557-bb93-4a64-9c51-3cd8c1227e00)
![20230518232619](https://github.com/ansible/ansible-hub-ui/assets/289743/bd5c2d56-8ef6-4d0e-857d-536dbb045119)
![20230518232633](https://github.com/ansible/ansible-hub-ui/assets/289743/cafab46d-472f-432a-bc5c-7c2723ef8f95)
![20230518233407](https://github.com/ansible/ansible-hub-ui/assets/289743/974e7dc2-143f-40c3-8e65-b3ec4765e2bf)
![20230518233856](https://github.com/ansible/ansible-hub-ui/assets/289743/755434d5-0823-48dc-b8d6-4f7c93714ea5)
