### PR TITLE
Rename legacy roles to Roles

### DIFF
--- a/src/containers/legacy-namespaces/legacy-namespace.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespace.tsx
@@ -306,7 +306,7 @@ class LegacyNamespace extends React.Component<
           closeAlert={(i) => this.closeAlert(i)}
         />
         <DataList
-          aria-label={t`Namespace Header`}
+          aria-label={t`Role namespace header`}
           className='hub-legacy-namespace-page'
         >
           <DataListItem data-cy='LegacyNamespace'>

--- a/src/containers/legacy-namespaces/legacy-namespaces.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespaces.tsx
@@ -150,7 +150,7 @@ class LegacyNamespaces extends React.Component<
             reference={this.state.wisdomReference}
           />
         )}
-        <BaseHeader title={t`Legacy Namespaces`} />
+        <BaseHeader title={t`Namespaces`} />
         <React.Fragment>
           {loading ? (
             <LoadingPageSpinner />
@@ -173,7 +173,7 @@ class LegacyNamespaces extends React.Component<
                 count={this.state.count}
               />
 
-              <DataList aria-label={t`List of Legacy Namespaces`}>
+              <DataList aria-label={t`List of namespaces`}>
                 {this.state.legacynamespaces &&
                   this.state.legacynamespaces.map((lnamespace) => (
                     <LegacyNamespaceListItem

--- a/src/containers/legacy-namespaces/legacy-namespaces.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespaces.tsx
@@ -150,14 +150,14 @@ class LegacyNamespaces extends React.Component<
             reference={this.state.wisdomReference}
           />
         )}
-        <BaseHeader title={t`Namespaces`} />
+        <BaseHeader title={t`Role Namespaces`} />
         <React.Fragment>
           {loading ? (
             <LoadingPageSpinner />
           ) : noData ? (
             <EmptyStateNoData
-              title={t`No namespaces yet`}
-              description={t`Namespaces will appear once created or roles are imported`}
+              title={t`No role namespaces yet`}
+              description={t`Role namespaces will appear once created or roles are imported`}
             />
           ) : (
             <div>
@@ -173,7 +173,7 @@ class LegacyNamespaces extends React.Component<
                 count={this.state.count}
               />
 
-              <DataList aria-label={t`List of namespaces`}>
+              <DataList aria-label={t`List of role namespaces`}>
                 {this.state.legacynamespaces &&
                   this.state.legacynamespaces.map((lnamespace) => (
                     <LegacyNamespaceListItem

--- a/src/containers/legacy-roles/legacy-roles.tsx
+++ b/src/containers/legacy-roles/legacy-roles.tsx
@@ -123,7 +123,7 @@ class LegacyRoles extends React.Component<RouteProps, IProps> {
 
     return (
       <div>
-        <BaseHeader title={t`Legacy Roles`} />
+        <BaseHeader title={t`Roles`} />
         <React.Fragment>
           {loading ? (
             <LoadingPageSpinner />
@@ -147,7 +147,7 @@ class LegacyRoles extends React.Component<RouteProps, IProps> {
                 count={this.state.count}
               />
 
-              <DataList aria-label={t`List of Legacy Roles`}>
+              <DataList aria-label={t`List of roles`}>
                 {this.state.legacyroles &&
                   this.state.legacyroles.map((lrole) => (
                     <LegacyRoleListItem

--- a/src/containers/not-found/dispatch.tsx
+++ b/src/containers/not-found/dispatch.tsx
@@ -111,22 +111,22 @@ export const Dispatch = (props: RouteProps) => {
           <>
             <SectionSeparator />
             <PageSection>
-              <SectionTitle>{t`Legacy roles`}</SectionTitle>
+              <SectionTitle>{t`Roles`}</SectionTitle>
 
               {roles === null ? (
                 <LoadingPageSpinner />
               ) : roles.length === 0 ? (
                 <EmptyStateNoData
-                  title={t`No matching legacy roles found.`}
+                  title={t`No matching roles found.`}
                   description={
                     <Link
                       to={formatPath(Paths.legacyRoles)}
-                    >{t`Show all legacy roles`}</Link>
+                    >{t`Show all roles`}</Link>
                   }
                 />
               ) : (
                 <>
-                  <DataList aria-label={t`Available matching legacy roles`}>
+                  <DataList aria-label={t`Available matching roles`}>
                     {roles.map((r) => (
                       <LegacyRoleListItem
                         key={r.id}
@@ -137,7 +137,7 @@ export const Dispatch = (props: RouteProps) => {
                   </DataList>
                   <Link
                     to={formatPath(Paths.legacyRoles)}
-                  >{t`Show all legacy roles`}</Link>
+                  >{t`Show all roles`}</Link>
                 </>
               )}
             </PageSection>

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -85,15 +85,15 @@ function standaloneMenu() {
       ],
     ),
     menuSection(
-      t`Legacy`,
+      t`Roles`,
       {
         condition: ({ featureFlags }) => featureFlags.legacy_roles,
       },
       [
-        menuItem(t`Legacy Roles`, {
+        menuItem(t`Roles`, {
           url: formatPath(Paths.legacyRoles),
         }),
-        menuItem(t`Legacy Namespaces`, {
+        menuItem(t`Namespaces`, {
           url: formatPath(Paths.legacyNamespaces),
         }),
       ],

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -181,9 +181,9 @@ function MenuItem({ item, context }) {
       {item.url && item.external ? (
         <a
           href={item.url}
-          data-cy={item['data-cy']}
           target='_blank'
           rel='noreferrer'
+          data-cy={`hub-menu-item-${item.name}`}
         >
           {item.name}
           <ExternalLinkAltIcon
@@ -191,7 +191,9 @@ function MenuItem({ item, context }) {
           />
         </a>
       ) : item.url ? (
-        <Link to={item.url}>{item.name}</Link>
+        <Link to={item.url} data-cy={`hub-menu-item-${item.name}`}>
+          {item.name}
+        </Link>
       ) : (
         item.name
       )}
@@ -206,6 +208,7 @@ function MenuSection({ section, context, expandedSections }) {
       groupId={section.name}
       isActive={section.active}
       isExpanded={expandedSections.includes(section.name)}
+      data-cy={`hub-menu-section-${section.name}`}
     >
       <Menu
         items={section.items}

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -93,7 +93,7 @@ function standaloneMenu() {
         menuItem(t`Roles`, {
           url: formatPath(Paths.legacyRoles),
         }),
-        menuItem(t`Namespaces`, {
+        menuItem(t`Role Namespaces`, {
           url: formatPath(Paths.legacyNamespaces),
         }),
       ],

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -210,11 +210,16 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
         isDisabled: isContainerDisabled,
       },
 
-      // LEGACY ...
+      // roles ...
       { component: LegacyNamespace, path: Paths.legacyNamespace },
       { component: LegacyNamespaces, path: Paths.legacyNamespaces },
       { component: LegacyRole, path: Paths.legacyRole },
       { component: LegacyRoles, path: Paths.legacyRoles },
+      // ... but still support legacy urls
+      { component: LegacyNamespace, path: Paths.compatLegacyNamespace },
+      { component: LegacyNamespaces, path: Paths.compatLegacyNamespaces },
+      { component: LegacyRole, path: Paths.compatLegacyRole },
+      { component: LegacyRoles, path: Paths.compatLegacyRoles },
 
       {
         component: TaskListView,

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -89,10 +89,10 @@ export enum Paths {
   login = '/login',
   logout = '/logout',
   landingPage = '/',
-  legacyRole = '/legacy/roles/:username/:name',
-  legacyRoles = '/legacy/roles/',
-  legacyNamespace = '/legacy/namespaces/:namespaceid',
-  legacyNamespaces = '/legacy/namespaces/',
+  legacyRole = '/standalone/roles/:username/:name',
+  legacyRoles = '/standalone/roles/',
+  legacyNamespace = '/standalone/namespaces/:namespaceid',
+  legacyNamespaces = '/standalone/namespaces/',
   searchByRepo = '/repo/:repo',
   myCollectionsByRepo = '/repo/:repo/my-namespaces/:namespace',
   collectionByRepo = '/repo/:repo/:namespace/:collection',
@@ -124,6 +124,12 @@ export enum Paths {
   taskList = '/tasks',
   signatureKeys = '/signature-keys',
   collections = '/collections',
+
+  // for compatibility with old beta routes, remove later
+  compatLegacyRole = '/legacy/roles/:username/:name',
+  compatLegacyRoles = '/legacy/roles/',
+  compatLegacyNamespace = '/legacy/namespaces/:namespaceid',
+  compatLegacyNamespaces = '/legacy/namespaces/',
 }
 
 export const namespaceBreadcrumb = () =>

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -14,21 +14,25 @@ Cypress.Commands.add('containsnear', {}, (...args) => {
   cy.log('constainsnear requires selector and content parameters');
 });
 
+const name2element = (name) => {
+  const [first, last] = name.split(' > ');
+  return last
+    ? cy.get(
+        `#page-sidebar [data-cy="hub-menu-section-${first}"] [data-cy="hub-menu-item-${last}"]`,
+      )
+    : cy.get(`#page-sidebar [data-cy="hub-menu-item-${first}"]`);
+};
+
 Cypress.Commands.add('menuPresent', {}, (name) => {
-  const last = name.split(' > ').pop();
-  return cy.contains('#page-sidebar a', last).should('exist');
+  return name2element(name).should('exist');
 });
 
 Cypress.Commands.add('menuMissing', {}, (name) => {
-  const last = name.split(' > ').pop();
-  return cy.get('#page-sidebar a').each(($el) => {
-    expect($el.text()).not.to.equal(last);
-  });
+  return name2element(name).should('not.exist');
 });
 
 Cypress.Commands.add('menuGo', {}, (name) => {
-  const last = name.split(' > ').pop();
-  return cy.contains('#page-sidebar a', last).click({ force: true });
+  return name2element(name).click({ force: true });
 });
 
 Cypress.Commands.add('assertTitle', {}, (title) => {


### PR DESCRIPTION
Related to https://github.com/ansible-community/community-topics/issues/272

Change Legacy Roles & Legacy Namespaces to Roles & Role Namespaces,
add `/ui/standalone/roles` and `/ui/standalone/namespaces` (but also support old `/ui/legacy/...` for now).

![20230907112813](https://github.com/ansible/ansible-hub-ui/assets/289743/481bf7ea-b548-46c6-a984-b91e76fc0ce6)

