### PR TITLE
[stable-4.6] Drop namespaceBreadcrumb

### DIFF
--- a/CHANGES/2433.bug
+++ b/CHANGES/2433.bug
@@ -1,0 +1,1 @@
+Fix Namespaces/Partners breadcrumb

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -8,7 +8,7 @@ import {
   Main,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { IBaseCollectionState, loadCollection } from './base';
 
@@ -44,7 +44,7 @@ class CollectionContent extends React.Component<
     }
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceByRepo, {
           namespace: collection.namespace.name,

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -20,7 +20,7 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { ParamHelper, errorMessage, filterIsSet } from 'src/utilities';
 import './collection-dependencies.scss';
 
@@ -87,7 +87,7 @@ class CollectionDependencies extends React.Component<
     }
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceByRepo, {
           namespace: collection.namespace.name,

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -1,3 +1,4 @@
+import { t } from '@lingui/macro';
 import { isEqual } from 'lodash';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -10,7 +11,7 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { IBaseCollectionState, loadCollection } from './base';
 
@@ -53,7 +54,7 @@ class CollectionDetail extends React.Component<
     }
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceByRepo, {
           namespace: collection.namespace.name,

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -16,7 +16,7 @@ import {
   TableOfContents,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { ParamHelper, sanitizeDocsUrls } from 'src/utilities';
 import { IBaseCollectionState, loadCollection } from './base';
 import './collection-detail.scss';
@@ -100,7 +100,7 @@ class CollectionDocs extends React.Component<
     }
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceByRepo, {
           namespace: collection.namespace.name,

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -9,7 +9,7 @@ import {
   Main,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { IBaseCollectionState, loadCollection } from './base';
 
@@ -55,7 +55,7 @@ class CollectionImportLog extends React.Component<RouteComponentProps, IState> {
     }
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceByRepo, {
           namespace: collection.namespace.name,

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -15,7 +15,7 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import {
   ErrorMessagesType,
   ParamHelper,
@@ -109,7 +109,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
         <PartnerHeader
           namespace={namespace}
           breadcrumbs={[
-            namespaceBreadcrumb,
+            { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
             {
               name: namespace.name,
               url: formatPath(Paths.myCollections, {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -47,7 +47,7 @@ import {
 } from 'src/components';
 import { Constants } from 'src/constants';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import {
   DeleteCollectionUtils,
   ParamHelper,
@@ -191,7 +191,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
     const tab = params['tab'] || 'collections';
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         name: namespace.name,
         url:
@@ -774,7 +774,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       NamespaceAPI.delete(name)
         .then(() => {
           this.setState({
-            redirect: formatPath(namespaceBreadcrumb.url, {}),
+            redirect: formatPath(Paths.namespaces),
             confirmDelete: false,
             isNamespacePending: false,
           });

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,4 +1,3 @@
-import { t } from '@lingui/macro';
 import { ParamHelper, ParamType } from 'src/utilities';
 
 export function formatPath(path: Paths, data = {}, params?: ParamType) {
@@ -69,8 +68,3 @@ export enum Paths {
   taskList = '/tasks',
   signatureKeys = '/signature-keys',
 }
-
-export const namespaceBreadcrumb = {
-  name: t`Namespaces`,
-  url: Paths.namespaces,
-};


### PR DESCRIPTION
to fix the l10n issue in #3896,
except we don't need the namespaces vs partners logic in the stable branches

=>

    perl -i -npe 's/, namespaceBreadcrumb// if /from..src.paths/; s/namespaceBreadcrumb.url/formatPath(Paths.namespaces)/; s/namespaceBreadcrumb.name/t`Namespaces`/; s/namespaceBreadcrumb/{ name: t`Namespaces`, url: formatPath(Paths.namespaces) }/' src/**/*.*
    vim src/paths.ts # manual cleanup of namespaceBreadcrumb
    npm run prettier
    npm run lint
    and fixups

Issue: AAH-2433