### PR TITLE
[stable-4.5] Rename master to main in workflows and docs

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -7,9 +7,9 @@ on:
     branches: [ 'main', 'stable-*', 'feature/*' ]
   push:
     branches: [ 'main', 'stable-*', 'feature/*' ]
-  # daily on main
+  # monthly on stable-4.5
   schedule:
-  - cron: '30 5 * * *'
+  - cron: '30 5 1 * *'
 
 concurrency:
   group: cypress-${{ github.ref }}
@@ -19,8 +19,8 @@ jobs:
   cypress:
     runs-on: ubuntu-latest
     env:
-      # base of a PR, or pushed-to branch outside PRs, or main
-      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/main' }}
+      # base of a PR, or pushed-to branch outside PRs, or stable-4.5
+      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/stable-4.5' }}
 
     steps:
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,10 +4,10 @@ on:
   # allow running manually
   workflow_dispatch:
   pull_request:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
+    branches: [ 'main', 'stable-*', 'feature/*' ]
   push:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
-  # daily on master
+    branches: [ 'main', 'stable-*', 'feature/*' ]
+  # daily on main
   schedule:
   - cron: '30 5 * * *'
 
@@ -19,8 +19,8 @@ jobs:
   cypress:
     runs-on: ubuntu-latest
     env:
-      # base of a PR, or pushed-to branch outside PRs, or master
-      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/master' }}
+      # base of a PR, or pushed-to branch outside PRs, or main
+      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/main' }}
 
     steps:
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,25 +6,6 @@ on:
 
 jobs:
 
-  check_commit:
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.after }}  # for PR avoids checking out merge commit
-        fetch-depth: 0  # include all history
-
-    - name: Run script to validate commits for both pull request and a push
-      env:
-        GITHUB_PR_COMMITS_URL: ${{ github.event.pull_request.commits_url }}
-        GITHUB_USER: ${{ github.event.pull_request.user.login }}
-        START_COMMIT: ${{ github.event.before }}
-        END_COMMIT: ${{ github.event.after }}
-      run: |
-        curl https://raw.githubusercontent.com/ansible/galaxy_ng/main/.ci/scripts/validate_commit_message_custom.py | python
-
   pr-checks:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,7 @@ name: "PR checks"
 
 on:
   pull_request:
-    branches: [ 'master', 'stable-*' ]
+    branches: [ 'main', 'stable-*' ]
 
 jobs:
 
@@ -23,7 +23,7 @@ jobs:
         START_COMMIT: ${{ github.event.before }}
         END_COMMIT: ${{ github.event.after }}
       run: |
-        curl https://raw.githubusercontent.com/ansible/galaxy_ng/master/.ci/scripts/validate_commit_message_custom.py | python
+        curl https://raw.githubusercontent.com/ansible/galaxy_ng/main/.ci/scripts/validate_commit_message_custom.py | python
 
   pr-checks:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ The app will run on http://localhost:8002 and proxy requests for `api/automation
 
 ## UI Testing
 
-For more information about UI testing go to [test README](https://github.com/ansible/ansible-hub-ui/tree/master/test/README.md).
+For more information about UI testing go to [test README](https://github.com/ansible/ansible-hub-ui/tree/stable-4.5/test/README.md).

--- a/test/README.md
+++ b/test/README.md
@@ -156,7 +156,7 @@ name like `$collection-form.js`
 name like `$collection-$action.js` (using camel\_case for both collection name and action name)
 
 * test the action on each available screen
-  * prefer to loop the same test over an array of "get me there" functions (see [`execution_environments_use_in_controller.js`](https://github.com/ansible/ansible-hub-ui/blob/master/test/cypress/integration/execution_environments_use_in_controller.js#L53-L83) for an example)
+  * prefer to loop the same test over an array of "get me there" functions (see [`execution_environments_use_in_controller.js`](https://github.com/ansible/ansible-hub-ui/blob/stable-4.5/test/cypress/integration/execution_environments_use_in_controller.js#L53-L83) for an example)
 * make sure to wait until every request associated with submitting that action ends, including tasks, and subsequent list screen reloads
 
 ## GalaxyKit Integration


### PR DESCRIPTION
and sometimes to stable-4.5 when it makes sense to prefer over main

---

AAH-2643

4.2: #4125
4.5: #4124
4.6: #4123
4.7: #4122
master/main: #4126
