### PR TITLE
Drop stable-4.4 dependabot config, l10n cron

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,23 +63,6 @@ updates:
 
   - package-ecosystem: 'npm'
     directory: '/'
-    target-branch: 'stable-4.4'
-    schedule:
-      interval: 'monthly'
-    commit-message:
-      prefix: '[stable-4.4] '
-    ignore:
-      - dependency-name: "react"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "react-dom"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/react"
-        update-types: ["version-update:semver-major"]
-
-  - package-ecosystem: 'npm'
-    directory: '/'
     target-branch: 'stable-4.2'
     schedule:
       interval: 'monthly'
@@ -122,14 +105,6 @@ updates:
     target-branch: 'stable-4.5'
     commit-message:
       prefix: '[stable-4.5] '
-    schedule:
-      interval: "monthly"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: 'stable-4.4'
-    commit-message:
-      prefix: '[stable-4.4] '
     schedule:
       interval: "monthly"
 

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         branch:
         - 'master'
-        - 'stable-4.4'
         - 'stable-4.5'
         - 'stable-4.6'
         - 'stable-4.7'

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ List of all workflows:
 - `cypress`: Run Cypress integration tests; on PRs, pushes and cron
 - `deploy-cloud`: Deploy to c.r.c; when the relevant branch is updated
 - `dev-release`: Build and upload to github releases, update `dev` tag; when master is updated
-- `i18n`: Extract and merge l10n strings for 4.4+; cron
+- `i18n`: Extract and merge l10n strings for 4.5+; cron
 - `pr-checks`: Check for linter errors, obsolete package-lock.json and merge commits; on PRs only
 - `stable-release`: Build and upload to github releases; when a stable release is created
 - `update-manifest`: Update https://github.com/RedHatInsights/manifests ; when master is updated
@@ -81,7 +81,6 @@ List by branches:
 - `prod-beta`: `deploy-cloud`
 - `prod-stable`: `deploy-cloud`
 - `stable-4.2`: `backported-labels`, `pr-checks`, `stable-release`
-- `stable-4.4`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
 - `stable-4.5`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
 - `stable-4.6`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
 - `stable-4.7`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
@@ -95,7 +94,7 @@ To map between the two:
 |-|-|
 |1.2|4.2|
 |2.0|4.3 (obsolete)|
-|2.1|4.4|
+|2.1|4.4 (obsolete)|
 |2.2|4.5|
 |2.3|4.6|
 |2.4|4.7|


### PR DESCRIPTION
Follows #2504 (4.3)

According to https://access.redhat.com/support/policy/updates/ansible-automation-platform 4.4 (2.1) is EOL as of June 2, 2023.

Dropping dependabot config for 4.4,
weekly string extraction,
and updating README.