### PR TITLE
Repository list - add columns, filters

### DIFF
--- a/CHANGES/2271.feature
+++ b/CHANGES/2271.feature
@@ -1,0 +1,1 @@
+Repository list - add columns, filters

--- a/CHANGES/2340.bugfix
+++ b/CHANGES/2340.bugfix
@@ -1,0 +1,1 @@
+Repositories, Remotes - clean filter text on search

--- a/src/api/response-types/ansible-repository.ts
+++ b/src/api/response-types/ansible-repository.ts
@@ -1,13 +1,16 @@
+import { LastSyncType } from './remote';
+
 export class AnsibleRepositoryType {
   description: string;
+  last_sync_task?: LastSyncType;
   latest_version_href?: string;
   name: string;
+  private?: boolean;
   pulp_created?: string;
   pulp_href?: string;
   pulp_labels?: { [key: string]: string };
   remote?: string;
   retain_repo_versions: number;
-  private?: boolean;
 
   // gpgkey
   // last_synced_metadata_time

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -230,6 +230,12 @@ export const ListPage = function <T>({
         user: this.context.user,
       };
 
+      const resetCompoundFilter = () =>
+        this.setState({
+          inputText: '',
+          selectedFilter: localizedFilterConfig[0].id,
+        });
+
       return (
         <React.Fragment>
           <AlertList alerts={alerts} closeAlert={(i) => this.closeAlert(i)} />
@@ -268,7 +274,7 @@ export const ListPage = function <T>({
                                 }
                               }}
                               updateParams={(p) => {
-                                this.setState({ inputText: '' });
+                                resetCompoundFilter();
                                 updateParams(p);
                               }}
                               params={params}
@@ -306,8 +312,8 @@ export const ListPage = function <T>({
                   <div>
                     <AppliedFilters
                       updateParams={(p) => {
+                        resetCompoundFilter();
                         updateParams(p);
-                        this.setState({ inputText: '' });
                       }}
                       params={params}
                       ignoredParams={['page_size', 'page', 'sort', 'ordering']}

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -76,14 +76,12 @@ export type LocalizedSortHeaders = {
   className?: string;
 }[];
 
-interface ListPageParams<T, ExtraState> {
+interface ListPageParams<T> {
   condition: PermissionContextType;
   defaultPageSize: number;
   defaultSort?: string;
-  didMount?: ({ context, addAlert }) => void;
   displayName: string;
   errorTitle: MessageDescriptor;
-  extraState?: ExtraState;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   filterConfig: any[]; // FilterOption[] but { title: MessageDescriptor }
   headerActions?: ActionType[];
@@ -98,11 +96,9 @@ interface ListPageParams<T, ExtraState> {
   title: MessageDescriptor;
 }
 
-export const ListPage = function <T, ExtraState = Record<string, never>>({
+export const ListPage = function <T>({
   // { featureFlags, settings, user } => bool
   condition,
-  // extra code to run on mount
-  didMount,
   // component name for debugging
   displayName,
   // initial page size
@@ -111,8 +107,6 @@ export const ListPage = function <T, ExtraState = Record<string, never>>({
   defaultSort,
   // alert on query failure
   errorTitle,
-  // extra initial state
-  extraState,
   // filters
   filterConfig,
   // displayed after filters
@@ -133,7 +127,7 @@ export const ListPage = function <T, ExtraState = Record<string, never>>({
   sortHeaders,
   // container title
   title,
-}: ListPageParams<T, ExtraState>) {
+}: ListPageParams<T>) {
   renderModals ||= function (actionContext) {
     return (
       <>
@@ -181,7 +175,6 @@ export const ListPage = function <T, ExtraState = Record<string, never>>({
         loading: true,
         params,
         unauthorised: false,
-        ...extraState,
       };
     }
 
@@ -194,13 +187,6 @@ export const ListPage = function <T, ExtraState = Record<string, never>>({
 
       this.setState({ alerts: this.context.alerts || [] });
       this.context.setAlerts([]);
-
-      if (didMount) {
-        didMount({
-          context: this.context,
-          addAlert: (alert) => this.addAlert(alert),
-        });
-      }
     }
 
     render() {

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -225,11 +225,11 @@ export const ListPage = function <T, ExtraState = Record<string, never>>({
 
       const niceValues = {};
       localizedFilterConfig
-        .filter((filter) => filter['options'] && filter['options'].length > 0)
-        .forEach((item) => {
-          const obj = (niceValues[item['id']] = {});
-          item['options'].forEach((option) => {
-            obj[option.id] = option.title;
+        .filter(({ options }) => options?.length)
+        .forEach(({ id: filterId, options }) => {
+          const obj = (niceValues[filterId] = {});
+          options.forEach(({ id: optionId, title }) => {
+            obj[optionId] = title;
           });
         });
 
@@ -274,7 +274,10 @@ export const ListPage = function <T, ExtraState = Record<string, never>>({
                               onChange={(inputText) =>
                                 this.setState({ inputText })
                               }
-                              updateParams={updateParams}
+                              updateParams={(p) => {
+                                this.setState({ inputText: '' });
+                                updateParams(p);
+                              }}
                               params={params}
                               filterConfig={localizedFilterConfig}
                             />

--- a/src/components/page/page-with-tabs.tsx
+++ b/src/components/page/page-with-tabs.tsx
@@ -46,13 +46,11 @@ interface IState<T> {
 
 type RenderModals = ({ addAlert, state, setState, query }) => React.ReactNode;
 
-interface PageWithTabsParams<T, ExtraState> {
+interface PageWithTabsParams<T> {
   breadcrumbs: ({ name, tab, params }) => { url?: string; name: string }[];
   condition: PermissionContextType;
-  didMount?: ({ context, addAlert }) => void;
   displayName: string;
   errorTitle: MessageDescriptor;
-  extraState?: ExtraState;
   headerActions?: ActionType[];
   headerDetails?: (item) => React.ReactNode;
   query: ({ name }) => Promise<T>;
@@ -64,20 +62,15 @@ interface PageWithTabsParams<T, ExtraState> {
 
 export const PageWithTabs = function <
   T extends { name: string; my_permissions?: string[] },
-  ExtraState = Record<string, never>,
 >({
   // ({ name }) => [{ url?, name }]
   breadcrumbs,
   // { featureFlags, settings, user } => bool
   condition,
-  // extra code to run on mount
-  didMount,
   // component name for debugging
   displayName,
   // alert on query failure
   errorTitle,
-  // extra initial state
-  extraState,
   // displayed after filters
   headerActions,
   // under title
@@ -91,7 +84,7 @@ export const PageWithTabs = function <
   tabs,
   // params => params
   tabUpdateParams,
-}: PageWithTabsParams<T, ExtraState>) {
+}: PageWithTabsParams<T>) {
   renderModals ||= function (actionContext) {
     return (
       <>
@@ -121,7 +114,6 @@ export const PageWithTabs = function <
         loading: true,
         unauthorised: false,
         params,
-        ...extraState,
       };
     }
 
@@ -134,13 +126,6 @@ export const PageWithTabs = function <
 
       this.setState({ alerts: this.context.alerts || [] });
       this.context.setAlerts([]);
-
-      if (didMount) {
-        didMount({
-          context: this.context,
-          addAlert: (alert) => this.addAlert(alert),
-        });
-      }
     }
 
     componentDidUpdate(prevProps) {

--- a/src/components/page/page.tsx
+++ b/src/components/page/page.tsx
@@ -35,13 +35,11 @@ interface IState<T> {
 
 type RenderModals = ({ addAlert, state, setState, query }) => React.ReactNode;
 
-interface PageParams<T, ExtraState> {
+interface PageParams<T> {
   breadcrumbs: ({ name }) => { url?: string; name: string }[];
   condition: PermissionContextType;
-  didMount?: ({ context, addAlert }) => void;
   displayName: string;
   errorTitle: MessageDescriptor;
-  extraState?: ExtraState;
   headerActions?: ActionType[];
   query: ({ name }) => Promise<T>;
   title: ({ name }) => string;
@@ -52,20 +50,15 @@ interface PageParams<T, ExtraState> {
 
 export const Page = function <
   T extends { name: string; my_permissions?: string[] },
-  ExtraState = Record<string, never>,
 >({
   // ({ name }) => [{ url?, name }]
   breadcrumbs,
   // { featureFlags, settings, user } => bool
   condition,
-  // extra code to run on mount
-  didMount,
   // component name for debugging
   displayName,
   // alert on query failure
   errorTitle,
-  // extra initial state
-  extraState,
   // displayed after filters
   headerActions,
   // () => Promise<T>
@@ -75,7 +68,7 @@ export const Page = function <
   // ({ addAlert, state, setState, query }) => <ConfirmationModal... />
   renderModals,
   render,
-}: PageParams<T, ExtraState>) {
+}: PageParams<T>) {
   renderModals ||= function (actionContext) {
     return (
       <>
@@ -98,7 +91,6 @@ export const Page = function <
         item: null,
         loading: true,
         unauthorised: false,
-        ...extraState,
       };
     }
 
@@ -116,13 +108,6 @@ export const Page = function <
 
         this.setState({ alerts: this.context.alerts || [] });
         this.context.setAlerts([]);
-
-        if (didMount) {
-          didMount({
-            context: this.context,
-            addAlert: (alert) => this.addAlert(alert),
-          });
-        }
       });
     }
 

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -54,7 +54,6 @@ export class CompoundFilter extends React.Component<IProps, IState> {
   constructor(props) {
     super(props);
 
-    // this is called again in repositories selector, but not in approval page (the same filter is here)...
     this.state = {
       selectedFilter: props.filterConfig[0],
       isExpanded: false,

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -166,9 +166,10 @@ export class CompoundFilter extends React.Component<IProps, IState> {
           />
         );
       case 'typeahead': {
-        const typeAheadResults = this.props.filterConfig
+        const typeaheadResults = this.props.filterConfig
           .find(({ id }) => id === selectedFilter.id)
           .options.map(({ id, title }) => ({ id, name: title }));
+
         return (
           <APISearchTypeAhead
             multiple={false}
@@ -179,13 +180,14 @@ export class CompoundFilter extends React.Component<IProps, IState> {
               this.props.onChange('');
             }}
             onSelect={(event, value) => {
-              this.submitFilter(value);
+              const item = typeaheadResults.find(({ name }) => name === value);
+              this.submitFilter(item?.id || value);
             }}
             placeholderText={
               selectedFilter?.placeholder ||
               t`Filter by ${selectedFilter.title.toLowerCase()}`
             }
-            results={typeAheadResults}
+            results={typeaheadResults}
           />
         );
       }

--- a/src/containers/ansible-remote/list.tsx
+++ b/src/containers/ansible-remote/list.tsx
@@ -1,4 +1,4 @@
-import { msg } from '@lingui/macro';
+import { msg, t } from '@lingui/macro';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -34,10 +34,10 @@ const AnsibleRemoteList = ListPage<AnsibleRemoteType>({
   defaultSort: '-pulp_created',
   displayName: 'AnsibleRemoteList',
   errorTitle: msg`Remotes could not be displayed.`,
-  filterConfig: [
+  filterConfig: () => [
     {
       id: 'name__icontains',
-      title: msg`Remote name`,
+      title: t`Remote name`,
     },
   ],
   headerActions: [ansibleRemoteCreateAction], // Add remote

--- a/src/containers/ansible-remote/list.tsx
+++ b/src/containers/ansible-remote/list.tsx
@@ -34,7 +34,6 @@ const AnsibleRemoteList = ListPage<AnsibleRemoteType>({
   defaultSort: '-pulp_created',
   displayName: 'AnsibleRemoteList',
   errorTitle: msg`Remotes could not be displayed.`,
-  extraState: {},
   filterConfig: [
     {
       id: 'name__icontains',

--- a/src/containers/ansible-repository/list.tsx
+++ b/src/containers/ansible-repository/list.tsx
@@ -44,20 +44,20 @@ const AnsibleRepositoryList = ListPage<AnsibleRepositoryType>({
       title: msg`Repository name`,
     },
     {
-      id: 'status',
-      title: msg`Status`,
+      id: 'pulp_label_select',
+      title: msg`Pipeline`,
       inputType: 'select',
       options: [
         {
-          id: Constants.NOTCERTIFIED,
+          id: `pipeline=${Constants.NOTCERTIFIED}`,
           title: msg`Rejected`,
         },
         {
-          id: Constants.NEEDSREVIEW,
+          id: `pipeline=${Constants.NEEDSREVIEW}`,
           title: msg`Needs Review`,
         },
         {
-          id: Constants.APPROVED,
+          id: `pipeline=${Constants.APPROVED}`,
           title: msg`Approved`,
         },
       ],
@@ -68,16 +68,7 @@ const AnsibleRepositoryList = ListPage<AnsibleRepositoryType>({
   noDataButton: ansibleRepositoryCreateAction.button,
   noDataDescription: msg`Repositories will appear once created.`,
   noDataTitle: msg`No repositories yet`,
-  query: ({ params }) => {
-    const queryParams = { ...params };
-
-    if (queryParams['status']) {
-      const status = queryParams['status'];
-      delete queryParams['status'];
-      queryParams['pulp_label_select'] = `pipeline=${status}`;
-    }
-    return AnsibleRepositoryAPI.list(queryParams);
-  },
+  query: ({ params }) => AnsibleRepositoryAPI.list(params),
   renderTableRow(item: AnsibleRepositoryType, index: number, actionContext) {
     const {
       last_sync_task,

--- a/src/containers/ansible-repository/list.tsx
+++ b/src/containers/ansible-repository/list.tsx
@@ -9,7 +9,12 @@ import {
   ansibleRepositorySyncAction,
 } from 'src/actions';
 import { AnsibleRepositoryAPI, AnsibleRepositoryType } from 'src/api';
-import { DateComponent, ListItemActions, ListPage } from 'src/components';
+import {
+  DateComponent,
+  ListItemActions,
+  ListPage,
+  PulpLabels,
+} from 'src/components';
 import { Constants } from 'src/constants';
 import { Paths, formatPath } from 'src/paths';
 import { canViewAnsibleRepositories } from 'src/permissions';
@@ -74,7 +79,15 @@ const AnsibleRepositoryList = ListPage<AnsibleRepositoryType>({
     return AnsibleRepositoryAPI.list(queryParams);
   },
   renderTableRow(item: AnsibleRepositoryType, index: number, actionContext) {
-    const { name, pulp_created, pulp_href } = item;
+    const {
+      last_sync_task,
+      name,
+      private: isPrivate,
+      pulp_created,
+      pulp_href,
+      pulp_labels,
+      remote,
+    } = item;
     const id = parsePulpIDFromURL(pulp_href);
 
     const kebabItems = listItemActions.map((action) =>
@@ -89,9 +102,13 @@ const AnsibleRepositoryList = ListPage<AnsibleRepositoryType>({
           </Link>
         </td>
         <td>
-          {!item.remote ? (
+          <PulpLabels labels={pulp_labels} />
+        </td>
+        <td>{isPrivate ? t`Yes` : t`No`}</td>
+        <td>
+          {!remote ? (
             t`no remote`
-          ) : !item.last_sync_task ? (
+          ) : !last_sync_task ? (
             t`never synced`
           ) : (
             <>
@@ -111,6 +128,16 @@ const AnsibleRepositoryList = ListPage<AnsibleRepositoryType>({
       title: msg`Repository name`,
       type: 'alpha',
       id: 'name',
+    },
+    {
+      title: msg`Labels`,
+      type: 'none',
+      id: 'pulp_labels',
+    },
+    {
+      title: msg`Private`,
+      type: 'none',
+      id: 'private',
     },
     {
       title: msg`Sync status`,

--- a/src/containers/ansible-repository/list.tsx
+++ b/src/containers/ansible-repository/list.tsx
@@ -37,7 +37,6 @@ const AnsibleRepositoryList = ListPage<AnsibleRepositoryType>({
   defaultSort: '-pulp_created',
   displayName: 'AnsibleRepositoryList',
   errorTitle: msg`Repositories could not be displayed.`,
-  extraState: {},
   filterConfig: [
     {
       id: 'name__icontains',

--- a/src/containers/ansible-repository/list.tsx
+++ b/src/containers/ansible-repository/list.tsx
@@ -88,8 +88,17 @@ const AnsibleRepositoryList = ListPage<AnsibleRepositoryType>({
             {name}
           </Link>
         </td>
-        <td>{lastSyncStatus(item) || '---'}</td>
-        <td>{lastSynced(item) || '---'}</td>
+        <td>
+          {!item.remote ? (
+            t`no remote`
+          ) : !item.last_sync_task ? (
+            t`never synced`
+          ) : (
+            <>
+              {lastSyncStatus(item)} {lastSynced(item)}
+            </>
+          )}
+        </td>
         <td>
           <DateComponent date={pulp_created} />
         </td>
@@ -106,12 +115,7 @@ const AnsibleRepositoryList = ListPage<AnsibleRepositoryType>({
     {
       title: msg`Sync status`,
       type: 'none',
-      id: 'lastSyncStatus',
-    },
-    {
-      title: msg`Last synced`,
-      type: 'none',
-      id: 'lastSynced',
+      id: 'last_sync_task',
     },
     {
       title: msg`Created date`,

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -69,7 +69,7 @@ interface IState {
     collection?: string;
     page?: number;
     page_size?: number;
-    status?: string;
+    repository_label?: string;
     sort?: string;
   };
   alerts: AlertType[];
@@ -106,8 +106,8 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
       params['sort'] = '-pulp_created';
     }
 
-    if (!params['status']) {
-      params['status'] = Constants.NEEDSREVIEW;
+    if (!params['repository_label']) {
+      params['repository_label'] = `pipeline=${Constants.NEEDSREVIEW}`;
     }
 
     this.state = {
@@ -234,20 +234,20 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
                             title: t`Collection Name`,
                           },
                           {
-                            id: 'status',
+                            id: 'repository_label',
                             title: t`Status`,
                             inputType: 'select',
                             options: [
                               {
-                                id: Constants.NOTCERTIFIED,
+                                id: `pipeline=${Constants.NOTCERTIFIED}`,
                                 title: t`Rejected`,
                               },
                               {
-                                id: Constants.NEEDSREVIEW,
+                                id: `pipeline=${Constants.NEEDSREVIEW}`,
                                 title: t`Needs Review`,
                               },
                               {
-                                id: Constants.APPROVED,
+                                id: `pipeline=${Constants.APPROVED}`,
                                 title: t`Approved`,
                               },
                             ],
@@ -276,14 +276,14 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
                   params={params}
                   ignoredParams={['page_size', 'page', 'sort']}
                   niceValues={{
-                    status: {
-                      [Constants.APPROVED]: t`Approved`,
-                      [Constants.NEEDSREVIEW]: t`Needs Review`,
-                      [Constants.NOTCERTIFIED]: t`Rejected`,
+                    repository_label: {
+                      [`pipeline=${Constants.APPROVED}`]: t`Approved`,
+                      [`pipeline=${Constants.NEEDSREVIEW}`]: t`Needs Review`,
+                      [`pipeline=${Constants.NOTCERTIFIED}`]: t`Rejected`,
                     },
                   }}
                   niceNames={{
-                    status: t`Status`,
+                    repository_label: t`Status`,
                   }}
                 />
               </div>
@@ -334,7 +334,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
 
   private renderTable(versions, params) {
     if (versions.length === 0) {
-      return filterIsSet(params, ['namespace', 'name', 'status']) ? (
+      return filterIsSet(params, ['namespace', 'name', 'repository_label']) ? (
         <EmptyStateFilter />
       ) : (
         <EmptyStateNoData
@@ -373,7 +373,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
         {
           title: t`Status`,
           type: 'none',
-          id: 'status',
+          id: 'repository_label',
         },
         {
           title: '',
@@ -818,16 +818,11 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
       });
     }
 
-    const { status, sort, ...params } = this.state.params;
-
+    const { sort, ...params } = this.state.params;
     const updatedParams = {
       order_by: sort,
       ...params,
     };
-
-    if (status) {
-      updatedParams['repository_label'] = `pipeline=${status}`;
-    }
 
     return CollectionVersionAPI.list(updatedParams)
       .then((result) => {

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -141,8 +141,18 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
 
       const promises = [];
 
-      promises.push(this.loadRepos('staging'));
-      promises.push(this.loadRepos('rejected'));
+      promises.push(
+        this.loadRepos('staging').then((stagingRepoNames) =>
+          this.setState({
+            stagingRepoNames,
+          }),
+        ),
+      );
+      promises.push(
+        this.loadRepos('rejected').then(([rejectedRepoName]) =>
+          this.setState({ rejectedRepoName }),
+        ),
+      );
 
       promises.push(
         RepositoriesUtils.listApproved()
@@ -169,19 +179,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
 
   private loadRepos(pipeline) {
     return Repositories.list({ pulp_label_select: `pipeline=${pipeline}` })
-      .then((data) => {
-        if (data.data.results.length > 0) {
-          if (pipeline == 'staging') {
-            this.setState({
-              stagingRepoNames: data.data.results.map((res) => res.name),
-            });
-          }
-
-          if (pipeline == 'rejected') {
-            this.setState({ rejectedRepoName: data.data.results[0].name });
-          }
-        }
-      })
+      .then(({ data: { results } }) => (results || []).map(({ name }) => name))
       .catch((error) => {
         this.addAlert(
           t`Error loading repository with label ${pipeline}.`,


### PR DESCRIPTION
Issue: AAH-2271, AAH-2340

* [x] Combine sync status and last sync into a single column. This should still show the last sync status and date. The date could be a popover. If no remote is set on the repository, this column should say something like "no remote". If a remote is set, but a sync has never been performed this should say something like "never synced".

|before|after|
|-|-|
|![20230530220652](https://github.com/ansible/ansible-hub-ui/assets/289743/ffc465f4-7bac-498f-b813-a3a83b5876e8)|![20230530220621](https://github.com/ansible/ansible-hub-ui/assets/289743/4063b9cc-041a-42eb-baf5-504a4e970711)|

* [x] Add a "Labels" column that includes the pipeline and hide from search label
* [x] Add a "Private" column that indicates if the repo is private or not

![20230530221522](https://github.com/ansible/ansible-hub-ui/assets/289743/aafcfd8e-528f-48fd-89fe-aeb1b7273a7c)

* [x] Add a "Pipeline" filter that lets the user select approved or staging repositories
* ~~Add a "Private" filter~~ (if the API doesn't support this, you can skip it for now)
  * https://beta-galaxy.ansible.com/api/v3/swagger-ui/#/Repositories%3A%20Ansible/repositories_ansible_ansible_list
* [x] Add a "Remote" filter that lets a user select None or a pick a remote from the list of configured remotes.

![20230612185713](https://github.com/ansible/ansible-hub-ui/assets/289743/1d7d0326-f64a-482c-ad46-39d5abc2f2a3)
![20230612185732](https://github.com/ansible/ansible-hub-ui/assets/289743/e0235d69-7930-46bc-ab06-d5ebc55169e4)
![20230612185748](https://github.com/ansible/ansible-hub-ui/assets/289743/2cb89815-773c-4bf9-9e73-64501d4e1d7e)
