### PR TITLE
dependabot: ignore `@patternfly/*` major version updates in stable-\*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,13 +18,13 @@ updates:
     commit-message:
       prefix: '[stable-4.7] '
     ignore:
+      - dependency-name: "@patternfly/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/react"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: 'npm'
@@ -43,13 +43,13 @@ updates:
     commit-message:
       prefix: '[stable-4.6] '
     ignore:
+      - dependency-name: "@patternfly/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/react"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: 'npm'
@@ -60,13 +60,13 @@ updates:
     commit-message:
       prefix: '[stable-4.5] '
     ignore:
+      - dependency-name: "@patternfly/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/react"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: 'npm'
@@ -77,13 +77,13 @@ updates:
     commit-message:
       prefix: '[stable-4.2] '
     ignore:
+      - dependency-name: "@patternfly/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/*"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "react"
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/react"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
to prevent dependabot from trying to update  to patternfly v5 in stable branches

also changes the ignore entries for `@types/*` to use a wildcard