### PR TITLE
cypress.yml: rename COMPOSE_PROFILE to BACKEND_FLAVOR

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -48,23 +48,23 @@ jobs:
         # pip install git+https://github.com/ansible/galaxykit.git@branch_name
         pip install git+https://github.com/ansible/galaxykit.git
 
-    - name: "Set env.SHORT_BRANCH, COMPOSE_PROFILE"
+    - name: "Set env.SHORT_BRANCH, BACKEND_FLAVOR"
       run: |
         SHORT_BRANCH=`sed 's/^refs\/heads\///' <<< $BRANCH`
 
         case "${{ matrix.test }}" in
           insights*)
-            COMPOSE_PROFILE=insights
+            BACKEND_FLAVOR=insights
             echo "insights"
             ;;
           *)
-            COMPOSE_PROFILE=standalone
+            BACKEND_FLAVOR=standalone
             echo "standalone"
             ;;
         esac
 
         echo "SHORT_BRANCH=${SHORT_BRANCH}" >> $GITHUB_ENV
-        echo "COMPOSE_PROFILE=${COMPOSE_PROFILE}" >> $GITHUB_ENV
+        echo "BACKEND_FLAVOR=${BACKEND_FLAVOR}" >> $GITHUB_ENV
         echo "COMPOSE_INTERACTIVE_NO_CLI=1" >> $GITHUB_ENV
 
     - name: "Set variables for screenshots"
@@ -102,7 +102,7 @@ jobs:
         pip install --editable ./client/
         # merge common, profile-specific and test matrix specific config
         cat ../ansible-hub-ui/.github/workflows/cypress/compose.env.common \
-          ../ansible-hub-ui/.github/workflows/cypress/compose.env."$COMPOSE_PROFILE" \
+          ../ansible-hub-ui/.github/workflows/cypress/compose.env."$BACKEND_FLAVOR" \
           ../ansible-hub-ui/test/cypress/e2e/"${{ matrix.test }}"/compose.env \
           | sed 's/^\s\+//' | tee compose.env || [ -s compose.env ]
 
@@ -131,7 +131,7 @@ jobs:
           npm-
 
     - name: "Build standalone UI"
-      if: ${{ env.COMPOSE_PROFILE == 'standalone' }}
+      if: ${{ env.BACKEND_FLAVOR == 'standalone' }}
       working-directory: 'ansible-hub-ui'
       run: |
         npm install
@@ -147,7 +147,7 @@ jobs:
         echo "BUILD_HASH=${BUILD_HASH}" >> $GITHUB_ENV
 
     - name: "Serve standalone UI"
-      if: ${{ env.COMPOSE_PROFILE == 'standalone' }}
+      if: ${{ env.BACKEND_FLAVOR == 'standalone' }}
       run: |
         mkdir -p www/static/
         mv ansible-hub-ui/dist www/static/galaxy_ng
@@ -161,7 +161,7 @@ jobs:
           --rewrite '/extensions/v2/(.*) -> http://localhost:5001/extensions/v2/$1' &
 
     - name: "Run insights UI"
-      if: ${{ env.COMPOSE_PROFILE == 'insights' }}
+      if: ${{ env.BACKEND_FLAVOR == 'insights' }}
       working-directory: 'ansible-hub-ui'
       run: |
         npm install
@@ -196,16 +196,16 @@ jobs:
     - name: "Configure Cypress"
       working-directory: 'ansible-hub-ui/test'
       run: |
-        cp -aiv ../.github/workflows/cypress/cypress.env.json."$COMPOSE_PROFILE" cypress.env.json
+        cp -aiv ../.github/workflows/cypress/cypress.env.json."$BACKEND_FLAVOR" cypress.env.json
 
     - name: "Ensure index.html uses the new js"
-      if: ${{ env.COMPOSE_PROFILE == 'standalone' }}
+      if: ${{ env.BACKEND_FLAVOR == 'standalone' }}
       run: |
         echo 'expecting /static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
         curl http://localhost:8002/static/galaxy_ng/index.html | tee /dev/stderr | grep '/static/galaxy_ng/js/App.'"$BUILD_HASH"'.js'
 
     - name: "Ensure insights is served"
-      if: ${{ env.COMPOSE_PROFILE == 'insights' }}
+      if: ${{ env.BACKEND_FLAVOR == 'insights' }}
       run: |
         echo waiting for containers to start
         sleep 30
@@ -213,12 +213,12 @@ jobs:
         sleep 30
 
     - name: "Ensure galaxykit can connect to API (standalone)"
-      if: ${{ env.COMPOSE_PROFILE == 'standalone' }}
+      if: ${{ env.BACKEND_FLAVOR == 'standalone' }}
       run: |
         galaxykit -s http://localhost:8002/api/galaxy/ -u admin -p admin collection list
 
     - name: "Ensure galaxykit can connect to API (insights)"
-      if: ${{ env.COMPOSE_PROFILE == 'insights' }}
+      if: ${{ env.BACKEND_FLAVOR == 'insights' }}
       run: |
         galaxykit -s http://localhost:8002/api/automation-hub/ \
           -u admin -p admin \
@@ -226,24 +226,24 @@ jobs:
           collection list
 
     - name: "Check initial feature flags (standalone)"
-      if: ${{ env.COMPOSE_PROFILE == 'standalone' }}
+      if: ${{ env.BACKEND_FLAVOR == 'standalone' }}
       run: |
         curl -s http://localhost:5001/api/galaxy/_ui/v1/feature-flags/ | jq
 
     - name: "Check initial feature flags (insights)"
-      if: ${{ env.COMPOSE_PROFILE == 'insights' }}
+      if: ${{ env.BACKEND_FLAVOR == 'insights' }}
       run: |
         curl -s http://localhost:5001/api/automation-hub/_ui/v1/feature-flags/ | jq
 
     - name: "Check component versions & settings (standalone)"
-      if: ${{ env.COMPOSE_PROFILE == 'standalone' }}
+      if: ${{ env.BACKEND_FLAVOR == 'standalone' }}
       run: |
         HUB_TOKEN=`curl -s -u admin:admin -d '' http://localhost:5001/api/galaxy/v3/auth/token/ | jq -r .token`
         curl -s -H "Authorization: Token $HUB_TOKEN" http://localhost:5001/api/galaxy/ | jq
         curl -s -H "Authorization: Token $HUB_TOKEN" http://localhost:5001/api/galaxy/_ui/v1/settings/ | jq
 
     - name: "Check component versions & settings (insights)"
-      if: ${{ env.COMPOSE_PROFILE == 'insights' }}
+      if: ${{ env.BACKEND_FLAVOR == 'insights' }}
       run: |
         BEARER=`curl -s -H "Content-Type: application/x-www-form-urlencoded" \
           -d "client_id=cloud-services&username=admin&password=admin&grant_type=password" \


### PR DESCRIPTION
it used to mean the actual compose profile in pre-oci-env CI, now it really means a set of predefined conditions and files to use

but now now oci-env started reading COMPOSE_PROFILE from env, which breaks with

    ERROR - utils.py:42 - standalone from COMPOSE_PROFILE does not exist at /home/runner/work/ansible-hub-ui/ansible-hub-ui/oci_env/profiles/standalone

so just renaming
