### PR TITLE
Respect `display_repositories` feature flag for collection/namespace/role filters list

### DIFF
--- a/CHANGES/2326.bug
+++ b/CHANGES/2326.bug
@@ -1,0 +1,1 @@
+Respect `display_repositories` feature flag for collection/namespace/role filters list.

--- a/src/components/collection-list/collection-filter.tsx
+++ b/src/components/collection-list/collection-filter.tsx
@@ -66,9 +66,10 @@ export const CollectionFilter = (props: IProps) => {
   }, [inputText]);
 
   const { ignoredParams, params, updateParams } = props;
-  const { display_signatures } = context.featureFlags;
+  const { display_signatures, display_repositories } = context.featureFlags;
   const displayTags = ignoredParams.includes('tags') === false;
-  const displayRepos = ignoredParams.includes('repository_name') === false;
+  const displayRepos =
+    ignoredParams.includes('repository_name') === false && display_repositories;
   const displayNamespaces = ignoredParams.includes('namespace') === false;
 
   const filterConfig = [


### PR DESCRIPTION
Issue: AAH-2326

Filters for legacy roles, collections search, namespace detail and legacy namespaces all use CollectionFilter,
but the logic of whether to display repository filter was based only on static ignoreParams.

Use the feature flag too, hiding the Repository filter when `display_repositories` is off.

(4.7 doesn't have the flag, not backporting)

