### PR TITLE
Remove alert from Task list view

### DIFF
--- a/CHANGES/2438.bug
+++ b/CHANGES/2438.bug
@@ -1,0 +1,1 @@
+Removed alert from task view page stating users could only see their tasks.  All authenticated users can list and retrieve task details.

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -93,13 +93,6 @@ export class TaskListView extends React.Component<RouteProps, IState> {
     } else {
       this.queryTasks();
     }
-
-    if (!hasPermission('core.view_task')) {
-      this.addAlert(
-        t`You do not have permission to view all tasks. Only tasks created by you are visible.`,
-        'info',
-      );
-    }
   }
 
   render() {

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -87,7 +87,7 @@ export class TaskListView extends React.Component<RouteProps, IState> {
   }
 
   componentDidMount() {
-    const { user, hasPermission } = this.context;
+    const { user } = this.context;
     if (!user || user.is_anonymous) {
       this.setState({ loading: false, unauthorised: true });
     } else {

--- a/test/cypress/e2e/misc/rbac.js
+++ b/test/cypress/e2e/misc/rbac.js
@@ -137,12 +137,11 @@ describe('RBAC test for user without permissions', () => {
     cy.contains('Sync from registry').should('not.exist');
   });
 
-  it("shouldn't let change task and delete task when user doesn't have permission", () => {
+  // TODO Create test for change/delete task without permission
+  it("should let view task when user doesn't have permission", () => {
     cy.visit(`${uiPrefix}tasks`);
-
     cy.get('[aria-label="Task list"] tr td a').first().click();
-
-    cy.contains('404 - Page not found');
+    cy.contains('Task detail');
   });
 });
 
@@ -377,7 +376,8 @@ describe('RBAC test for user with permissions', () => {
     );
   });
 
-  it('should let change and delete task when user has permission', () => {
+  // TODO Create test for change/delete task with permission
+  it('should let view task when user has permission', () => {
     cy.galaxykit('-i group role add', groupName, 'galaxy.test_task_management');
     cy.login(userName, userPassword);
 

--- a/test/cypress/e2e/misc/rbac.js
+++ b/test/cypress/e2e/misc/rbac.js
@@ -210,7 +210,7 @@ describe('RBAC test for user with permissions', () => {
     },
     {
       group: 'task_management',
-      permissions: ['core.view_task', 'core.delete_task', 'core.change_task'],
+      permissions: ['core.delete_task', 'core.change_task'],
     },
   ];
 
@@ -377,7 +377,7 @@ describe('RBAC test for user with permissions', () => {
     );
   });
 
-  it('should let view all tasks, change and delete task when user has permission', () => {
+  it('should let view all tasks. should let change and delete task when user has permission', () => {
     cy.galaxykit('-i group role add', groupName, 'galaxy.test_task_management');
     cy.login(userName, userPassword);
 

--- a/test/cypress/e2e/misc/rbac.js
+++ b/test/cypress/e2e/misc/rbac.js
@@ -137,7 +137,7 @@ describe('RBAC test for user without permissions', () => {
     cy.contains('Sync from registry').should('not.exist');
   });
 
-  it("shouldn't let view all tasks, change and delete task when user doesn't have permission", () => {
+  it("shouldn't let change task and delete task when user doesn't have permission", () => {
     cy.visit(`${uiPrefix}tasks`);
 
     cy.get('[aria-label="Task list"] tr td a').first().click();
@@ -377,7 +377,7 @@ describe('RBAC test for user with permissions', () => {
     );
   });
 
-  it('should let view all tasks. should let change and delete task when user has permission', () => {
+  it('should let change and delete task when user has permission', () => {
     cy.galaxykit('-i group role add', groupName, 'galaxy.test_task_management');
     cy.login(userName, userPassword);
 


### PR DESCRIPTION
Removed check for `core.view_task` permission that displayed an alert.  All authenticated users are able to [list tasks](https://github.com/ansible/galaxy_ng/blob/master/galaxy_ng/app/access_control/statements/pulp.py#L583) and [retrieve task details](https://github.com/ansible/galaxy_ng/blob/master/galaxy_ng/app/access_control/statements/pulp.py#L588) .

Issue: AAH-2438
