### PR TITLE
[stable-4.7] CI: Fix galaxykit version to 0.14

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -43,7 +43,7 @@ jobs:
     - name: "Install galaxykit dependency"
       run: |
         # pip install git+https://github.com/ansible/galaxykit.git@branch_name
-        pip install galaxykit
+        pip install galaxykit==0.14.0
 
     - name: "Set env.SHORT_BRANCH"
       run: |


### PR DESCRIPTION
Setting galaxykit version on 4.7 CI  to 0.14.0 to make sure future releases don't break things.

4.6: https://github.com/ansible/ansible-hub-ui/pull/3503, 0.13.0
4.5: https://github.com/ansible/ansible-hub-ui/pull/1969, 0.8.0