### PR TITLE
[stable-4.6] Rename master to main in workflows and docs

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,7 +2,7 @@ name: Automerge
 
 on:
   pull_request_target:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
+    branches: [ 'main', 'stable-*', 'feature/*' ]
 
 jobs:
   automerge:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,9 +7,9 @@ on:
     branches: [ 'main', 'stable-*', 'feature/*' ]
   push:
     branches: [ 'main', 'stable-*', 'feature/*' ]
-  # daily on main
+  # monthly on stable-4.6
   schedule:
-  - cron: '30 5 * * *'
+  - cron: '30 5 1 * *'
 
 concurrency:
   group: cypress-${{ github.ref }}
@@ -19,8 +19,8 @@ jobs:
   cypress:
     runs-on: ubuntu-latest
     env:
-      # base of a PR, or pushed-to branch outside PRs, or main
-      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/main' }}
+      # base of a PR, or pushed-to branch outside PRs, or stable-4.6
+      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/stable-4.6' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,10 +4,10 @@ on:
   # allow running manually
   workflow_dispatch:
   pull_request:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
+    branches: [ 'main', 'stable-*', 'feature/*' ]
   push:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
-  # daily on master
+    branches: [ 'main', 'stable-*', 'feature/*' ]
+  # daily on main
   schedule:
   - cron: '30 5 * * *'
 
@@ -19,8 +19,8 @@ jobs:
   cypress:
     runs-on: ubuntu-latest
     env:
-      # base of a PR, or pushed-to branch outside PRs, or master
-      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/master' }}
+      # base of a PR, or pushed-to branch outside PRs, or main
+      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/main' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,7 @@ name: "PR checks"
 
 on:
   pull_request:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
+    branches: [ 'main', 'stable-*', 'feature/*' ]
 
 jobs:
 

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ The app will run on http://localhost:8002/ui and proxy requests for `/api/automa
 
 ## UI Testing
 
-For more information about UI testing go to [test README](https://github.com/ansible/ansible-hub-ui/tree/master/test/README.md).
+For more information about UI testing go to [test README](https://github.com/ansible/ansible-hub-ui/tree/stable-4.6/test/README.md).

--- a/test/README.md
+++ b/test/README.md
@@ -160,7 +160,7 @@ name like `$collection-form.js`
 name like `$collection-$action.js` (using camel\_case for both collection name and action name)
 
 * test the action on each available screen
-  * prefer to loop the same test over an array of "get me there" functions (see [`execution_environments_use_in_controller.js`](https://github.com/ansible/ansible-hub-ui/blob/master/test/cypress/integration/execution_environments_use_in_controller.js#L53-L83) for an example)
+  * prefer to loop the same test over an array of "get me there" functions (see [`execution_environments_use_in_controller.js`](https://github.com/ansible/ansible-hub-ui/blob/stable-4.6/test/cypress/integration/execution_environments_use_in_controller.js#L53-L83) for an example)
 * make sure to wait until every request associated with submitting that action ends, including tasks, and subsequent list screen reloads
 
 ## GalaxyKit Integration


### PR DESCRIPTION
and sometimes to stable-4.6 when it makes sense to prefer over main

---

AAH-2643

4.2: #4125
4.5: #4124
4.6: #4123
4.7: #4122
master/main: #4126