### PR TITLE
[stable-4.7] Delete collection all or single repo (#3759)

### DIFF
--- a/CHANGES/2261.task
+++ b/CHANGES/2261.task
@@ -1,0 +1,1 @@
+ Delete collection or version from repo only.

--- a/src/components/delete-modal/delete-collection-modal.tsx
+++ b/src/components/delete-modal/delete-collection-modal.tsx
@@ -13,6 +13,7 @@ interface IProps {
   cancelAction: () => void;
   deleteAction: () => void;
   setConfirmDelete: (val) => void;
+  deleteFromRepo: string;
 }
 
 export const DeleteCollectionModal = (props: IProps) => {
@@ -25,7 +26,10 @@ export const DeleteCollectionModal = (props: IProps) => {
     cancelAction,
     deleteAction,
     setConfirmDelete,
+    deleteFromRepo,
   } = props;
+
+  const lastCollectionVersion = collectionVersion && collections.length === 1;
 
   return (
     deleteCollection && (
@@ -42,34 +46,28 @@ export const DeleteCollectionModal = (props: IProps) => {
       >
         <Text style={{ paddingBottom: 'var(--pf-global--spacer--md)' }}>
           {collectionVersion ? (
-            <>
-              {(collections as CollectionVersionSearch[]).length === 1 ? (
-                <Trans>
-                  Deleting{' '}
-                  <b>
-                    {deleteCollection.collection_version.name} v
-                    {collectionVersion}
-                  </b>{' '}
-                  and its data will be lost and this will cause the entire
-                  collection to be deleted.
-                </Trans>
-              ) : (
-                <Trans>
-                  Deleting{' '}
-                  <b>
-                    {deleteCollection.collection_version.name} v
-                    {collectionVersion}
-                  </b>{' '}
-                  and its data will be lost.
-                </Trans>
-              )}
-            </>
+            <Trans>
+              Deleting{' '}
+              <b>
+                {deleteCollection.collection_version.name} v{collectionVersion}
+              </b>
+              , its data will be lost.
+            </Trans>
           ) : (
             <Trans>
-              Deleting <b>{deleteCollection.collection_version.name}</b> and its
+              Deleting <b>{deleteCollection.collection_version.name}</b>, its
               data will be lost.
             </Trans>
           )}
+          {lastCollectionVersion ? (
+            <> {t`This will cause the entire collection to be deleted.`}</>
+          ) : null}
+          {deleteFromRepo ? (
+            <>
+              {' '}
+              {t`The collection will be deleted only from repository ${deleteFromRepo}.`}
+            </>
+          ) : null}
         </Text>
         <Checkbox
           isChecked={confirmDelete}

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -91,6 +91,7 @@ interface IState {
   showRoleRemoveModal?: string;
   showRoleSelectWizard?: { roles?: RoleType[] };
   group: GroupType;
+  deleteAll: boolean;
 }
 
 export class NamespaceDetail extends React.Component<RouteProps, IState> {
@@ -137,6 +138,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
       showRoleRemoveModal: null,
       showRoleSelectWizard: null,
       group: null,
+      deleteAll: true,
     };
   }
 
@@ -308,6 +310,9 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     delete tabParams.group;
 
     const repository = params['repository_name'] || null;
+    const deleteFromRepo = this.state.deleteAll
+      ? null
+      : deleteCollection?.repository?.name;
 
     return (
       <React.Fragment>
@@ -345,9 +350,11 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
                 load: () => this.load(),
                 redirect: false,
                 addAlert: (alert) => this.addAlert(alert),
+                deleteFromRepo,
               }),
             )
           }
+          deleteFromRepo={deleteFromRepo}
         />
         {isOpenNamespaceModal && (
           <DeleteModal
@@ -947,6 +954,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
   private renderCollectionControls(collection: CollectionVersionSearch) {
     const { hasPermission } = this.context;
     const { showControls } = this.state;
+    const { display_repositories } = this.context.featureFlags;
 
     if (!showControls) {
       return;
@@ -977,7 +985,23 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
                   addAlert: (alert) => this.addAlert(alert),
                   setState: (state) => this.setState(state),
                   collection,
+                  deleteAll: true,
                 }),
+              deleteAll: true,
+              display_repositories: display_repositories,
+            }),
+            DeleteCollectionUtils.deleteMenuOption({
+              canDeleteCollection: hasPermission('ansible.delete_collection'),
+              noDependencies: null,
+              onClick: () =>
+                DeleteCollectionUtils.tryOpenDeleteModalWithConfirm({
+                  addAlert: (alert) => this.addAlert(alert),
+                  setState: (state) => this.setState(state),
+                  collection,
+                  deleteAll: false,
+                }),
+              deleteAll: false,
+              display_repositories: display_repositories,
             }),
             <DropdownItem
               onClick={() =>

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -62,6 +62,7 @@ interface IState {
   deleteCollection: CollectionVersionSearch;
   confirmDelete: boolean;
   isDeletionPending: boolean;
+  deleteAll: boolean;
 }
 
 class Search extends React.Component<RouteProps, IState> {
@@ -100,6 +101,7 @@ class Search extends React.Component<RouteProps, IState> {
       deleteCollection: null,
       confirmDelete: false,
       isDeletionPending: false,
+      deleteAll: true,
     };
   }
 
@@ -150,6 +152,10 @@ class Search extends React.Component<RouteProps, IState> {
     const updateParams = (p) =>
       this.updateParams(p, () => this.queryCollections());
 
+    const deleteFromRepo = this.state.deleteAll
+      ? null
+      : deleteCollection?.repository?.name;
+
     return (
       <div className='search-page'>
         <AlertList
@@ -171,9 +177,11 @@ class Search extends React.Component<RouteProps, IState> {
                 load: () => this.load(),
                 redirect: false,
                 addAlert: (alert) => this.addAlert(alert),
+                deleteFromRepo,
               }),
             )
           }
+          deleteFromRepo={deleteFromRepo}
         />
 
         {showImportModal && (
@@ -355,6 +363,8 @@ class Search extends React.Component<RouteProps, IState> {
 
   private renderMenu(list, collection) {
     const { hasPermission } = this.context;
+    const { display_repositories } = this.context.featureFlags;
+
     const menuItems = [
       DeleteCollectionUtils.deleteMenuOption({
         canDeleteCollection: hasPermission('ansible.delete_collection'),
@@ -364,7 +374,23 @@ class Search extends React.Component<RouteProps, IState> {
             addAlert: (alert) => this.addAlert(alert),
             setState: (state) => this.setState(state),
             collection,
+            deleteAll: true,
           }),
+        deleteAll: true,
+        display_repositories: display_repositories,
+      }),
+      DeleteCollectionUtils.deleteMenuOption({
+        canDeleteCollection: hasPermission('ansible.delete_collection'),
+        noDependencies: null,
+        onClick: () =>
+          DeleteCollectionUtils.tryOpenDeleteModalWithConfirm({
+            addAlert: (alert) => this.addAlert(alert),
+            setState: (state) => this.setState(state),
+            collection,
+            deleteAll: false,
+          }),
+        deleteAll: false,
+        display_repositories: display_repositories,
       }),
       hasPermission('galaxy.upload_to_namespace') && (
         <DropdownItem

--- a/test/cypress/e2e/approval/approval_process.js
+++ b/test/cypress/e2e/approval/approval_process.js
@@ -4,8 +4,6 @@ const apiPrefix = Cypress.env('apiPrefix');
 describe('Approval Dashboard process', () => {
   before(() => {
     cy.deleteNamespacesAndCollections();
-    cy.galaxykit('-i namespace create', 'appp_n_test');
-    cy.galaxykit('-i collection upload', 'appp_n_test', 'appp_c_test1');
   });
 
   after(() => {
@@ -17,6 +15,9 @@ describe('Approval Dashboard process', () => {
   });
 
   it('should test the whole approval process.', () => {
+    cy.galaxykit('-i namespace create', 'appp_n_test');
+    cy.galaxykit('-i collection upload', 'appp_n_test', 'appp_c_test1');
+    cy.galaxykit('task wait all');
     cy.visit(`${uiPrefix}collections`);
     cy.contains('No collections yet');
 

--- a/test/cypress/e2e/collections/collection.js
+++ b/test/cypress/e2e/collections/collection.js
@@ -4,6 +4,12 @@ const uiPrefix = Cypress.env('uiPrefix');
 describe('collection tests', () => {
   before(() => {
     cy.deleteNamespacesAndCollections();
+    cy.deleteRepositories();
+  });
+
+  after(() => {
+    cy.deleteNamespacesAndCollections();
+    cy.deleteRepositories();
   });
 
   beforeEach(() => {
@@ -46,11 +52,12 @@ describe('collection tests', () => {
   });
 
   it('should copy collection version to validated repository', () => {
+    cy.deleteNamespacesAndCollections();
     const rand = Math.floor(Math.random() * 9999999);
     const namespace = `foo_${rand}`;
     const collection = `bar_${rand}`;
     cy.galaxykit(`-i collection upload ${namespace} ${collection}`);
-    cy.visit(`${uiPrefix}repo/staging/${namespace}/${collection}`);
+    cy.visit(`${uiPrefix}repo/published/${namespace}/${collection}`);
 
     cy.get('[data-cy="kebab-toggle"]').click();
     cy.get(
@@ -70,9 +77,106 @@ describe('collection tests', () => {
     cy.get('.pf-m-primary').contains('Select').click();
 
     cy.get('[data-cy="AlertList"]').contains(
-      `Started adding ${namespace}.${collection} v1.0.0 from "staging" to repository "validated".`,
+      `Started adding ${namespace}.${collection} v1.0.0 from "published" to repository "validated".`,
     );
     cy.get('[data-cy="AlertList"]').contains('detail page').click();
     cy.contains('Completed');
+  });
+
+  it('deletes an collection from repository', () => {
+    cy.deleteNamespacesAndCollections();
+    cy.deleteRepositories();
+    cy.galaxykit('-i collection upload test_namespace test_repo_collection2');
+    cy.galaxykit('repository create repo2 --pipeline approved');
+    cy.galaxykit('distribution create repo2');
+
+    cy.galaxykit('task wait all');
+    cy.galaxykit(
+      'collection copy test_namespace test_repo_collection2 1.0.0 published repo2',
+    );
+
+    cy.visit(`${uiPrefix}collections?view_type=list`);
+    cy.contains('Collections');
+    cy.contains('[data-cy="CollectionListItem"]', 'published');
+    cy.contains('[data-cy="CollectionListItem"]', 'repo2');
+
+    cy.get('.collection-container [aria-label="Actions"]:first').click({
+      force: true,
+    });
+    cy.contains('Delete collection from repository').click();
+    cy.get('input[id=delete_confirm]').click();
+    cy.get('button').contains('Delete').click();
+    cy.contains(
+      'Collection "test_repo_collection2" has been successfully deleted.',
+      {
+        timeout: 10000,
+      },
+    );
+    cy.contains('[data-cy="CollectionListItem"]', 'repo2');
+    cy.contains('[data-cy="CollectionListItem"]', 'published').should(
+      'not.exist',
+    );
+
+    cy.deleteAllCollections();
+    cy.deleteRepositories();
+  });
+
+  it('deletes an collection version from repository', () => {
+    cy.deleteNamespacesAndCollections();
+    cy.deleteRepositories();
+    cy.galaxykit('repository create repo2 --pipeline approved');
+    cy.galaxykit('distribution create repo2');
+
+    cy.galaxykit(
+      '-i collection upload test_namespace test_repo_collection_version2 1.0.0',
+    );
+    cy.galaxykit('task wait all');
+    cy.galaxykit(
+      'collection copy test_namespace test_repo_collection_version2 1.0.0 published repo2',
+    );
+
+    cy.galaxykit(
+      '-i collection upload test_namespace test_repo_collection_version2 1.0.1',
+    );
+    cy.galaxykit('task wait all');
+    cy.galaxykit(
+      'collection copy test_namespace test_repo_collection_version2 1.0.1 published repo2',
+    );
+
+    cy.visit(`${uiPrefix}collections?view_type=list`);
+    cy.contains('Collections');
+    cy.contains('[data-cy="CollectionListItem"]', 'published');
+    cy.contains('[data-cy="CollectionListItem"]', 'repo2');
+
+    cy.visit(
+      `${uiPrefix}repo/repo2/test_namespace/test_repo_collection_version2/?version=1.0.0`,
+    );
+
+    cy.get('[data-cy="kebab-toggle"] [aria-label="Actions"]:first').click();
+    cy.contains('Delete version 1.0.0 from repository').click();
+    cy.get('input[id=delete_confirm]').click();
+    cy.get('button').contains('Delete').click();
+    cy.contains(
+      'Collection "test_repo_collection_version2 v1.0.0" has been successfully deleted.',
+      {
+        timeout: 10000,
+      },
+    );
+
+    cy.visit(
+      `${uiPrefix}repo/repo2/test_namespace/test_repo_collection_version2/?version=1.0.0`,
+    );
+    cy.contains(`We couldn't find the page you're looking for!`);
+
+    cy.visit(
+      `${uiPrefix}repo/published/test_namespace/test_repo_collection_version2/?version=1.0.0`,
+    );
+    cy.contains('test_repo_collection_version2');
+    cy.contains(`We couldn't find the page you're looking for!`).should(
+      'not.exist',
+    );
+
+    cy.deleteAllCollections();
+    cy.deleteRepositories();
   });
 });

--- a/test/cypress/e2e/collections/collections_list.js
+++ b/test/cypress/e2e/collections/collections_list.js
@@ -127,7 +127,7 @@ describe('Collections list Tests', () => {
     cy.get('.hub-list').contains('my_collection0');
 
     cy.get('.collection-container [aria-label="Actions"]').click();
-    cy.contains('Delete entire collection').click();
+    cy.contains('Delete entire collection from system').click();
     cy.get('[data-cy=modal_checkbox] input').click();
     cy.get('[data-cy=delete-button] button').click();
     cy.contains('Collection "my_collection0" has been successfully deleted.', {
@@ -155,7 +155,7 @@ describe('Collections list Tests', () => {
     cy.get('.body').contains('my_collection1');
 
     cy.get('.body [aria-label="Actions"]').click();
-    cy.contains('Delete entire collection').click();
+    cy.contains('Delete entire collection from system').click();
     cy.get('[data-cy=modal_checkbox] input').click();
     cy.get('[data-cy=delete-button] button').click();
 

--- a/test/cypress/e2e/misc/rbac.js
+++ b/test/cypress/e2e/misc/rbac.js
@@ -286,7 +286,7 @@ describe('RBAC test for user with permissions', () => {
 
     // can Delete collection
     cy.get('[data-cy=kebab-toggle]').should('exist').click();
-    cy.contains('Delete entire collection');
+    cy.contains('Delete entire collection from system');
   });
 
   it('should let view, add, change and delete users when user has permissions', () => {


### PR DESCRIPTION
Backports #3759 

(conflict with `issueUrl` not in 4.7)

---

* Menu option to delete collection from all/repo

* Delete collection operation

* Collection version menu option

* Delete collection version

* Test changes

* Test changes repairs

* Test for deletion collection from repo

* Tests fix

* WIP

* Clear of orphans

* Clear collections only

* Better cleanup

* Remove cleanup

* Delete version from repo test

* Handle translations

* Issue Issue: AAH-2261

* PR Checks

* Repair selector for insights

* Fix collection test for insights

* Fix collection test for insights2

* Finally really fix insights tests :)

* Switch contains and not contains

* Disable new test for insights

* Do not delete repos

* WIP

* Correct tests

* Collection Tests back to normal + new repo test

* Fix collection test

* Clear the mess done by previous commits in deleteAllCollections

* Make deleteNamespacesAndCollections clearer

* Move test to approvals

* Fix copy collection version test

* Disable removal from repo for insights

* Better translations in delete modal

* Change condition to display delete from repo to feature flag instead of insights mode

* Add deleteFromRepo string type

(cherry picked from commit c09590f3cc5e0b787a9739d7646254e78316349b)