### PR TITLE
"Add collection" modal - disable "Select" button when no collections are selected

### DIFF
--- a/src/actions/ansible-repository-collection-version-add.tsx
+++ b/src/actions/ansible-repository-collection-version-add.tsx
@@ -133,7 +133,7 @@ const AddCollectionVersionModal = ({
           key='confirm'
           onClick={() => addAction(selected)}
           variant='primary'
-          isDisabled={!selected}
+          isDisabled={!selected.length}
         >
           {t`Select`}
         </Button>,


### PR DESCRIPTION
In repository detail, collection versions tab, when adding a collection to a repo, and no collections are selected, the "Select" button is still enabled.

Disabling when no collections are selected :)

![20230904115019](https://github.com/ansible/ansible-hub-ui/assets/289743/5d80e634-9c36-4a95-93e2-38f18c9dd19f)
