### PR TITLE
[stable-4.5] Drop namespaceBreadcrumb

### DIFF
--- a/CHANGES/2433.bug
+++ b/CHANGES/2433.bug
@@ -1,0 +1,1 @@
+Fix Namespaces/Partners breadcrumb

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -8,7 +8,7 @@ import {
   Main,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { IBaseCollectionState, loadCollection } from './base';
 
@@ -40,7 +40,7 @@ class CollectionContent extends React.Component<
     }
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceByRepo, {
           namespace: collection.namespace.name,

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -20,7 +20,7 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { ParamHelper, errorMessage, filterIsSet } from 'src/utilities';
 import './collection-dependencies.scss';
 
@@ -87,7 +87,7 @@ class CollectionDependencies extends React.Component<
     }
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceByRepo, {
           namespace: collection.namespace.name,

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -1,3 +1,4 @@
+import { t } from '@lingui/macro';
 import { isEqual } from 'lodash';
 import * as React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -10,7 +11,7 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { IBaseCollectionState, loadCollection } from './base';
 
@@ -49,7 +50,7 @@ class CollectionDetail extends React.Component<
     }
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceByRepo, {
           namespace: collection.namespace.name,

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -16,7 +16,7 @@ import {
   TableOfContents,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { ParamHelper, sanitizeDocsUrls } from 'src/utilities';
 import { IBaseCollectionState, loadCollection } from './base';
 import './collection-detail.scss';
@@ -96,7 +96,7 @@ class CollectionDocs extends React.Component<
     }
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceByRepo, {
           namespace: collection.namespace.name,

--- a/src/containers/collection-detail/collection-import-log.tsx
+++ b/src/containers/collection-detail/collection-import-log.tsx
@@ -9,7 +9,7 @@ import {
   Main,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import { ParamHelper } from 'src/utilities/param-helper';
 import { IBaseCollectionState, loadCollection } from './base';
 
@@ -55,7 +55,7 @@ class CollectionImportLog extends React.Component<RouteComponentProps, IState> {
     }
 
     const breadcrumbs = [
-      namespaceBreadcrumb,
+      { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
       {
         url: formatPath(Paths.namespaceByRepo, {
           namespace: collection.namespace.name,

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -15,7 +15,7 @@ import {
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import {
   ErrorMessagesType,
   ParamHelper,
@@ -103,7 +103,7 @@ class EditNamespace extends React.Component<RouteComponentProps, IState> {
         <PartnerHeader
           namespace={namespace}
           breadcrumbs={[
-            namespaceBreadcrumb,
+            { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
             {
               name: namespace.name,
               url: formatPath(Paths.myCollections, {

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -45,7 +45,7 @@ import {
 } from 'src/components';
 import { Constants } from 'src/constants';
 import { AppContext } from 'src/loaders/app-context';
-import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
+import { Paths, formatPath } from 'src/paths';
 import {
   ParamHelper,
   canSign as canSignNS,
@@ -245,7 +245,10 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
         ) : null}
         <PartnerHeader
           namespace={namespace}
-          breadcrumbs={[namespaceBreadcrumb, { name: namespace.name }]}
+          breadcrumbs={[
+            { name: t`Namespaces`, url: formatPath(Paths.namespaces) },
+            { name: namespace.name },
+          ]}
           tabs={tabs}
           params={params}
           updateParams={(p) => this.updateParams(p)}
@@ -656,7 +659,7 @@ export class NamespaceDetail extends React.Component<IProps, IState> {
       NamespaceAPI.delete(name)
         .then(() => {
           this.setState({
-            redirect: formatPath(namespaceBreadcrumb.url, {}),
+            redirect: formatPath(Paths.namespaces),
             confirmDelete: false,
             isNamespacePending: false,
           });

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,4 +1,3 @@
-import { t } from '@lingui/macro';
 import { ParamHelper, ParamType } from 'src/utilities';
 
 export function formatPath(path: Paths, data = {}, params?: ParamType) {
@@ -63,8 +62,3 @@ export enum Paths {
   repositories = '/repositories',
   taskList = '/tasks',
 }
-
-export const namespaceBreadcrumb = {
-  name: t`Namespaces`,
-  url: Paths.namespaces,
-};


### PR DESCRIPTION
to fix the l10n issue in #3896,
except we don't need the namespaces vs partners logic in the stable branches

=>

    perl -i -npe 's/, namespaceBreadcrumb// if /from..src.paths/; s/namespaceBreadcrumb.url/formatPath(Paths.namespaces)/; s/namespaceBreadcrumb.name/t`Namespaces`/; s/namespaceBreadcrumb/{ name: t`Namespaces`, url: formatPath(Paths.namespaces) }/' src/**/*.*
    vim src/paths.ts # manual cleanup of namespaceBreadcrumb
    npm run prettier
    npm run lint
    and fixups

Issue: AAH-2433