### PR TITLE
Fix Namespaces/Partners breadcrumb

### DIFF
--- a/CHANGES/2433.bug
+++ b/CHANGES/2433.bug
@@ -1,0 +1,1 @@
+Fix Namespaces/Partners breadcrumb

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -46,7 +46,7 @@ class CollectionContent extends React.Component<
     const { collection_version, repository } = collection;
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      namespaceBreadcrumb(),
       {
         url: formatPath(Paths.namespaceDetail, {
           namespace: collection_version.namespace,

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -89,7 +89,7 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
     const { collection_version: version, repository } = collection;
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      namespaceBreadcrumb(),
       {
         url: formatPath(Paths.namespaceDetail, {
           namespace: version.namespace,

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -62,7 +62,7 @@ class CollectionDetail extends React.Component<
     const { collection_version: version } = collection;
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      namespaceBreadcrumb(),
       {
         url: formatPath(Paths.namespaceDetail, {
           namespace: version.namespace,

--- a/src/containers/collection-detail/collection-distributions.tsx
+++ b/src/containers/collection-detail/collection-distributions.tsx
@@ -90,7 +90,7 @@ const CollectionDistributions = (props: RouteProps) => {
   const { collection_version, repository } = collection;
 
   const breadcrumbs = [
-    namespaceBreadcrumb,
+    namespaceBreadcrumb(),
     {
       url: formatPath(Paths.namespaceDetail, {
         namespace: collection_version.namespace,

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -99,7 +99,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
     const { collection_version, repository } = collection;
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      namespaceBreadcrumb(),
       {
         url: formatPath(Paths.namespaceDetail, {
           namespace: collection_version.namespace,

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -63,7 +63,7 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
     const { collection_version, repository } = collection;
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      namespaceBreadcrumb(),
       {
         url: formatPath(Paths.namespaceDetail, {
           namespace: collection_version.namespace,

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -110,7 +110,7 @@ class EditNamespace extends React.Component<RouteProps, IState> {
         <PartnerHeader
           namespace={namespace}
           breadcrumbs={[
-            namespaceBreadcrumb,
+            namespaceBreadcrumb(),
             {
               name: namespace.name,
               url: formatPath(Paths.namespaceDetail, {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -245,7 +245,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     const tab = params['tab'] || 'collections';
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      namespaceBreadcrumb(),
       {
         name: namespace.name,
         url:
@@ -899,7 +899,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
       NamespaceAPI.delete(name)
         .then(() => {
           this.setState({
-            redirect: namespaceBreadcrumb.url,
+            redirect: namespaceBreadcrumb().url,
             confirmDelete: false,
             isNamespacePending: false,
           });

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -1,4 +1,3 @@
-import { i18n } from '@lingui/core';
 import { t } from '@lingui/macro';
 import {
   Button,
@@ -156,7 +155,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
     }
 
     // Namespaces or Partners
-    const title = i18n._(namespaceBreadcrumb.name);
+    const title = namespaceBreadcrumb().name;
 
     return (
       <div className='hub-namespace-page'>

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -125,10 +125,8 @@ export enum Paths {
   collections = '/collections',
 }
 
-export const namespaceBreadcrumb = () => ({
-  name: {
-    namespaces: t`Namespaces`,
-    partners: t`Partners`,
-  }[NAMESPACE_TERM],
-  url: formatPath(Paths[NAMESPACE_TERM]),
-});
+export const namespaceBreadcrumb = () =>
+  ({
+    namespaces: { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
+    partners: { name: t`Partners`, url: formatPath(Paths.partners) },
+  }[NAMESPACE_TERM]);

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -125,10 +125,10 @@ export enum Paths {
   collections = '/collections',
 }
 
-export const namespaceBreadcrumb = {
+export const namespaceBreadcrumb = () => ({
   name: {
     namespaces: t`Namespaces`,
     partners: t`Partners`,
   }[NAMESPACE_TERM],
   url: formatPath(Paths[NAMESPACE_TERM]),
-};
+});


### PR DESCRIPTION
Issue: AAH-2433

Namespace/Partners breadcrumb translation was happening in the top context, leading to hashes instead of text in breadcrumbs.
Making `namespaceBreadcrumb` a function to force late eval.
