### PR TITLE
Dependabot, labeler: end of 4.6 full support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
     directory: '/'
     target-branch: 'stable-4.6'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     commit-message:
       prefix: '[stable-4.6] '
     ignore:
@@ -98,7 +98,7 @@ updates:
     commit-message:
       prefix: '[stable-4.6] '
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,10 +2,6 @@
 # to be looked at by PR author and reviewer to keep or remove
 # called by .github/workflows/labeler.yml
 
-backport-4.6:
-- src/**/*
-- test/**/*
-
 backport-4.7:
 - src/**/*
 - test/**/*


### PR DESCRIPTION
Change dependabot to update 4.6 monthly,
change labeler to not add backport-4.6 by default.