### PR TITLE
dependabot: keep 4.7 tests up to date as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,14 @@ updates:
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: 'npm'
+    directory: '/test'
+    target-branch: 'stable-4.7'
+    schedule:
+      interval: 'weekly'
+    commit-message:
+      prefix: '[stable-4.7] '
+
+  - package-ecosystem: 'npm'
     directory: '/'
     target-branch: 'stable-4.6'
     schedule:


### PR DESCRIPTION
to minimize differences from master

test/ is now identical between the two, except for insights/community tests removed from 4.7
