### PR TITLE
Fix dispatch page filter param - use github_user for legacy roles

### DIFF
--- a/CHANGES/2670.bug
+++ b/CHANGES/2670.bug
@@ -1,0 +1,1 @@
+Fix dispatch page filter param

--- a/src/containers/not-found/dispatch.tsx
+++ b/src/containers/not-found/dispatch.tsx
@@ -46,7 +46,7 @@ export const Dispatch = (props: RouteProps) => {
       .catch(() => setCollections([]));
 
     if (featureFlags.legacy_roles) {
-      LegacyRoleAPI.list({ username: namespace, name })
+      LegacyRoleAPI.list({ github_user: namespace, name })
         .then(({ data: { results } }) => setRoles(results || []))
         .catch(() => setRoles([]));
     }


### PR DESCRIPTION
Issue: AAH-2670
(Introduced in #4090)

`?username` filter doesn't work on the legacy role API, use `?github_user` instead.