### PR TITLE
proxy /static/rest_framework/ to the django API

### DIFF
--- a/CHANGES/2148.bug
+++ b/CHANGES/2148.bug
@@ -1,0 +1,1 @@
+Properly display DRF API in browser with CSS

--- a/config/community.dev.webpack.config.js
+++ b/config/community.dev.webpack.config.js
@@ -46,5 +46,6 @@ module.exports = webpackBase({
     '/complete/': `http://${proxyHost}:${proxyPort}`,
     '/login/': `http://${proxyHost}:${proxyPort}`,
     '/pulp/api/': `http://${proxyHost}:${proxyPort}`,
+    '/static/rest_framework/': `http://${proxyHost}:${proxyPort}`,
   },
 });


### PR DESCRIPTION
Issue: AAH-2148

This properly loads the CSS for DRF's API views in the browser.