### PR TITLE
[stable-4.7] Rename master to main in workflows and docs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,7 +2,7 @@ name: Automerge
 
 on:
   pull_request_target:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
+    branches: [ 'main', 'stable-*', 'feature/*' ]
 
 jobs:
   automerge:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,9 +7,9 @@ on:
     branches: [ 'main', 'stable-*', 'feature/*' ]
   push:
     branches: [ 'main', 'stable-*', 'feature/*' ]
-  # daily on main
+  # weekly on stable-4.7
   schedule:
-  - cron: '30 5 * * *'
+  - cron: '30 5 * * 1'
 
 concurrency:
   group: cypress-${{ github.ref }}
@@ -19,8 +19,8 @@ jobs:
   cypress:
     runs-on: ubuntu-latest
     env:
-      # base of a PR, or pushed-to branch outside PRs, or main
-      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/main' }}
+      # base of a PR, or pushed-to branch outside PRs, or stable-4.7
+      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/stable-4.7' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,10 +4,10 @@ on:
   # allow running manually
   workflow_dispatch:
   pull_request:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
+    branches: [ 'main', 'stable-*', 'feature/*' ]
   push:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
-  # daily on master
+    branches: [ 'main', 'stable-*', 'feature/*' ]
+  # daily on main
   schedule:
   - cron: '30 5 * * *'
 
@@ -19,8 +19,8 @@ jobs:
   cypress:
     runs-on: ubuntu-latest
     env:
-      # base of a PR, or pushed-to branch outside PRs, or master
-      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/master' }}
+      # base of a PR, or pushed-to branch outside PRs, or main
+      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/main' }}
 
     strategy:
       fail-fast: false
@@ -55,8 +55,8 @@ jobs:
     - name: "Set variables for screenshots"
       if: matrix.test == 'screenshots'
       run: |
-        UI_COMMIT_MASTER=`curl -s https://api.github.com/repos/ansible/ansible-hub-ui/branches/${SHORT_BRANCH} | jq -r .commit.sha`
-        echo "UI_COMMIT_MASTER=${UI_COMMIT_MASTER}" >> $GITHUB_ENV
+        UI_COMMIT_MAIN=`curl -s https://api.github.com/repos/ansible/ansible-hub-ui/branches/${SHORT_BRANCH} | jq -r .commit.sha`
+        echo "UI_COMMIT_MAIN=${UI_COMMIT_MAIN}" >> $GITHUB_ENV
 
         COMPARE_SCREENSHOTS=${{ github.event_name == 'pull_request' }}
         echo 'compare screenshots:'
@@ -182,12 +182,12 @@ jobs:
       run: |
         diff -Naur <(ls test/cypress/e2e) <(yq '.jobs.cypress.strategy.matrix.test[]' .github/workflows/cypress.yml | sort)
 
-    - name: "Cache master screenshots"
+    - name: "Cache original screenshots"
       if: matrix.test == 'screenshots'
       uses: actions/cache@v3
       with:
         path: ansible-hub-ui/test/screenshots-main/
-        key: screenshots-${{env.SHORT_BRANCH}}-${{ env.UI_COMMIT_MASTER }}
+        key: screenshots-${{env.SHORT_BRANCH}}-${{ env.UI_COMMIT_MAIN }}
         restore-keys: |
           screenshots-${{env.SHORT_BRANCH}}-
 
@@ -238,7 +238,7 @@ jobs:
           exit 1
         fi
 
-    - name: "Move Cache master screenshots"
+    - name: "Move cached screenshots"
       if: ${{ matrix.test == 'screenshots' && env.COMPARE_SCREENSHOTS == 'false' }}
       working-directory: 'ansible-hub-ui/test'
       run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,29 +2,9 @@ name: "PR checks"
 
 on:
   pull_request:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
+    branches: [ 'main', 'stable-*', 'feature/*' ]
 
 jobs:
-
-  check_commit:
-    runs-on: ubuntu-latest
-    if: ${{ github.base_ref == 'master' }}
-    steps:
-
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
-        fetch-depth: 0  # include all history
-
-    - name: Run script to validate commits for both pull request and a push
-      env:
-        GITHUB_PR_COMMITS_URL: ${{ github.event.pull_request.commits_url }}
-        GITHUB_USER: ${{ github.event.pull_request.user.login }}
-        START_COMMIT: ${{ github.event.before }}
-        END_COMMIT: ${{ github.event.after }}
-      run: |
-        curl https://raw.githubusercontent.com/ansible/galaxy_ng/master/.ci/scripts/validate_commit_message_custom.py | python
 
   pr-checks:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ The app will run on http://localhost:8002/ui and proxy requests for `/api/automa
 
 ## UI Testing
 
-For more information about UI testing go to [test README](https://github.com/ansible/ansible-hub-ui/tree/master/test/README.md).
+For more information about UI testing go to [test README](https://github.com/ansible/ansible-hub-ui/tree/stable-4.7/test/README.md).

--- a/test/README.md
+++ b/test/README.md
@@ -158,7 +158,7 @@ name like `$collection-form.js`
 name like `$collection-$action.js` (using camel\_case for both collection name and action name)
 
 * test the action on each available screen
-  * prefer to loop the same test over an array of "get me there" functions (see [`execution_environments_use_in_controller.js`](https://github.com/ansible/ansible-hub-ui/blob/master/test/cypress/integration/execution_environments_use_in_controller.js#L53-L83) for an example)
+  * prefer to loop the same test over an array of "get me there" functions (see [`execution_environments_use_in_controller.js`](https://github.com/ansible/ansible-hub-ui/blob/stable-4.7/test/cypress/integration/execution_environments_use_in_controller.js#L53-L83) for an example)
 * make sure to wait until every request associated with submitting that action ends, including tasks, and subsequent list screen reloads
 
 ## GalaxyKit Integration


### PR DESCRIPTION
and sometimes to stable-4.7 when it makes sense to prefer over main

---

AAH-2643

4.2: #4125
4.5: #4124
4.6: #4123
4.7: #4122
master/main: #4126