### PR TITLE
Add a 404 Dispatch page, handle some old galaxy URLs

### DIFF
--- a/CHANGES/2342.bug
+++ b/CHANGES/2342.bug
@@ -1,0 +1,1 @@
+Support old galaxy URLs outside of base path, disambiguate

--- a/src/api/response-types/task.ts
+++ b/src/api/response-types/task.ts
@@ -1,4 +1,4 @@
-import { PulpStatus } from 'src/api';
+import { PulpStatus } from './pulp';
 
 export class TaskType {
   pulp_created: string;

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -31,6 +31,7 @@ export { default as MyImports } from './my-imports/my-imports';
 export { default as NamespaceDetail } from './namespace-detail/namespace-detail';
 export { default as MyNamespaces } from './namespace-list/my-namespaces';
 export { default as Partners } from './namespace-list/partners';
+export { default as Dispatch } from './not-found/dispatch';
 export { default as NotFound } from './not-found/not-found';
 export { default as RoleCreate } from './role-management/role-create';
 export { default as EditRole } from './role-management/role-edit';

--- a/src/containers/legacy-roles/legacy-role.tsx
+++ b/src/containers/legacy-roles/legacy-role.tsx
@@ -363,7 +363,7 @@ class LegacyRole extends React.Component<RouteProps, IProps> {
     const breadcrumbs = [
       {
         name: 'Legacy Roles',
-        url: formatPath(Paths.legacyRoles, {}),
+        url: formatPath(Paths.legacyRoles),
       },
       {
         name: this.state.github_user,

--- a/src/containers/not-found/dispatch.tsx
+++ b/src/containers/not-found/dispatch.tsx
@@ -1,0 +1,26 @@
+import { t } from '@lingui/macro';
+import React from 'react';
+import { BaseHeader, Main } from 'src/components';
+import { ParamHelper, RouteProps, withRouter } from 'src/utilities';
+
+export const Dispatch = (props: RouteProps) => {
+  const { pathname } = ParamHelper.parseParamString(props.location.search) as {
+    pathname: string;
+  };
+
+  // TODO query collections and legacy roles apis, show links if exists
+
+  return (
+    <>
+      <BaseHeader title={t`404 - Page not found`} />
+      <Main>
+        <section className='body'>
+          <div>{t`We couldn't find the page you're looking for!`}</div>
+          <div className='pf-c-content'>{pathname}</div>
+        </section>
+      </Main>
+    </>
+  );
+};
+
+export default withRouter(Dispatch);

--- a/src/containers/not-found/dispatch.tsx
+++ b/src/containers/not-found/dispatch.tsx
@@ -7,6 +7,7 @@ import { CollectionVersionAPI, LegacyRoleAPI } from 'src/api';
 import {
   BaseHeader,
   CollectionListItem,
+  EmptyStateNoData,
   LegacyRoleListItem,
   LoadingPageSpinner,
   Main,
@@ -51,8 +52,6 @@ export const Dispatch = (props: RouteProps) => {
     }
   }, [pathname]);
 
-  // TODO empty states proper
-
   return (
     <>
       <BaseHeader title={t`404 - Page not found`} />
@@ -82,23 +81,30 @@ export const Dispatch = (props: RouteProps) => {
           {collections === null ? (
             <LoadingPageSpinner />
           ) : collections.length === 0 ? (
+            <EmptyStateNoData
+              title={t`No matching collections found.`}
+              description={
+                <Link
+                  to={formatPath(Paths.collections)}
+                >{t`Show all collections`}</Link>
+              }
+            />
+          ) : (
             <>
-              <div>{t`No matching collections found.`}</div>
+              <DataList aria-label={t`Available matching collections`}>
+                {collections.map((c, i) => (
+                  <CollectionListItem
+                    key={i}
+                    collection={c}
+                    displaySignatures={featureFlags.display_signatures}
+                    showNamespace={true}
+                  />
+                ))}
+              </DataList>
               <Link
                 to={formatPath(Paths.collections)}
               >{t`Show all collections`}</Link>
             </>
-          ) : (
-            <DataList aria-label={t`Available matching collections`}>
-              {collections.map((c, i) => (
-                <CollectionListItem
-                  key={i}
-                  collection={c}
-                  displaySignatures={featureFlags.display_signatures}
-                  showNamespace={true}
-                />
-              ))}
-            </DataList>
           )}
         </PageSection>
         {featureFlags.legacy_roles ? (
@@ -110,22 +116,29 @@ export const Dispatch = (props: RouteProps) => {
               {roles === null ? (
                 <LoadingPageSpinner />
               ) : roles.length === 0 ? (
+                <EmptyStateNoData
+                  title={t`No matching legacy roles found.`}
+                  description={
+                    <Link
+                      to={formatPath(Paths.legacyRoles)}
+                    >{t`Show all legacy roles`}</Link>
+                  }
+                />
+              ) : (
                 <>
-                  <div>{t`No matching legacy roles found.`}</div>
+                  <DataList aria-label={t`Available matching legacy roles`}>
+                    {roles.map((r) => (
+                      <LegacyRoleListItem
+                        key={r.id}
+                        role={r}
+                        show_thumbnail={true}
+                      />
+                    ))}
+                  </DataList>
                   <Link
                     to={formatPath(Paths.legacyRoles)}
                   >{t`Show all legacy roles`}</Link>
                 </>
-              ) : (
-                <DataList aria-label={t`Available matching legacy roles`}>
-                  {roles.map((r) => (
-                    <LegacyRoleListItem
-                      key={r.id}
-                      role={r}
-                      show_thumbnail={true}
-                    />
-                  ))}
-                </DataList>
               )}
             </PageSection>
           </>

--- a/src/containers/not-found/dispatch.tsx
+++ b/src/containers/not-found/dispatch.tsx
@@ -1,23 +1,101 @@
-import { t } from '@lingui/macro';
-import React from 'react';
-import { BaseHeader, Main } from 'src/components';
+import { Trans, t } from '@lingui/macro';
+import { DataList } from '@patternfly/react-core';
+import React, { ReactNode, useEffect, useState } from 'react';
+import { CollectionVersionAPI, LegacyRoleAPI } from 'src/api';
+import {
+  BaseHeader,
+  CollectionListItem,
+  LegacyRoleListItem,
+  LoadingPageSpinner,
+  Main,
+} from 'src/components';
 import { ParamHelper, RouteProps, withRouter } from 'src/utilities';
+
+const PageSection = ({ children, ...rest }: { children: ReactNode }) => (
+  <section className='body' {...rest}>
+    {children}
+  </section>
+);
+
+const SectionSeparator = () => <section>&nbsp;</section>;
+
+const SectionTitle = ({ children }: { children: ReactNode }) => (
+  <h2 className='pf-c-title'>{children}</h2>
+);
 
 export const Dispatch = (props: RouteProps) => {
   const { pathname } = ParamHelper.parseParamString(props.location.search) as {
     pathname: string;
   };
 
-  // TODO query collections and legacy roles apis, show links if exists
+  const [namespace, name] = pathname.split('/').filter(Boolean);
+
+  const [collections, setCollections] = useState(null);
+  const [roles, setRoles] = useState(null);
+
+  useEffect(() => {
+    CollectionVersionAPI.list({ namespace, name, is_highest: true })
+      .then(({ data: { data } }) => setCollections(data || []))
+      .catch(() => setCollections([]));
+    LegacyRoleAPI.list({ username: namespace, name })
+      .then(({ data: { results } }) => setRoles(results || []))
+      .catch(() => setRoles([]));
+  }, [pathname]);
+
+  // TODO condition for roles feature flag, signatures feature flag
+  // TODO empty states proper
+  // TODO center empty state top
 
   return (
     <>
       <BaseHeader title={t`404 - Page not found`} />
       <Main>
-        <section className='body'>
+        <PageSection>
           <div>{t`We couldn't find the page you're looking for!`}</div>
-          <div className='pf-c-content'>{pathname}</div>
-        </section>
+          <div>
+            <Trans>
+              Pathname <pre style={{ display: 'inline-block' }}>{pathname}</pre>{' '}
+              could refer to a collection or a role.
+            </Trans>
+          </div>
+        </PageSection>
+        <SectionSeparator />
+        <PageSection>
+          <SectionTitle>{t`Collections`}</SectionTitle>
+
+          {collections === null ? (
+            <LoadingPageSpinner />
+          ) : collections.length === 0 ? (
+            <div>{t`No matching collections found.`}</div>
+          ) : (
+            <DataList aria-label={t`Available matching collections`}>
+              {collections.map((c, i) => (
+                <CollectionListItem
+                  key={i}
+                  collection={c}
+                  displaySignatures={true}
+                  showNamespace={true}
+                />
+              ))}
+            </DataList>
+          )}
+        </PageSection>
+        <SectionSeparator />
+        <PageSection>
+          <SectionTitle>{t`Legacy roles`}</SectionTitle>
+
+          {roles === null ? (
+            <LoadingPageSpinner />
+          ) : roles.length === 0 ? (
+            <div>{t`No matching legacy roles found.`}</div>
+          ) : (
+            <DataList aria-label={t`Available matching legacy roles`}>
+              {roles.map((r) => (
+                <LegacyRoleListItem key={r.id} role={r} show_thumbnail={true} />
+              ))}
+            </DataList>
+          )}
+        </PageSection>
       </Main>
     </>
   );

--- a/src/containers/not-found/dispatch.tsx
+++ b/src/containers/not-found/dispatch.tsx
@@ -1,7 +1,8 @@
 import { Trans, t } from '@lingui/macro';
-import { DataList } from '@patternfly/react-core';
+import { Bullseye, DataList } from '@patternfly/react-core';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
+import NotFoundImage from 'src/../static/images/not_found.svg';
 import { CollectionVersionAPI, LegacyRoleAPI } from 'src/api';
 import {
   BaseHeader,
@@ -51,23 +52,28 @@ export const Dispatch = (props: RouteProps) => {
   }, [pathname]);
 
   // TODO empty states proper
-  // TODO center empty state top
 
   return (
     <>
       <BaseHeader title={t`404 - Page not found`} />
       <Main>
         <PageSection>
-          <div>{t`We couldn't find the page you're looking for!`}</div>
-          <div>
-            <Trans>
-              Pathname <pre style={{ display: 'inline-block' }}>{pathname}</pre>{' '}
-              could refer to a collection or a role.
-            </Trans>{' '}
-            {featureFlags.legacy_roles ? null : (
-              <Trans>Roles are not currently enabled.</Trans>
-            )}
-          </div>
+          <Bullseye>
+            <div className='hub-c-bullseye__center'>
+              <img src={NotFoundImage} alt={t`Not found`} width='128px' />
+              <div>{t`We couldn't find the page you're looking for!`}</div>
+              <div className='pf-c-content'>
+                <Trans>
+                  Pathname{' '}
+                  <pre style={{ display: 'inline-block' }}>{pathname}</pre>{' '}
+                  could refer to a collection or a role.
+                </Trans>{' '}
+                {featureFlags.legacy_roles ? null : (
+                  <Trans>Roles are not currently enabled.</Trans>
+                )}
+              </div>
+            </div>
+          </Bullseye>
         </PageSection>
         <SectionSeparator />
         <PageSection>

--- a/src/entry-standalone.tsx
+++ b/src/entry-standalone.tsx
@@ -6,27 +6,20 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import 'src/l10n';
 import App from './loaders/standalone/loader';
 
-// support common original galaxy urls
-// return falsy for default, or an url starting with a slash
-function redirect(from) {
-  console.debug('pathname outside base path', from);
-
-  // match /namespace/name & /namespace/name/
-  if (from.match(/^\/(\w+)\/(\w+)\/?$/)) {
-    return '/dispatch/?pathname=' + encodeURIComponent(from);
-  }
-}
-
 // Entrypoint for compiling the app to run in standalone mode
 
-// react-router v6 won't redirect to base path by default
-if (!window.location.pathname.includes(UI_BASE_PATH)) {
-  window.history.pushState(
-    null,
-    null,
-    UI_BASE_PATH.replace(/\/$/, '') +
-      (redirect(window.location.pathname) || '/'),
-  );
+if (!window.location.pathname.startsWith(UI_BASE_PATH)) {
+  // react-router v6 won't redirect to base path by default
+  // also support old-galaxy /namespace/name/ urls
+  const originalPath = window.location.pathname;
+  const newPath = originalPath.match(/^\/(\w+)\/(\w+)\/?$/)
+    ? UI_BASE_PATH.replace(
+        /\/$/,
+        '/dispatch/?pathname=' + encodeURIComponent(originalPath),
+      )
+    : UI_BASE_PATH;
+
+  window.history.pushState(null, null, newPath);
 }
 
 ReactDOM.render(

--- a/src/entry-standalone.tsx
+++ b/src/entry-standalone.tsx
@@ -6,11 +6,27 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import 'src/l10n';
 import App from './loaders/standalone/loader';
 
+// support common original galaxy urls
+// return falsy for default, or an url starting with a slash
+function redirect(from) {
+  console.debug('pathname outside base path', from);
+
+  // match /namespace/name & /namespace/name/
+  if (from.match(/^\/(\w+)\/(\w+)\/?$/)) {
+    return '/dispatch/?pathname=' + encodeURIComponent(from);
+  }
+}
+
 // Entrypoint for compiling the app to run in standalone mode
 
+// react-router v6 won't redirect to base path by default
 if (!window.location.pathname.includes(UI_BASE_PATH)) {
-  // react-router v6 won't redirect to base path by default
-  window.history.pushState(null, null, UI_BASE_PATH);
+  window.history.pushState(
+    null,
+    null,
+    UI_BASE_PATH.replace(/\/$/, '') +
+      (redirect(window.location.pathname) || '/'),
+  );
 }
 
 ReactDOM.render(

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -221,7 +221,7 @@ function Menu({ items, context, expandedSections }) {
     <>
       {items.map((item) => (
         <ItemOrSection
-          key={item.name}
+          key={item.url || item.name}
           item={item}
           context={context}
           expandedSections={expandedSections}

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -16,6 +16,7 @@ import {
   CollectionDistributions,
   CollectionDocs,
   CollectionImportLog,
+  Dispatch,
   EditNamespace,
   EditRole,
   EditUser,
@@ -289,6 +290,7 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
       { component: NamespaceDetail, path: Paths.namespace },
       { component: Search, path: Paths.collections },
       { component: LandingPage, path: Paths.landingPage },
+      { component: Dispatch, path: Paths.dispatch },
     ];
   }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -63,6 +63,7 @@ export enum Paths {
   ansibleRepositories = '/ansible/repositories',
   ansibleRepositoryDetail = '/ansible/repositories/:name',
   ansibleRepositoryEdit = '/ansible/repositories/:name/edit',
+  dispatch = '/dispatch',
   executionEnvironmentDetail = '/containers/:container',
   executionEnvironmentDetailWithNamespace = '/containers/:namespace/:container',
   executionEnvironmentDetailActivities = '/containers/:container/_content/activity',


### PR DESCRIPTION
Issue: AAH-2342

old galaxy UI base path is `/`, `/{namespace}/{name}/` is a valid old galaxy URL

new galaxy UI base path is `/ui/`, and URLs for collections are different from URLs for legacy roles

we still want to support old URLs, so, when navigating to `(new-galaxy)/foo/bar/`:
* backend will just serve the UI for unknown urls
* UI entry-standalone will notice URLs outside the `/ui/` base path, and redirect to `/ui/dispatch?pathname=/foo/bar`
* `/dispatch` is a new route, renders a 404-like `Dispatch` container
* `Dispatch` container can query the APIs and show links to either the `foo/bar` collection or the `foo/bar` role, or both.

![20230811010510](https://github.com/ansible/ansible-hub-ui/assets/289743/cecc388a-daad-4f05-afd7-d4288f7ed018)
![20230811010520](https://github.com/ansible/ansible-hub-ui/assets/289743/21c92688-4d50-4b84-9a6b-6922916f01a8)
![20230811010622](https://github.com/ansible/ansible-hub-ui/assets/289743/95a5f32e-7b3c-4641-93ec-42ba9258ee04)
