### PR TITLE
Rename master to main in workflows and docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 Thank you for a new Pull Request!
 
 Please, make reviewers work easier by checking, if you are not introducing any technical debt:
-https://github.com/ansible/ansible-hub-ui/blob/master/developer_guidelines.md
+https://github.com/ansible/ansible-hub-ui/blob/main/developer_guidelines.md
 
 Describe the rationale and use case for this pull request.  Provide any background, examples, and images that provide further information to accurately describe what it is that you are adding to the repo.  Add subsections as necessary to organize and feel free to link and reference other PRs as necessary, but also include them in the links section below as a quick reference.
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -2,7 +2,7 @@ name: Automerge
 
 on:
   pull_request_target:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
+    branches: [ 'main', 'stable-*', 'feature/*' ]
 
 jobs:
   automerge:

--- a/.github/workflows/cloud-stage-disable.yml
+++ b/.github/workflows/cloud-stage-disable.yml
@@ -1,4 +1,4 @@
-name: "Disable automatic stage-stable deploy on push to master"
+name: "Disable automatic stage-stable deploy on push to main"
 
 on:
   workflow_dispatch: # allow running manually
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: "Checkout ansible-hub-ui master"
+    - name: "Checkout ansible-hub-ui main"
       uses: actions/checkout@v3
       with:
-        ref: 'master'
+        ref: 'main'
 
-    - name: "Disable, push to master"
+    - name: "Disable, push to main"
       run: |
         git config --global user.name 'GH Actions'
         git config --global user.email 'gh_actions@users.noreply.github.com'
@@ -22,4 +22,4 @@ jobs:
 
         git commit -m 'Disable cloud stage cron deploy '`date --iso=d`
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/ansible/ansible-hub-ui.git
-        git push origin HEAD:master
+        git push origin HEAD:main

--- a/.github/workflows/cloud-stage-enable.yml
+++ b/.github/workflows/cloud-stage-enable.yml
@@ -1,4 +1,4 @@
-name: "Enable automatic stage-stable deploy on push to master"
+name: "Enable automatic stage-stable deploy on push to main"
 
 on:
   workflow_dispatch: # allow running manually
@@ -8,12 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: "Checkout ansible-hub-ui master"
+    - name: "Checkout ansible-hub-ui main"
       uses: actions/checkout@v3
       with:
-        ref: 'master'
+        ref: 'main'
 
-    - name: "Enable, push to master"
+    - name: "Enable, push to main"
       run: |
         git config --global user.name 'GH Actions'
         git config --global user.email 'gh_actions@users.noreply.github.com'
@@ -23,4 +23,4 @@ jobs:
 
         git commit -m 'Enable cloud stage cron deploy '`date --iso=d`
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/ansible/ansible-hub-ui.git
-        git push origin HEAD:master
+        git push origin HEAD:main

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,10 +4,10 @@ on:
   # allow running manually
   workflow_dispatch:
   pull_request:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
+    branches: [ 'main', 'stable-*', 'feature/*' ]
   push:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
-  # daily on master
+    branches: [ 'main', 'stable-*', 'feature/*' ]
+  # daily on main
   schedule:
   - cron: '30 5 * * *'
 
@@ -19,8 +19,8 @@ jobs:
   cypress:
     runs-on: ubuntu-latest
     env:
-      # base of a PR, or pushed-to branch outside PRs, or master
-      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/master' }}
+      # base of a PR, or pushed-to branch outside PRs, or main
+      BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/main' }}
 
     strategy:
       fail-fast: false
@@ -74,8 +74,8 @@ jobs:
     - name: "Set variables for screenshots"
       if: matrix.test == 'screenshots'
       run: |
-        UI_COMMIT_MASTER=`curl -s https://api.github.com/repos/ansible/ansible-hub-ui/branches/${SHORT_BRANCH} | jq -r .commit.sha`
-        echo "UI_COMMIT_MASTER=${UI_COMMIT_MASTER}" >> $GITHUB_ENV
+        UI_COMMIT_MAIN=`curl -s https://api.github.com/repos/ansible/ansible-hub-ui/branches/${SHORT_BRANCH} | jq -r .commit.sha`
+        echo "UI_COMMIT_MAIN=${UI_COMMIT_MAIN}" >> $GITHUB_ENV
 
         COMPARE_SCREENSHOTS=${{ github.event_name == 'pull_request' }}
         echo 'compare screenshots:'
@@ -314,12 +314,12 @@ jobs:
       run: |
         diff -Naur <(ls test/cypress/e2e) <(yq '.jobs.cypress.strategy.matrix.test[]' .github/workflows/cypress.yml | sort)
 
-    - name: "Cache master screenshots"
+    - name: "Cache original screenshots"
       if: matrix.test == 'screenshots'
       uses: actions/cache@v3
       with:
         path: ansible-hub-ui/test/screenshots-main/
-        key: screenshots-${{env.SHORT_BRANCH}}-${{ env.UI_COMMIT_MASTER }}
+        key: screenshots-${{env.SHORT_BRANCH}}-${{ env.UI_COMMIT_MAIN }}
         restore-keys: |
           screenshots-${{env.SHORT_BRANCH}}-
 
@@ -370,7 +370,7 @@ jobs:
           exit 1
         fi
 
-    - name: "Move Cache master screenshots"
+    - name: "Move cached screenshots"
       if: ${{ matrix.test == 'screenshots' && env.COMPARE_SCREENSHOTS == 'false' }}
       working-directory: 'ansible-hub-ui/test'
       run: |

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -3,7 +3,7 @@ name: "Deploy cloud.redhat.com"
 on:
   workflow_dispatch: # allow running manually
   push:
-    branches: [ "master", "prod-beta", "prod-stable" ]
+    branches: [ "main", "prod-beta", "prod-stable" ]
 
 concurrency:
   group: deploy-cloud-${{ github.ref }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,11 +1,11 @@
-# Updates the "dev" github release whenever new changes are merged into master.
+# Updates the "dev" github release whenever new changes are merged into main.
 # This provides an up to date tarball that https://github.com/ansible/galaxy_ng can use.
 name: "Dev release"
 
 on:
   workflow_dispatch: # allow running manually
   push:
-    branches: [ 'master' ]
+    branches: [ 'main' ]
 
 concurrency:
   group: dev-release-${{ github.ref }}
@@ -15,7 +15,7 @@ jobs:
   dev:
     runs-on: ubuntu-latest
     env:
-      BRANCH: 'master' # for webpack
+      BRANCH: 'main' # for webpack
       NODE_OPTIONS: "--max-old-space-size=4096 --max_old_space_size=4096"
 
     steps:
@@ -57,6 +57,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_NAME: "UI Dev Release"
-        RELEASE_BODY: "This is a special release that provides an up to date build off of the latest changes in the `master` branch. The `automation-hub-ui-dist.tar.gz` artifact provided here corresponds to the latest version of `master`."
+        RELEASE_BODY: "This is a special release that provides an up to date build off of the latest changes in the `main` branch. The `automation-hub-ui-dist.tar.gz` artifact provided here corresponds to the latest version of `main`."
         RELEASE_FILE: 'automation-hub-ui-dist.tar.gz'
         RELEASE_TAG: 'dev'

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         branch:
-        - 'master'
+        - 'main'
         - 'stable-4.5'
         - 'stable-4.6'
         - 'stable-4.7'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,4 +1,4 @@
-# Add labels to pull requests against master
+# Add labels to pull requests against main
 # uses logic in .github/labeler.yml
 
 ---
@@ -6,7 +6,7 @@ name: "Add labels to pull request"
 
 on:
   pull_request_target:
-    branches: [ "master" ]
+    branches: [ "main" ]
     types: [ "opened" ]
 
 jobs:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,13 +2,13 @@ name: "PR checks"
 
 on:
   pull_request:
-    branches: [ 'master', 'stable-*', 'feature/*' ]
+    branches: [ 'main', 'stable-*', 'feature/*' ]
 
 jobs:
 
   check_commit:
     runs-on: ubuntu-latest
-    if: ${{ github.base_ref == 'master' }}
+    if: ${{ github.base_ref == 'main' }}
     steps:
 
     - name: Checkout code
@@ -24,7 +24,7 @@ jobs:
         START_COMMIT: ${{ github.event.before }}
         END_COMMIT: ${{ github.event.after }}
       run: |
-        curl https://raw.githubusercontent.com/ansible/galaxy_ng/master/.ci/scripts/validate_commit_message_custom.py | python
+        curl https://raw.githubusercontent.com/ansible/galaxy_ng/main/.ci/scripts/validate_commit_message_custom.py | python
 
   pr-checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -3,7 +3,7 @@ name: "Generate package manifest"
 on:
   workflow_dispatch: # allow running manually
   push:
-    branches: [ 'master', 'stable-prod' ]
+    branches: [ 'main', 'stable-prod' ]
 
 concurrency:
   group: update-manifest-${{ github.ref }}

--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -8,7 +8,7 @@ push () {
     .travis/release.sh "$1"
 }
 
-if [ "${TRAVIS_BRANCH}" = "master" ]; then
+if [ "${TRAVIS_BRANCH}" = "main" ]; then
     # always push to stage-beta
     HUB_CLOUD_BETA="true" npm run deploy
     push "qa-beta"

--- a/.travis/update_manifest.sh
+++ b/.travis/update_manifest.sh
@@ -27,7 +27,7 @@ if [[ "$TRAVIS_PULL_REQUEST" != 'false' ]]; then
 fi
 
 
-if [[ "${TRAVIS_BRANCH}" == 'master' ]]; then
+if [[ "${TRAVIS_BRANCH}" == 'main' ]]; then
     manifests_branch='master'
 elif [[ "${TRAVIS_BRANCH}" == 'stable-prod' ]]; then
     manifests_branch='stable' # FIXME: no such branch

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ We're using Github Actions for deployment.
 
 The Github Action invokes the [RedHatInsights/insights-frontend-builder-common//bootstrap.sh](https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh) script, which builds the local branch and pushes the results to [RedHatInsights/ansible-hub-ui-build](https://github.com/RedHatInsights/ansible-hub-ui-build/branches). There, a separate Jenkins process awaits.
 
-- any push to the `master` branch will deploy to `ansible-hub-ui-build` `qa-beta` branch
-- any push to the `master` branch will ALSO deploy to `ansible-hub-ui-build` `qa-stable` branch when `.cloud-stage-cron.enabled` exists
+- any push to the `main` branch will deploy to `ansible-hub-ui-build` `qa-beta` branch
+- any push to the `main` branch will ALSO deploy to `ansible-hub-ui-build` `qa-stable` branch when `.cloud-stage-cron.enabled` exists
 - any push to the `prod-beta` branch will deploy to a `ansible-hub-ui-build` `prod-beta` branch
 - any push to the `prod-stable` branch will deploy to a `ansible-hub-ui-build` `prod-stable` branch
-- the `ansible-hub-ui-build` `master` branch is not used, as PRs against `master` end up in `qa-beta`
+- the `ansible-hub-ui-build` `master` branch is not used, as PRs against `main` end up in `qa-beta`
 
 - `qa-beta` builds end up on `console.stage.redhat.com/preview` (and `/beta`)
 - `qa-stable` builds end up on `console.stage.redhat.com`
@@ -65,25 +65,25 @@ The Github Action invokes the [RedHatInsights/insights-frontend-builder-common//
 List of all workflows:
 
 - `backported-labels`: Add a backported-* label when a PR is backported to stable-*; on patchback merges
-- `cloud-stage-disable`: Disable deploy-cloud from master to stage-stable (stage-beta always on); manual
-- `cloud-stage-enable`: Enable deploy-cloud from master to stage-stable (stage-beta always on); manual
+- `cloud-stage-disable`: Disable deploy-cloud from main to stage-stable (stage-beta always on); manual
+- `cloud-stage-enable`: Enable deploy-cloud from main to stage-stable (stage-beta always on); manual
 - `cypress`: Run Cypress integration tests; on PRs, pushes and cron
 - `deploy-cloud`: Deploy to c.r.c; when the relevant branch is updated
-- `dev-release`: Build and upload to github releases, update `dev` tag; when master is updated
+- `dev-release`: Build and upload to github releases, update `dev` tag; when main is updated
 - `i18n`: Extract and merge l10n strings for 4.5+; cron
 - `pr-checks`: Check for linter errors, obsolete package-lock.json and merge commits; on PRs only
 - `stable-release`: Build and upload to github releases; when a stable release is created
-- `update-manifest`: Update https://github.com/RedHatInsights/manifests ; when master is updated
+- `update-manifest`: Update https://github.com/RedHatInsights/manifests ; when main is updated
 
 List by branches:
 
-- `master`: `backported-labels`, `cypress`, `deploy-cloud`, `dev-release`, `i18n`, `pr-checks`, `stable-release`, `update-manifest`
+- `main`: `backported-labels`, `cypress`, `deploy-cloud`, `dev-release`, `i18n`, `pr-checks`, `stable-release`, `update-manifest`
 - `prod-beta`: `deploy-cloud`
 - `prod-stable`: `deploy-cloud`
 - `stable-4.2`: `backported-labels`, `pr-checks`, `stable-release`
-- `stable-4.5`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
-- `stable-4.6`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
-- `stable-4.7`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
+- `stable-4.5`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from main)
+- `stable-4.6`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from main)
+- `stable-4.7`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from main)
 
 ### Version mapping
 
@@ -110,4 +110,4 @@ Insights Platform will deliver components and static assets through [npm](https:
 
 ## UI Testing
 
-For more information about UI testing go to [test README](https://github.com/ansible/ansible-hub-ui/tree/master/test/README.md).
+For more information about UI testing go to [test README](https://github.com/ansible/ansible-hub-ui/tree/main/test/README.md).

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -140,7 +140,7 @@ module.exports = (inputConfigs) => {
         registry: [insightsMockAPIs],
       }),
 
-    // insights deployments from master
+    // insights deployments from main
     ...(!isStandalone &&
       cloudBeta && {
         deployment: cloudBeta === 'true' ? 'beta/apps' : 'apps',

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -20,7 +20,7 @@ export IMAGE_FRONTEND_SHA1=$(git rev-parse HEAD)
 export IMAGE=${IMAGE_FRONTEND}
 
 export IMAGE_BACKEND="quay.io/cloudservices/automation-hub-galaxy-ng"
-export IMAGE_BACKEND_TAG=$(curl -s https://api.github.com/repos/ansible/galaxy_ng/commits/master | jq -r '.sha' | head -c7)
+export IMAGE_BACKEND_TAG=$(curl -s https://api.github.com/repos/ansible/galaxy_ng/commits/main | jq -r '.sha' | head -c7)
 export BACKUP_APP_ROOT=$APP_ROOT
 
 set -exv
@@ -42,7 +42,7 @@ bonfire deploy \
     ${APP_NAME} \
     --source=appsre \
     --ref-env insights-stage \
-    --set-template-ref ${COMPONENT_NAME}=master \
+    --set-template-ref ${COMPONENT_NAME}=main \
     --set-image-tag ${IMAGE_BACKEND}=${IMAGE_BACKEND_TAG} \
     --set-image-tag ${IMAGE_FRONTEND}=${IMAGE_FRONTEND_TAG} \
     --set-template-ref automation-hub-frontend=${IMAGE_FRONTEND_SHA1} \

--- a/test/README.md
+++ b/test/README.md
@@ -159,7 +159,7 @@ name like `$collection-form.js`
 name like `$collection-$action.js` (using camel\_case for both collection name and action name)
 
 * test the action on each available screen
-  * prefer to loop the same test over an array of "get me there" functions (see [`execution_environments_use_in_controller.js`](https://github.com/ansible/ansible-hub-ui/blob/master/test/cypress/integration/execution_environments_use_in_controller.js#L53-L83) for an example)
+  * prefer to loop the same test over an array of "get me there" functions (see [`execution_environments_use_in_controller.js`](https://github.com/ansible/ansible-hub-ui/blob/main/test/cypress/integration/execution_environments_use_in_controller.js#L53-L83) for an example)
 * make sure to wait until every request associated with submitting that action ends, including tasks, and subsequent list screen reloads
 
 ## GalaxyKit Integration


### PR DESCRIPTION
except when linking RedHatInsights repos still using master

---

AAH-2643

4.2: #4125
4.5: #4124
4.6: #4123
4.7: #4122
master/main: #4126
