### PR TITLE
Repository tests - unskip clipboard test, grant permissions

### DIFF
--- a/test/cypress/e2e/repo/repository_list.js
+++ b/test/cypress/e2e/repo/repository_list.js
@@ -9,6 +9,17 @@ describe('Repository', () => {
     range(5).forEach((i) => {
       cy.galaxykit('repository create repoListTest' + i);
     });
+
+    // chrome only - prevent 'Write permission denied.' when copying to clipboard
+    cy.wrap(
+      Cypress.automation('remote:debugger:protocol', {
+        command: 'Browser.grantPermissions',
+        params: {
+          permissions: ['clipboardReadWrite', 'clipboardSanitizedWrite'],
+          origin: window.location.origin,
+        },
+      }),
+    );
   });
 
   beforeEach(() => {
@@ -141,7 +152,7 @@ describe('Repository', () => {
     cy.get('[data-cy="Page-AnsibleRepositoryEdit"]');
   });
 
-  it.skip('tests CLI config', () => {
+  it('tests CLI config', () => {
     cy.get('[data-cy="compound_filter"] input')
       .clear()
       .type('repoListTest3{enter}');


### PR DESCRIPTION
Fixes #3736

the repo test was skipped because in headless chrome, copying to clipboard fails with 'Write permission denied.'

grant the permission in before, so the test can pass
(https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/testing-dom__clipboard/cypress/e2e/permissions-spec.cy.js)

(this only works for chrome/chromium)