### PR TITLE
Repository/Remote delete: wait for task before requery, redirect to list screen instead of 404 after delete on detail

### DIFF
--- a/src/actions/action.tsx
+++ b/src/actions/action.tsx
@@ -4,7 +4,13 @@ import React from 'react';
 import { Tooltip } from 'src/components';
 import { type PermissionContextType } from 'src/permissions';
 
-type ModalType = ({ addAlert, state, setState, query }) => React.ReactNode;
+type ModalType = ({
+  addAlert,
+  listQuery,
+  query,
+  setState,
+  state,
+}) => React.ReactNode;
 
 interface ActionParams {
   buttonVariant?: 'primary' | 'secondary';

--- a/src/actions/ansible-remote-delete.tsx
+++ b/src/actions/ansible-remote-delete.tsx
@@ -9,12 +9,12 @@ import { Action } from './action';
 export const ansibleRemoteDeleteAction = Action({
   condition: canDeleteAnsibleRemote,
   title: msg`Delete`,
-  modal: ({ addAlert, query, setState, state }) =>
+  modal: ({ addAlert, listQuery, setState, state }) =>
     state.deleteModalOpen ? (
       <DeleteAnsibleRemoteModal
         closeAction={() => setState({ deleteModalOpen: null })}
         deleteAction={() =>
-          deleteRemote(state.deleteModalOpen, { addAlert, setState, query })
+          deleteRemote(state.deleteModalOpen, { addAlert, setState, listQuery })
         }
         name={state.deleteModalOpen.name}
       />
@@ -28,13 +28,13 @@ export const ansibleRemoteDeleteAction = Action({
     }),
 });
 
-function deleteRemote({ name, pulpId }, { addAlert, setState, query }) {
+function deleteRemote({ name, pulpId }, { addAlert, setState, listQuery }) {
   return AnsibleRemoteAPI.delete(pulpId)
     .then(({ data }) => {
       addAlert(taskAlert(data.task, t`Removal started for remote ${name}`));
 
       setState({ deleteModalOpen: null });
-      query();
+      listQuery();
     })
     .catch(
       handleHttpError(t`Failed to remove remote ${name}`, () => null, addAlert),

--- a/src/actions/ansible-remote-delete.tsx
+++ b/src/actions/ansible-remote-delete.tsx
@@ -3,7 +3,12 @@ import React from 'react';
 import { AnsibleRemoteAPI } from 'src/api';
 import { DeleteAnsibleRemoteModal } from 'src/components';
 import { canDeleteAnsibleRemote } from 'src/permissions';
-import { handleHttpError, parsePulpIDFromURL, taskAlert } from 'src/utilities';
+import {
+  handleHttpError,
+  parsePulpIDFromURL,
+  taskAlert,
+  waitForTaskUrl,
+} from 'src/utilities';
 import { Action } from './action';
 
 export const ansibleRemoteDeleteAction = Action({
@@ -32,10 +37,10 @@ function deleteRemote({ name, pulpId }, { addAlert, setState, listQuery }) {
   return AnsibleRemoteAPI.delete(pulpId)
     .then(({ data }) => {
       addAlert(taskAlert(data.task, t`Removal started for remote ${name}`));
-
       setState({ deleteModalOpen: null });
-      listQuery();
+      return waitForTaskUrl(data.task);
     })
+    .then(() => listQuery())
     .catch(
       handleHttpError(t`Failed to remove remote ${name}`, () => null, addAlert),
     );

--- a/src/actions/ansible-repository-delete.tsx
+++ b/src/actions/ansible-repository-delete.tsx
@@ -10,12 +10,16 @@ import { Action } from './action';
 export const ansibleRepositoryDeleteAction = Action({
   condition: canDeleteAnsibleRepository,
   title: msg`Delete`,
-  modal: ({ addAlert, query, setState, state }) =>
+  modal: ({ addAlert, listQuery, setState, state }) =>
     state.deleteModalOpen ? (
       <DeleteAnsibleRepositoryModal
         closeAction={() => setState({ deleteModalOpen: null })}
         deleteAction={() =>
-          deleteRepository(state.deleteModalOpen, { addAlert, setState, query })
+          deleteRepository(state.deleteModalOpen, {
+            addAlert,
+            listQuery,
+            setState,
+          })
         }
         name={state.deleteModalOpen.name}
       />
@@ -42,7 +46,7 @@ export const ansibleRepositoryDeleteAction = Action({
 
 async function deleteRepository(
   { name, pulp_href, pulpId },
-  { addAlert, setState, query },
+  { addAlert, setState, listQuery },
 ) {
   const distributionsToDelete = await AnsibleDistributionAPI.list({
     repository: pulp_href,
@@ -91,6 +95,6 @@ async function deleteRepository(
     ...distributionsToDelete.map(deleteDistribution),
   ]).then(() => {
     setState({ deleteModalOpen: null });
-    query();
+    listQuery();
   });
 }

--- a/src/components/page/list-page.tsx
+++ b/src/components/page/list-page.tsx
@@ -64,7 +64,13 @@ export type RenderTableRow<T> = (
   { addAlert, setState = null },
   listItemActions?,
 ) => React.ReactNode;
-type RenderModals = ({ addAlert, state, setState, query }) => React.ReactNode;
+type RenderModals = ({
+  addAlert,
+  listQuery,
+  query,
+  setState,
+  state,
+}) => React.ReactNode;
 type SortHeaders = {
   title: MessageDescriptor;
   type: string;
@@ -222,6 +228,7 @@ export const ListPage = function <T>({
         addAlert: (alert) => this.addAlert(alert),
         hasObjectPermission: () => false, // list items don't load my_permissions .. but superadmin should still work
         hasPermission: this.context.hasPermission,
+        listQuery: () => this.query(),
         navigate: this.props.navigate,
         query: () => this.query(),
         queueAlert: this.context.queueAlert,

--- a/src/components/page/page-with-tabs.tsx
+++ b/src/components/page/page-with-tabs.tsx
@@ -44,7 +44,13 @@ interface IState<T> {
 // unauthorised - only EmptyStateUnauthorized, header and alerts
 // (data) - renders detail
 
-type RenderModals = ({ addAlert, state, setState, query }) => React.ReactNode;
+type RenderModals = ({
+  addAlert,
+  listQuery,
+  query,
+  setState,
+  state,
+}) => React.ReactNode;
 
 interface PageWithTabsParams<T> {
   breadcrumbs: ({ name, tab, params }) => { url?: string; name: string }[];
@@ -53,6 +59,7 @@ interface PageWithTabsParams<T> {
   errorTitle: MessageDescriptor;
   headerActions?: ActionType[];
   headerDetails?: (item) => React.ReactNode;
+  listUrl: string;
   query: ({ name }) => Promise<T>;
   renderModals?: RenderModals;
   renderTab: (tab, item, actionContext) => React.ReactNode;
@@ -75,6 +82,8 @@ export const PageWithTabs = function <
   headerActions,
   // under title
   headerDetails,
+  // formatPath result to navigate to - to get to the list screen
+  listUrl,
   // () => Promise<T>
   query,
   // ({ addAlert, state, setState, query }) => <ConfirmationModal... />
@@ -144,6 +153,7 @@ export const PageWithTabs = function <
         hasObjectPermission: (permission) =>
           item?.my_permissions?.includes?.(permission),
         hasPermission: this.context.hasPermission,
+        listQuery: () => this.props.navigate(listUrl),
         navigate: this.props.navigate,
         query: () => this.query(),
         queueAlert: this.context.queueAlert,

--- a/src/components/page/page.tsx
+++ b/src/components/page/page.tsx
@@ -33,7 +33,13 @@ interface IState<T> {
 // unauthorised - only EmptyStateUnauthorized, header and alerts
 // (data) - renders detail
 
-type RenderModals = ({ addAlert, state, setState, query }) => React.ReactNode;
+type RenderModals = ({
+  addAlert,
+  listQuery,
+  query,
+  setState,
+  state,
+}) => React.ReactNode;
 
 interface PageParams<T> {
   breadcrumbs: ({ name }) => { url?: string; name: string }[];
@@ -41,6 +47,7 @@ interface PageParams<T> {
   displayName: string;
   errorTitle: MessageDescriptor;
   headerActions?: ActionType[];
+  listUrl: string;
   query: ({ name }) => Promise<T>;
   title: ({ name }) => string;
   transformParams: (routeParams) => Record<string, string>;
@@ -61,6 +68,8 @@ export const Page = function <
   errorTitle,
   // displayed after filters
   headerActions,
+  // formatPath result to navigate to - to get to the list screen
+  listUrl,
   // () => Promise<T>
   query,
   title,
@@ -120,6 +129,7 @@ export const Page = function <
         hasObjectPermission: (permission) =>
           item?.my_permissions?.includes?.(permission),
         hasPermission: this.context.hasPermission,
+        listQuery: () => this.props.navigate(listUrl),
         navigate: this.props.navigate,
         query: () => this.query(),
         queueAlert: this.context.queueAlert,

--- a/src/containers/ansible-remote/detail.tsx
+++ b/src/containers/ansible-remote/detail.tsx
@@ -49,6 +49,7 @@ const AnsibleRemoteDetail = PageWithTabs<AnsibleRemoteType>({
     ansibleRemoteDownloadCAAction,
     ansibleRemoteDeleteAction,
   ],
+  listUrl: formatPath(Paths.ansibleRemotes),
   query: ({ name }) => {
     return AnsibleRemoteAPI.list({ name })
       .then(({ data: { results } }) => results[0])

--- a/src/containers/ansible-remote/edit.tsx
+++ b/src/containers/ansible-remote/edit.tsx
@@ -41,6 +41,7 @@ const AnsibleRemoteEdit = Page<AnsibleRemoteType>({
     canAddAnsibleRemote(context) || canEditAnsibleRemote(context, item),
   displayName: 'AnsibleRemoteEdit',
   errorTitle: msg`Remote could not be displayed.`,
+  listUrl: formatPath(Paths.ansibleRemotes),
   query: ({ name }) => {
     return AnsibleRemoteAPI.list({ name })
       .then(({ data: { results } }) => results[0])

--- a/src/containers/ansible-repository/detail.tsx
+++ b/src/containers/ansible-repository/detail.tsx
@@ -69,6 +69,7 @@ const AnsibleRepositoryDetail = PageWithTabs<AnsibleRepositoryType>({
       )}
     </>
   ),
+  listUrl: formatPath(Paths.ansibleRepositories),
   query: ({ name }) => {
     return AnsibleRepositoryAPI.list({ name })
       .then(({ data: { results } }) => results[0])

--- a/src/containers/ansible-repository/edit.tsx
+++ b/src/containers/ansible-repository/edit.tsx
@@ -36,6 +36,7 @@ const AnsibleRepositoryEdit = Page<AnsibleRepositoryType>({
     canAddAnsibleRepository(context) || canEditAnsibleRepository(context, item),
   displayName: 'AnsibleRepositoryEdit',
   errorTitle: msg`Repository could not be displayed.`,
+  listUrl: formatPath(Paths.ansibleRepositories),
   query: ({ name }) => {
     return AnsibleRepositoryAPI.list({ name })
       .then(({ data: { results } }) => results[0])

--- a/src/utilities/fail-alerts.ts
+++ b/src/utilities/fail-alerts.ts
@@ -22,27 +22,25 @@ export function errorMessage(
 }
 
 export const handleHttpError = (title, callback, addAlert) => (e) => {
-  const { status, statusText } = e.response;
-  console.log(typeof e.response.data);
+  let description = e.toString();
 
-  let message = '';
-  const err_detail = mapErrorMessages(e);
-  for (const msg in err_detail) {
-    message = message + err_detail[msg] + ' ';
-  }
+  if (e.response) {
+    // HTTP error
+    const { status, statusText } = e.response;
 
-  let description;
+    const err = mapErrorMessages(e);
+    const message = Object.values(err).join(' ');
 
-  if (message !== '') {
-    description = errorMessage(status, statusText, message);
-  } else {
-    description = errorMessage(status, statusText);
+    description = message
+      ? errorMessage(status, statusText, message)
+      : errorMessage(status, statusText);
   }
 
   addAlert({
     title,
     variant: 'danger',
-    description: description,
+    description,
   });
+
   callback();
 };

--- a/test/cypress/e2e/collections/collection.js
+++ b/test/cypress/e2e/collections/collection.js
@@ -82,7 +82,7 @@ describe('collection tests', () => {
       `Started adding ${namespace}.${collection} v1.0.0 from "published" to repository "validated".`,
     );
     cy.get('[data-cy="AlertList"]').contains('detail page').click();
-    cy.contains('Completed');
+    cy.contains('Completed', { timeout: 10000 });
   });
 
   it('deletes an collection from repository', () => {

--- a/test/cypress/e2e/repo/repository.js
+++ b/test/cypress/e2e/repo/repository.js
@@ -13,14 +13,16 @@ function versionCheck(version) {
   );
 }
 
-describe('Repository', () => {
-  ['with remote', 'without remote'].forEach((mode) => {
-    it('creates, edit and sync repository ' + mode, () => {
+['with remote', 'without remote'].forEach((mode) => {
+  const withRemote = mode === 'with remote';
+
+  describe(`Repository ${mode}`, () => {
+    it('creates, edit and sync repository', () => {
       cy.login();
 
       cy.deleteRepositories();
 
-      if (mode == 'with remote') {
+      if (withRemote) {
         cy.galaxykit(
           '-i remote create',
           'exampleTestRepository',
@@ -81,7 +83,7 @@ describe('Repository', () => {
         .clear()
         .type('5');
 
-      if (mode == 'with remote') {
+      if (withRemote) {
         // add remote
         cy.get('[data-cy="remote"] button').click();
         cy.contains('[data-cy="remote"]', 'rh-certified');
@@ -104,7 +106,7 @@ describe('Repository', () => {
         '5',
       );
 
-      if (mode == 'with remote') {
+      if (withRemote) {
         // try to sync it
         cy.contains('button', 'Sync').click();
         cy.get('.pf-c-modal-box__footer .pf-m-primary')
@@ -117,11 +119,11 @@ describe('Repository', () => {
       }
     });
 
-    it('checks there is only 1 version ' + mode, () => {
+    it('checks there is only 1 version', () => {
       versionCheck(0);
     });
 
-    it('adds  collections ' + mode, () => {
+    it('adds collections', () => {
       cy.login();
       cy.visit(uiPrefix + 'ansible/repositories/repo1Test/');
       cy.contains('button', 'Collection versions').click();
@@ -142,22 +144,19 @@ describe('Repository', () => {
       cy.contains('Completed', { timeout: 10000 });
     });
 
-    it(
-      'checks there are 2 versions and collection is here (' + mode + ')',
-      () => {
-        versionCheck(1);
-        cy.contains(
-          '[data-cy="PageWithTabs-AnsibleRepositoryDetail-repository-versions"] a',
-          1,
-        ).click();
-        cy.contains(
-          '[data-cy="PageWithTabs-AnsibleRepositoryDetail-repository-versions"]',
-          'repo_test_namespace.repo_test_collection v1.0.0',
-        );
-      },
-    );
+    it('checks there are 2 versions and collection is here', () => {
+      versionCheck(1);
+      cy.contains(
+        '[data-cy="PageWithTabs-AnsibleRepositoryDetail-repository-versions"] a',
+        1,
+      ).click();
+      cy.contains(
+        '[data-cy="PageWithTabs-AnsibleRepositoryDetail-repository-versions"]',
+        'repo_test_namespace.repo_test_collection v1.0.0',
+      );
+    });
 
-    it('removes  collections ' + mode, () => {
+    it('removes collections', () => {
       cy.login();
       cy.visit(
         uiPrefix + 'ansible/repositories/repo1Test/?tab=collection-versions',
@@ -170,7 +169,7 @@ describe('Repository', () => {
       // checking for message and clicking detail page does not work, it fails, not sure why
     });
 
-    it('checks if collection was removed ' + mode, () => {
+    it('checks if collection was removed', () => {
       cy.login();
       cy.visit(
         uiPrefix + 'ansible/repositories/repo1Test/?tab=collection-versions',
@@ -179,7 +178,7 @@ describe('Repository', () => {
       cy.contains('No collection versions yet');
     });
 
-    it('checks there are 3 versions and revert repo ' + mode, () => {
+    it('checks there are 3 versions and revert repo', () => {
       versionCheck(2);
       cy.get(
         '[data-cy="PageWithTabs-AnsibleRepositoryDetail-repository-versions"] [aria-label="Actions"]',
@@ -190,7 +189,7 @@ describe('Repository', () => {
       cy.contains('button', 'Revert').click();
     });
 
-    it('checks if collection is added again ' + mode, () => {
+    it('checks if collection is added again', () => {
       cy.login();
       cy.visit(
         uiPrefix + 'ansible/repositories/repo1Test/?tab=collection-versions',


### PR DESCRIPTION
For both Ansible Repositories and Ansible Remotes,

before, on a list screen: delete triggers a pulp task and reloads the list - the list may update before the delete task finished
after: UI waits for pulp task to finish before reloading

before, on a detail screen: delete triggers a pulp task and reloads the detail - can either update before deletion or successfully 404
after: UI waits for pulp task to finish before redirecting to list screen
