### PR TITLE
Menu: allow alternative url prefixes to highlight active menu item

### DIFF
--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -44,14 +44,14 @@ function standaloneMenu() {
         condition: ({ settings, user }) =>
           settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
           !user.is_anonymous,
-        activeUrls: [formatPath(Paths.searchByRepo)],
+        alternativeUrls: [formatPath(Paths.searchByRepo)],
       }),
       menuItem(t`Namespaces`, {
         url: formatPath(Paths[NAMESPACE_TERM]),
         condition: ({ settings, user }) =>
           settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
           !user.is_anonymous,
-        activeUrls: [formatPath(Paths.myNamespaces)],
+        alternativeUrls: [formatPath(Paths.myNamespaces)],
       }),
       menuItem(t`Repositories`, {
         condition: canViewAnsibleRepositories,
@@ -94,18 +94,18 @@ function standaloneMenu() {
       [
         menuItem(t`Legacy Roles`, {
           url: formatPath(Paths.legacyRoles),
-          // activeUrls: [formatPath(Paths.compatLegacyRoles)],
+          // alternativeUrls: [formatPath(Paths.compatLegacyRoles)],
         }),
         menuItem(t`Legacy Namespaces`, {
           url: formatPath(Paths.legacyNamespaces),
-          // activeUrls: [formatPath(Paths.compatLegacyNamespaces)],
+          // alternativeUrls: [formatPath(Paths.compatLegacyNamespaces)],
         }),
       ],
     ),
     menuItem(t`Task Management`, {
       url: formatPath(Paths.taskList),
       condition: isLoggedIn,
-      activeUrls: [formatPath(Paths.taskDetail)],
+      alternativeUrls: [formatPath(Paths.taskDetail)],
     }),
     menuItem(t`Signature Keys`, {
       url: formatPath(Paths.signatureKeys),
@@ -142,12 +142,12 @@ function standaloneMenu() {
       menuItem(t`Groups`, {
         condition: (context) => hasPermission(context, 'galaxy.view_group'),
         url: formatPath(Paths.groupList),
-        activeUrls: [formatPath(Paths.groupDetail)],
+        alternativeUrls: [formatPath(Paths.groupDetail)],
       }),
       menuItem(t`Roles`, {
         condition: (context) => hasPermission(context, 'galaxy.view_group'),
         url: formatPath(Paths.roleList),
-        activeUrls: [formatPath(Paths.roleEdit)],
+        alternativeUrls: [formatPath(Paths.roleEdit)],
       }),
     ]),
   ];
@@ -165,8 +165,8 @@ function activateMenu(items, pathname) {
       item.type === 'section'
         ? activateMenu(item.items, pathname)
         : normalizedPathname.startsWith(normalize(item.url)) ||
-          (item.activeUrls?.length &&
-            item.activeUrls.some((url) =>
+          (item.alternativeUrls?.length &&
+            item.alternativeUrls.some((url) =>
               normalizedPathname.startsWith(normalize(url)),
             ));
   });

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -44,12 +44,14 @@ function standaloneMenu() {
         condition: ({ settings, user }) =>
           settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
           !user.is_anonymous,
+        activeUrls: [formatPath(Paths.searchByRepo)],
       }),
       menuItem(t`Namespaces`, {
         url: formatPath(Paths[NAMESPACE_TERM]),
         condition: ({ settings, user }) =>
           settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
           !user.is_anonymous,
+        activeUrls: [formatPath(Paths.myNamespaces)],
       }),
       menuItem(t`Repositories`, {
         condition: canViewAnsibleRepositories,
@@ -92,15 +94,18 @@ function standaloneMenu() {
       [
         menuItem(t`Legacy Roles`, {
           url: formatPath(Paths.legacyRoles),
+          // activeUrls: [formatPath(Paths.compatLegacyRoles)],
         }),
         menuItem(t`Legacy Namespaces`, {
           url: formatPath(Paths.legacyNamespaces),
+          // activeUrls: [formatPath(Paths.compatLegacyNamespaces)],
         }),
       ],
     ),
     menuItem(t`Task Management`, {
       url: formatPath(Paths.taskList),
       condition: isLoggedIn,
+      activeUrls: [formatPath(Paths.taskDetail)],
     }),
     menuItem(t`Signature Keys`, {
       url: formatPath(Paths.signatureKeys),
@@ -137,21 +142,33 @@ function standaloneMenu() {
       menuItem(t`Groups`, {
         condition: (context) => hasPermission(context, 'galaxy.view_group'),
         url: formatPath(Paths.groupList),
+        activeUrls: [formatPath(Paths.groupDetail)],
       }),
       menuItem(t`Roles`, {
         condition: (context) => hasPermission(context, 'galaxy.view_group'),
         url: formatPath(Paths.roleList),
+        activeUrls: [formatPath(Paths.roleEdit)],
       }),
     ]),
   ];
 }
 
 function activateMenu(items, pathname) {
+  const normalize = (s) => s.replace(/\/$/, '').replace(/\/:[^\/:]+$/, '');
+  const normalizedPathname = normalize(pathname).replace(
+    /\/repo\/[^\/]+\//,
+    '/repo/:repo/',
+  );
+
   items.forEach((item) => {
     item.active =
       item.type === 'section'
         ? activateMenu(item.items, pathname)
-        : pathname.replace(/\/$/, '').startsWith(item.url.replace(/\/$/, ''));
+        : normalizedPathname.startsWith(normalize(item.url)) ||
+          (item.activeUrls?.length &&
+            item.activeUrls.some((url) =>
+              normalizedPathname.startsWith(normalize(url)),
+            ));
   });
 
   return some(items, 'active');

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -154,9 +154,9 @@ function standaloneMenu() {
 }
 
 function activateMenu(items, pathname) {
-  const normalize = (s) => s.replace(/\/$/, '').replace(/\/:[^\/:]+$/, '');
+  const normalize = (s) => s.replace(/\/$/, '').replace(/\/:[^/:]+$/, '');
   const normalizedPathname = normalize(pathname).replace(
-    /\/repo\/[^\/]+\//,
+    /\/repo\/[^/]+\//,
     '/repo/:repo/',
   );
 


### PR DESCRIPTION
Fixes https://github.com/ansible/galaxy_ng/discussions/1870

the right menu item is only highlighted when the current url matches, or is prefixed by, the menu item url

that works in most cases, but not in my namespaces, access role edit, group and task detail, etc.

adding support for an array of alternative urls which are also matched against when highlighting a menu item

current path gets normalized to change `/repo/*/` to `/repo/:repo` (to match `src/paths.ts`), both sets of paths get normalized to skip any trailing `/:whatever` (to make `/namespaces/:namespaces` match `/namespaces/anything`)