### PR TITLE
[stable-4.6] Use only namespace in ee owners tab

### DIFF
--- a/CHANGES/2122.bugfix
+++ b/CHANGES/2122.bugfix
@@ -1,0 +1,1 @@
+Filter out namespace name from container name

--- a/src/containers/execution-environment-detail/execution_environment_detail_owners.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_owners.tsx
@@ -62,7 +62,7 @@ class ExecutionEnvironmentDetailOwners extends React.Component<
         reload={loadAll}
         selectRolesMessage={t`The selected roles will be added to this specific Execution Environment.`}
         updateGroups={(groups) =>
-          ExecutionEnvironmentNamespaceAPI.update(name, {
+          ExecutionEnvironmentNamespaceAPI.update(this.getNamespace(name), {
             groups,
           })
         }
@@ -74,7 +74,9 @@ class ExecutionEnvironmentDetailOwners extends React.Component<
   }
 
   queryNamespace(name) {
-    ExecutionEnvironmentNamespaceAPI.get(name).then(
+    const namespace = this.getNamespace(name);
+
+    ExecutionEnvironmentNamespaceAPI.get(namespace).then(
       ({ data: { groups, my_permissions } }) =>
         this.setState({
           name: name,
@@ -84,6 +86,11 @@ class ExecutionEnvironmentDetailOwners extends React.Component<
             this.context.user.model_permissions.change_containernamespace,
         }),
     );
+  }
+
+  // filter namespace name
+  private getNamespace(name) {
+    return name.includes('/') ? name.split('/')[0] : name;
   }
 }
 


### PR DESCRIPTION
Issue: AAH-2122

Filter out the namespace part if the container is in the format `<namespace>/<name>` 