### PR TITLE
Repository tests: create distribution for one repo, copy cli fails without it

### DIFF
--- a/test/cypress/e2e/repo/repository_list.js
+++ b/test/cypress/e2e/repo/repository_list.js
@@ -9,6 +9,7 @@ describe('Repository', () => {
     range(5).forEach((i) => {
       cy.galaxykit('repository create repoListTest' + i);
     });
+    cy.galaxykit('distribution create repoListTest3');
 
     // chrome only - prevent 'Write permission denied.' when copying to clipboard
     cy.wrap(


### PR DESCRIPTION
Fixes... (https://github.com/ansible/ansible-hub-ui/actions/runs/5115885593/jobs/9197538188?pr=3778#step:30:363)

```
    1) tests CLI config
 4 passing (47s)
 1 failing
 
1) Repository
      tests CLI config:
    AssertionError: Timed out retrying after 4000ms: Expected to find content: 'Successfully copied to clipboard' but never did.
     at Context.eval (webpack:///./cypress/e2e/repo/repository_list.js:168:7)
```

by making sure there is a distribution associated with the repository.