### PR TITLE
Import only individual icons from react-icons

### DIFF
--- a/src/components/card-list-switcher/card-list-switcher.tsx
+++ b/src/components/card-list-switcher/card-list-switcher.tsx
@@ -1,4 +1,5 @@
-import { ListIcon, ThLargeIcon } from '@patternfly/react-icons';
+import ListIcon from '@patternfly/react-icons/dist/esm/icons/list-icon';
+import ThLargeIcon from '@patternfly/react-icons/dist/esm/icons/th-large-icon';
 import cx from 'classnames';
 import React from 'react';
 import { ParamHelper } from 'src/utilities';

--- a/src/components/collection-detail/collection-content-list.tsx
+++ b/src/components/collection-detail/collection-content-list.tsx
@@ -5,7 +5,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import cx from 'classnames';
 import React from 'react';
 import { Link } from 'react-router-dom';

--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -7,7 +7,7 @@ import {
   Split,
   SplitItem,
 } from '@patternfly/react-core';
-import { DownloadIcon } from '@patternfly/react-icons';
+import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -163,9 +163,7 @@ export const CollectionInfo = ({
         {content?.requires_ansible && (
           <GridItem>
             <Split hasGutter={true}>
-              <SplitItem className='install-title'>
-                {t`Requires Ansible`}
-              </SplitItem>
+              <SplitItem className='install-title'>{t`Requires Ansible`}</SplitItem>
               <SplitItem isFilled data-cy='ansible-requirement'>
                 {content?.requires_ansible}
               </SplitItem>

--- a/src/components/collection-detail/download-signature-grid-item.tsx
+++ b/src/components/collection-detail/download-signature-grid-item.tsx
@@ -8,7 +8,7 @@ import {
   Split,
   SplitItem,
 } from '@patternfly/react-core';
-import { DownloadIcon } from '@patternfly/react-icons';
+import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import React, { useState } from 'react';
 import { CollectionAPI, CollectionVersionSearch } from 'src/api';
 import { LoadingPageSpinner } from 'src/components';

--- a/src/components/empty-state/empty-state-filter.tsx
+++ b/src/components/empty-state/empty-state-filter.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { Button } from '@patternfly/react-core';
-import { SearchIcon } from '@patternfly/react-icons';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import React from 'react';
 import { EmptyStateCustom } from './empty-state-custom';
 

--- a/src/components/empty-state/empty-state-no-data.tsx
+++ b/src/components/empty-state/empty-state-no-data.tsx
@@ -1,4 +1,5 @@
-import { CubesIcon, PlusCircleIcon } from '@patternfly/react-icons';
+import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
+import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import React from 'react';
 import { ReactElement, ReactNode } from 'react';
 import { EmptyStateCustom } from './empty-state-custom';

--- a/src/components/empty-state/empty-state-unauthorized.tsx
+++ b/src/components/empty-state/empty-state-unauthorized.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import { LockIcon } from '@patternfly/react-icons';
+import LockIcon from '@patternfly/react-icons/dist/esm/icons/lock-icon';
 import React from 'react';
 import { LoginLink } from 'src/components';
 import { EmptyStateCustom } from './empty-state-custom';

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -12,7 +12,8 @@ import {
   ListItem,
   Modal,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon, TagIcon } from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import TagIcon from '@patternfly/react-icons/dist/esm/icons/tag-icon';
 import React, { useEffect, useState } from 'react';
 import { ControllerAPI, ExecutionEnvironmentAPI } from 'src/api';
 import {
@@ -294,9 +295,7 @@ export const PublishToControllerModal = (props: IProps) => {
         <>
           <DescriptionList isHorizontal>
             <DescriptionListGroup>
-              <DescriptionListTerm>
-                {t`Execution Environment`}
-              </DescriptionListTerm>
+              <DescriptionListTerm>{t`Execution Environment`}</DescriptionListTerm>
               <DescriptionListDescription>{image}</DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>

--- a/src/components/execution-environment/repository-form.tsx
+++ b/src/components/execution-environment/repository-form.tsx
@@ -11,7 +11,7 @@ import {
   TextArea,
   TextInput,
 } from '@patternfly/react-core';
-import { TagIcon } from '@patternfly/react-icons';
+import TagIcon from '@patternfly/react-icons/dist/esm/icons/tag-icon';
 import React from 'react';
 import {
   ContainerDistributionAPI,

--- a/src/components/execution-environment/tag-manifest-modal.tsx
+++ b/src/components/execution-environment/tag-manifest-modal.tsx
@@ -12,7 +12,7 @@ import {
   Spinner,
   TextInput,
 } from '@patternfly/react-core';
-import { TagIcon } from '@patternfly/react-icons';
+import TagIcon from '@patternfly/react-icons/dist/esm/icons/tag-icon';
 import React from 'react';
 import {
   ContainerManifestType,
@@ -178,14 +178,10 @@ export class TagManifestModal extends React.Component<IProps, IState> {
                         this.addTag(tagToVerify),
                       )
                     }
-                  >
-                    {t`Yes`}
-                  </AlertActionLink>
+                  >{t`Yes`}</AlertActionLink>
                   <AlertActionLink
                     onClick={() => this.setState({ tagToVerify: '' })}
-                  >
-                    {t`No`}
-                  </AlertActionLink>
+                  >{t`No`}</AlertActionLink>
                 </>
               }
             />

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -14,7 +14,7 @@ import {
   Spinner,
   Text,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import * as moment from 'moment';
 import React from 'react';
 import { Navigate } from 'react-router-dom';

--- a/src/components/headers/partner-header.tsx
+++ b/src/components/headers/partner-header.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import React from 'react';
 import { NamespaceType } from 'src/api';
 import {

--- a/src/components/helper-text/helper-text.tsx
+++ b/src/components/helper-text/helper-text.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { Button, Popover, PopoverPosition } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import React from 'react';
 import './helper-text.scss';
 

--- a/src/components/import-modal/import-modal.tsx
+++ b/src/components/import-modal/import-modal.tsx
@@ -1,6 +1,7 @@
 import { t } from '@lingui/macro';
 import { Button, Modal, Radio } from '@patternfly/react-core';
-import { FolderOpenIcon, SpinnerIcon } from '@patternfly/react-icons';
+import FolderOpenIcon from '@patternfly/react-icons/dist/esm/icons/folder-open-icon';
+import SpinnerIcon from '@patternfly/react-icons/dist/esm/icons/spinner-icon';
 import axios from 'axios';
 import cx from 'classnames';
 import React from 'react';

--- a/src/components/legacy-namespace-list/legacy-namespace-item.tsx
+++ b/src/components/legacy-namespace-list/legacy-namespace-item.tsx
@@ -62,9 +62,9 @@ export class LegacyNamespaceListItem extends React.Component<LegacyNamespaceProp
     const dropdownItems = [];
 
     dropdownItems.push(
-      <DropdownItem onClick={() => this.props.openModal(namespace)}>
-        {t`Ansible Lightspeed settings`}
-      </DropdownItem>,
+      <DropdownItem
+        onClick={() => this.props.openModal(namespace)}
+      >{t`Ansible Lightspeed settings`}</DropdownItem>,
     );
 
     if (showWisdom) {

--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -1,6 +1,7 @@
 import { t } from '@lingui/macro';
 import { Form, FormGroup, TextArea, TextInput } from '@patternfly/react-core';
-import { PlusCircleIcon, TrashIcon } from '@patternfly/react-icons';
+import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
+import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
 import React from 'react';
 import { NamespaceType } from 'src/api';
 import { NamespaceCard } from 'src/components';

--- a/src/components/patternfly-wrappers/compound-filter.tsx
+++ b/src/components/patternfly-wrappers/compound-filter.tsx
@@ -10,7 +10,8 @@ import {
   SelectVariant,
   TextInput,
 } from '@patternfly/react-core';
-import { FilterIcon, SearchIcon } from '@patternfly/react-icons';
+import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
+import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import React from 'react';
 import { APISearchTypeAhead, StatefulDropdown } from 'src/components';
 import { ParamHelper } from 'src/utilities';

--- a/src/components/patternfly-wrappers/sort.tsx
+++ b/src/components/patternfly-wrappers/sort.tsx
@@ -1,11 +1,9 @@
 import { t } from '@lingui/macro';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
-import {
-  SortAlphaDownIcon,
-  SortAlphaUpIcon,
-  SortAmountDownIcon,
-  SortAmountUpIcon,
-} from '@patternfly/react-icons';
+import SortAlphaDownIcon from '@patternfly/react-icons/dist/esm/icons/sort-alpha-down-icon';
+import SortAlphaUpIcon from '@patternfly/react-icons/dist/esm/icons/sort-alpha-up-icon';
+import SortAmountDownIcon from '@patternfly/react-icons/dist/esm/icons/sort-amount-down-icon';
+import SortAmountUpIcon from '@patternfly/react-icons/dist/esm/icons/sort-amount-up-icon';
 import React from 'react';
 import { ParamHelper } from 'src/utilities';
 import './sort.scss';

--- a/src/components/repositories/lazy-distributions.tsx
+++ b/src/components/repositories/lazy-distributions.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { Button, Spinner, Tooltip } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import React, { useEffect, useState } from 'react';
 import { AnsibleDistributionAPI } from 'src/api';
 import { errorMessage } from 'src/utilities';

--- a/src/components/repositories/lazy-repositories.tsx
+++ b/src/components/repositories/lazy-repositories.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { Button, Spinner, Tooltip } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { AnsibleRepositoryAPI } from 'src/api';

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -13,11 +13,9 @@ import {
   Switch,
   TextInput,
 } from '@patternfly/react-core';
-import {
-  DownloadIcon,
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-} from '@patternfly/react-icons';
+import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import React from 'react';
 import { RemoteType, WriteOnlyFieldType } from 'src/api';
 import { FileUpload, HelperText, WriteOnlyField } from 'src/components';

--- a/src/components/shared/download-count.tsx
+++ b/src/components/shared/download-count.tsx
@@ -1,5 +1,5 @@
 import { Trans, t } from '@lingui/macro';
-import { DownloadIcon } from '@patternfly/react-icons';
+import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import React from 'react';
 import { Tooltip } from 'src/components';
 import { Constants } from 'src/constants';

--- a/src/components/signing/signature-badge.tsx
+++ b/src/components/signing/signature-badge.tsx
@@ -1,9 +1,7 @@
 import { t } from '@lingui/macro';
 import { Label, LabelProps } from '@patternfly/react-core';
-import {
-  CheckCircleIcon,
-  ExclamationTriangleIcon,
-} from '@patternfly/react-icons';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import React, { FC } from 'react';
 
 interface Props extends LabelProps {

--- a/src/components/sort-table/sort-table.tsx
+++ b/src/components/sort-table/sort-table.tsx
@@ -1,8 +1,6 @@
-import {
-  ArrowsAltVIcon,
-  LongArrowAltDownIcon,
-  LongArrowAltUpIcon,
-} from '@patternfly/react-icons';
+import ArrowsAltVIcon from '@patternfly/react-icons/dist/esm/icons/arrows-alt-v-icon';
+import LongArrowAltDownIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-down-icon';
+import LongArrowAltUpIcon from '@patternfly/react-icons/dist/esm/icons/long-arrow-alt-up-icon';
 import React from 'react';
 import { ParamHelper } from 'src/utilities';
 import './sort-table.scss';

--- a/src/components/status/status-indicator.tsx
+++ b/src/components/status/status-indicator.tsx
@@ -1,12 +1,10 @@
 import { t } from '@lingui/macro';
 import { Label, LabelProps } from '@patternfly/react-core';
-import {
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-  ExclamationIcon,
-  OutlinedClockIcon,
-  SyncAltIcon,
-} from '@patternfly/react-icons';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import ExclamationIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-icon';
+import OutlinedClockIcon from '@patternfly/react-icons/dist/esm/icons/outlined-clock-icon';
+import SyncAltIcon from '@patternfly/react-icons/dist/esm/icons/sync-alt-icon';
 import React from 'react';
 import { PulpStatus } from 'src/api';
 

--- a/src/components/tag-label/tag-label.tsx
+++ b/src/components/tag-label/tag-label.tsx
@@ -1,5 +1,5 @@
 import { Label } from '@patternfly/react-core';
-import { TagIcon } from '@patternfly/react-icons';
+import TagIcon from '@patternfly/react-icons/dist/esm/icons/tag-icon';
 import React from 'react';
 
 interface IProps {

--- a/src/components/wisdom-modal/wisdom-modal.tsx
+++ b/src/components/wisdom-modal/wisdom-modal.tsx
@@ -6,7 +6,7 @@ import {
   Modal,
   Spinner,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import React, { useEffect, useState } from 'react';
 import { WisdomDenyIndexAPI } from 'src/api';
 import { AlertList, AlertType, closeAlert } from 'src/components';

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -10,12 +10,10 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import {
-  CheckCircleIcon,
-  DownloadIcon,
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-} from '@patternfly/react-icons';
+import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
+import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -530,9 +528,7 @@ class CertificationDashboard extends React.Component<RouteProps, IState> {
         <React.Fragment key='upload'>
           <Button
             onClick={() => this.openUploadCertificateModal(collectionData)}
-          >
-            {t`Upload signature`}
-          </Button>{' '}
+          >{t`Upload signature`}</Button>{' '}
         </React.Fragment>
       ),
       <Button

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -1,9 +1,7 @@
 import { t } from '@lingui/macro';
 import { Alert } from '@patternfly/react-core';
-import {
-  ExclamationCircleIcon,
-  ExclamationTriangleIcon,
-} from '@patternfly/react-icons';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
+import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';

--- a/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_activities.tsx
@@ -219,9 +219,7 @@ class ExecutionEnvironmentDetailActivities extends React.Component<
               activities.push({
                 created: lastActivity.created,
                 action: (
-                  <React.Fragment>
-                    {t`${this.props.containerRepository.name} was added`}
-                  </React.Fragment>
+                  <React.Fragment>{t`${this.props.containerRepository.name} was added`}</React.Fragment>
                 ),
               });
             }

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -10,7 +10,8 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { AngleDownIcon, AngleRightIcon } from '@patternfly/react-icons';
+import AngleDownIcon from '@patternfly/react-icons/dist/esm/icons/angle-down-icon';
+import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
 import { sum } from 'lodash';
 import React from 'react';
 import { Link } from 'react-router-dom';

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -8,7 +8,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import {

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -541,9 +541,7 @@ class GroupDetail extends React.Component<RouteProps, IState> {
                     <ToolbarItem>
                       <Button
                         onClick={() => this.setState({ addModalVisible: true })}
-                      >
-                        {t`Add`}
-                      </Button>
+                      >{t`Add`}</Button>
                     </ToolbarItem>
                   </ToolbarGroup>
                 )}

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -187,9 +187,7 @@ class GroupList extends React.Component<RouteProps, IState> {
                             onClick={() =>
                               this.setState({ createModalVisible: true })
                             }
-                          >
-                            {t`Create`}
-                          </Button>
+                          >{t`Create`}</Button>
                         </ToolbarItem>
                       </ToolbarGroup>
                     )}

--- a/src/containers/legacy-namespaces/legacy-namespace.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespace.tsx
@@ -276,9 +276,7 @@ class LegacyNamespace extends React.Component<
         dropdownItems.push(
           <DropdownItem
             onClick={() => this.setState({ isOpenWisdomModal: true })}
-          >
-            {t`Ansible Lightspeed settings`}
-          </DropdownItem>,
+          >{t`Ansible Lightspeed settings`}</DropdownItem>,
         );
       }
 

--- a/src/containers/legacy-roles/legacy-role.tsx
+++ b/src/containers/legacy-roles/legacy-role.tsx
@@ -14,7 +14,7 @@ import {
   TextContent,
   TextVariants,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import {

--- a/src/containers/login/login.tsx
+++ b/src/containers/login/login.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { LoginPage as PFLoginPage } from '@patternfly/react-core';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import Logo from 'src/../static/images/logo_large.svg';

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -8,7 +8,7 @@ import {
   Text,
   Tooltip,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { Link, Navigate } from 'react-router-dom';
@@ -438,9 +438,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
                   this.state.showControls && (
                     <Button
                       onClick={() => this.setState({ showImportModal: true })}
-                    >
-                      {t`Upload collection`}
-                    </Button>
+                    >{t`Upload collection`}</Button>
                   )
                 }
               />
@@ -799,9 +797,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
           {unfilteredCount === 0 ? (
             <DropdownItem
               onClick={() => this.setState({ isOpenNamespaceModal: true })}
-            >
-              {t`Delete namespace`}
-            </DropdownItem>
+            >{t`Delete namespace`}</DropdownItem>
           ) : (
             <Tooltip
               isVisible={false}
@@ -870,9 +866,9 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
       <div className='hub-namespace-page-controls' data-cy='kebab-toggle'>
         {' '}
         {collections.length !== 0 && (
-          <Button onClick={() => this.setState({ showImportModal: true })}>
-            {t`Upload collection`}
-          </Button>
+          <Button
+            onClick={() => this.setState({ showImportModal: true })}
+          >{t`Upload collection`}</Button>
         )}
         {dropdownItems.length > 0 && (
           <div data-cy='ns-kebab-toggle'>

--- a/src/containers/settings/user-profile.tsx
+++ b/src/containers/settings/user-profile.tsx
@@ -85,9 +85,9 @@ class UserProfile extends React.Component<RouteProps, IState> {
             !isUserMgmtDisabled && (
               <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
                 <div>
-                  <Button onClick={() => this.setState({ inEditMode: true })}>
-                    {t`Edit`}
-                  </Button>
+                  <Button
+                    onClick={() => this.setState({ inEditMode: true })}
+                  >{t`Edit`}</Button>
                 </div>
               </div>
             )

--- a/src/containers/task-management/task_detail.tsx
+++ b/src/containers/task-management/task_detail.tsx
@@ -11,7 +11,7 @@ import {
   FlexItem,
   Title,
 } from '@patternfly/react-core';
-import { CubesIcon } from '@patternfly/react-icons';
+import CubesIcon from '@patternfly/react-icons/dist/esm/icons/cubes-icon';
 import { capitalize } from 'lodash';
 import React from 'react';
 import { Link, Navigate } from 'react-router-dom';

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -10,7 +10,7 @@ import {
   ToolbarItem,
   Tooltip,
 } from '@patternfly/react-core';
-import { UserPlusIcon } from '@patternfly/react-icons';
+import UserPlusIcon from '@patternfly/react-icons/dist/esm/icons/user-plus-icon';
 import React from 'react';
 import { Link, Navigate } from 'react-router-dom';
 import { UserAPI, UserType } from 'src/api';

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -8,10 +8,8 @@ import {
   PageHeaderTools,
   PageSidebar,
 } from '@patternfly/react-core';
-import {
-  ExternalLinkAltIcon,
-  QuestionCircleIcon,
-} from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
+import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
 import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import Logo from 'src/../static/images/logo_large.svg';

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -7,7 +7,7 @@ import {
   NavItem,
   NavList,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import ExternalLinkAltIcon from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { reject, some } from 'lodash';
 import React, { useEffect, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';


### PR DESCRIPTION
As per https://medium.com/@marvusm.mmi/webpack-module-federation-think-twice-before-sharing-a-dependency-18b3b0e352cb ,
importing individual icons should better support tree-shaking in the c.r.c federated modules environment.

    echo "printWidth: 500" >> .prettierrc.yaml
    npm run prettier
    perl -i -npe 'if (/{\s*(.*?)\s*}.*from.*react-icons/) { my @a = split /\s*,\s*/, $1; $_ = ""; for my $i (@a) { $j = $i; $j =~ s/[A-Z]/-\l$&/g; $j =~ s/^-//; $_ .= "import $i from '\''\@patternfly/react-icons/dist/esm/icons/$j'\'';"; }; s/$/\n/; }' src/**/*.*
    git checkout .prettierrc.yaml
    npm run prettier
