### PR TITLE
Namespace detail: use is_highest consistently

### DIFF
--- a/CHANGES/2443.bug
+++ b/CHANGES/2443.bug
@@ -1,0 +1,1 @@
+Namespace detail: use is_highest consistently


### PR DESCRIPTION
namespace detail shows the number of collections .. until we call `updateParams` when adding a filter or doing pagination, then it switches to showing the numnber of collection versions.

Merge the 3 list queries into one function that's called twice .. once with real filters to set `collections` and `filteredCount`, and once with `page: 1, page_size: 1` to get the total `unfilteredCount` of all collections (which we then compare with 0).

Issue: AAH-2443