### PR TITLE
c.r.c. move alert list so it's not covered by breadcrumbs

### DIFF
--- a/CHANGES/2432.bug
+++ b/CHANGES/2432.bug
@@ -1,0 +1,1 @@
+c.r.c. move alert list so it's not covered by breadcrumbs

--- a/src/components/patternfly-wrappers/alert-list.tsx
+++ b/src/components/patternfly-wrappers/alert-list.tsx
@@ -4,6 +4,7 @@ import {
   AlertProps,
 } from '@patternfly/react-core';
 import React from 'react';
+import { Constants } from 'src/constants';
 
 interface IProps {
   /** List of alerts to display */
@@ -25,7 +26,10 @@ export const AlertList = ({ alerts, closeAlert }: IProps) => (
     style={{
       position: 'fixed',
       right: '5px',
-      top: '80px',
+      top:
+        DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
+          ? '124px' // 70 + 50 + 4
+          : '80px', // 76 + 4
       zIndex: 300,
       display: 'flex',
       flexDirection: 'column',


### PR DESCRIPTION
Issue: AAH-2432

c.r.c added breadcrumbs, but our alert list uses a fixed position, not accounting for the new size => alerts can get hidden under the breadcrumbs

Recomputing the value for insights mode, while keeping the original for standalone.

Before breadcrumbs, good:

![20230627193442](https://github.com/ansible/ansible-hub-ui/assets/289743/3fc2a61a-da64-4690-a5d2-44bfe85d5a46)

After breadcrumbs, hidden:

![20230627193416](https://github.com/ansible/ansible-hub-ui/assets/289743/c86355a2-f4d9-49df-97f4-dc68b714afc3)

Standalone, before and after:

![20230627193941](https://github.com/ansible/ansible-hub-ui/assets/289743/a4cd12bf-319d-4b94-996a-8443e699cf2e)

Insights after this PR:

![20230627195259](https://github.com/ansible/ansible-hub-ui/assets/289743/9f0cb029-0046-43fe-8923-ed4caece7677)
