### PR TITLE
screenshot tests - fix Signature keys inconsistent order

### DIFF
--- a/src/api/signing-service.ts
+++ b/src/api/signing-service.ts
@@ -11,6 +11,7 @@ export class SigningServiceType {
 
 export class API extends PulpAPI {
   apiPath = 'signing-services/';
+  useOrdering = true;
 
   // list(params?)
 }

--- a/src/containers/signature-keys/list.tsx
+++ b/src/containers/signature-keys/list.tsx
@@ -233,7 +233,7 @@ export class SignatureKeysList extends React.Component<RouteProps, IState> {
     return (
       <tr key={index}>
         <td>{name}</td>
-        <td>{pubkey_fingerprint}</td>
+        <td data-cy='hub-signature-list-fingerprint'>{pubkey_fingerprint}</td>
         <td>
           <DateComponent date={pulp_created} />
         </td>
@@ -253,7 +253,7 @@ export class SignatureKeysList extends React.Component<RouteProps, IState> {
 
   private query() {
     this.setState({ loading: true }, () => {
-      SigningServiceAPI.list(this.state.params)
+      SigningServiceAPI.list({ sort: 'name', ...this.state.params })
         .then((result) => {
           this.setState({
             items: result.data.results,

--- a/test/cypress/e2e/screenshots/screenshots.js
+++ b/test/cypress/e2e/screenshots/screenshots.js
@@ -48,7 +48,9 @@ describe('screenshots', () => {
     screenshot('/legacy/namespaces');
 
     screenshot('/tasks', { blackout: ['time'] });
-    screenshot('/signature-keys', { blackout: ['time'] });
+    screenshot('/signature-keys', {
+      blackout: ['time', '[data-cy=hub-signature-list-fingerprint]'],
+    });
     screenshot('/users', { blackout: ['time'] });
     screenshot('/group-list');
     screenshot('/roles', { blackout: ['time'] });


### PR DESCRIPTION
fix Signature keys inconsistent order and fingerprint changing..

default to sort by name (instead of undefined),
and blackout the fingerprint for the screenshot so we don't fail on differences there.
