### PR TITLE
insights tests: ignore chrome api errors

### DIFF
--- a/test/cypress/e2e/collections/collection.js
+++ b/test/cypress/e2e/collections/collection.js
@@ -11,7 +11,7 @@ describe('collection tests', () => {
   });
 
   it('deletes an entire collection', () => {
-    cy.createApprovedCollection('test_namespace', 'test_collection');
+    cy.galaxykit('-i collection upload test_namespace test_collection');
 
     cy.visit(`${uiPrefix}repo/published/test_namespace/test_collection`);
 
@@ -23,7 +23,7 @@ describe('collection tests', () => {
   });
 
   it('deletes a collection version', () => {
-    cy.createApprovedCollection('my_namespace', 'my_collection');
+    cy.galaxykit('-i collection upload my_namespace my_collection');
 
     cy.visit(`${uiPrefix}collections`);
 

--- a/test/cypress/e2e/collections/collection_detail.js
+++ b/test/cypress/e2e/collections/collection_detail.js
@@ -19,9 +19,8 @@ describe('Collection detail', () => {
 
   before(() => {
     cy.deleteNamespacesAndCollections();
-    cy.createApprovedCollection(
-      'collection_detail_test_namespace',
-      'collection_detail_test_collection',
+    cy.galaxykit(
+      '-i collection upload collection_detail_test_namespace collection_detail_test_collection',
     );
   });
 

--- a/test/cypress/e2e/collections/collection_upload.js
+++ b/test/cypress/e2e/collections/collection_upload.js
@@ -1,6 +1,5 @@
 const apiPrefix = Cypress.env('apiPrefix');
 const uiPrefix = Cypress.env('uiPrefix');
-const insightsLogin = Cypress.env('insightsLogin');
 
 describe('Collection Upload Tests', () => {
   const userName = 'testUser';
@@ -9,61 +8,57 @@ describe('Collection Upload Tests', () => {
   before(() => {
     cy.deleteNamespacesAndCollections();
 
-    if (!insightsLogin) {
-      cy.login();
-      cy.deleteTestGroups();
-      cy.deleteTestUsers();
-      cy.createUser(userName, userPassword);
-    }
-    cy.createApprovedCollection('testspace', 'testcollection');
+    cy.login();
+    cy.deleteTestGroups();
+    cy.deleteTestUsers();
+    cy.createUser(userName, userPassword);
+    cy.galaxykit('-i collection upload testspace testcollection');
   });
 
-  if (!insightsLogin) {
-    it('should not upload new collection version in collection list when user does not have permissions', () => {
-      cy.login(userName, userPassword);
-      cy.visit(
-        `${uiPrefix}collections?page_size=10&view_type=list&keywords=testcollection`,
-      );
-      cy.contains('testcollection');
-      cy.contains('Upload new version').should('not.exist');
-    });
+  it('should not upload new collection version in collection list when user does not have permissions', () => {
+    cy.login(userName, userPassword);
+    cy.visit(
+      `${uiPrefix}collections?page_size=10&view_type=list&keywords=testcollection`,
+    );
+    cy.contains('testcollection');
+    cy.contains('Upload new version').should('not.exist');
+  });
 
-    it('should not upload new collection version in collection list/cards when user does not have permissions', () => {
-      cy.login(userName, userPassword);
-      cy.visit(
-        `${uiPrefix}collections?page_size=10&view_type=card&keywords=testcollection`,
-      );
-      cy.contains('testcollection');
-      cy.get('[aria-label="Actions"]').should('not.exist');
-    });
+  it('should not upload new collection version in collection list/cards when user does not have permissions', () => {
+    cy.login(userName, userPassword);
+    cy.visit(
+      `${uiPrefix}collections?page_size=10&view_type=card&keywords=testcollection`,
+    );
+    cy.contains('testcollection');
+    cy.get('[aria-label="Actions"]').should('not.exist');
+  });
 
-    it('should not upload new collection version in collection detail when user does not have permissions', () => {
-      cy.login(userName, userPassword);
-      cy.visit(`${uiPrefix}repo/published/testspace/testcollection`);
-      cy.contains('testcollection');
-      cy.get('button[aria-label="Actions"]').click();
-      cy.contains('Upload new version').click();
-      cy.contains("You don't have rights to do this operation.");
-    });
+  it('should not upload new collection version in collection detail when user does not have permissions', () => {
+    cy.login(userName, userPassword);
+    cy.visit(`${uiPrefix}repo/published/testspace/testcollection`);
+    cy.contains('testcollection');
+    cy.get('button[aria-label="Actions"]').click();
+    cy.contains('Upload new version').click();
+    cy.contains("You don't have rights to do this operation.");
+  });
 
-    it('should see upload new collection version in collection list when user does have permissions', () => {
-      cy.login();
-      cy.visit(
-        `${uiPrefix}collections?page_size=10&view_type=list&keywords=testcollection`,
-      );
-      cy.contains('testcollection');
-      cy.contains('Upload new version').click();
-      cy.contains('New version of testcollection');
+  it('should see upload new collection version in collection list when user does have permissions', () => {
+    cy.login();
+    cy.visit(
+      `${uiPrefix}collections?page_size=10&view_type=list&keywords=testcollection`,
+    );
+    cy.contains('testcollection');
+    cy.contains('Upload new version').click();
+    cy.contains('New version of testcollection');
 
-      cy.visit(
-        `${uiPrefix}collections?page_size=10&view_type=card&keywords=testcollection`,
-      );
-      cy.contains('testcollection');
-      cy.get('button[aria-label="Actions"]').click();
-      cy.contains('Upload new version').click();
-      cy.contains('New version of testcollection');
-    });
-  }
+    cy.visit(
+      `${uiPrefix}collections?page_size=10&view_type=card&keywords=testcollection`,
+    );
+    cy.contains('testcollection');
+    cy.get('button[aria-label="Actions"]').click();
+    cy.contains('Upload new version').click();
+    cy.contains('New version of testcollection');
+  });
 
   it('should see upload new collection version in collection detail when user does have permissions', () => {
     cy.login();
@@ -74,20 +69,18 @@ describe('Collection Upload Tests', () => {
     cy.contains('New version of testcollection');
   });
 
-  if (!insightsLogin) {
-    it('user should not be able to upload new collection without permissions', () => {
-      cy.login(userName, userPassword);
-      cy.intercept(
-        'GET',
-        `${apiPrefix}v3/plugin/ansible/search/collection-versions/?namespace=*`,
-      ).as('upload');
-      cy.galaxykit('-i namespace create', 'ansible');
-      cy.menuGo('Collections > Namespaces');
+  it('user should not be able to upload new collection without permissions', () => {
+    cy.login(userName, userPassword);
+    cy.intercept(
+      'GET',
+      `${apiPrefix}v3/plugin/ansible/search/collection-versions/?namespace=*`,
+    ).as('upload');
+    cy.galaxykit('-i namespace create', 'ansible');
+    cy.menuGo('Collections > Namespaces');
 
-      cy.get(`a[href="${uiPrefix}namespaces/ansible/"]`).click();
-      cy.contains('Upload collection').should('not.exist');
-    });
-  }
+    cy.get(`a[href="${uiPrefix}namespaces/ansible/"]`).click();
+    cy.contains('Upload collection').should('not.exist');
+  });
 
   it('collection should be uploaded', () => {
     cy.login();
@@ -96,7 +89,7 @@ describe('Collection Upload Tests', () => {
       `${apiPrefix}v3/plugin/ansible/search/collection-versions/?namespace=*`,
     ).as('upload');
     cy.galaxykit('-i namespace create', 'ansible');
-    cy.goToNamespaces();
+    cy.menuGo('Collections > Namespaces');
 
     cy.get(`a[href="${uiPrefix}namespaces/ansible/"]`).click();
     cy.contains('Upload collection').click();
@@ -120,15 +113,13 @@ describe('Collection Upload Tests', () => {
     cy.get('.pf-c-label__content').contains('Completed').should('exist');
   });
 
-  if (!insightsLogin) {
-    it('should not upload new collection version when user does not have permissions', () => {
-      cy.login(userName, userPassword);
-      cy.visit(`${uiPrefix}namespaces/testspace`);
+  it('should not upload new collection version when user does not have permissions', () => {
+    cy.login(userName, userPassword);
+    cy.visit(`${uiPrefix}namespaces/testspace`);
 
-      cy.get('[data-cy="CollectionList-name"]').contains('testcollection');
-      cy.contains('Upload new version').should('not.exist');
-    });
-  }
+    cy.get('[data-cy="CollectionList-name"]').contains('testcollection');
+    cy.contains('Upload new version').should('not.exist');
+  });
 
   it('should deprecate let user deprecate and undeprecate collections', () => {
     cy.login();

--- a/test/cypress/e2e/collections/collections_list.js
+++ b/test/cypress/e2e/collections/collections_list.js
@@ -2,7 +2,6 @@ import { range } from 'lodash';
 
 const apiPrefix = Cypress.env('apiPrefix');
 const uiPrefix = Cypress.env('uiPrefix');
-const insightsLogin = Cypress.env('insightsLogin');
 
 describe('Collections list Tests', () => {
   function deprecate(list) {
@@ -49,7 +48,7 @@ describe('Collections list Tests', () => {
     cy.galaxykit('namespace create my_namespace');
     // insert test data
     range(11).forEach((i) => {
-      cy.createApprovedCollection('my_namespace', 'my_collection' + i);
+      cy.galaxykit(`-i collection upload my_namespace my_collection${i}`);
     });
   });
 
@@ -64,11 +63,9 @@ describe('Collections list Tests', () => {
     cy.contains('Collections');
   });
 
-  if (!insightsLogin) {
-    it('checks if its deprecated and if yes, undeprecate it', () => {
-      undeprecateIfDeprecated();
-    });
-  }
+  it('checks if its deprecated and if yes, undeprecate it', () => {
+    undeprecateIfDeprecated();
+  });
 
   it('can deprecate', () => {
     cy.get('[data-cy="view_type_list"] svg').click();

--- a/test/cypress/e2e/insights/menu.js
+++ b/test/cypress/e2e/insights/menu.js
@@ -30,6 +30,7 @@ describe('Insights Menu Tests', () => {
   });
 
   beforeEach(() => {
+    cy.on('uncaught:exception', () => false);
     cy.login();
     cy.visit(uiPrefix);
     cy.wait(2000);
@@ -71,12 +72,6 @@ describe('Insights Menu Tests', () => {
   });
 
   it('can navigate to Connect to Hub', () => {
-    cy.on('uncaught:exception', () => {
-      return false;
-      // this is needed, otherwise it fails on (fetch)POST 404 /api/featureflags/v0/client/metrics
-      // it seems that cy on duration is valid inside it, it does not catch api calls outisde
-    });
-
     menuClick('Connect to Hub');
     cy.contains('main', 'Connect Private Automation Hub');
     cy.contains('main .body', 'Connect Private Automation Hub');

--- a/test/cypress/e2e/insights/namespace_delete.js
+++ b/test/cypress/e2e/insights/namespace_delete.js
@@ -1,1 +1,62 @@
-./../namespaces/namespace_delete.js
+const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
+
+describe('Delete a namespace', () => {
+  before(() => {
+    cy.deleteNamespacesAndCollections();
+  });
+
+  beforeEach(() => {
+    cy.on('uncaught:exception', () => false);
+    cy.login();
+  });
+
+  it('deletes a namespace', () => {
+    cy.galaxykit('-i namespace create', 'testns1');
+    cy.visit(`${uiPrefix}partners`);
+
+    cy.intercept('GET', `${apiPrefix}_ui/v1/namespaces/?sort=name*`).as(
+      'reload',
+    );
+    cy.get(`a[href*="${uiPrefix}namespaces/testns1"]`).click();
+    cy.get('[data-cy="ns-kebab-toggle"]').click();
+    cy.contains('Delete namespace').click();
+    cy.get('input[id=delete_confirm]').click();
+    cy.get('button').contains('Delete').click();
+    cy.wait('@reload');
+    cy.contains('Namespace "testns1" has been successfully deleted.');
+  });
+
+  it('cannot delete a non-empty namespace', () => {
+    //create namespace
+    cy.intercept('GET', `${apiPrefix}_ui/v1/namespaces/?sort=name*`).as(
+      'reload',
+    );
+    cy.galaxykit('-i namespace create', 'ansible');
+    cy.visit(`${uiPrefix}partners`);
+    cy.wait('@reload');
+
+    cy.get(`a[href*="${uiPrefix}namespaces/ansible"]`).click();
+
+    //upload a collection
+    cy.galaxykit('-i collection upload ansible network');
+    cy.galaxykit('-i collection move ansible network');
+
+    // wait for imports to finish successfully
+
+    cy.wait(10000);
+
+    // attempt deletion
+    cy.intercept(
+      'GET',
+      `${apiPrefix}_ui/v1/namespaces/?sort=name&offset=0&limit=20`,
+    ).as('namespaces');
+    cy.visit(`${uiPrefix}partners`);
+    cy.wait('@namespaces');
+    cy.contains('ansible').parent().contains('View collections').click();
+    cy.get('[data-cy=ns-kebab-toggle]').click();
+    cy.contains('Delete namespace')
+      .invoke('attr', 'aria-disabled')
+      .should('eq', 'true');
+  });
+});

--- a/test/cypress/e2e/insights/namespace_detail.js
+++ b/test/cypress/e2e/insights/namespace_detail.js
@@ -1,1 +1,82 @@
-./../namespaces/namespace_detail.js
+const uiPrefix = Cypress.env('uiPrefix');
+const apiPrefix = Cypress.env('apiPrefix');
+
+describe('Namespace detail screen', () => {
+  before(() => {
+    cy.deleteNamespacesAndCollections();
+    cy.galaxykit('-i namespace create', 'namespace_detail_test');
+    cy.galaxykit('-i collection upload namespace_detail_test collection1');
+    cy.galaxykit('-i collection move namespace_detail_test collection1');
+    cy.galaxykit('-i collection upload namespace_detail_test collection2');
+    cy.galaxykit('-i collection move namespace_detail_test collection2');
+  });
+
+  after(() => {
+    cy.deleteNamespacesAndCollections();
+  });
+
+  beforeEach(() => {
+    cy.on('uncaught:exception', () => false);
+    cy.login();
+    cy.visit(`${uiPrefix}namespaces/namespace_detail_test`);
+  });
+
+  it('should display the collections belonging to the namespace', () => {
+    cy.get('[data-cy="CollectionListItem"]').should('have.length', 2);
+    cy.get('[data-cy="CollectionListItem"]').contains('collection1');
+    cy.get('[data-cy="CollectionListItem"]').contains('collection2');
+  });
+
+  it('should show deprecation label after button click and page reload', () => {
+    cy.get(
+      '[data-cy="CollectionListItem"]:first button[aria-label="Actions"]',
+    ).click();
+    cy.contains('.body ul a', 'Deprecate').click();
+
+    // Reload the page
+    cy.visit(`${uiPrefix}namespaces/namespace_detail_test`);
+
+    cy.get('[data-cy="CollectionListItem"]:first').contains('DEPRECATED');
+  });
+
+  it('should show the correct URL when clicking on the CLI configuration tab', () => {
+    cy.get('.pf-c-tabs__link').eq(1).click();
+    cy.get('[aria-label="Copyable input"]')
+      .invoke('val')
+      .should('contain', apiPrefix);
+  });
+
+  it('should show an error when tring to upload a new collecting wiht invalid name', () => {
+    cy.get('[data-cy="kebab-toggle"] > .pf-c-button').click();
+    cy.fixture('collections/invalid-collection-name-1.0.0-bad.tar.gz', 'binary')
+      .then(Cypress.Blob.binaryStringToBlob)
+      .then((fileContent) => {
+        cy.get('input[type="file"]').attachFile({
+          fileContent,
+          fileName: 'invalid-collection-name-1.0.0-bad.tar.gz',
+          mimeType: 'application/gzip',
+        });
+      });
+    cy.get('.file-error-messages').should(
+      'contain',
+      'does not match this namespace',
+    );
+
+    cy.fixture(
+      'collections/namespace_detail_test-invalid-1.0.0(1).tar.gz',
+      'binary',
+    )
+      .then(Cypress.Blob.binaryStringToBlob)
+      .then((fileContent) => {
+        cy.get('input[type="file"]').attachFile({
+          fileContent,
+          fileName: 'namespace_detail_test-invalid-1.0.0(1).tar.gz',
+          mimeType: 'application/gzip',
+        });
+      });
+    cy.get('[data-cy="confirm-upload"]').click();
+    cy.get('.file-error-messages').should('contain', 'Invalid filename');
+
+    // The test for success are impmeneted in the collection_upload file
+  });
+});

--- a/test/cypress/e2e/insights/namespace_edit.js
+++ b/test/cypress/e2e/insights/namespace_edit.js
@@ -1,1 +1,155 @@
-./../namespaces/namespace_edit.js
+const uiPrefix = Cypress.env('uiPrefix');
+
+describe('Edit a namespace', () => {
+  let kebabToggle = () => {
+    cy.get('[data-cy="ns-kebab-toggle"] button[aria-label="Actions"]').click({
+      force: true,
+    });
+  };
+
+  let saveButton = () => {
+    return cy.contains('Save');
+  };
+
+  let getLinkTextField = () => {
+    return cy
+      .get('div.useful-links > div.link-name input')
+      .invoke('attr', 'placeholder', 'Link text')
+      .click();
+  };
+
+  let getUrlField = () => {
+    return cy.get('div.useful-links div.link-url #url').click();
+  };
+
+  let linksHelper = () => {
+    return cy.get('#links-helper');
+  };
+
+  let getEditTab = () => {
+    return cy
+      .get(
+        'ul.pf-c-tabs__list > li.pf-c-tabs__item > button > span.pf-c-tabs__item-text',
+      )
+      .contains('Edit resources')
+      .click();
+  };
+
+  let getTextField = () => {
+    return cy.get('div.pf-c-form__group-control > textarea.pf-c-form-control');
+  };
+
+  before(() => {
+    cy.deleteTestGroups();
+    cy.galaxykit('-i group create', 'namespace-owner-autocomplete');
+  });
+
+  beforeEach(() => {
+    cy.on('uncaught:exception', () => false);
+    cy.login();
+    cy.galaxykit('-i namespace create', 'testns1');
+    cy.visit(`${uiPrefix}partners`);
+    cy.get(`a[href*="${uiPrefix}namespaces/testns1"]`).click();
+    cy.contains('No collections yet');
+    kebabToggle();
+    cy.contains('Edit namespace').click();
+  });
+
+  it('tests that the name field is disabled from editing', () => {
+    cy.get('#name').should('be.disabled');
+  });
+
+  it('tests the company name for errors', () => {
+    cy.get('#company')
+      .clear()
+      .type(
+        'This name is too long vaðlaheiðarvegavinnuverkfærageymsluskúraútidyralyklakippuhringur',
+      );
+    saveButton().click();
+    let helperText = cy.get('#company-helper');
+    helperText.should(
+      'have.text',
+      'Ensure this field has no more than 64 characters.',
+    );
+  });
+
+  it('saves a new company name', () => {
+    cy.get('#company').clear().type('Company name');
+    saveButton().click();
+    cy.url().should('match', new RegExp(`${uiPrefix}namespaces/testns1`));
+    cy.get('.pf-c-title').should('contain', 'Company name');
+  });
+
+  it('tests the Logo URL field', () => {
+    const url = 'https://example.com/';
+    cy.get('#avatar_url').clear().type('abcde');
+    saveButton().click();
+    cy.get('#avatar_url-helper').should('have.text', 'Enter a valid URL.');
+    cy.get('#avatar_url').clear().type(url);
+    saveButton().click();
+    cy.get('div.title-box > div.image > img').should('have.attr', 'src', url);
+  });
+
+  it('tests the Description field', () => {
+    cy.get('#description').type(`
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas magna velit, tempor at interdum viverra, egestas quis libero. Aenean arcu magna, sodales ut dictum accumsan, consectetur vitae mi. Maecenas efficitur ipsum a orci condimentum, in lobortis turpis accumsan. Vivamus non libero varius, vulputate nunc vitae, posuere risus. In ut malesuada magna. Cras ac rhoncus mi. Nulla tempus semper interdum. Aliquam scelerisque, purus quis vestibulum finibus, dolor augue dictum erat, id commodo justo quam non metus.`);
+    saveButton().click();
+    cy.get('#description-helper').should(
+      'have.text',
+      'Ensure this field has no more than 256 characters.',
+    );
+    cy.get('#description').clear().type('A namespace description');
+    saveButton().click();
+    cy.get('.header-bottom').should('contain', 'A namespace description');
+  });
+
+  it('tests the Links field', () => {
+    getLinkTextField().first().type('Too long ^TrR>dG(F55:5(P:!sdafd#ZWCf2');
+    getUrlField().first().type('https://example.com');
+    saveButton().click();
+    linksHelper().should(
+      'contain',
+      'Text: Ensure this field has no more than 32 characters.',
+    );
+    getLinkTextField().first().clear();
+    cy.contains('.useful-links', 'Name must not be empty.');
+
+    getLinkTextField().first().type('Link to example website');
+    getUrlField().first().clear();
+    cy.contains('.useful-links', 'URL must not be empty.');
+
+    getUrlField().first().type('example.com');
+    cy.contains('.useful-links', 'The URL needs to be in');
+
+    getUrlField().first().clear().type('https://example.com/');
+    saveButton().click();
+    cy.get('div.link a')
+      .should('contain', 'Link to example website')
+      .and('have.attr', 'href', 'https://example.com/');
+  });
+
+  it('removes a link', () => {
+    cy.get(
+      'div.useful-links:first-child > div.link-button > div.link-container svg',
+    )
+      .first()
+      .click();
+    saveButton().click();
+  });
+
+  it('edits namespace resources', () => {
+    getEditTab();
+    getTextField()
+      .invoke('attr', 'placeholder')
+      .should(
+        'contain',
+        '## Custom resources\n\nYou can use this page to add any resources which you think might help your users automate all the things.',
+      );
+    getTextField().click().type('Editing the readme file');
+    saveButton().click();
+    kebabToggle();
+    cy.contains('Edit namespace').click();
+    getEditTab();
+    getTextField().should('contain', 'Editing the readme file');
+  });
+});

--- a/test/cypress/e2e/insights/namespace_form.js
+++ b/test/cypress/e2e/insights/namespace_form.js
@@ -1,1 +1,91 @@
-./../namespaces/namespace_form.js
+const uiPrefix = Cypress.env('uiPrefix');
+
+describe('A namespace form', () => {
+  let getMessage = () => {
+    return cy.get('.pf-c-form__helper-text');
+  };
+  let getCreateButton = () => {
+    return cy.get('.pf-c-modal-box__footer .pf-m-primary');
+  };
+  let getInputBox = () => {
+    return cy.get('input[name="newNamespaceName"]');
+  };
+  let clearInput = () => {
+    return getInputBox().clear();
+  };
+  let createNamespace = () => {
+    return cy.galaxykit('-i namespace create', 'testns1');
+  };
+
+  before(() => {
+    cy.deleteNamespacesAndCollections();
+  });
+
+  beforeEach(() => {
+    cy.on('uncaught:exception', () => false);
+    cy.login();
+    createNamespace();
+    cy.visit(`${uiPrefix}partners`);
+    cy.contains('button', 'Create').click();
+    cy.contains('Create a new namespace');
+  });
+
+  it('should give message if input has no characters', () => {
+    // error is shown only when start typing and then left empty
+    getInputBox().type('A{backspace}');
+    getMessage().should('have.text', 'Please, provide the namespace name');
+    getCreateButton().should('be.disabled');
+  });
+
+  it('should give message if input is empty', () => {
+    getInputBox().type(' ');
+    getMessage().should(
+      'have.text',
+      'Name can only contain letters and numbers',
+    );
+    getCreateButton().should('be.disabled');
+    clearInput();
+  });
+
+  it('should give message if input has incorrect characters', () => {
+    getInputBox().type('!/^[a-zA-Z0-9_]+$/.');
+    getMessage().should(
+      'have.text',
+      'Name can only contain letters and numbers',
+    );
+    getCreateButton().should('be.disabled');
+    clearInput();
+  });
+
+  it('should give message if input is shorter than 3 characters', () => {
+    getInputBox().type('na');
+    getMessage().should('have.text', 'Name must be longer than 2 characters');
+    getCreateButton().should('be.disabled');
+    clearInput();
+  });
+
+  it('should give message if input begins with underscore', () => {
+    getInputBox().type('_namespace');
+    getMessage().should('have.text', "Name cannot begin with '_'");
+    getCreateButton().should('be.disabled');
+    clearInput();
+  });
+
+  it('should give message if name already exists', () => {
+    getInputBox().type('testns1');
+    getCreateButton().click();
+    getCreateButton().should('be.disabled');
+    getMessage().should(
+      'have.text',
+      'A namespace named testns1 already exists.',
+    );
+    clearInput();
+  });
+
+  it('creates a new namespace with no error messages', () => {
+    let id = parseInt(Math.random() * 1000000);
+    getInputBox().type(`testns_${id}`);
+    getCreateButton().click();
+    cy.url().should('match', new RegExp(`${uiPrefix}namespaces/testns_`));
+  });
+});

--- a/test/cypress/e2e/insights/namespace_list.js
+++ b/test/cypress/e2e/insights/namespace_list.js
@@ -1,1 +1,24 @@
-./../namespaces/namespace_list.js
+const uiPrefix = Cypress.env('uiPrefix');
+
+describe('Namespaces Page Tests', () => {
+  before(() => {
+    cy.deleteNamespacesAndCollections();
+    cy.galaxykit('-i namespace create', 'testns1');
+    cy.galaxykit('-i namespace create', 'testns2');
+  });
+
+  beforeEach(() => {
+    cy.on('uncaught:exception', () => false);
+  });
+
+  after(() => {
+    cy.deleteNamespacesAndCollections();
+  });
+
+  it('can navigate to admin public namespace list', () => {
+    cy.login();
+    cy.visit(`${uiPrefix}partners`);
+    cy.contains('testns2').should('exist');
+    cy.contains('testns1').should('exist');
+  });
+});

--- a/test/cypress/e2e/insights/smoke.js
+++ b/test/cypress/e2e/insights/smoke.js
@@ -16,6 +16,8 @@ describe('cloud smoketest', () => {
     cy.galaxykit(`collection upload autohubtest3 ${collectionName}3`);
     cy.galaxykit(`collection move autohubtest3 ${collectionName}3`);
 
+    cy.on('uncaught:exception', () => false);
+
     // handle cloud login
     cy.login();
 
@@ -36,67 +38,54 @@ describe('cloud smoketest', () => {
     cy.get('.collection-container').should('be.visible');
   });
 
-  describe('with download', () => {
-    it('can load a Collection', () => {
-      // wait for collections to appear
-      cy.get('.collection-container').should('be.visible');
+  beforeEach(() => {
+    cy.on('uncaught:exception', () => false);
+  });
 
-      // wait for collections to load
-      cy.get('.hub-c-card-collection-container .name a').should('exist');
+  it('can load a Collection', () => {
+    // wait for collections to appear
+    cy.get('.collection-container').should('be.visible');
 
-      // click on the first available collection
-      cy.get('.hub-c-card-collection-container .name a').first().click();
+    // wait for collections to load
+    cy.get('.hub-c-card-collection-container .name a').should('exist');
 
-      // wait for collection detail to load
-      cy.get('.info-panel');
+    // click on the first available collection
+    cy.get('.hub-c-card-collection-container .name a').first().click();
 
-      // ensure the download button appears
-      cy.contains('button', 'Download tarball').should('exist');
-    });
+    // wait for collection detail to load
+    cy.get('.info-panel');
 
-    it('can load a Partners list of collections', () => {
-      cy.login();
-      // wait for the Partners button to appear and then click on it
-      cy.get('[data-ouia-component-id="Partners"]').click();
+    // ensure the download button appears
+    cy.contains('button', 'Download tarball').should('exist');
+  });
 
-      // wait for the the Partners list to appear
-      cy.get('.hub-namespace-page').should('be.visible');
+  it('can load a Partners list of collections', () => {
+    cy.login();
+    // wait for the Partners button to appear and then click on it
+    cy.get('[data-ouia-component-id="Partners"]').click();
 
-      // click on the first available Partner
-      cy.get('.hub-c-card-ns-container .pf-c-card__footer a').first().click();
+    // wait for the the Partners list to appear
+    cy.get('.hub-namespace-page').should('be.visible');
 
-      // wait for the summary|list to load
-      cy.get('[aria-label="List of Collections"]').should('be.visible');
+    // click on the first available Partner
+    cy.get('.hub-c-card-ns-container .pf-c-card__footer a').first().click();
 
-      // ensure the upload collection button appears
-      cy.contains('button', 'Upload collection').should('exist');
+    // wait for the summary|list to load
+    cy.get('[aria-label="List of Collections"]').should('be.visible');
 
-      // ensure the upload new version button appears
-      cy.contains('button', 'Upload new version').should('exist');
-    });
+    // ensure the upload collection button appears
+    cy.contains('button', 'Upload collection').should('exist');
 
-    it.skip('can load the Repo Management page', () => {
-      cy.login();
-      // wait for the Repo management button to appear and then click on it
-      cy.get('[data-ouia-component-id="Repositories"]').click();
+    // ensure the upload new version button appears
+    cy.contains('button', 'Upload new version').should('exist');
+  });
 
-      // wait for the the repository list to appear
-      cy.get('.repository-list').should('be.visible');
-    });
+  it('can load the Connect to hub page', () => {
+    cy.login();
+    // wait for the Connect to hub button to appear and then click on it
+    cy.get('[data-ouia-component-id="Connect to Hub"]').click();
 
-    it('can load the Connect to hub page', () => {
-      cy.on('uncaught:exception', () => {
-        return false;
-        // this is needed, otherwise it fails on some HTTP request
-        // it seems that cy on duration is valid inside it, it does not catch api calls outisde
-      });
-
-      cy.login();
-      // wait for the Connect to hub button to appear and then click on it
-      cy.get('[data-ouia-component-id="Connect to Hub"]').click();
-
-      // ensure the load token button appears
-      cy.contains('button', 'Load token').should('exist');
-    });
+    // ensure the load token button appears
+    cy.contains('button', 'Load token').should('exist');
   });
 });

--- a/test/cypress/e2e/insights_collections/collection.js
+++ b/test/cypress/e2e/insights_collections/collection.js
@@ -1,1 +1,50 @@
-./../collections/collection.js
+const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
+
+describe('collection tests', () => {
+  before(() => {
+    cy.deleteNamespacesAndCollections();
+  });
+
+  beforeEach(() => {
+    cy.on('uncaught:exception', () => false);
+    cy.login();
+  });
+
+  it('deletes an entire collection', () => {
+    cy.galaxykit('-i collection upload test_namespace test_collection');
+    cy.galaxykit('-i collection move test_namespace test_collection');
+
+    cy.visit(`${uiPrefix}repo/published/test_namespace/test_collection`);
+
+    cy.get('[data-cy=kebab-toggle]').click();
+    cy.get('[data-cy=delete-collection-dropdown]').click();
+    cy.get('input[id=delete_confirm]').click();
+    cy.get('button').contains('Delete').click();
+    cy.contains('No collections yet', { timeout: 10000 });
+  });
+
+  it('deletes a collection version', () => {
+    cy.galaxykit('-i collection upload my_namespace my_collection');
+    cy.galaxykit('-i collection move my_namespace my_collection');
+
+    cy.visit(`${uiPrefix}collections`);
+
+    cy.intercept('GET', `${apiPrefix}_ui/v1/namespaces/my_namespace/?*`).as(
+      'reload',
+    );
+    cy.get(
+      `a[href*="${uiPrefix}repo/published/my_namespace/my_collection"]`,
+    ).click();
+    cy.get('[data-cy=kebab-toggle]').click();
+    cy.get('[data-cy=delete-version-dropdown]').click();
+    cy.get('input[id=delete_confirm]').click();
+    cy.get('button').contains('Delete').click();
+    cy.wait('@reload', { timeout: 50000 });
+    cy.wait(5000);
+    cy.get('[data-cy="AlertList"] h4[class=pf-c-alert__title]').should(
+      'have.text',
+      'Success alert:Collection "my_collection v1.0.0" has been successfully deleted.',
+    );
+  });
+});

--- a/test/cypress/e2e/insights_collections/collection_detail.js
+++ b/test/cypress/e2e/insights_collections/collection_detail.js
@@ -1,1 +1,170 @@
-./../collections/collection_detail.js
+const uiPrefix = Cypress.env('uiPrefix');
+
+describe('Collection detail', () => {
+  const baseURL = `${uiPrefix}repo/published/collection_detail_test_namespace/collection_detail_test_collection`;
+
+  function deprecate() {
+    cy.get('[data-cy="kebab-toggle"] [aria-label="Actions"]').click();
+    cy.contains('Deprecate').click();
+    cy.contains('This collection has been deprecated.', { timeout: 10000 });
+  }
+
+  function undeprecate() {
+    cy.get('[data-cy="kebab-toggle"] [aria-label="Actions"]').click();
+    cy.contains('Undeprecate').click();
+    cy.contains('This collection has been deprecated.', {
+      timeout: 10000,
+    }).should('not.exist');
+  }
+
+  before(() => {
+    cy.on('uncaught:exception', () => false);
+    cy.deleteNamespacesAndCollections();
+    cy.galaxykit(
+      '-i collection upload collection_detail_test_namespace collection_detail_test_collection',
+    );
+    cy.galaxykit(
+      '-i collection move collection_detail_test_namespace collection_detail_test_collection',
+    );
+  });
+
+  beforeEach(() => {
+    cy.on('uncaught:exception', () => false);
+    cy.login();
+  });
+
+  it('can Deprecate', () => {
+    cy.visit(baseURL);
+    deprecate();
+  });
+
+  it('can Undeprecate', () => {
+    cy.visit(baseURL);
+    undeprecate();
+  });
+
+  it('should change the url when clicking on the tabs', () => {
+    cy.visit(baseURL);
+
+    const tabs = [
+      {
+        name: 'Documentation',
+        url: `${baseURL}/docs`,
+      },
+      {
+        name: 'Import log',
+        url: `${baseURL}/import-log`,
+      },
+      {
+        name: 'Dependencies',
+        url: `${baseURL}/dependencies`,
+      },
+      {
+        name: 'Contents',
+        url: `${baseURL}/content`,
+      },
+      {
+        name: 'Install',
+        url: `${baseURL}`,
+      },
+    ];
+
+    tabs.forEach((tab) => {
+      cy.contains('li a span', tab.name).click();
+      cy.url().should('include', tab.url);
+      // All tabs contain the repo link
+      cy.contains('a', 'Repo');
+
+      // better synchronization, wait for the rest of the page to load
+
+      if (tab.name == 'Documentation') {
+        cy.contains('.docs-container', 'Documentation');
+      }
+
+      if (tab.name == 'Import log') {
+        cy.contains('.body', 'Approval status', {
+          timeout: 10000,
+        });
+      }
+
+      if (tab.name == 'Contents') {
+        cy.contains('.body', 'Description');
+      }
+
+      if (tab.name == 'Dependencies') {
+        cy.contains('.body', 'No dependencies');
+      }
+
+      if (tab.name == 'Install') {
+        cy.contains('.body', 'License');
+      }
+    });
+  });
+
+  it('should have working UI on install tab', () => {
+    cy.visit(baseURL);
+    // should have Install, License and Installation strings, and correct docs link
+    cy.get('.body').contains('Install');
+    cy.get('.body').contains('License');
+    cy.get('.body').contains('Installation');
+
+    cy.get('.body').contains(
+      `a[href="${uiPrefix}repo/published/collection_detail_test_namespace/collection_detail_test_collection/docs/"]`,
+      'Go to documentation',
+    );
+
+    /*
+     * This test needs some external library and custom command to test if the download had started.
+     * For now it fails if the button is not there.
+     */
+    // should be able to download the tarball
+    cy.get('[data-cy="download-collection-tarball-button"]').contains(
+      'Download tarball',
+    );
+
+    // should have the correct tags
+    cy.get('[data-cy="tag"]').should('have.length', 1);
+    cy.get('[data-cy="tag"]:first').contains('tools');
+
+    // should have the correct ansible version
+    cy.get('[data-cy="ansible-requirement"]').contains('>=2');
+  });
+
+  it('should have working UI on docs tab', () => {
+    cy.visit(`${baseURL}/docs`);
+    // should have the search field
+    cy.get('.body').get('input[aria-label="find-content"');
+
+    // should have Readme menu item
+    cy.get('.sidebar').contains('Readme');
+
+    // should still show the readme when searching readme
+    cy.get('input[aria-label="find-content"').type('readme');
+    cy.get('.sidebar').contains('Readme');
+
+    // should not display readme if searching for no entry
+    cy.get('input[aria-label="find-content"').type('no entry');
+    cy.get('.sidebar').not(':contains("Readme")');
+  });
+
+  it('should have a search field and the table headers on contents tab', () => {
+    cy.visit(`${baseURL}/content`);
+    cy.get('.body').get('input[aria-label="find-content"');
+    cy.get('.body').contains('th', 'Name');
+    cy.get('.body').contains('th', 'Type');
+    cy.get('.body').contains('th', 'Description');
+  });
+
+  it('should display import log tab', () => {
+    cy.visit(`${baseURL}/import-log`);
+    cy.get('.body').get('.title-bar');
+    cy.get('.body').get('.message-list');
+    cy.get('.body').get('.last-message');
+  });
+
+  it('should display "No Dependencies" when opening the tab', () => {
+    cy.visit(`${baseURL}/dependencies`);
+    cy.get('.body').contains('Dependencies');
+    cy.get('.body').contains('No dependencies');
+  });
+});

--- a/test/cypress/e2e/insights_collections/collection_upload.js
+++ b/test/cypress/e2e/insights_collections/collection_upload.js
@@ -1,1 +1,70 @@
-./../collections/collection_upload.js
+const apiPrefix = Cypress.env('apiPrefix');
+const uiPrefix = Cypress.env('uiPrefix');
+
+describe('Collection Upload Tests', () => {
+  before(() => {
+    cy.deleteNamespacesAndCollections();
+
+    cy.galaxykit('-i collection upload testspace testcollection');
+    cy.galaxykit('-i collection move testspace testcollection');
+  });
+
+  beforeEach(() => {
+    cy.on('uncaught:exception', () => false);
+  });
+
+  it('should see upload new collection version in collection detail when user does have permissions', () => {
+    cy.login();
+    cy.visit(`${uiPrefix}repo/published/testspace/testcollection`);
+    cy.contains('testcollection');
+    cy.get('[data-cy="kebab-toggle"] button[aria-label="Actions"]').click();
+    cy.contains('Upload new version').click();
+    cy.contains('New version of testcollection');
+  });
+
+  it('collection should be uploaded', () => {
+    cy.login();
+    cy.intercept(
+      'GET',
+      `${apiPrefix}v3/plugin/ansible/search/collection-versions/?namespace=*`,
+    ).as('upload');
+    cy.galaxykit('-i namespace create', 'ansible');
+    cy.visit(`${uiPrefix}partners`);
+
+    cy.get(`a[href="${uiPrefix}namespaces/ansible/"]`).click();
+    cy.contains('Upload collection').click();
+    cy.fixture('collections/ansible-posix-1.4.0.tar.gz', 'binary')
+      .then(Cypress.Blob.binaryStringToBlob)
+      .then((fileContent) => {
+        cy.get('input[type="file"]').attachFile({
+          fileContent,
+          fileName: 'ansible-posix-1.4.0.tar.gz',
+          mimeType: 'application/gzip',
+        });
+      });
+    cy.get('[data-cy="confirm-upload"]').click();
+    cy.wait('@upload');
+    cy.wait(10000);
+    cy.contains('My imports');
+    cy.get('.pf-c-label__content').contains('Running').should('exist');
+    cy.wait('@upload', { timeout: 10000 });
+    cy.wait(5000);
+    cy.get('.pf-c-label__content').contains('Failed').should('not.exist');
+    cy.get('.pf-c-label__content').contains('Completed').should('exist');
+  });
+
+  it('should deprecate let user deprecate and undeprecate collections', () => {
+    cy.login();
+    cy.visit(`${uiPrefix}namespaces/testspace`);
+    cy.get('[aria-label=collection-kebab]').first().click();
+    cy.contains('Deprecate').click();
+    cy.visit(`${uiPrefix}namespaces/testspace`);
+    cy.contains('DEPRECATED');
+
+    cy.visit(`${uiPrefix}namespaces/testspace`);
+    cy.get('[aria-label=collection-kebab]').first().click();
+    cy.contains('Undeprecate').click();
+    cy.visit(`${uiPrefix}namespaces/testspace`);
+    cy.contains('DEPRECATED').should('not.exist');
+  });
+});

--- a/test/cypress/e2e/insights_collections/collections_list.js
+++ b/test/cypress/e2e/insights_collections/collections_list.js
@@ -1,1 +1,151 @@
-./../collections/collections_list.js
+import { range } from 'lodash';
+
+const uiPrefix = Cypress.env('uiPrefix');
+
+describe('Collections list Tests', () => {
+  function deprecate(list) {
+    const container = list ? '.hub-list' : '.hub-cards';
+
+    cy.get('.toolbar')
+      .get('[aria-label="keywords"]:first')
+      .type('my_collection0{enter}');
+    cy.get(container).contains('my_collection2').should('not.exist');
+    cy.get(container).contains('my_collection0');
+
+    cy.get('.collection-container [aria-label="Actions"]').click();
+    cy.contains('Deprecate').click();
+    cy.contains('No results found', { timeout: 10000 });
+  }
+
+  function undeprecate() {
+    cy.visit(`${uiPrefix}repo/published/my_namespace/my_collection0`);
+    cy.contains('This collection has been deprecated.');
+    cy.get('[data-cy="kebab-toggle"] [aria-label="Actions"]').click();
+    cy.contains('Undeprecate').click();
+    cy.contains('This collection has been deprecated.', {
+      timeout: 10000,
+    }).should('not.exist');
+  }
+
+  before(() => {
+    cy.deleteNamespacesAndCollections();
+
+    cy.galaxykit('namespace create my_namespace');
+    // insert test data
+    range(11).forEach((i) => {
+      cy.galaxykit(`-i collection upload my_namespace my_collection${i}`);
+      cy.galaxykit(`-i collection move my_namespace my_collection${i}`);
+    });
+  });
+
+  after(() => {
+    cy.galaxykit('task wait all');
+    cy.deleteNamespacesAndCollections();
+  });
+
+  beforeEach(() => {
+    cy.on('uncaught:exception', () => false);
+    cy.login();
+    cy.visit(`${uiPrefix}collections`);
+    cy.contains('Collections');
+  });
+
+  it('can deprecate', () => {
+    cy.get('[data-cy="view_type_list"] svg').click();
+    deprecate(true);
+  });
+
+  it('can undeprecate', () => {
+    cy.get('[data-cy="view_type_list"] svg').click();
+    undeprecate();
+  });
+
+  it('can deprecate in Cards', () => {
+    cy.get('[data-cy="view_type_card"] svg').click();
+    deprecate(false);
+  });
+
+  it('can undeprecate in Cards', () => {
+    cy.get('[data-cy="view_type_card"] svg').click();
+    undeprecate(false);
+  });
+
+  it('paging is working', () => {
+    // this page cant sort items, so we can only count them, there should be 11 items that we inserted
+    cy.get('.collection-container').get('article').should('have.length', 10);
+
+    cy.get('.hub-cards').get('[aria-label="Go to next page"]:first').click();
+    cy.get('.collection-container').get('article').should('have.length', 1);
+  });
+
+  it('filter is working', () => {
+    cy.get('.hub-cards')
+      .get('[aria-label="keywords"]:first')
+      .type('my_collection0{enter}');
+    cy.get('.hub-cards').contains('my_collection0');
+    cy.get('.hub-cards').contains('my_collection1').should('not.exist');
+  });
+
+  it('set page size is working', () => {
+    cy.get('.hub-cards')
+      .get('button[aria-label="Items per page"]:first')
+      .click();
+    cy.get('.hub-cards').get('[data-action="per-page-20"]').click();
+
+    cy.get('.collection-container').get('article').should('have.length', 11);
+  });
+
+  it('Cards/List switch is working', () => {
+    cy.get('[data-cy="view_type_list"] svg').click();
+
+    cy.get('[data-cy="CollectionListItem"]').should('have.length', 10);
+  });
+
+  it('Can delete collection in collection list', () => {
+    cy.get('[data-cy="view_type_list"] svg').click();
+    cy.get('.toolbar')
+      .get('[aria-label="keywords"]:first')
+      .type('my_collection0{enter}');
+    cy.get('.hub-list').contains('my_collection2').should('not.exist');
+    cy.get('.hub-list').contains('my_collection0');
+
+    cy.get('.collection-container [aria-label="Actions"]').click();
+    cy.contains('Delete entire collection').click();
+    cy.get('[data-cy=modal_checkbox] input').click();
+    cy.get('[data-cy=delete-button] button').click();
+    cy.contains('Collection "my_collection0" has been successfully deleted.', {
+      timeout: 15000,
+    });
+    cy.contains('No results found');
+    cy.galaxykit('-i collection upload my_namespace my_collection0');
+  });
+
+  it('Can delete collection in namespace collection list', () => {
+    cy.visit(`${uiPrefix}namespaces/my_namespace`);
+    cy.get('.toolbar')
+      .get('[aria-label="keywords"]:first')
+      .type('my_collection1{enter}');
+
+    // because of randomized order of items in list and weird filter behavior
+    // we have to check that all of them dissapeared, not only one particular
+    range(11).forEach((i) => {
+      if (i != 1) {
+        cy.get('.body')
+          .contains('my_collection' + i)
+          .should('not.exist');
+      }
+    });
+    cy.get('.body').contains('my_collection1');
+
+    cy.get('.body [aria-label="Actions"]').click();
+    cy.contains('Delete entire collection').click();
+    cy.get('[data-cy=modal_checkbox] input').click();
+    cy.get('[data-cy=delete-button] button').click();
+
+    cy.contains('Collection "my_collection1" has been successfully deleted.', {
+      timeout: 15000,
+    });
+    cy.contains('No results found');
+    cy.galaxykit('-i collection upload my_namespace my_collection1');
+  });
+});

--- a/test/cypress/e2e/namespaces/namespace_delete.js
+++ b/test/cypress/e2e/namespaces/namespace_delete.js
@@ -12,7 +12,7 @@ describe('Delete a namespace', () => {
 
   it('deletes a namespace', () => {
     cy.galaxykit('-i namespace create', 'testns1');
-    cy.goToNamespaces();
+    cy.menuGo('Collections > Namespaces');
 
     cy.intercept('GET', `${apiPrefix}_ui/v1/namespaces/?sort=name*`).as(
       'reload',
@@ -32,13 +32,13 @@ describe('Delete a namespace', () => {
       'reload',
     );
     cy.galaxykit('-i namespace create', 'ansible');
-    cy.goToNamespaces();
+    cy.menuGo('Collections > Namespaces');
     cy.wait('@reload');
 
     cy.get(`a[href*="${uiPrefix}namespaces/ansible"]`).click();
 
     //upload a collection
-    cy.createApprovedCollection('ansible', 'network');
+    cy.galaxykit('-i collection upload ansible network');
 
     // wait for imports to finish successfully
 
@@ -49,7 +49,7 @@ describe('Delete a namespace', () => {
       'GET',
       `${apiPrefix}_ui/v1/namespaces/?sort=name&offset=0&limit=20`,
     ).as('namespaces');
-    cy.goToNamespaces();
+    cy.menuGo('Collections > Namespaces');
     cy.wait('@namespaces');
     cy.contains('ansible').parent().contains('View collections').click();
     cy.get('[data-cy=ns-kebab-toggle]').click();

--- a/test/cypress/e2e/namespaces/namespace_detail.js
+++ b/test/cypress/e2e/namespaces/namespace_detail.js
@@ -5,8 +5,8 @@ describe('Namespace detail screen', () => {
   before(() => {
     cy.deleteNamespacesAndCollections();
     cy.galaxykit('-i namespace create', 'namespace_detail_test');
-    cy.createApprovedCollection('namespace_detail_test', 'collection1');
-    cy.createApprovedCollection('namespace_detail_test', 'collection2');
+    cy.galaxykit('-i collection upload namespace_detail_test collection1');
+    cy.galaxykit('-i collection upload namespace_detail_test collection2');
   });
 
   after(() => {

--- a/test/cypress/e2e/namespaces/namespace_edit.js
+++ b/test/cypress/e2e/namespaces/namespace_edit.js
@@ -47,7 +47,7 @@ describe('Edit a namespace', () => {
   beforeEach(() => {
     cy.login();
     cy.galaxykit('-i namespace create', 'testns1');
-    cy.goToNamespaces();
+    cy.menuGo('Collections > Namespaces');
     cy.get(`a[href*="${uiPrefix}namespaces/testns1"]`).click();
     cy.contains('No collections yet');
     kebabToggle();

--- a/test/cypress/e2e/namespaces/namespace_form.js
+++ b/test/cypress/e2e/namespaces/namespace_form.js
@@ -24,7 +24,7 @@ describe('A namespace form', () => {
   beforeEach(() => {
     cy.login();
     createNamespace();
-    cy.goToNamespaces();
+    cy.menuGo('Collections > Namespaces');
     cy.contains('button', 'Create').click();
     cy.contains('Create a new namespace');
   });

--- a/test/cypress/e2e/namespaces/namespace_list.js
+++ b/test/cypress/e2e/namespaces/namespace_list.js
@@ -1,5 +1,3 @@
-const insightsLogin = Cypress.env('insightsLogin');
-
 describe('Namespaces Page Tests', () => {
   before(() => {
     cy.deleteNamespacesAndCollections();
@@ -13,30 +11,28 @@ describe('Namespaces Page Tests', () => {
 
   it('can navigate to admin public namespace list', () => {
     cy.login();
-    cy.goToNamespaces();
+    cy.menuGo('Collections > Namespaces');
     cy.contains('testns2').should('exist');
     cy.contains('testns1').should('exist');
   });
 
-  if (!insightsLogin) {
-    it('can navigate to user public namespace list', () => {
-      cy.deleteTestUsers();
-      cy.deleteTestGroups();
+  it('can navigate to user public namespace list', () => {
+    cy.deleteTestUsers();
+    cy.deleteTestGroups();
 
-      cy.galaxykit('-i group create', 'testGroup1');
-      cy.galaxykit('-i group create', 'testGroup2');
+    cy.galaxykit('-i group create', 'testGroup1');
+    cy.galaxykit('-i group create', 'testGroup2');
 
-      cy.galaxykit('-i user create', 'testUser2', 'p@ssword1');
-      cy.galaxykit('user group add', 'testUser2', 'testGroup2');
+    cy.galaxykit('-i user create', 'testUser2', 'p@ssword1');
+    cy.galaxykit('user group add', 'testUser2', 'testGroup2');
 
-      cy.login('testUser2', 'p@ssword1');
-      cy.menuGo('Collections > Namespaces');
+    cy.login('testUser2', 'p@ssword1');
+    cy.menuGo('Collections > Namespaces');
 
-      cy.contains('testns2').should('exist');
-      cy.contains('testns1').should('exist');
+    cy.contains('testns2').should('exist');
+    cy.contains('testns1').should('exist');
 
-      cy.deleteTestUsers();
-      cy.deleteTestGroups();
-    });
-  }
+    cy.deleteTestUsers();
+    cy.deleteTestGroups();
+  });
 });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -4,7 +4,6 @@ import shell from 'shell-escape-tag';
 
 const apiPrefix = Cypress.env('apiPrefix');
 const uiPrefix = Cypress.env('uiPrefix');
-const insightsLogin = Cypress.env('insightsLogin');
 
 Cypress.Commands.add('findnear', { prevSubject: true }, (subject, selector) => {
   return subject.closest(`*:has(${selector})`).find(selector);
@@ -436,25 +435,6 @@ Cypress.Commands.add('deleteContainersManual', {}, () => {
     });
   });
 });
-
-Cypress.Commands.add('goToNamespaces', {}, () => {
-  if (insightsLogin) {
-    cy.visit(`${uiPrefix}partners`);
-  } else {
-    cy.menuGo('Collections > Namespaces');
-  }
-});
-
-Cypress.Commands.add(
-  'createApprovedCollection',
-  {},
-  (namespace, collection) => {
-    cy.galaxykit(`-i collection upload ${namespace} ${collection}`);
-    if (insightsLogin) {
-      cy.galaxykit(`-i collection move ${namespace} ${collection}`);
-    }
-  },
-);
 
 Cypress.Commands.add('deleteRepositories', {}, () => {
   const initRepos = [

--- a/test/cypress/support/login.js
+++ b/test/cypress/support/login.js
@@ -3,16 +3,6 @@ const apiPrefix = Cypress.env('apiPrefix');
 const uiPrefix = Cypress.env('uiPrefix');
 const insightsLogin = Cypress.env('insightsLogin');
 
-const sessionOptions = {
-  validate: insightsLogin
-    ? () => {
-        cy.visit(uiPrefix);
-        cy.get('#UserMenu');
-      }
-    : () =>
-        cy.request(`${apiPrefix}_ui/v1/me/`).its('status').should('eq', 200),
-};
-
 function apiLogin(username, password) {
   cy.session(
     ['apiLogin', username],
@@ -29,7 +19,10 @@ function apiLogin(username, password) {
         });
       });
     },
-    sessionOptions,
+    {
+      validate: () =>
+        cy.request(`${apiPrefix}_ui/v1/me/`).its('status').should('eq', 200),
+    },
   );
 
   cy.visit('/');
@@ -47,9 +40,15 @@ function manualCloudLogin(username, password) {
       // wait for the user menu
       cy.get('#UserMenu');
     },
-    sessionOptions,
+    {
+      validate: () => {
+        cy.visit(uiPrefix);
+        cy.get('#UserMenu');
+      },
+    },
   );
 
+  cy.on('uncaught:exception', () => false);
   cy.visit(uiPrefix);
   cy.get('#UserMenu');
 }


### PR DESCRIPTION
Change insights test from mostly symlinking non-insights versions to proper copies,
unwind logic around insights vs non-insights there,
and add (empty) exception handlers in insights tests.

This means we no longer notice API errors in insights mode tests,
but also that tests no longer stop working every time the insights platform adds a new API call we don't mock.