### PR TITLE
Add banner linking discussions on beta galaxy

### DIFF
--- a/CHANGES/1893.misc
+++ b/CHANGES/1893.misc
@@ -1,0 +1,1 @@
+beta-galaxy: add banner linking discussions

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -1,5 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import {
+  Alert,
   DropdownItem,
   DropdownSeparator,
   Page,
@@ -168,6 +169,24 @@ export const StandaloneLayout = ({
 
   return (
     <Page isManagedSidebar={true} header={Header} sidebar={Sidebar}>
+      <Alert
+        isInline
+        variant='info'
+        title={
+          <Trans>
+            Thanks for trying out the new and improved Beta Galaxy, please share
+            your feedback on{' '}
+            <a
+              href='https://github.com/ansible/galaxy_ng/discussions'
+              target='_blank'
+              rel='noreferrer'
+            >
+              github.com/ansible/galaxy_ng/discussions
+            </a>
+            .
+          </Trans>
+        }
+      />
       {children}
       {aboutModalVisible && aboutModal}
     </Page>

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -169,20 +169,22 @@ export const StandaloneLayout = ({
 
   return (
     <Page isManagedSidebar={true} header={Header} sidebar={Sidebar}>
-      <Banner>
-        <Trans>
-          Thanks for trying out the new and improved Beta Galaxy, please share
-          your feedback on{' '}
-          <a
-            href='https://github.com/ansible/galaxy_ng/discussions'
-            target='_blank'
-            rel='noreferrer'
-          >
-            github.com/ansible/galaxy_ng/discussions
-          </a>
-          .
-        </Trans>
-      </Banner>
+      {featureFlags?.ai_deny_index ? (
+        <Banner>
+          <Trans>
+            Thanks for trying out the new and improved Beta Galaxy, please share
+            your feedback on{' '}
+            <a
+              href='https://github.com/ansible/galaxy_ng/discussions'
+              target='_blank'
+              rel='noreferrer'
+            >
+              github.com/ansible/galaxy_ng/discussions
+            </a>
+            .
+          </Trans>
+        </Banner>
+      ) : null}
       {children}
       {aboutModalVisible && aboutModal}
     </Page>

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -1,6 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import {
-  Alert,
+  Banner,
   DropdownItem,
   DropdownSeparator,
   Page,
@@ -169,24 +169,20 @@ export const StandaloneLayout = ({
 
   return (
     <Page isManagedSidebar={true} header={Header} sidebar={Sidebar}>
-      <Alert
-        isInline
-        variant='info'
-        title={
-          <Trans>
-            Thanks for trying out the new and improved Beta Galaxy, please share
-            your feedback on{' '}
-            <a
-              href='https://github.com/ansible/galaxy_ng/discussions'
-              target='_blank'
-              rel='noreferrer'
-            >
-              github.com/ansible/galaxy_ng/discussions
-            </a>
-            .
-          </Trans>
-        }
-      />
+      <Banner>
+        <Trans>
+          Thanks for trying out the new and improved Beta Galaxy, please share
+          your feedback on{' '}
+          <a
+            href='https://github.com/ansible/galaxy_ng/discussions'
+            target='_blank'
+            rel='noreferrer'
+          >
+            github.com/ansible/galaxy_ng/discussions
+          </a>
+          .
+        </Trans>
+      </Banner>
       {children}
       {aboutModalVisible && aboutModal}
     </Page>


### PR DESCRIPTION
Issue: AAH-1893
old-galaxy PR: https://github.com/ansible/galaxy/pull/3223

![20230814215957](https://github.com/ansible/ansible-hub-ui/assets/289743/795f3a08-625b-4991-a997-81d61f0d84ce)

(using pf4 Banner (http://v4-archive.patternfly.org/v4/components/banner))