### PR TITLE
Import modal: better error for Invalid file format.

### DIFF
--- a/src/components/import-modal/import-modal.scss
+++ b/src/components/import-modal/import-modal.scss
@@ -3,7 +3,11 @@ $green: #5bb75b;
 
 .upload-collection {
   .file-error-messages {
-    color: #c00;
+    color: var(--pf-global--danger-color--100);
+
+    &.skipped {
+      color: var(--pf-global--warning-color--100);
+    }
   }
 
   .upload-file {

--- a/src/components/import-modal/import-modal.tsx
+++ b/src/components/import-modal/import-modal.tsx
@@ -314,8 +314,10 @@ export class ImportModal extends React.Component<IProps, IState> {
         errors: t`Please select no more than one file.`,
       });
     } else if (!this.acceptedFileTypes.includes(newCollection.type)) {
+      const detectedType = newCollection.type || t`unknown`;
+      const acceptedTypes: string = this.acceptedFileTypes.join(', ');
       this.setState({
-        errors: t`Invalid file format.`,
+        errors: t`Invalid file format: ${detectedType} (expected: ${acceptedTypes}).`,
         file: newCollection,
         uploadProgress: 0,
       });


### PR DESCRIPTION
we're checking the mime-type before allowing collection upload, this mostly works, but in some cases (see AAP-15541), it can fail unexpectedly.

This should make debugging that case easier, by including the detected type in the error message:

![20230830180831](https://github.com/ansible/ansible-hub-ui/assets/289743/61ebd119-def8-4a17-977b-98d03ab1a4dc)
![20230830181141](https://github.com/ansible/ansible-hub-ui/assets/289743/ef41e3b4-f78d-4ce0-93a4-acdd644294c7)
