### PR TITLE
[stable-4.7] Fix namespaces breadcrumb l10n (#3896)

### DIFF
--- a/CHANGES/2433.bug
+++ b/CHANGES/2433.bug
@@ -1,0 +1,1 @@
+Fix Namespaces/Partners breadcrumb

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -7,7 +7,7 @@ import {
   Main,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { IBaseCollectionState, loadCollection } from './base';
@@ -46,7 +46,7 @@ class CollectionContent extends React.Component<
     const { collection_version, repository } = collection;
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceDetail, {
           namespace: collection_version.namespace,

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -17,7 +17,7 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
 import { ParamHelper, errorMessage, filterIsSet } from 'src/utilities';
 import { IBaseCollectionState, loadCollection } from './base';
@@ -89,7 +89,7 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
     const { collection_version: version, repository } = collection;
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceDetail, {
           namespace: version.namespace,

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -1,3 +1,4 @@
+import { t } from '@lingui/macro';
 import { isEqual } from 'lodash';
 import * as React from 'react';
 import {
@@ -9,7 +10,7 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { IBaseCollectionState, loadCollection } from './base';
@@ -62,7 +63,7 @@ class CollectionDetail extends React.Component<
     const { collection_version: version } = collection;
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceDetail, {
           namespace: version.namespace,

--- a/src/containers/collection-detail/collection-distributions.tsx
+++ b/src/containers/collection-detail/collection-distributions.tsx
@@ -16,7 +16,7 @@ import {
   Pagination,
   SortTable,
 } from 'src/components';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import {
   ParamHelper,
   RouteProps,
@@ -90,7 +90,7 @@ const CollectionDistributions = (props: RouteProps) => {
   const { collection_version, repository } = collection;
 
   const breadcrumbs = [
-    namespaceBreadcrumb,
+    { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
     {
       url: formatPath(Paths.namespaceDetail, {
         namespace: collection_version.namespace,

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -17,7 +17,7 @@ import {
   TableOfContents,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
 import { ParamHelper, sanitizeDocsUrls } from 'src/utilities';
 import { IBaseCollectionState, loadCollection } from './base';
@@ -99,7 +99,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
     const { collection_version, repository } = collection;
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceDetail, {
           namespace: collection_version.namespace,

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -8,7 +8,7 @@ import {
   Main,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { IBaseCollectionState, loadCollection } from './base';
@@ -63,7 +63,7 @@ class CollectionImportLog extends React.Component<RouteProps, IState> {
     const { collection_version, repository } = collection;
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceDetail, {
           namespace: collection_version.namespace,

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -15,7 +15,7 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
 import {
   ErrorMessagesType,
@@ -110,7 +110,7 @@ class EditNamespace extends React.Component<RouteProps, IState> {
         <PartnerHeader
           namespace={namespace}
           breadcrumbs={[
-            namespaceBreadcrumb,
+            { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
             {
               name: namespace.name,
               url: formatPath(Paths.namespaceDetail, {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -44,7 +44,7 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
 import {
   DeleteCollectionUtils,
@@ -243,7 +243,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     const tab = params['tab'] || 'collections';
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         name: namespace.name,
         url:

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,4 +1,3 @@
-import { t } from '@lingui/macro';
 import { ParamHelper, ParamType } from 'src/utilities';
 
 export function formatPath(path: Paths, data = {}, params?: ParamType) {
@@ -115,8 +114,3 @@ export enum Paths {
   signatureKeys = '/signature-keys',
   collections = '/collections',
 }
-
-export const namespaceBreadcrumb = {
-  name: t`Namespaces`,
-  url: formatPath(Paths.namespaces),
-};


### PR DESCRIPTION
to fix the l10n issue in #3896,
except we don't need the namespaces vs partners logic in the stable branches

=>

    perl -i -npe 's/, namespaceBreadcrumb// if /from..src.paths/; s/namespaceBreadcrumb.url/formatPath(Paths.namespaces)/; s/namespaceBreadcrumb.name/t`Namespaces`/; s/namespaceBreadcrumb/{ name: t`Namespaces`, url: formatPath(Paths.namespaces) }/' src/**/*.*
    vim src/paths.ts # manual cleanup of namespaceBreadcrumb
    npm run prettier
    npm run lint
    and fixups

Issue: AAH-2433