### PR TITLE
clean up react imports

### DIFF
--- a/src/components/card-list-switcher/card-list-switcher.tsx
+++ b/src/components/card-list-switcher/card-list-switcher.tsx
@@ -1,6 +1,6 @@
 import { ListIcon, ThLargeIcon } from '@patternfly/react-icons';
 import cx from 'classnames';
-import * as React from 'react';
+import React from 'react';
 import { ParamHelper } from 'src/utilities/param-helper';
 import './switcher.scss';
 

--- a/src/components/cards/collection-card.tsx
+++ b/src/components/cards/collection-card.tsx
@@ -11,7 +11,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import cx from 'classnames';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { CollectionVersionSearch } from 'src/api';
 import { CollectionNumericLabel, Logo, SignatureBadge } from 'src/components';

--- a/src/components/cards/landing-page-card.tsx
+++ b/src/components/cards/landing-page-card.tsx
@@ -1,5 +1,5 @@
 import { Card, CardBody, CardHeader, Title } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 
 interface IProps {
   title: string;

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -8,7 +8,7 @@ import {
   CardTitle,
   Tooltip,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { Logo } from 'src/components';
 import './cards.scss';

--- a/src/components/collection-dependencies-list/collection-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-dependencies-list.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { List, ListItem, ListVariant } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { CollectionVersion, CollectionVersionSearch } from 'src/api';
 import { EmptyStateNoData, HelperText } from 'src/components';

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -5,7 +5,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { CollectionUsedByDependencies } from 'src/api';
 import {

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -7,7 +7,7 @@ import {
 } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 import cx from 'classnames';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { CollectionVersionSearch, ContentSummaryType } from 'src/api';
 import { EmptyStateCustom } from 'src/components';

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -8,7 +8,7 @@ import {
   SplitItem,
 } from '@patternfly/react-core';
 import { DownloadIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import {
   CollectionAPI,

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -5,7 +5,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { useEffect, useState } from 'react';
 import { Repositories } from 'src/api';
 import { AppliedFilters, CompoundFilter } from 'src/components';

--- a/src/components/collection-list/collection-list-item.tsx
+++ b/src/components/collection-list/collection-list-item.tsx
@@ -12,7 +12,7 @@ import {
   TextContent,
   TextVariants,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { CollectionVersionSearch } from 'src/api';
 import {

--- a/src/components/collection-list/collection-list.tsx
+++ b/src/components/collection-list/collection-list.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { DataList } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { CollectionVersionSearch } from 'src/api';
 import {
   CollectionListItem,

--- a/src/components/confirm-modal/confirm-modal.tsx
+++ b/src/components/confirm-modal/confirm-modal.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { Button, Modal, Spinner } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 
 interface IProps {
   cancelAction: () => void;

--- a/src/components/date-component/date-component.tsx
+++ b/src/components/date-component/date-component.tsx
@@ -1,5 +1,5 @@
 import * as moment from 'moment';
-import * as React from 'react';
+import React from 'react';
 import { Tooltip } from 'src/components';
 
 interface IProps {

--- a/src/components/delete-modal/delete-modal.tsx
+++ b/src/components/delete-modal/delete-modal.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { Button, Modal, ModalProps, Spinner } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 
 export interface IProps {
   cancelAction: () => void;

--- a/src/components/empty-state/empty-state-custom.tsx
+++ b/src/components/empty-state/empty-state-custom.tsx
@@ -6,7 +6,7 @@ import {
   EmptyStateVariant,
   Title,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { ComponentClass } from 'react';
 import { ReactElement, ReactNode } from 'react';
 

--- a/src/components/empty-state/empty-state-filter.tsx
+++ b/src/components/empty-state/empty-state-filter.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { Button } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { EmptyStateCustom } from './empty-state-custom';
 
 interface IProps {

--- a/src/components/empty-state/empty-state-no-data.tsx
+++ b/src/components/empty-state/empty-state-no-data.tsx
@@ -1,5 +1,5 @@
 import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { ReactElement, ReactNode } from 'react';
 import { EmptyStateCustom } from './empty-state-custom';
 

--- a/src/components/empty-state/empty-state-unauthorized.tsx
+++ b/src/components/empty-state/empty-state-unauthorized.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { LockIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { LoginLink } from 'src/components';
 import { EmptyStateCustom } from './empty-state-custom';
 

--- a/src/components/execution-environment-header/execution-environment-header.tsx
+++ b/src/components/execution-environment-header/execution-environment-header.tsx
@@ -1,6 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import { Tooltip } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { ContainerRepositoryType } from 'src/api';
 import { BaseHeader, Breadcrumbs, SignatureBadge, Tabs } from 'src/components';
 import { Paths, formatEEPath, formatPath } from 'src/paths';

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -12,7 +12,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { TagIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import {
   ContainerDistributionAPI,
   ExecutionEnvironmentRegistryAPI,

--- a/src/components/execution-environment/tag-manifest-modal.tsx
+++ b/src/components/execution-environment/tag-manifest-modal.tsx
@@ -13,7 +13,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { TagIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import {
   ContainerManifestType,
   ContainerRepositoryType,

--- a/src/components/headers/base-header.tsx
+++ b/src/components/headers/base-header.tsx
@@ -1,6 +1,6 @@
 import { Title } from '@patternfly/react-core';
 import cx from 'classnames';
-import * as React from 'react';
+import React from 'react';
 import './header.scss';
 
 interface IProps {

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -16,7 +16,7 @@ import {
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import * as moment from 'moment';
-import * as React from 'react';
+import React from 'react';
 import { Navigate } from 'react-router-dom';
 import {
   CertificateUploadAPI,

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { NamespaceType } from 'src/api';
 import {
   BaseHeader,

--- a/src/components/helper-text/helper-text.tsx
+++ b/src/components/helper-text/helper-text.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import './helper-text.scss';
 
 interface IProps {

--- a/src/components/import-modal/import-modal.tsx
+++ b/src/components/import-modal/import-modal.tsx
@@ -2,7 +2,7 @@ import { t } from '@lingui/macro';
 import { Button, Modal } from '@patternfly/react-core';
 import { FolderOpenIcon, SpinnerIcon } from '@patternfly/react-icons';
 import axios from 'axios';
-import * as React from 'react';
+import React from 'react';
 import {
   CollectionAPI,
   CollectionUploadType,

--- a/src/components/legacy-namespace-list/legacy-namespace-item.tsx
+++ b/src/components/legacy-namespace-list/legacy-namespace-item.tsx
@@ -6,7 +6,7 @@ import {
   DataListItemRow,
   DropdownItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { LegacyNamespaceDetailType } from 'src/api';
 import { Logo, StatefulDropdown } from 'src/components';

--- a/src/components/legacy-role-list/legacy-role-item.tsx
+++ b/src/components/legacy-role-list/legacy-role-item.tsx
@@ -9,7 +9,7 @@ import {
   TextContent,
   TextVariants,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { LegacyRoleDetailType } from 'src/api/response-types/legacy-role';
 import { DateComponent, Logo, Tag } from 'src/components';

--- a/src/components/loading/loading-page-spinner.tsx
+++ b/src/components/loading/loading-page-spinner.tsx
@@ -1,5 +1,5 @@
 import { Bullseye, Spinner } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 
 export class LoadingPageSpinner extends React.Component {
   render() {

--- a/src/components/loading/loading-with-header.tsx
+++ b/src/components/loading/loading-with-header.tsx
@@ -1,5 +1,5 @@
 import { Skeleton, Title } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { LoadingPageSpinner, Main } from 'src/components';
 
 export class LoadingPageWithHeader extends React.Component {

--- a/src/components/logo/logo.tsx
+++ b/src/components/logo/logo.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 // had to declare *.svg in src/index.d.ts
 import DefaultLogo from 'src/../static/images/default-logo.svg';
 

--- a/src/components/logo/small-logo.tsx
+++ b/src/components/logo/small-logo.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import SmallLogoImage from 'src/../static/images/logo_small.svg';
 
 interface IProps {

--- a/src/components/markdown-editor/markdown-editor.tsx
+++ b/src/components/markdown-editor/markdown-editor.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { Form, FormGroup, TextArea } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import './markdown-editor.scss';
 

--- a/src/components/my-imports/import-console.tsx
+++ b/src/components/my-imports/import-console.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { Spinner, Tooltip } from '@patternfly/react-core';
 import cx from 'classnames';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import {
   CollectionVersionSearch,

--- a/src/components/my-imports/import-list.tsx
+++ b/src/components/my-imports/import-list.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { Pagination, Toolbar } from '@patternfly/react-core';
 import cx from 'classnames';
-import * as React from 'react';
+import React from 'react';
 import {
   ImportListType,
   MyNamespaceAPI,

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { Form, FormGroup, TextArea, TextInput } from '@patternfly/react-core';
 import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { NamespaceType } from 'src/api';
 import { NamespaceCard } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';

--- a/src/components/namespace-modal/namespace-modal.tsx
+++ b/src/components/namespace-modal/namespace-modal.tsx
@@ -8,7 +8,7 @@ import {
   ModalVariant,
   TextInput,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { NamespaceAPI } from 'src/api';
 import { HelperText } from 'src/components';
 import { ErrorMessagesType } from 'src/utilities';

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -11,7 +11,7 @@ import {
   TextInput,
 } from '@patternfly/react-core';
 import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { APISearchTypeAhead, StatefulDropdown } from 'src/components';
 import { ParamHelper } from 'src/utilities';
 

--- a/src/components/patternfly-wrappers/sort.tsx
+++ b/src/components/patternfly-wrappers/sort.tsx
@@ -6,7 +6,7 @@ import {
   SortAmountDownIcon,
   SortAmountUpIcon,
 } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { ParamHelper } from 'src/utilities/param-helper';
 import './sort.scss';
 

--- a/src/components/rbac/access-tab.tsx
+++ b/src/components/rbac/access-tab.tsx
@@ -7,7 +7,7 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import { sortBy } from 'lodash';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { GroupType, RoleType } from 'src/api';
 import {

--- a/src/components/rbac/delete-group-modal.tsx
+++ b/src/components/rbac/delete-group-modal.tsx
@@ -1,6 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import { Alert, List, ListItem, Spinner } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { UserType } from 'src/api';
 import { DeleteModal } from 'src/components/delete-modal/delete-modal';
 

--- a/src/components/rbac/delete-user-modal.tsx
+++ b/src/components/rbac/delete-user-modal.tsx
@@ -1,5 +1,5 @@
 import { Trans, t } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 import { UserAPI, UserType } from 'src/api';
 import { DeleteModal } from 'src/components/delete-modal/delete-modal';
 import { AppContext } from 'src/loaders/app-context';

--- a/src/components/rbac/group-modal.tsx
+++ b/src/components/rbac/group-modal.tsx
@@ -7,7 +7,7 @@ import {
   ModalVariant,
   TextInput,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { ErrorMessagesType } from 'src/utilities';
 
 interface IProps {

--- a/src/components/rbac/permission-categories.tsx
+++ b/src/components/rbac/permission-categories.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { Flex, FlexItem } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { ModelPermissionsType } from 'src/api';
 import { PermissionChipSelector } from 'src/components';
 import { Constants } from 'src/constants';

--- a/src/components/rbac/permission-chip-selector.tsx
+++ b/src/components/rbac/permission-chip-selector.tsx
@@ -6,7 +6,7 @@ import {
   SelectOption,
   SelectVariant,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { AppContext } from 'src/loaders/app-context';
 import { chipGroupProps } from 'src/utilities';
 

--- a/src/components/rbac/role-form.tsx
+++ b/src/components/rbac/role-form.tsx
@@ -10,7 +10,7 @@ import {
   TextInput,
   Title,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { PermissionCategories } from 'src/components';
 
 interface IState {

--- a/src/components/rbac/user-form-page.tsx
+++ b/src/components/rbac/user-form-page.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { UserType } from 'src/api';
 import {
   BaseHeader,

--- a/src/components/rbac/user-form.tsx
+++ b/src/components/rbac/user-form.tsx
@@ -10,7 +10,7 @@ import {
   TextInputTypes,
   Tooltip,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { GroupAPI, UserType } from 'src/api';
 import { APISearchTypeAhead, AlertType, HelperText } from 'src/components';
 import { DataForm } from 'src/components/shared/data-form';

--- a/src/components/render-plugin-doc/render-plugin-doc.tsx
+++ b/src/components/render-plugin-doc/render-plugin-doc.tsx
@@ -1,5 +1,5 @@
 import { dom, parse } from 'antsibull-docs';
-import * as React from 'react';
+import React from 'react';
 import {
   PluginContentType,
   PluginDoc,

--- a/src/components/shared/data-form.tsx
+++ b/src/components/shared/data-form.tsx
@@ -4,7 +4,7 @@ import {
   TextInput,
   TextInputTypes,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { ErrorMessagesType } from 'src/utilities';
 
 interface IProps {

--- a/src/components/typeahead/typeahead.tsx
+++ b/src/components/typeahead/typeahead.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { chipGroupProps } from 'src/utilities';
 
 interface IProps {

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -15,7 +15,7 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import {
   AnsibleDistributionAPI,

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 import {
   CollectionContentList,
   CollectionHeader,

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 import {
   CollectionAPI,
   CollectionUsedByDependencies,

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -1,5 +1,5 @@
 import { isEqual } from 'lodash';
-import * as React from 'react';
+import React from 'react';
 import {
   AlertList,
   CollectionHeader,

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -4,7 +4,7 @@ import {
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
 import { CollectionVersionSearch } from 'src/api';

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 import { ImportAPI, ImportDetailType, ImportListType } from 'src/api';
 import {
   CollectionHeader,

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -1,6 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import { ActionGroup, Button, Form, Spinner } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { MyNamespaceAPI, NamespaceLinkType, NamespaceType } from 'src/api';
 import {

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -1,6 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import { Button, DropdownItem } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Navigate } from 'react-router-dom';
 import {
   ContainerRepositoryType,

--- a/src/containers/execution-environment-detail/execution_environment_detail.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail.tsx
@@ -7,7 +7,7 @@ import {
   FlexItem,
   Title,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { ExecutionEnvironmentAPI, GroupObjectPermissionType } from 'src/api';
 import {
   ClipboardCopy,

--- a/src/containers/execution-environment-detail/execution_environment_detail_access.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_access.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 import {
   ExecutionEnvironmentNamespaceAPI,
   GroupAPI,

--- a/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
@@ -1,6 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import { Button, Flex, FlexItem } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { ActivitiesAPI } from 'src/api';
 import {

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
 import { sum } from 'lodash';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { ContainerManifestType, ExecutionEnvironmentAPI } from 'src/api';
 import {

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -9,7 +9,7 @@ import {
   ToolbarItem,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import {
   ExecutionEnvironmentAPI,

--- a/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
+++ b/src/containers/execution-environment-manifest/execution-environment-manifest.tsx
@@ -15,7 +15,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { sum } from 'lodash';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { ExecutionEnvironmentAPI } from 'src/api';
 import {

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -8,7 +8,7 @@ import {
   ToolbarItem,
   Tooltip,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { ExecutionEnvironmentRegistryAPI, RemoteType } from 'src/api';
 import {
   AlertList,

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -8,7 +8,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link, Navigate } from 'react-router-dom';
 import {
   GroupAPI,

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -7,7 +7,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link, Navigate } from 'react-router-dom';
 import {
   GroupAPI,

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -1,5 +1,5 @@
 import { Trans, t } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import {
   AlertList,

--- a/src/containers/legacy-namespaces/legacy-namespace.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespace.tsx
@@ -7,7 +7,7 @@ import {
   DataListItemRow,
   DropdownItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { LegacyNamespaceListType, LegacyRoleListType } from 'src/api';
 import { LegacyNamespaceAPI } from 'src/api/legacynamespace';

--- a/src/containers/legacy-namespaces/legacy-namespaces.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespaces.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { DataList } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { LegacyNamespaceListType } from 'src/api';
 import { LegacyNamespaceAPI } from 'src/api/legacynamespace';
 import {

--- a/src/containers/legacy-roles/legacy-role.tsx
+++ b/src/containers/legacy-roles/legacy-role.tsx
@@ -15,7 +15,7 @@ import {
   TextVariants,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { LegacyRoleAPI } from 'src/api/legacyrole';
 import { LegacyRoleDetailType } from 'src/api/response-types/legacy-role';

--- a/src/containers/legacy-roles/legacy-roles.tsx
+++ b/src/containers/legacy-roles/legacy-roles.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { DataList } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { LegacyRoleListType } from 'src/api';
 import { LegacyRoleAPI } from 'src/api/legacyrole';
 import {

--- a/src/containers/login/login.tsx
+++ b/src/containers/login/login.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { LoginForm, LoginPage as PFLoginPage } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import { Navigate } from 'react-router-dom';
 import Logo from 'src/../static/images/logo_large.svg';
 import { ActiveUserAPI } from 'src/api';

--- a/src/containers/my-imports/my-imports.tsx
+++ b/src/containers/my-imports/my-imports.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { cloneDeep } from 'lodash';
-import * as React from 'react';
+import React from 'react';
 import {
   CollectionVersionAPI,
   CollectionVersionSearch,

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import * as React from 'react';
+import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Link, Navigate } from 'react-router-dom';
 import {

--- a/src/containers/namespace-list/my-namespaces.tsx
+++ b/src/containers/namespace-list/my-namespaces.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { EmptyStateUnauthorized } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
 import { Paths } from 'src/paths';

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -7,7 +7,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { MyNamespaceAPI, NamespaceAPI, NamespaceListType } from 'src/api';
 import {

--- a/src/containers/namespace-list/partners.tsx
+++ b/src/containers/namespace-list/partners.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { Paths } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
 import { NamespaceList } from './namespace-list';

--- a/src/containers/role-management/role-edit.tsx
+++ b/src/containers/role-management/role-edit.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { RoleType } from 'src/api/response-types/role';
 import { RoleAPI } from 'src/api/role';

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -1,7 +1,7 @@
 import { t } from '@lingui/macro';
 import { Button, DataList, DropdownItem, Switch } from '@patternfly/react-core';
 import cx from 'classnames';
-import * as React from 'react';
+import React from 'react';
 import { Navigate } from 'react-router-dom';
 import {
   CollectionAPI,

--- a/src/containers/signature-keys/list.tsx
+++ b/src/containers/signature-keys/list.tsx
@@ -6,7 +6,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { SigningServiceAPI, SigningServiceType } from 'src/api';
 import {
   AlertList,

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -7,7 +7,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import { TaskManagementAPI } from 'src/api';
 import { TaskType } from 'src/api/response-types/task';

--- a/src/containers/task-management/task_detail.tsx
+++ b/src/containers/task-management/task_detail.tsx
@@ -13,7 +13,7 @@ import {
 } from '@patternfly/react-core';
 import { CubesIcon } from '@patternfly/react-icons';
 import { capitalize } from 'lodash';
-import * as React from 'react';
+import React from 'react';
 import { Link, Navigate } from 'react-router-dom';
 import { GenericPulpAPI, TaskManagementAPI } from 'src/api';
 import { TaskType } from 'src/api/response-types/task';

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -1,6 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import { Button, ClipboardCopyVariant } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { MyDistributionAPI } from 'src/api';
 import {
   AlertList,

--- a/src/containers/token/token-standalone.tsx
+++ b/src/containers/token/token-standalone.tsx
@@ -1,6 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import { Button, Card, CardBody, CardTitle } from '@patternfly/react-core';
-import * as React from 'react';
+import React from 'react';
 import { ActiveUserAPI } from 'src/api';
 import {
   AlertList,

--- a/src/containers/user-management/user-create.tsx
+++ b/src/containers/user-management/user-create.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { UserAPI, UserType } from 'src/api';
 import {

--- a/src/containers/user-management/user-edit.tsx
+++ b/src/containers/user-management/user-edit.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import * as React from 'react';
+import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { UserAPI, UserType } from 'src/api';
 import {

--- a/src/entry-standalone.tsx
+++ b/src/entry-standalone.tsx
@@ -1,7 +1,7 @@
 import { i18n } from '@lingui/core';
 import { I18nProvider } from '@lingui/react';
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import React from 'react';
+import ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
 import 'src/l10n';
 import App from './loaders/standalone/loader';

--- a/src/loaders/app-context.ts
+++ b/src/loaders/app-context.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { FeatureFlagsType, SettingsType, UserType } from 'src/api';
 import { AlertType } from 'src/components';
 

--- a/src/utilities/last-sync-task.tsx
+++ b/src/utilities/last-sync-task.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import React from 'react';
 import { DateComponent, HelperText, StatusIndicator } from 'src/components';
 
 export function lastSynced(entity) {


### PR DESCRIPTION
we can do `import React from 'react'`, `import React, { foobar } from 'react'`, `import * as React from 'react'`, but not `import * as React, { foobar } from 'react'`

unifying on the first 2

    perl -i -npe 's/import \* as React/import React/' src/**/*.*