### PR TITLE
Search page

### DIFF
--- a/CHANGES/2697.misc
+++ b/CHANGES/2697.misc
@@ -1,0 +1,1 @@
+Add a Search page for searching accross collections, roles, namespaces, etc.

--- a/src/components/empty-state/empty-state-custom.tsx
+++ b/src/components/empty-state/empty-state-custom.tsx
@@ -27,7 +27,7 @@ export const EmptyStateCustom = ({
 }: IProps) => {
   return (
     <EmptyState variant={EmptyStateVariant[variant]} data-cy='EmptyState'>
-      <EmptyStateIcon icon={icon} />
+      {icon ? <EmptyStateIcon icon={icon} /> : null}
       <Title headingLevel='h4' size='lg'>
         {title}
       </Title>

--- a/src/components/empty-state/empty-state-xs.tsx
+++ b/src/components/empty-state/empty-state-xs.tsx
@@ -1,0 +1,19 @@
+import React, { ReactElement, ReactNode } from 'react';
+import { EmptyStateCustom } from './empty-state-custom';
+
+interface IProps {
+  button?: ReactElement;
+  title: string;
+  description: ReactNode;
+}
+
+export const EmptyStateXs = (props: IProps) => {
+  return (
+    <EmptyStateCustom
+      variant='xs'
+      title={props.title}
+      description={props.description}
+      button={props.button}
+    />
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -119,6 +119,7 @@ export { DownloadCount } from './shared/download-count';
 export { LoginLink } from './shared/login-link';
 export { MultiRepoModal } from './shared/multi-repo-modal';
 export { MultiSearchSearch } from './shared/multi-search-search';
+export { NamespaceListItem } from './shared/namespace-list-item';
 export { CollectionRatings, RoleRatings } from './shared/ratings';
 export { UIVersion } from './shared/ui-version';
 export {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -25,6 +25,7 @@ export { EmptyStateCustom } from './empty-state/empty-state-custom';
 export { EmptyStateFilter } from './empty-state/empty-state-filter';
 export { EmptyStateNoData } from './empty-state/empty-state-no-data';
 export { EmptyStateUnauthorized } from './empty-state/empty-state-unauthorized';
+export { EmptyStateXs } from './empty-state/empty-state-xs';
 export { ExecutionEnvironmentHeader } from './execution-environment-header/execution-environment-header';
 export { PublishToControllerModal } from './execution-environment/publish-to-controller-modal';
 export { RepositoryForm } from './execution-environment/repository-form';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -117,6 +117,7 @@ export { Details } from './shared/details';
 export { DownloadCount } from './shared/download-count';
 export { LoginLink } from './shared/login-link';
 export { MultiRepoModal } from './shared/multi-repo-modal';
+export { MultiSearchSearch } from './shared/multi-search-search';
 export { CollectionRatings, RoleRatings } from './shared/ratings';
 export { UIVersion } from './shared/ui-version';
 export {

--- a/src/components/legacy-namespace-list/legacy-namespace-item.tsx
+++ b/src/components/legacy-namespace-list/legacy-namespace-item.tsx
@@ -16,7 +16,7 @@ import './legacy-namespace-item.scss';
 
 interface LegacyNamespaceProps {
   namespace: LegacyNamespaceDetailType;
-  openModal: (namespace) => void;
+  openModal?: (namespace) => void;
 }
 
 export function LegacyNamespaceListItem({
@@ -70,7 +70,7 @@ export function LegacyNamespaceListItem({
     >{t`Ansible Lightspeed settings`}</DropdownItem>,
   );
 
-  if (showWisdom) {
+  if (showWisdom && openModal) {
     cells.push(
       <DataListCell key='menu' alignRight={true}>
         <div style={{ float: 'right' }}>

--- a/src/components/shared/multi-search-search.tsx
+++ b/src/components/shared/multi-search-search.tsx
@@ -1,0 +1,67 @@
+import { t } from '@lingui/macro';
+import {
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import React, { ReactNode, useState } from 'react';
+import { AppliedFilters, CompoundFilter } from 'src/components';
+
+const PageSection = ({ children, style }: { children: ReactNode; style }) => (
+  <section className='body' style={style}>
+    {children}
+  </section>
+);
+
+export const MultiSearchSearch = ({
+  params,
+  style,
+  updateParams,
+}: {
+  params?;
+  style?;
+  updateParams: (p) => void;
+}) => {
+  const [inputText, setInputText] = useState<string>('');
+
+  return (
+    <PageSection style={style}>
+      <div className='hub-toolbar'>
+        <Toolbar>
+          <ToolbarContent>
+            <ToolbarGroup>
+              <ToolbarItem>
+                <CompoundFilter
+                  inputText={inputText}
+                  onChange={setInputText}
+                  updateParams={(p) => updateParams(p)}
+                  params={params || {}}
+                  filterConfig={[
+                    {
+                      id: 'keywords',
+                      title: t`Keywords`,
+                    },
+                  ]}
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
+          </ToolbarContent>
+        </Toolbar>
+      </div>
+      <div>
+        <AppliedFilters
+          updateParams={(p) => {
+            updateParams(p);
+            setInputText('');
+          }}
+          params={params || {}}
+          ignoredParams={['page_size', 'page', 'sort', 'ordering']}
+          niceNames={{
+            keywords: t`Keywords`,
+          }}
+        />
+      </div>
+    </PageSection>
+  );
+};

--- a/src/components/shared/namespace-list-item.tsx
+++ b/src/components/shared/namespace-list-item.tsx
@@ -1,0 +1,55 @@
+import { t } from '@lingui/macro';
+import {
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+} from '@patternfly/react-core';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Logo } from 'src/components';
+import { Paths, formatPath } from 'src/paths';
+import { namespaceTitle } from 'src/utilities';
+
+export function NamespaceListItem({
+  namespace,
+}: {
+  namespace: { avatar_url: string; company: string; name: string };
+}) {
+  const { avatar_url, name } = namespace;
+  const namespace_url = formatPath(Paths.namespaces, {
+    namespace: name,
+  });
+  const title = namespaceTitle(namespace);
+
+  return (
+    <DataListItem data-cy='NamespaceListItem'>
+      <DataListItemRow>
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell isFilled={false} alignRight={false} key='ns'>
+              <Logo
+                alt={t`${title} logo`}
+                fallbackToDefault
+                image={avatar_url}
+                size='40px'
+                unlockWidth
+                width='97px'
+              />
+            </DataListCell>,
+            <DataListCell key='content' size={10}>
+              <div>
+                <Link to={namespace_url}>{title}</Link>
+              </div>
+            </DataListCell>,
+            title !== name ? (
+              <DataListCell key='content' size={5}>
+                <div>{name}</div>
+              </DataListCell>
+            ) : null,
+          ].filter(Boolean)}
+        />
+      </DataListItemRow>
+    </DataListItem>
+  );
+}

--- a/src/containers/index.ts
+++ b/src/containers/index.ts
@@ -36,6 +36,7 @@ export { default as NotFound } from './not-found/not-found';
 export { default as RoleCreate } from './role-management/role-create';
 export { default as EditRole } from './role-management/role-edit';
 export { default as RoleList } from './role-management/role-list';
+export { default as MultiSearch } from './search/multi-search';
 export { default as Search } from './search/search';
 export { default as UserProfile } from './settings/user-profile';
 export { default as SignatureKeysList } from './signature-keys/list';

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -7,6 +7,7 @@ import {
   BaseHeader,
   LandingPageCard,
   Main,
+  MultiSearchSearch,
   closeAlertMixin,
 } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
@@ -49,6 +50,13 @@ export class LandingPage extends React.Component<RouteProps, IState> {
         <AlertList alerts={alerts} closeAlert={(i) => this.closeAlert(i)} />
         <BaseHeader title={t`Welcome to Galaxy`} />
         <Main>
+          <MultiSearchSearch
+            updateParams={({ keywords }) =>
+              this.props.navigate(formatPath(Paths.search, {}, { keywords }))
+            }
+            style={{ marginBottom: '16px' }}
+          />
+
           <div
             style={{
               display: 'flex',

--- a/src/containers/search/multi-search.tsx
+++ b/src/containers/search/multi-search.tsx
@@ -20,7 +20,6 @@ import {
   LoadingPageSpinner,
   Main,
   MultiSearchSearch,
-  NamespaceCard,
   NamespaceListItem,
   closeAlert,
 } from 'src/components';

--- a/src/containers/search/multi-search.tsx
+++ b/src/containers/search/multi-search.tsx
@@ -1,13 +1,5 @@
 import { t } from '@lingui/macro';
-import {
-  DataList,
-  Label,
-  Toolbar,
-  ToolbarContent,
-  ToolbarGroup,
-  ToolbarItem,
-  Tooltip,
-} from '@patternfly/react-core';
+import { DataList, Label, Tooltip } from '@patternfly/react-core';
 import React, { ReactNode, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -20,15 +12,14 @@ import {
 import {
   AlertList,
   AlertType,
-  AppliedFilters,
   BaseHeader,
   CollectionListItem,
-  CompoundFilter,
   EmptyStateNoData,
   LegacyNamespaceListItem,
   LegacyRoleListItem,
   LoadingPageSpinner,
   Main,
+  MultiSearchSearch,
   NamespaceCard,
   closeAlert,
 } from 'src/components';
@@ -74,7 +65,6 @@ const loading = [];
 export const MultiSearch = (props: RouteProps) => {
   const { featureFlags } = useContext();
   const [alerts, setAlerts] = useState<AlertType[]>([]);
-  const [inputText, setInputText] = useState<string>('');
   const [params, setParams] = useState({});
 
   const [collections, setCollections] = useState([]);
@@ -234,43 +224,10 @@ export const MultiSearch = (props: RouteProps) => {
         closeAlert={(i) => closeAlert(i, { alerts, setAlerts })}
       />
       <Main>
-        <PageSection>
-          <div className='hub-toolbar'>
-            <Toolbar>
-              <ToolbarContent>
-                <ToolbarGroup>
-                  <ToolbarItem>
-                    <CompoundFilter
-                      inputText={inputText}
-                      onChange={setInputText}
-                      updateParams={(p) => updateParams(p)}
-                      params={params}
-                      filterConfig={[
-                        {
-                          id: 'keywords',
-                          title: t`Keywords`,
-                        },
-                      ]}
-                    />
-                  </ToolbarItem>
-                </ToolbarGroup>
-              </ToolbarContent>
-            </Toolbar>
-          </div>
-          <div>
-            <AppliedFilters
-              updateParams={(p) => {
-                updateParams(p);
-                setInputText('');
-              }}
-              params={params}
-              ignoredParams={['page_size', 'page', 'sort', 'ordering']}
-              niceNames={{
-                keywords: t`Keywords`,
-              }}
-            />
-          </div>
-        </PageSection>
+        <MultiSearchSearch
+          params={params}
+          updateParams={(p) => updateParams(p)}
+        />
 
         {/* loading and non-empty lists go before not found */}
         <ResultsSection

--- a/src/containers/search/multi-search.tsx
+++ b/src/containers/search/multi-search.tsx
@@ -1,0 +1,405 @@
+import { t } from '@lingui/macro';
+import {
+  DataList,
+  Label,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  Tooltip,
+} from '@patternfly/react-core';
+import React, { ReactNode, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  CollectionVersionAPI,
+  ExecutionEnvironmentAPI,
+  LegacyNamespaceAPI,
+  LegacyRoleAPI,
+  NamespaceAPI,
+} from 'src/api';
+import {
+  AlertList,
+  AlertType,
+  AppliedFilters,
+  BaseHeader,
+  CollectionListItem,
+  CompoundFilter,
+  DateComponent,
+  EmptyStateNoData,
+  LegacyNamespaceListItem,
+  LegacyRoleListItem,
+  LoadingPageSpinner,
+  Main,
+  NamespaceCard,
+  closeAlert,
+} from 'src/components';
+import { useContext } from 'src/loaders/app-context';
+import { Paths, formatEEPath, formatPath } from 'src/paths';
+import {
+  ParamHelper,
+  RouteProps,
+  handleHttpError,
+  withRouter,
+} from 'src/utilities';
+
+const PageSection = ({ children, ...rest }: { children: ReactNode }) => (
+  <section className='body' {...rest}>
+    {children}
+  </section>
+);
+
+const SectionSeparator = () => <section>&nbsp;</section>;
+
+const SectionTitle = ({ children }: { children: ReactNode }) => (
+  <h2 className='pf-c-title'>{children}</h2>
+);
+
+export const MultiSearch = (props: RouteProps) => {
+  const { featureFlags } = useContext();
+  const [alerts, setAlerts] = useState<AlertType[]>([]);
+  const [inputText, setInputText] = useState<string>('');
+  const [params, setParams] = useState({});
+
+  const [collections, setCollections] = useState([]);
+  const [roles, setRoles] = useState([]);
+  const [namespaces, setNamespaces] = useState([]);
+  const [roleNamespaces, setRoleNamespaces] = useState([]);
+  const [containers, setContainers] = useState([]);
+
+  const keywords = (params as { keywords: string })?.keywords || '';
+
+  function addAlert(alert: AlertType) {
+    setAlerts((prevAlerts) => [...prevAlerts, alert]);
+  }
+
+  function query() {
+    if (!keywords) {
+      setCollections([]);
+      setNamespaces([]);
+      setRoles([]);
+      setRoleNamespaces([]);
+      setContainers([]);
+    }
+
+    CollectionVersionAPI.list({ keywords, is_highest: true })
+      .then(({ data: { data } }) => setCollections(data || []))
+      .catch(
+        handleHttpError(
+          t`Failed to search collections (${keywords})`,
+          () => setCollections([]),
+          addAlert,
+        ),
+      );
+    NamespaceAPI.list({ keywords })
+      .then(({ data: { data } }) => setNamespaces(data || []))
+      .catch(
+        handleHttpError(
+          t`Failed to search namespaces (${keywords})`,
+          () => setNamespaces([]),
+          addAlert,
+        ),
+      );
+
+    if (featureFlags.legacy_roles) {
+      LegacyRoleAPI.list({ keywords })
+        .then(({ data: { results } }) => setRoles(results || []))
+        .catch(
+          handleHttpError(
+            t`Failed to search roles (${keywords})`,
+            () => setRoles([]),
+            addAlert,
+          ),
+        );
+      LegacyNamespaceAPI.list({ keywords })
+        .then(({ data: { results } }) => setRoleNamespaces(results || []))
+        .catch(
+          handleHttpError(
+            t`Failed to search role namespaces (${keywords})`,
+            () => setRoleNamespaces([]),
+            addAlert,
+          ),
+        );
+    }
+
+    if (featureFlags.execution_environments) {
+      ExecutionEnvironmentAPI.list({ keywords })
+        .then(({ data: { data } }) => setContainers(data || []))
+        .catch(
+          handleHttpError(
+            t`Failed to search execution environments (${keywords})`,
+            () => setContainers([]),
+            addAlert,
+          ),
+        );
+    }
+  }
+
+  function updateParams(params) {
+    delete params.page;
+
+    props.navigate({
+      search: '?' + ParamHelper.getQueryString(params || []),
+    });
+
+    setParams(params);
+  }
+
+  useEffect(() => {
+    setParams(ParamHelper.parseParamString(props.location.search));
+  }, [props.location.search]);
+
+  useEffect(() => {
+    query();
+  }, [keywords]);
+
+  return (
+    <>
+      <BaseHeader title={t`Search`} />
+      <AlertList
+        alerts={alerts}
+        closeAlert={(i) => closeAlert(i, { alerts, setAlerts })}
+      />
+      <Main>
+        <PageSection>
+          <div className='hub-toolbar'>
+            <Toolbar>
+              <ToolbarContent>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    <CompoundFilter
+                      inputText={inputText}
+                      onChange={setInputText}
+                      updateParams={(p) => updateParams(p)}
+                      params={params}
+                      filterConfig={[
+                        {
+                          id: 'keywords',
+                          title: t`Keywords`,
+                        },
+                      ]}
+                    />
+                  </ToolbarItem>
+                </ToolbarGroup>
+              </ToolbarContent>
+            </Toolbar>
+          </div>
+          <div>
+            <AppliedFilters
+              updateParams={(p) => {
+                updateParams(p);
+                setInputText('');
+              }}
+              params={params}
+              ignoredParams={['page_size', 'page', 'sort', 'ordering']}
+              niceNames={{
+                keywords: t`Keywords`,
+              }}
+            />
+          </div>
+        </PageSection>
+        <SectionSeparator />
+        <PageSection>
+          <SectionTitle>{t`Collections`}</SectionTitle>
+
+          {collections === null ? (
+            <LoadingPageSpinner />
+          ) : collections.length === 0 ? (
+            <EmptyStateNoData
+              title={t`No matching collections found.`}
+              description={
+                <Link
+                  to={formatPath(Paths.collections)}
+                >{t`Show all collections`}</Link>
+              }
+            />
+          ) : (
+            <>
+              <DataList aria-label={t`Available matching collections`}>
+                {collections.map((c, i) => (
+                  <CollectionListItem
+                    key={i}
+                    collection={c}
+                    displaySignatures={featureFlags.display_signatures}
+                    showNamespace={true}
+                  />
+                ))}
+              </DataList>
+              <Link
+                to={formatPath(Paths.collections)}
+              >{t`Show all collections`}</Link>
+            </>
+          )}
+        </PageSection>
+        <SectionSeparator />
+        <PageSection>
+          <SectionTitle>{t`Namespaces`}</SectionTitle>
+
+          {namespaces === null ? (
+            <LoadingPageSpinner />
+          ) : namespaces.length === 0 ? (
+            <EmptyStateNoData
+              title={t`No matching namespaces found.`}
+              description={
+                <Link
+                  to={formatPath(Paths.namespaces)}
+                >{t`Show all namespaces`}</Link>
+              }
+            />
+          ) : (
+            <>
+              <section className='card-layout'>
+                {namespaces.map((ns, i) => (
+                  <div key={i} className='card-wrapper'>
+                    <NamespaceCard
+                      namespaceURL={formatPath(Paths.namespaces, {
+                        namespace: ns.name,
+                      })}
+                      key={i}
+                      {...ns}
+                    />
+                  </div>
+                ))}
+              </section>
+              <Link
+                to={formatPath(Paths.namespaces)}
+              >{t`Show all namespaces`}</Link>
+            </>
+          )}
+        </PageSection>
+        {featureFlags.legacy_roles ? (
+          <>
+            <SectionSeparator />
+            <PageSection>
+              <SectionTitle>{t`Roles`}</SectionTitle>
+
+              {roles === null ? (
+                <LoadingPageSpinner />
+              ) : roles.length === 0 ? (
+                <EmptyStateNoData
+                  title={t`No matching roles found.`}
+                  description={
+                    <Link
+                      to={formatPath(Paths.legacyRoles)}
+                    >{t`Show all roles`}</Link>
+                  }
+                />
+              ) : (
+                <>
+                  <DataList aria-label={t`Available matching roles`}>
+                    {roles.map((r) => (
+                      <LegacyRoleListItem
+                        key={r.id}
+                        role={r}
+                        show_thumbnail={true}
+                      />
+                    ))}
+                  </DataList>
+                  <Link
+                    to={formatPath(Paths.legacyRoles)}
+                  >{t`Show all roles`}</Link>
+                </>
+              )}
+            </PageSection>
+            <SectionSeparator />
+            <PageSection>
+              <SectionTitle>{t`Role Namespaces`}</SectionTitle>
+
+              {roleNamespaces === null ? (
+                <LoadingPageSpinner />
+              ) : roleNamespaces.length === 0 ? (
+                <EmptyStateNoData
+                  title={t`No matching role namespaces found.`}
+                  description={
+                    <Link
+                      to={formatPath(Paths.legacyNamespaces)}
+                    >{t`Show all role namespaces`}</Link>
+                  }
+                />
+              ) : (
+                <>
+                  <DataList aria-label={t`Available matching role namespaces`}>
+                    {roleNamespaces.map((r) => (
+                      <LegacyNamespaceListItem key={r.id} namespace={r} />
+                    ))}
+                  </DataList>
+                  <Link
+                    to={formatPath(Paths.legacyNamespaces)}
+                  >{t`Show all role namespaces`}</Link>
+                </>
+              )}
+            </PageSection>
+          </>
+        ) : null}
+        {featureFlags.execution_environments ? (
+          <>
+            <SectionSeparator />
+            <PageSection>
+              <SectionTitle>{t`Execution Environments`}</SectionTitle>
+
+              {containers === null ? (
+                <LoadingPageSpinner />
+              ) : containers.length === 0 ? (
+                <EmptyStateNoData
+                  title={t`No matching execution environments found.`}
+                  description={
+                    <Link
+                      to={formatPath(Paths.executionEnvironments)}
+                    >{t`Show all execution environments`}</Link>
+                  }
+                />
+              ) : (
+                <>
+                  <DataList
+                    aria-label={t`Available matching execution environments`}
+                  >
+                    {containers.map((item, index) => (
+                      <tr
+                        data-cy={`ExecutionEnvironmentList-row-${item.name}`}
+                        key={index}
+                      >
+                        <td>
+                          <Link
+                            to={formatEEPath(Paths.executionEnvironmentDetail, {
+                              container: item.pulp.distribution.base_path,
+                            })}
+                          >
+                            {item.name}
+                          </Link>
+                        </td>
+                        {item.description ? (
+                          <td className={'pf-m-truncate'}>
+                            <Tooltip content={item.description}>
+                              {item.description}
+                            </Tooltip>
+                          </td>
+                        ) : (
+                          <td />
+                        )}
+                        <td>
+                          <DateComponent date={item.created_at} />
+                        </td>
+                        <td>
+                          <DateComponent date={item.updated_at} />
+                        </td>
+                        <td>
+                          <Label>
+                            {item.pulp.repository.remote ? t`Remote` : t`Local`}
+                          </Label>
+                        </td>
+                      </tr>
+                    ))}
+                  </DataList>
+                  <Link
+                    to={formatPath(Paths.executionEnvironments)}
+                  >{t`Show all execution environments`}</Link>
+                </>
+              )}
+            </PageSection>
+          </>
+        ) : null}
+      </Main>
+    </>
+  );
+};
+
+export default withRouter(MultiSearch);

--- a/src/containers/search/multi-search.tsx
+++ b/src/containers/search/multi-search.tsx
@@ -21,6 +21,7 @@ import {
   Main,
   MultiSearchSearch,
   NamespaceCard,
+  NamespaceListItem,
   closeAlert,
 } from 'src/components';
 import { useContext } from 'src/loaders/app-context';
@@ -270,19 +271,11 @@ export const MultiSearch = (props: RouteProps) => {
             >{t`Show more namespaces`}</Link>
           }
         >
-          <section className='card-layout'>
+          <DataList aria-label={t`Available matching namespaces`}>
             {namespaces.map((ns, i) => (
-              <div key={i} className='card-wrapper'>
-                <NamespaceCard
-                  namespaceURL={formatPath(Paths.namespaces, {
-                    namespace: ns.name,
-                  })}
-                  key={i}
-                  {...ns}
-                />
-              </div>
+              <NamespaceListItem key={i} namespace={ns} />
             ))}
-          </section>
+          </DataList>
         </ResultsSection>
 
         {featureFlags.legacy_roles ? (

--- a/src/containers/search/multi-search.tsx
+++ b/src/containers/search/multi-search.tsx
@@ -14,7 +14,7 @@ import {
   AlertType,
   BaseHeader,
   CollectionListItem,
-  EmptyStateNoData,
+  EmptyStateXs,
   LegacyNamespaceListItem,
   LegacyRoleListItem,
   LoadingPageSpinner,
@@ -212,7 +212,7 @@ export const MultiSearch = (props: RouteProps) => {
   }) =>
     keywords && items !== loading && !items.length ? (
       <Section title={title}>
-        <EmptyStateNoData title={emptyStateTitle} description={showAllLink} />
+        <EmptyStateXs title={emptyStateTitle} description={showAllLink} />
       </Section>
     ) : null;
 

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -38,6 +38,12 @@ const menuSection = (name, options = {}, items = []) => ({
 
 function standaloneMenu() {
   return [
+    menuItem(t`Search`, {
+      url: formatPath(Paths.search),
+      condition: ({ settings, user }) =>
+        settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
+        !user.is_anonymous,
+    }),
     menuSection(t`Collections`, {}, [
       menuItem(t`Collections`, {
         url: formatPath(Paths.collections),

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -35,6 +35,7 @@ import {
   LegacyRole,
   LegacyRoles,
   LoginPage,
+  MultiSearch,
   MyImports,
   MyNamespaces,
   NamespaceDetail,
@@ -296,6 +297,7 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
       { component: Search, path: Paths.collections },
       { component: LandingPage, path: Paths.landingPage },
       { component: Dispatch, path: Paths.dispatch },
+      { component: MultiSearch, path: Paths.search },
     ];
   }
 

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -64,6 +64,7 @@ export enum Paths {
   ansibleRepositoryDetail = '/ansible/repositories/:name',
   ansibleRepositoryEdit = '/ansible/repositories/:name/edit',
   dispatch = '/dispatch',
+  search = '/search',
   executionEnvironmentDetail = '/containers/:container',
   executionEnvironmentDetailWithNamespace = '/containers/:namespace/:container',
   executionEnvironmentDetailActivities = '/containers/:container/_content/activity',


### PR DESCRIPTION
AAH-2697

modelled after the Dispatch page (#4090), but replacing the 404 bits with a search bar

![20230911153420](https://github.com/ansible/ansible-hub-ui/assets/289743/7b594d6f-2c98-4c37-a91d-955b536c66af)

design: 

![untitled-2023-09-11-1554](https://github.com/ansible/ansible-hub-ui/assets/289743/c37e5695-aaa5-4cc2-95c1-7f41d89387d6)

---

empty, loading, error:
![20230918190710](https://github.com/ansible/ansible-hub-ui/assets/289743/f7b9afac-6529-4e41-ba45-b2cc0ecf6303)
![20230918191003](https://github.com/ansible/ansible-hub-ui/assets/289743/491a2b90-ab9d-4628-b3b0-87a774c3399d)
![20230918190735](https://github.com/ansible/ansible-hub-ui/assets/289743/a7ff0c5a-2a73-47b9-a313-e0593aacfc59)

landing page w/ search:
![20230919215716](https://github.com/ansible/ansible-hub-ui/assets/289743/3d2e5fbb-2f5b-4384-92bb-7802048f1f98)
