### PR TITLE
Repository sync - modal to set mirror, optimize

### DIFF
--- a/CHANGES/2301.feature
+++ b/CHANGES/2301.feature
@@ -1,0 +1,1 @@
+Repository sync - modal to set mirror, optimize

--- a/src/actions/ansible-repository-sync.tsx
+++ b/src/actions/ansible-repository-sync.tsx
@@ -1,30 +1,123 @@
 import { t } from '@lingui/macro';
+import {
+  Button,
+  FormGroup,
+  Modal,
+  Spinner,
+  Switch,
+} from '@patternfly/react-core';
+import React, { useEffect, useState } from 'react';
 import { AnsibleRepositoryAPI } from 'src/api';
+import { HelperText } from 'src/components';
 import { canSyncAnsibleRepository } from 'src/permissions';
 import { handleHttpError, parsePulpIDFromURL, taskAlert } from 'src/utilities';
 import { Action } from './action';
 
+const SyncModal = ({
+  closeAction,
+  syncAction,
+  name,
+}: {
+  closeAction: () => null;
+  syncAction: (syncParams) => Promise<void>;
+  name: string;
+}) => {
+  const [pending, setPending] = useState(false);
+  const [syncParams, setSyncParams] = useState({
+    mirror: true,
+    optimize: true,
+  });
+
+  useEffect(() => {
+    setPending(false);
+    setSyncParams({ mirror: true, optimize: true });
+  }, [name]);
+
+  if (!name) {
+    return null;
+  }
+
+  return (
+    <Modal
+      actions={[
+        <div data-cy='sync-button' key='sync'>
+          <Button
+            key='sync'
+            onClick={() => {
+              setPending(true);
+              syncAction(syncParams)
+                .then(closeAction)
+                .finally(() => setPending(false));
+            }}
+            variant='primary'
+            isDisabled={pending}
+          >
+            {t`Sync`}
+            {pending && <Spinner size='sm' />}
+          </Button>
+        </div>,
+        <Button key='close' onClick={closeAction} variant='link'>
+          {t`Close`}
+        </Button>,
+      ]}
+      isOpen={true}
+      onClose={closeAction}
+      title={t`Sync repository "${name}"`}
+      variant='medium'
+    >
+      <FormGroup
+        label={t`Mirror`}
+        labelIcon={
+          <HelperText
+            content={t`If selected, all content that is not present in the remote repository will be removed from the local repository; otherwise, sync will add missing content.`}
+          />
+        }
+      >
+        <Switch
+          isChecked={syncParams.mirror}
+          onChange={(mirror) => setSyncParams({ ...syncParams, mirror })}
+          label={t`Content not present in remote repository will be removed from the local repository`}
+          labelOff={t`Sync will only add missing content`}
+        />
+      </FormGroup>
+      <br />
+      <FormGroup
+        label={t`Optimize`}
+        labelIcon={
+          <HelperText
+            content={t`Only perform the sync if no changes are reported by the remote server. To force a sync to happen, deselect this option.`}
+          />
+        }
+      >
+        <Switch
+          isChecked={syncParams.optimize}
+          onChange={(optimize) => setSyncParams({ ...syncParams, optimize })}
+          label={t`Only perform the sync if no changes are reported by the remote server.`}
+          labelOff={t`Force a sync to happen.`}
+        />
+      </FormGroup>
+      <br />
+    </Modal>
+  );
+};
+
 export const ansibleRepositorySyncAction = Action({
   condition: canSyncAnsibleRepository,
   title: t`Sync`,
-  onClick: ({ name, pulp_href }, { addAlert, query }) => {
-    const pulpId = parsePulpIDFromURL(pulp_href);
-    AnsibleRepositoryAPI.sync(pulpId, { mirror: true })
-      .then(({ data }) => {
-        addAlert(
-          taskAlert(data.task, t`Sync started for repository "${name}".`),
-        );
-
-        query();
-      })
-      .catch(
-        handleHttpError(
-          t`Failed to sync repository "${name}"`,
-          () => null,
-          addAlert,
-        ),
-      );
-  },
+  modal: ({ addAlert, query, setState, state }) =>
+    state.syncModalOpen ? (
+      <SyncModal
+        closeAction={() => setState({ syncModalOpen: null })}
+        syncAction={(syncParams) =>
+          syncRepository(state.syncModalOpen, { addAlert, query }, syncParams)
+        }
+        name={state.syncModalOpen.name}
+      />
+    ) : null,
+  onClick: ({ name, pulp_href }, { setState }) =>
+    setState({
+      syncModalOpen: { name, pulp_href },
+    }),
   visible: (_item, { hasPermission }) =>
     hasPermission('ansible.change_collectionremote'),
   disabled: ({ remote, last_sync_task }) => {
@@ -42,3 +135,20 @@ export const ansibleRepositorySyncAction = Action({
     return null;
   },
 });
+
+function syncRepository({ name, pulp_href }, { addAlert, query }, syncParams) {
+  const pulpId = parsePulpIDFromURL(pulp_href);
+  return AnsibleRepositoryAPI.sync(pulpId, syncParams || { mirror: true })
+    .then(({ data }) => {
+      addAlert(taskAlert(data.task, t`Sync started for repository "${name}".`));
+
+      query();
+    })
+    .catch(
+      handleHttpError(
+        t`Failed to sync repository "${name}"`,
+        () => null,
+        addAlert,
+      ),
+    );
+}

--- a/test/cypress/e2e/misc/task_list.js
+++ b/test/cypress/e2e/misc/task_list.js
@@ -16,6 +16,7 @@ describe('Task table contains correct headers and filter', () => {
 
     cy.get('[aria-label="Actions"]').eq(1).click();
     cy.get('tr').eq(2).contains('Sync').click();
+    cy.get('.pf-c-modal-box__footer .pf-m-primary').contains('Sync').click();
 
     cy.get('.pf-c-alert.pf-m-info');
   });

--- a/test/cypress/e2e/misc/task_management_detail.js
+++ b/test/cypress/e2e/misc/task_management_detail.js
@@ -16,6 +16,7 @@ describe('Task detail', () => {
 
     cy.get('[aria-label="Actions"]').eq(1).click();
     cy.get('tr').eq(2).contains('Sync').click();
+    cy.get('.pf-c-modal-box__footer .pf-m-primary').contains('Sync').click();
 
     cy.get('.pf-c-alert.pf-m-info');
   });

--- a/test/cypress/e2e/repo/repository.js
+++ b/test/cypress/e2e/repo/repository.js
@@ -107,6 +107,10 @@ describe('Repository', () => {
       if (mode == 'with remote') {
         // try to sync it
         cy.contains('button', 'Sync').click();
+        cy.get('.pf-c-modal-box__footer .pf-m-primary')
+          .contains('Sync')
+          .click();
+
         cy.contains('Sync started for repository "repo1Test".');
         cy.contains('a', 'detail page').click();
         cy.contains('Failed', { timeout: 10000 });


### PR DESCRIPTION
Issue: AAH-2301

Add Repository sync modal, instead of directly syncing with `{ mirror:true }`, we open a modal with `{ mirror: true, optimize: true }` preset, and allow changing both.

![20230530190946](https://github.com/ansible/ansible-hub-ui/assets/289743/53e92d71-7ee0-4392-8c6f-2fb13015bfbc)
![20230530190954](https://github.com/ansible/ansible-hub-ui/assets/289743/fd71a4dc-6c99-480b-a86b-fff742539b3c)
