### PR TITLE
generate_manifest: support lockfileVersion 3

### DIFF
--- a/.travis/generate_manifest.js
+++ b/.travis/generate_manifest.js
@@ -18,13 +18,13 @@ function processPackage(name, pkg, result) {
         result[entry] = entry
     }
 
-    if (pkg.dependencies) {
+    if (pkg.packages) {
         processDependencies(pkg, result);
     }
 }
 
 function processDependencies(pkg, result) {
-    Object.entries(pkg.dependencies).forEach(([name, entry]) => {
+    Object.entries(pkg.packages).forEach(([name, entry]) => {
         if (entry.dev === true) {
             return;
         }


### PR DESCRIPTION
`package-lock.json` changed from v2 to v3,
and now dependencies are just called packages.

fixes `TypeError: Cannot convert undefined or null to object` during the `update-manifst` GH action
https://github.com/ansible/ansible-hub-ui/actions/runs/5741637467/job/15562150565#step:5:14