### PR TITLE
Access tab: add users

### DIFF
--- a/CHANGES/2284.feature
+++ b/CHANGES/2284.feature
@@ -1,0 +1,1 @@
+Add Users section to Access tab (Namespaces, Remotes, Repositories, EEs)

--- a/src/api/response-types/namespace.ts
+++ b/src/api/response-types/namespace.ts
@@ -17,6 +17,7 @@ export class NamespaceListType {
 
 export class NamespaceType extends NamespaceListType {
   groups: GroupObjectPermissionType[];
+  users: { username: string; object_roles: string[] }[];
   resources: string;
   owners: string[];
   links: NamespaceLinkType[];

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -87,12 +87,12 @@ export { AccessTab } from './rbac/access-tab';
 export { DeleteGroupModal } from './rbac/delete-group-modal';
 export { DeleteUserModal } from './rbac/delete-user-modal';
 export { GroupModal } from './rbac/group-modal';
-export { GroupRolePermissions } from './rbac/group-role-permissions';
 export { PermissionCategories } from './rbac/permission-categories';
 export { PermissionChipSelector } from './rbac/permission-chip-selector';
 export { PreviewRoles } from './rbac/preview-roles';
 export { RoleForm } from './rbac/role-form';
 export { RoleHeader } from './rbac/role-header';
+export { RolePermissions } from './rbac/role-permissions';
 export {
   CheckboxRow,
   ExpandableRow,
@@ -101,6 +101,7 @@ export {
 } from './rbac/role-list-table';
 export { SelectGroup } from './rbac/select-group';
 export { SelectRoles } from './rbac/select-roles';
+export { SelectUser } from './rbac/select-user';
 export { UserForm } from './rbac/user-form';
 export { UserFormPage } from './rbac/user-form-page';
 export { RenderPluginDoc } from './render-plugin-doc/render-plugin-doc';

--- a/src/components/rbac/preview-roles.tsx
+++ b/src/components/rbac/preview-roles.tsx
@@ -1,14 +1,19 @@
 import { Trans } from '@lingui/macro';
 import { Divider, Flex, FlexItem, Label } from '@patternfly/react-core';
 import React from 'react';
-import { GroupType, RoleType } from 'src/api';
+import { RoleType } from 'src/api';
 import { Tooltip } from 'src/components';
 import { useContext } from 'src/loaders/app-context';
 import { translateLockedRolesDescription } from 'src/utilities';
 
 interface Props {
-  group: GroupType;
   selectedRoles: RoleType[];
+  user?: {
+    username: string;
+  };
+  group?: {
+    name: string;
+  };
 }
 
 const splitByDot = (perm: string) => {
@@ -21,23 +26,31 @@ const splitByDot = (perm: string) => {
   );
 };
 
-export const PreviewRoles = ({ group, selectedRoles }: Props) => {
+export const PreviewRoles = ({ user, group, selectedRoles }: Props) => {
   const { model_permissions } = useContext().user;
 
   return (
     <div className='hub-custom-wizard-layout'>
       <p>
-        <Trans>
-          The following roles will be applied to group:{' '}
-          <strong>{group.name}</strong>
-        </Trans>
+        {user ? (
+          <Trans>
+            The following roles will be applied to user:{' '}
+            <strong>{user.username}</strong>
+          </Trans>
+        ) : null}
+        {group ? (
+          <Trans>
+            The following roles will be applied to group:{' '}
+            <strong>{group.name}</strong>
+          </Trans>
+        ) : null}
       </p>
       <Flex direction={{ default: 'column' }} className='hub-preview-roles'>
         {selectedRoles.map((role) => (
           <React.Fragment key={role.name}>
             <FlexItem>
               <strong>{role.name}</strong>{' '}
-              {role?.description &&
+              {role.description &&
                 `- ${translateLockedRolesDescription(
                   role.name,
                   role.description,

--- a/src/components/rbac/role-permissions.tsx
+++ b/src/components/rbac/role-permissions.tsx
@@ -7,7 +7,7 @@ interface IProps {
   name: string;
 }
 
-export const GroupRolePermissions = ({ name }: IProps) => {
+export const RolePermissions = ({ name }: IProps) => {
   const [role, setRole] = useState(null);
 
   useEffect(() => {

--- a/src/components/rbac/select-user.tsx
+++ b/src/components/rbac/select-user.tsx
@@ -1,7 +1,7 @@
 import { Trans, t } from '@lingui/macro';
 import { Flex, FlexItem, Label } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
-import { GroupAPI, GroupType } from 'src/api';
+import { UserAPI } from 'src/api';
 import {
   AppliedFilters,
   CompoundFilter,
@@ -14,20 +14,24 @@ import {
 } from 'src/components';
 import { filterIsSet } from 'src/utilities';
 
-interface IProps {
-  assignedGroups: GroupType[];
-  selectedGroup?: GroupType;
-  updateGroup?: (group) => void;
+interface UserType {
+  username: string;
 }
 
-export const SelectGroup: React.FC<IProps> = ({
-  assignedGroups,
-  selectedGroup,
-  updateGroup,
+interface IProps {
+  assignedUsers: UserType[];
+  selectedUser?: UserType;
+  updateUser?: (user) => void;
+}
+
+export const SelectUser: React.FC<IProps> = ({
+  assignedUsers,
+  selectedUser,
+  updateUser,
 }) => {
   const [inputText, setInputText] = useState<string>('');
-  const [groups, setGroups] = useState<GroupType[]>([]);
-  const [groupsCount, setGroupsCount] = useState<number>(0);
+  const [users, setUsers] = useState<UserType[]>([]);
+  const [usersCount, setUsersCount] = useState<number>(0);
 
   const [loading, setLoading] = useState<boolean>(true);
   const [localParams, setLocalParams] = useState({
@@ -36,14 +40,14 @@ export const SelectGroup: React.FC<IProps> = ({
   });
 
   useEffect(() => {
-    queryGroups();
+    queryUsers();
   }, [localParams]);
 
-  const queryGroups = () => {
+  const queryUsers = () => {
     setLoading(true);
-    GroupAPI.list(localParams).then(({ data }) => {
-      setGroups(data.data);
-      setGroupsCount(data.meta.count);
+    UserAPI.list(localParams).then(({ data }) => {
+      setUsers(data.data);
+      setUsersCount(data.meta.count);
       setLoading(false);
     });
   };
@@ -56,23 +60,23 @@ export const SelectGroup: React.FC<IProps> = ({
     );
   }
 
-  const isSelected = ({ name }) => selectedGroup?.name === name;
+  const isSelected = ({ username }) => selectedUser?.username === username;
 
-  const noData = groups.length === 0;
+  const noData = users.length === 0;
 
-  if (noData && !filterIsSet(localParams, ['name__icontains'])) {
+  if (noData && !filterIsSet(localParams, ['username__contains'])) {
     return (
       <div className='hub-custom-wizard-layout hub-no-data'>
         <EmptyStateNoData
-          title={t`No assignable groups.`}
-          description={t`There are currently no groups that can be assigned ownership.`}
+          title={t`No assignable users.`}
+          description={t`There are currently no users that can be assigned ownership.`}
         />
       </div>
     );
   }
 
-  const isAssigned = ({ name }) =>
-    assignedGroups.some((group) => group.name === name);
+  const isAssigned = ({ username }) =>
+    assignedUsers.some((user) => user.username === username);
 
   const tabHeader = {
     headers: [
@@ -82,9 +86,9 @@ export const SelectGroup: React.FC<IProps> = ({
         id: 'expander',
       },
       {
-        title: t`Group`,
+        title: t`User`,
         type: 'alpha',
-        id: 'name',
+        id: 'username',
       },
     ],
   };
@@ -108,22 +112,22 @@ export const SelectGroup: React.FC<IProps> = ({
             }}
             direction={{ default: 'column' }}
           >
-            {selectedGroup ? (
+            {selectedUser ? (
               <FlexItem>
                 <Flex>
                   <FlexItem>
                     <strong>
-                      <Trans>Selected group</Trans>
+                      <Trans>Selected user</Trans>
                     </strong>
                   </FlexItem>
 
                   <FlexItem flex={{ default: 'flex_1' }}>
                     <Flex>
                       <FlexItem
-                        key={selectedGroup.name}
+                        key={selectedUser.username}
                         className='hub-permission'
                       >
-                        <Label>{selectedGroup.name}</Label>
+                        <Label>{selectedUser.username}</Label>
                       </FlexItem>
                     </Flex>
                   </FlexItem>
@@ -140,7 +144,7 @@ export const SelectGroup: React.FC<IProps> = ({
                   updateParams={(p) => setLocalParams(p)}
                   filterConfig={[
                     {
-                      id: 'name__icontains',
+                      id: 'username__contains',
                       title: t`Name`,
                     },
                   ]}
@@ -153,14 +157,14 @@ export const SelectGroup: React.FC<IProps> = ({
                   setInputText('');
                 }}
                 params={localParams}
-                niceNames={{ name__icontains: t`Name` }}
+                niceNames={{ username__contains: t`Name` }}
                 ignoredParams={['sort', 'page_size', 'page']}
                 style={{ marginTop: '8px' }}
               />
             </FlexItem>
 
             <FlexItem style={{ flexGrow: 1 }}>
-              {noData && filterIsSet(localParams, ['name__icontains']) ? (
+              {noData && filterIsSet(localParams, ['username__contains']) ? (
                 <div className='hub-no-filter-data'>
                   <EmptyStateFilter />
                 </div>
@@ -174,16 +178,16 @@ export const SelectGroup: React.FC<IProps> = ({
                     }}
                     tableHeader={tabHeader}
                   >
-                    {groups.map((group, i) => (
+                    {users.map((user, i) => (
                       <RadioRow
                         rowIndex={i}
-                        key={group.name}
-                        isSelected={isSelected(group)}
-                        onSelect={() => updateGroup(group)}
-                        isDisabled={isAssigned(group)}
-                        data-cy={`GroupListTable-CheckboxRow-row-${group.name}`}
+                        key={user.username}
+                        isSelected={isSelected(user)}
+                        onSelect={() => updateUser(user)}
+                        isDisabled={isAssigned(user)}
+                        data-cy={`UserListTable-CheckboxRow-row-${user.username}`}
                       >
-                        <td>{group.name}</td>
+                        <td>{user.username}</td>
                       </RadioRow>
                     ))}
                   </RoleListTable>
@@ -198,7 +202,7 @@ export const SelectGroup: React.FC<IProps> = ({
             <Pagination
               params={localParams}
               updateParams={(p) => setLocalParams(p)}
-              count={groupsCount}
+              count={usersCount}
             />
           </FlexItem>
         )}

--- a/src/containers/ansible-remote/detail.tsx
+++ b/src/containers/ansible-remote/detail.tsx
@@ -21,11 +21,11 @@ const tabs = [
 ];
 
 const AnsibleRemoteDetail = PageWithTabs<AnsibleRemoteType>({
-  breadcrumbs: ({ name, tab, params: { group } }) =>
+  breadcrumbs: ({ name, tab, params: { user, group } }) =>
     [
       { url: formatPath(Paths.ansibleRemotes), name: t`Remotes` },
       { url: formatPath(Paths.ansibleRemoteDetail, { name }), name },
-      tab.id === 'access' && group
+      tab.id === 'access' && (group || user)
         ? {
             url: formatPath(
               Paths.ansibleRepositoryDetail,
@@ -35,9 +35,9 @@ const AnsibleRemoteDetail = PageWithTabs<AnsibleRemoteType>({
             name: tab.name,
           }
         : null,
-      tab.id === 'access' && group
-        ? { name: t`Group ${group}` }
-        : { name: tab.name },
+      tab.id === 'access' && group ? { name: t`Group ${group}` } : null,
+      tab.id === 'access' && user ? { name: t`User ${user}` } : null,
+      tab.id === 'access' && !user && !group ? { name: tab.name } : null,
     ].filter(Boolean),
   condition: canViewAnsibleRemotes,
   displayName: 'AnsibleRemoteDetail',
@@ -78,6 +78,7 @@ const AnsibleRemoteDetail = PageWithTabs<AnsibleRemoteType>({
   tabs,
   tabUpdateParams: (p) => {
     delete p.group;
+    delete p.user;
     return p;
   },
 });

--- a/src/containers/ansible-remote/tab-access.tsx
+++ b/src/containers/ansible-remote/tab-access.tsx
@@ -6,11 +6,17 @@ import {
   GroupAPI,
   GroupType,
   RoleType,
+  UserAPI,
 } from 'src/api';
 import { AccessTab } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { canEditAnsibleRemoteAccess } from 'src/permissions';
-import { errorMessage, parsePulpIDFromURL } from 'src/utilities';
+import { assignRoles, errorMessage, parsePulpIDFromURL } from 'src/utilities';
+
+interface UserType {
+  username: string;
+  object_roles: string[];
+}
 
 interface TabProps {
   item: AnsibleRemoteType;
@@ -36,8 +42,16 @@ export const RemoteAccessTab = ({
   const id = item?.pulp_href && parsePulpIDFromURL(item.pulp_href);
   const [name, setName] = useState<string>(item?.name);
   const [groups, setGroups] = useState<GroupType[]>(null); // loading
+  const [users, setUsers] = useState<UserType[]>(null); // loading
   const [canEditOwners, setCanEditOwners] = useState<boolean>(false);
   const [selectedGroup, setSelectedGroup] = useState<GroupType>(null);
+  const [selectedUser, setSelectedUser] = useState<UserType>(null);
+  const [showUserRemoveModal, setShowUserRemoveModal] =
+    useState<UserType>(null);
+  const [showUserSelectWizard, setShowUserSelectWizard] = useState<{
+    user?: UserType;
+    roles?: RoleType[];
+  }>(null);
   const [showGroupRemoveModal, setShowGroupRemoveModal] =
     useState<GroupType>(null);
   const [showGroupSelectWizard, setShowGroupSelectWizard] = useState<{
@@ -50,7 +64,9 @@ export const RemoteAccessTab = ({
   }>(null);
 
   const query = () => {
+    setUsers(null);
     setGroups(null);
+
     AnsibleRemoteAPI.myPermissions(id)
       .then(({ data: { permissions } }) => {
         setCanEditOwners(
@@ -62,39 +78,28 @@ export const RemoteAccessTab = ({
             featureFlags,
           }),
         );
-        AnsibleRemoteAPI.listRoles(id)
+        // TODO handle pagination
+        AnsibleRemoteAPI.listRoles(id, { page_size: 100 })
           .then(({ data: { roles } }) => {
-            const groupRoles = [];
-            for (const { groups, role } of roles) {
-              for (const name of groups) {
-                const groupIndex = groupRoles.findIndex((g) => g.name === name);
-                if (groupIndex == -1) {
-                  groupRoles.push({ name, object_roles: [role] });
-                } else {
-                  groupRoles[groupIndex].object_roles.push(role);
-                }
-              }
-            }
+            const { users, groups } = assignRoles(roles);
 
             setName(name);
-            setGroups(groupRoles);
+            setUsers(users as UserType[]);
+            setGroups(groups as GroupType[]);
           })
           .catch(() => {
+            setUsers([]);
             setGroups([]);
           });
       })
       .catch(() => {
+        setUsers([]);
         setGroups([]);
         setCanEditOwners(false);
       });
   };
 
-  const updateGroupRoles = ({
-    roles,
-    alertSuccess,
-    alertFailure,
-    stateUpdate,
-  }) => {
+  const updateRoles = ({ roles, alertSuccess, alertFailure, stateUpdate }) => {
     Promise.all(roles)
       .then(() => {
         addAlert({
@@ -115,6 +120,36 @@ export const RemoteAccessTab = ({
       });
   };
 
+  const addUser = (user, roles) => {
+    const rolePromises = roles.map((role) =>
+      AnsibleRemoteAPI.addRole(id, {
+        role: role.name,
+        users: [user.username],
+      }),
+    );
+    updateRoles({
+      roles: rolePromises,
+      alertSuccess: t`User "${user.username}" has been successfully added to "${name}".`,
+      alertFailure: t`User "${user.username}" could not be added to "${name}".`,
+      stateUpdate: { showUserSelectWizard: null },
+    });
+  };
+
+  const removeUser = (user) => {
+    const roles = user.object_roles.map((role) =>
+      AnsibleRemoteAPI.removeRole(id, {
+        role,
+        users: [user.username],
+      }),
+    );
+    updateRoles({
+      roles,
+      alertSuccess: t`User "${user.username}" has been successfully removed from "${name}".`,
+      alertFailure: t`User "${user.username}" could not be removed from "${name}".`,
+      stateUpdate: { showUserRemoveModal: null },
+    });
+  };
+
   const addGroup = (group, roles) => {
     const rolePromises = roles.map((role) =>
       AnsibleRemoteAPI.addRole(id, {
@@ -122,7 +157,7 @@ export const RemoteAccessTab = ({
         groups: [group.name],
       }),
     );
-    updateGroupRoles({
+    updateRoles({
       roles: rolePromises,
       alertSuccess: t`Group "${group.name}" has been successfully added to "${name}".`,
       alertFailure: t`Group "${group.name}" could not be added to "${name}".`,
@@ -137,13 +172,42 @@ export const RemoteAccessTab = ({
         groups: [group.name],
       }),
     );
-    updateGroupRoles({
+    updateRoles({
       roles,
       alertSuccess: t`Group "${group.name}" has been successfully removed from "${name}".`,
       alertFailure: t`Group "${group.name}" could not be removed from "${name}".`,
       stateUpdate: { showGroupRemoveModal: null },
     });
   };
+
+  const addUserRole = (user, roles) => {
+    const rolePromises = roles.map((role) =>
+      AnsibleRemoteAPI.addRole(id, {
+        role: role.name,
+        users: [user.username],
+      }),
+    );
+    updateRoles({
+      roles: rolePromises,
+      alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
+      alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
+      stateUpdate: { showRoleSelectWizard: null },
+    });
+  };
+
+  const removeUserRole = (role, user) => {
+    const removedRole = AnsibleRemoteAPI.removeRole(id, {
+      role,
+      users: [user.username],
+    });
+    updateRoles({
+      roles: [removedRole],
+      alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
+      alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
+      stateUpdate: { showRoleRemoveModal: null },
+    });
+  };
+
   const addRole = (group, roles) => {
     const rolePromises = roles.map((role) =>
       AnsibleRemoteAPI.addRole(id, {
@@ -151,19 +215,20 @@ export const RemoteAccessTab = ({
         groups: [group.name],
       }),
     );
-    updateGroupRoles({
+    updateRoles({
       roles: rolePromises,
       alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
       alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
       stateUpdate: { showRoleSelectWizard: null },
     });
   };
+
   const removeRole = (role, group) => {
     const removedRole = AnsibleRemoteAPI.removeRole(id, {
       role,
       groups: [group.name],
     });
-    updateGroupRoles({
+    updateRoles({
       roles: [removedRole],
       alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
       alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
@@ -174,6 +239,12 @@ export const RemoteAccessTab = ({
   const updateProps = (props) => {
     Object.entries(props).forEach(([k, v]) => {
       switch (k) {
+        case 'showUserRemoveModal':
+          setShowUserRemoveModal(v as UserType);
+          break;
+        case 'showUserSelectWizard':
+          setShowUserSelectWizard(v as { user?: UserType; roles?: RoleType[] });
+          break;
         case 'showGroupRemoveModal':
           setShowGroupRemoveModal(v as GroupType);
           break;
@@ -195,6 +266,22 @@ export const RemoteAccessTab = ({
   };
 
   useEffect(query, [item.pulp_href]);
+
+  useEffect(() => {
+    if (!users) {
+      return;
+    }
+
+    if (!params?.user) {
+      setSelectedUser(null);
+      return;
+    }
+
+    UserAPI.list({ username: params.user }).then(({ data: { data } }) => {
+      setSelectedUser(users.find((u) => u.username === data[0].username));
+    });
+  }, [params?.user, users]);
+
   useEffect(() => {
     if (!groups) {
       return;
@@ -214,6 +301,8 @@ export const RemoteAccessTab = ({
     <AccessTab
       addGroup={addGroup}
       addRole={addRole}
+      addUser={addUser}
+      addUserRole={addUserRole}
       canEditOwners={canEditOwners}
       group={selectedGroup}
       groups={groups}
@@ -221,12 +310,18 @@ export const RemoteAccessTab = ({
       pulpObjectType='remotes/ansible/collection'
       removeGroup={removeGroup}
       removeRole={removeRole}
+      removeUser={removeUser}
+      removeUserRole={removeUserRole}
       selectRolesMessage={t`The selected roles will be added to this specific Ansible remote.`}
       showGroupRemoveModal={showGroupRemoveModal}
       showGroupSelectWizard={showGroupSelectWizard}
       showRoleRemoveModal={showRoleRemoveModal}
       showRoleSelectWizard={showRoleSelectWizard}
+      showUserRemoveModal={showUserRemoveModal}
+      showUserSelectWizard={showUserSelectWizard}
       updateProps={updateProps}
+      user={selectedUser}
+      users={users}
       urlPrefix={formatPath(Paths.ansibleRemoteDetail, {
         name,
       })}

--- a/src/containers/ansible-repository/detail.tsx
+++ b/src/containers/ansible-repository/detail.tsx
@@ -32,12 +32,12 @@ const tabs = [
 const AnsibleRepositoryDetail = PageWithTabs<
   AnsibleRepositoryType & { remote?: AnsibleRemoteType }
 >({
-  breadcrumbs: ({ name, tab, params: { repositoryVersion, group } }) =>
+  breadcrumbs: ({ name, tab, params: { repositoryVersion, user, group } }) =>
     [
       { url: formatPath(Paths.ansibleRepositories), name: t`Repositories` },
       { url: formatPath(Paths.ansibleRepositoryDetail, { name }), name },
-      (tab.id === 'repository-versions' && repositoryVersion) ||
-      (tab.id === 'access' && group)
+      (tab.id === 'access' && (group || user)) ||
+      (tab.id === 'repository-versions' && repositoryVersion)
         ? {
             url: formatPath(
               Paths.ansibleRepositoryDetail,
@@ -47,11 +47,15 @@ const AnsibleRepositoryDetail = PageWithTabs<
             name: tab.name,
           }
         : null,
+      tab.id === 'access' && group ? { name: t`Group ${group}` } : null,
+      tab.id === 'access' && user ? { name: t`User ${user}` } : null,
       tab.id === 'repository-versions' && repositoryVersion
         ? { name: t`Version ${repositoryVersion}` }
-        : tab.id === 'access' && group
-        ? { name: t`Group ${group}` }
-        : { name: tab.name },
+        : null,
+      (tab.id === 'access' && !user && !group) ||
+      (tab.id === 'repository-versions' && !repositoryVersion)
+        ? { name: tab.name }
+        : null,
     ].filter(Boolean),
   condition: canViewAnsibleRepositories,
   displayName: 'AnsibleRepositoryDetail',
@@ -124,6 +128,7 @@ const AnsibleRepositoryDetail = PageWithTabs<
   tabUpdateParams: (p) => {
     delete p.repositoryVersion;
     delete p.group;
+    delete p.user;
     return p;
   },
 });

--- a/src/containers/execution-environment-detail/execution_environment_detail_access.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_access.tsx
@@ -131,160 +131,162 @@ class ExecutionEnvironmentDetailAccess extends React.Component<
       this.state;
 
     return (
-      <AccessTab
-        canEditOwners={canEditOwners}
-        group={selectedGroup}
-        groups={groups}
-        name={name}
-        pulpObjectType='pulp_container/namespaces'
-        selectRolesMessage={t`The selected roles will be added to this specific Execution Environment.`}
-        showGroupRemoveModal={this.state.showGroupRemoveModal}
-        showGroupSelectWizard={this.state.showGroupSelectWizard}
-        showRoleRemoveModal={this.state.showRoleRemoveModal}
-        showRoleSelectWizard={this.state.showRoleSelectWizard}
-        showUserRemoveModal={this.state.showUserRemoveModal}
-        showUserSelectWizard={this.state.showUserSelectWizard}
-        updateProps={(prop) => {
-          this.setState(prop);
-        }}
-        urlPrefix={formatEEPath(Paths.executionEnvironmentDetailAccess, {
-          container: name,
-        })}
-        user={selectedUser}
-        users={users}
-        addUser={(user, roles) => {
-          const rolePromises = roles.map((role) =>
-            ExecutionEnvironmentNamespaceAPI.addRole(
-              this.props.containerRepository.namespace.id,
-              {
-                role: role.name,
-                users: [user.username],
-              },
-            ),
-          );
-          this.updateRoles({
-            roles: rolePromises,
-            alertSuccess: t`User "${user.username}" has been successfully added to "${name}".`,
-            alertFailure: t`User "${user.username}" could not be added to "${name}".`,
-            stateUpdate: { showUserSelectWizard: null },
-          });
-        }}
-        removeUser={(user) => {
-          const roles = user.object_roles.map((role) =>
-            ExecutionEnvironmentNamespaceAPI.removeRole(
+      <section className='body'>
+        <AccessTab
+          canEditOwners={canEditOwners}
+          group={selectedGroup}
+          groups={groups}
+          name={name}
+          pulpObjectType='pulp_container/namespaces'
+          selectRolesMessage={t`The selected roles will be added to this specific Execution Environment.`}
+          showGroupRemoveModal={this.state.showGroupRemoveModal}
+          showGroupSelectWizard={this.state.showGroupSelectWizard}
+          showRoleRemoveModal={this.state.showRoleRemoveModal}
+          showRoleSelectWizard={this.state.showRoleSelectWizard}
+          showUserRemoveModal={this.state.showUserRemoveModal}
+          showUserSelectWizard={this.state.showUserSelectWizard}
+          updateProps={(prop) => {
+            this.setState(prop);
+          }}
+          urlPrefix={formatEEPath(Paths.executionEnvironmentDetailAccess, {
+            container: name,
+          })}
+          user={selectedUser}
+          users={users}
+          addUser={(user, roles) => {
+            const rolePromises = roles.map((role) =>
+              ExecutionEnvironmentNamespaceAPI.addRole(
+                this.props.containerRepository.namespace.id,
+                {
+                  role: role.name,
+                  users: [user.username],
+                },
+              ),
+            );
+            this.updateRoles({
+              roles: rolePromises,
+              alertSuccess: t`User "${user.username}" has been successfully added to "${name}".`,
+              alertFailure: t`User "${user.username}" could not be added to "${name}".`,
+              stateUpdate: { showUserSelectWizard: null },
+            });
+          }}
+          removeUser={(user) => {
+            const roles = user.object_roles.map((role) =>
+              ExecutionEnvironmentNamespaceAPI.removeRole(
+                this.props.containerRepository.namespace.id,
+                {
+                  role,
+                  users: [user.username],
+                },
+              ),
+            );
+            this.updateRoles({
+              roles,
+              alertSuccess: t`User "${user.username}" has been successfully removed from "${name}".`,
+              alertFailure: t`User "${user.username}" could not be removed from "${name}".`,
+              stateUpdate: { showUserRemoveModal: null },
+            });
+          }}
+          addGroup={(group, roles) => {
+            const rolePromises = roles.map((role) =>
+              ExecutionEnvironmentNamespaceAPI.addRole(
+                this.props.containerRepository.namespace.id,
+                {
+                  role: role.name,
+                  groups: [group.name],
+                },
+              ),
+            );
+            this.updateRoles({
+              roles: rolePromises,
+              alertSuccess: t`Group "${group.name}" has been successfully added to "${name}".`,
+              alertFailure: t`Group "${group.name}" could not be added to "${name}".`,
+              stateUpdate: { showGroupSelectWizard: null },
+            });
+          }}
+          removeGroup={(group) => {
+            const roles = group.object_roles.map((role) =>
+              ExecutionEnvironmentNamespaceAPI.removeRole(
+                this.props.containerRepository.namespace.id,
+                {
+                  role,
+                  groups: [group.name],
+                },
+              ),
+            );
+            this.updateRoles({
+              roles,
+              alertSuccess: t`Group "${group.name}" has been successfully removed from "${name}".`,
+              alertFailure: t`Group "${group.name}" could not be removed from "${name}".`,
+              stateUpdate: { showGroupRemoveModal: null },
+            });
+          }}
+          addUserRole={(user, roles) => {
+            const rolePromises = roles.map((role) =>
+              ExecutionEnvironmentNamespaceAPI.addRole(
+                this.props.containerRepository.namespace.id,
+                {
+                  role: role.name,
+                  users: [user.username],
+                },
+              ),
+            );
+            this.updateRoles({
+              roles: rolePromises,
+              alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
+              alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
+              stateUpdate: { showRoleSelectWizard: null },
+            });
+          }}
+          removeUserRole={(role, user) => {
+            const removedRole = ExecutionEnvironmentNamespaceAPI.removeRole(
               this.props.containerRepository.namespace.id,
               {
                 role,
                 users: [user.username],
               },
-            ),
-          );
-          this.updateRoles({
-            roles,
-            alertSuccess: t`User "${user.username}" has been successfully removed from "${name}".`,
-            alertFailure: t`User "${user.username}" could not be removed from "${name}".`,
-            stateUpdate: { showUserRemoveModal: null },
-          });
-        }}
-        addGroup={(group, roles) => {
-          const rolePromises = roles.map((role) =>
-            ExecutionEnvironmentNamespaceAPI.addRole(
-              this.props.containerRepository.namespace.id,
-              {
-                role: role.name,
-                groups: [group.name],
-              },
-            ),
-          );
-          this.updateRoles({
-            roles: rolePromises,
-            alertSuccess: t`Group "${group.name}" has been successfully added to "${name}".`,
-            alertFailure: t`Group "${group.name}" could not be added to "${name}".`,
-            stateUpdate: { showGroupSelectWizard: null },
-          });
-        }}
-        removeGroup={(group) => {
-          const roles = group.object_roles.map((role) =>
-            ExecutionEnvironmentNamespaceAPI.removeRole(
+            );
+            this.updateRoles({
+              roles: [removedRole],
+              alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
+              alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
+              stateUpdate: { showRoleRemoveModal: null },
+            });
+          }}
+          addRole={(group, roles) => {
+            const rolePromises = roles.map((role) =>
+              ExecutionEnvironmentNamespaceAPI.addRole(
+                this.props.containerRepository.namespace.id,
+                {
+                  role: role.name,
+                  groups: [group.name],
+                },
+              ),
+            );
+            this.updateRoles({
+              roles: rolePromises,
+              alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
+              alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
+              stateUpdate: { showRoleSelectWizard: null },
+            });
+          }}
+          removeRole={(role, group) => {
+            const removedRole = ExecutionEnvironmentNamespaceAPI.removeRole(
               this.props.containerRepository.namespace.id,
               {
                 role,
                 groups: [group.name],
               },
-            ),
-          );
-          this.updateRoles({
-            roles,
-            alertSuccess: t`Group "${group.name}" has been successfully removed from "${name}".`,
-            alertFailure: t`Group "${group.name}" could not be removed from "${name}".`,
-            stateUpdate: { showGroupRemoveModal: null },
-          });
-        }}
-        addUserRole={(user, roles) => {
-          const rolePromises = roles.map((role) =>
-            ExecutionEnvironmentNamespaceAPI.addRole(
-              this.props.containerRepository.namespace.id,
-              {
-                role: role.name,
-                users: [user.username],
-              },
-            ),
-          );
-          this.updateRoles({
-            roles: rolePromises,
-            alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
-            alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
-            stateUpdate: { showRoleSelectWizard: null },
-          });
-        }}
-        removeUserRole={(role, user) => {
-          const removedRole = ExecutionEnvironmentNamespaceAPI.removeRole(
-            this.props.containerRepository.namespace.id,
-            {
-              role,
-              users: [user.username],
-            },
-          );
-          this.updateRoles({
-            roles: [removedRole],
-            alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
-            alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
-            stateUpdate: { showRoleRemoveModal: null },
-          });
-        }}
-        addRole={(group, roles) => {
-          const rolePromises = roles.map((role) =>
-            ExecutionEnvironmentNamespaceAPI.addRole(
-              this.props.containerRepository.namespace.id,
-              {
-                role: role.name,
-                groups: [group.name],
-              },
-            ),
-          );
-          this.updateRoles({
-            roles: rolePromises,
-            alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
-            alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
-            stateUpdate: { showRoleSelectWizard: null },
-          });
-        }}
-        removeRole={(role, group) => {
-          const removedRole = ExecutionEnvironmentNamespaceAPI.removeRole(
-            this.props.containerRepository.namespace.id,
-            {
-              role,
-              groups: [group.name],
-            },
-          );
-          this.updateRoles({
-            roles: [removedRole],
-            alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
-            alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
-            stateUpdate: { showRoleRemoveModal: null },
-          });
-        }}
-      />
+            );
+            this.updateRoles({
+              roles: [removedRole],
+              alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
+              alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
+              stateUpdate: { showRoleRemoveModal: null },
+            });
+          }}
+        />
+      </section>
     );
   }
 

--- a/src/containers/execution-environment-detail/execution_environment_detail_access.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_access.tsx
@@ -5,12 +5,13 @@ import {
   GroupAPI,
   GroupType,
   RoleType,
+  UserAPI,
 } from 'src/api';
 import { AccessTab } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatEEPath } from 'src/paths';
 import { withRouter } from 'src/utilities';
-import { ParamHelper, errorMessage } from 'src/utilities';
+import { ParamHelper, assignRoles, errorMessage } from 'src/utilities';
 import {
   IDetailSharedProps,
   withContainerParamFix,
@@ -18,18 +19,28 @@ import {
 } from './base';
 import './execution-environment-detail.scss';
 
+interface UserType {
+  username: string;
+  object_roles: string[];
+}
+
 interface IState {
-  name: string;
-  groups: GroupType[];
   canEditOwners: boolean;
-  selectedGroup: GroupType;
+  groups: GroupType[];
+  name: string;
   params: {
-    group?: number;
+    group?: string;
+    user?: string;
   };
+  selectedGroup: GroupType;
+  selectedUser: UserType;
   showGroupRemoveModal?: GroupType;
   showGroupSelectWizard?: { group?: GroupType; roles?: RoleType[] };
   showRoleRemoveModal?: string;
   showRoleSelectWizard?: { roles?: RoleType[] };
+  showUserRemoveModal?: UserType;
+  showUserSelectWizard?: { user?: UserType; roles?: RoleType[] };
+  users: UserType[];
 }
 
 class ExecutionEnvironmentDetailAccess extends React.Component<
@@ -39,18 +50,24 @@ class ExecutionEnvironmentDetailAccess extends React.Component<
   constructor(props) {
     super(props);
 
-    const params = ParamHelper.parseParamString(this.props.location.search);
+    const params = ParamHelper.parseParamString(
+      this.props.location.search,
+    ) as IState['params'];
 
     this.state = {
-      name: props.containerRepository.name,
-      groups: null, // loading
       canEditOwners: false,
-      selectedGroup: null,
+      groups: null, // loading
+      name: props.containerRepository.name,
       params,
+      selectedGroup: null,
+      selectedUser: null,
       showGroupRemoveModal: null,
       showGroupSelectWizard: null,
       showRoleRemoveModal: null,
       showRoleSelectWizard: null,
+      showUserRemoveModal: null,
+      showUserSelectWizard: null,
+      users: null, // loading
     };
   }
 
@@ -60,11 +77,18 @@ class ExecutionEnvironmentDetailAccess extends React.Component<
 
   componentDidUpdate(prevProps) {
     if (prevProps.location.search !== this.props.location.search) {
-      const params = ParamHelper.parseParamString(this.props.location.search);
+      const params = ParamHelper.parseParamString(
+        this.props.location.search,
+      ) as IState['params'];
 
-      if (!params['group']) {
+      if (!params.group) {
         this.setState({
           selectedGroup: null,
+        });
+      }
+      if (!params.user) {
+        this.setState({
+          selectedUser: null,
         });
       }
 
@@ -74,17 +98,24 @@ class ExecutionEnvironmentDetailAccess extends React.Component<
     }
   }
 
-  updateGroupRoles({ roles, alertSuccess, alertFailure, stateUpdate }) {
+  updateRoles({ roles, alertSuccess, alertFailure, stateUpdate }) {
+    const {
+      addAlert,
+      containerRepository: { namespace },
+    } = this.props;
+
     Promise.all(roles)
       .then(() => {
-        this.props.addAlert({
+        addAlert({
           title: alertSuccess,
           variant: 'success',
         });
-        this.queryNamespace(this.props.containerRepository.namespace); // ensure reload() sets groups: null to trigger loading spinner
+
+        // ensure reload() sets users/groups: null to trigger loading spinner
+        this.queryNamespace(namespace);
       })
       .catch(({ response: { status, statusText } }) => {
-        this.props.addAlert({
+        addAlert({
           title: alertFailure,
           variant: 'danger',
           description: errorMessage(status, statusText),
@@ -96,21 +127,64 @@ class ExecutionEnvironmentDetailAccess extends React.Component<
   }
 
   render() {
-    const { name, groups, canEditOwners, selectedGroup } = this.state;
+    const { canEditOwners, groups, name, selectedGroup, selectedUser, users } =
+      this.state;
 
     return (
       <AccessTab
-        showGroupRemoveModal={this.state.showGroupRemoveModal}
-        showGroupSelectWizard={this.state.showGroupSelectWizard}
-        showRoleRemoveModal={this.state.showRoleRemoveModal}
-        showRoleSelectWizard={this.state.showRoleSelectWizard}
         canEditOwners={canEditOwners}
         group={selectedGroup}
         groups={groups}
         name={name}
         pulpObjectType='pulp_container/namespaces'
+        selectRolesMessage={t`The selected roles will be added to this specific Execution Environment.`}
+        showGroupRemoveModal={this.state.showGroupRemoveModal}
+        showGroupSelectWizard={this.state.showGroupSelectWizard}
+        showRoleRemoveModal={this.state.showRoleRemoveModal}
+        showRoleSelectWizard={this.state.showRoleSelectWizard}
+        showUserRemoveModal={this.state.showUserRemoveModal}
+        showUserSelectWizard={this.state.showUserSelectWizard}
         updateProps={(prop) => {
           this.setState(prop);
+        }}
+        urlPrefix={formatEEPath(Paths.executionEnvironmentDetailAccess, {
+          container: name,
+        })}
+        user={selectedUser}
+        users={users}
+        addUser={(user, roles) => {
+          const rolePromises = roles.map((role) =>
+            ExecutionEnvironmentNamespaceAPI.addRole(
+              this.props.containerRepository.namespace.id,
+              {
+                role: role.name,
+                users: [user.username],
+              },
+            ),
+          );
+          this.updateRoles({
+            roles: rolePromises,
+            alertSuccess: t`User "${user.username}" has been successfully added to "${name}".`,
+            alertFailure: t`User "${user.username}" could not be added to "${name}".`,
+            stateUpdate: { showUserSelectWizard: null },
+          });
+        }}
+        removeUser={(user) => {
+          const roles = user.object_roles.map((role) =>
+            ExecutionEnvironmentNamespaceAPI.removeRole(
+              this.props.containerRepository.namespace.id,
+              {
+                role,
+                users: [user.username],
+              },
+            ),
+          );
+          this.updateRoles({
+            roles,
+            alertSuccess: t`User "${user.username}" has been successfully removed from "${name}".`,
+            alertFailure: t`User "${user.username}" could not be removed from "${name}".`,
+            stateUpdate: { showUserRemoveModal: null },
+          });
         }}
         addGroup={(group, roles) => {
           const rolePromises = roles.map((role) =>
@@ -122,7 +196,7 @@ class ExecutionEnvironmentDetailAccess extends React.Component<
               },
             ),
           );
-          this.updateGroupRoles({
+          this.updateRoles({
             roles: rolePromises,
             alertSuccess: t`Group "${group.name}" has been successfully added to "${name}".`,
             alertFailure: t`Group "${group.name}" could not be added to "${name}".`,
@@ -139,11 +213,43 @@ class ExecutionEnvironmentDetailAccess extends React.Component<
               },
             ),
           );
-          this.updateGroupRoles({
+          this.updateRoles({
             roles,
             alertSuccess: t`Group "${group.name}" has been successfully removed from "${name}".`,
             alertFailure: t`Group "${group.name}" could not be removed from "${name}".`,
             stateUpdate: { showGroupRemoveModal: null },
+          });
+        }}
+        addUserRole={(user, roles) => {
+          const rolePromises = roles.map((role) =>
+            ExecutionEnvironmentNamespaceAPI.addRole(
+              this.props.containerRepository.namespace.id,
+              {
+                role: role.name,
+                users: [user.username],
+              },
+            ),
+          );
+          this.updateRoles({
+            roles: rolePromises,
+            alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
+            alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
+            stateUpdate: { showRoleSelectWizard: null },
+          });
+        }}
+        removeUserRole={(role, user) => {
+          const removedRole = ExecutionEnvironmentNamespaceAPI.removeRole(
+            this.props.containerRepository.namespace.id,
+            {
+              role,
+              users: [user.username],
+            },
+          );
+          this.updateRoles({
+            roles: [removedRole],
+            alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
+            alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
+            stateUpdate: { showRoleRemoveModal: null },
           });
         }}
         addRole={(group, roles) => {
@@ -156,7 +262,7 @@ class ExecutionEnvironmentDetailAccess extends React.Component<
               },
             ),
           );
-          this.updateGroupRoles({
+          this.updateRoles({
             roles: rolePromises,
             alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
             alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
@@ -171,34 +277,23 @@ class ExecutionEnvironmentDetailAccess extends React.Component<
               groups: [group.name],
             },
           );
-          this.updateGroupRoles({
+          this.updateRoles({
             roles: [removedRole],
             alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
             alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
             stateUpdate: { showRoleRemoveModal: null },
           });
         }}
-        selectRolesMessage={t`The selected roles will be added to this specific Execution Environment.`}
-        urlPrefix={formatEEPath(Paths.executionEnvironmentDetailAccess, {
-          container: name,
-        })}
       />
     );
   }
 
-  assignRolesToGroup(roles) {
-    const groupRoles = [];
-    for (const { groups, role } of roles) {
-      for (const name of groups) {
-        const groupIndex = groupRoles.findIndex((g) => g.name === name);
-        if (groupIndex == -1) {
-          groupRoles.push({ name, object_roles: [role] });
-        } else {
-          groupRoles[groupIndex].object_roles.push(role);
-        }
-      }
-    }
-    return groupRoles;
+  querySelectedUser(username, users) {
+    UserAPI.list({ username }).then(({ data: { data } }) => {
+      this.setState({
+        selectedUser: users.find((u) => u.username === data[0].username),
+      });
+    });
   }
 
   querySelectedGroup(name, groups) {
@@ -209,36 +304,44 @@ class ExecutionEnvironmentDetailAccess extends React.Component<
     });
   }
 
-  queryNamespace({ id, name: repoName }) {
+  queryNamespace({ id, name }) {
     const { hasPermission } = this.context;
-    ExecutionEnvironmentNamespaceAPI.myPermissions(id)
-      .then(({ data: { permissions } }) => {
-        ExecutionEnvironmentNamespaceAPI.listRoles(id)
-          .then(({ data: { roles } }) => {
-            const groupRoles = this.assignRolesToGroup(roles);
+    Promise.all([
+      ExecutionEnvironmentNamespaceAPI.myPermissions(id).then(
+        ({ data: { permissions } }) => permissions,
+      ),
+      // TODO handle pagination
+      ExecutionEnvironmentNamespaceAPI.listRoles(id, { page_size: 100 }).then(
+        ({ data: { roles } }) => roles,
+      ),
+    ])
+      .then(([permissions, roles]) => {
+        const { users, groups } = assignRoles(roles) as {
+          users: UserType[];
+          groups: GroupType[];
+        };
 
-            this.setState({
-              name: repoName,
-              groups: groupRoles,
-              canEditOwners:
-                permissions.includes('container.change_containernamespace') ||
-                hasPermission('container.change_containernamespace'),
-            });
+        this.setState({
+          name,
+          canEditOwners:
+            permissions.includes('container.change_containernamespace') ||
+            hasPermission('container.change_containernamespace'),
+          groups,
+          users,
+        });
 
-            if (this.state.params?.group) {
-              this.querySelectedGroup(this.state.params.group, groupRoles);
-            }
-          })
-          .catch(() => {
-            this.setState({
-              groups: [],
-            });
-          });
+        if (this.state.params?.user) {
+          this.querySelectedUser(this.state.params.user, users);
+        }
+        if (this.state.params?.group) {
+          this.querySelectedGroup(this.state.params.group, groups);
+        }
       })
       .catch(() => {
         this.setState({
-          groups: [],
           canEditOwners: false,
+          groups: [],
+          users: [],
         });
       });
   }

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -843,10 +843,13 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
             user: this.filterUser(this.state.params.user, namespace.users),
             namespace: {
               ...namespace,
-              users: namespace.users.map(({ name, object_roles }) => ({
-                username: name,
-                object_roles,
-              })),
+              // transform to use username, don't break when missing
+              users: namespace.users
+                ? namespace.users.map(({ name, object_roles }) => ({
+                    username: name,
+                    object_roles,
+                  }))
+                : [],
             },
             showControls: !!myNamespace,
             unfilteredCount,

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -189,7 +189,9 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
   }
 
   filterUser(username, users) {
-    return username ? users.find((u) => u.username === username) : null;
+    return username
+      ? users.find((u) => u.name === username || u.username === username)
+      : null;
   }
 
   filterGroup(name, groups) {
@@ -507,152 +509,154 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
           ) : null}
           {tab === 'resources' ? this.renderResources(namespace) : null}
           {tab === 'access' ? (
-            <AccessTab
-              showUserRemoveModal={this.state.showUserRemoveModal}
-              showUserSelectWizard={this.state.showUserSelectWizard}
-              showGroupRemoveModal={this.state.showGroupRemoveModal}
-              showGroupSelectWizard={this.state.showGroupSelectWizard}
-              showRoleRemoveModal={this.state.showRoleRemoveModal}
-              showRoleSelectWizard={this.state.showRoleSelectWizard}
-              canEditOwners={canEditOwners}
-              group={this.state.group}
-              groups={namespace.groups}
-              user={this.state.user}
-              users={namespace.users}
-              name={namespace.name}
-              pulpObjectType='pulp_ansible/namespaces'
-              selectRolesMessage={t`The selected roles will be added to this specific namespace.`}
-              updateProps={(prop) => {
-                this.setState(prop);
-              }}
-              addUser={(user, roles) => {
-                const { users, name } = namespace;
-                const newUser = {
-                  ...user,
-                  object_roles: roles.map(({ name }) => name),
-                };
-                const newUsers = [...users, newUser];
+            <section className='body'>
+              <AccessTab
+                showUserRemoveModal={this.state.showUserRemoveModal}
+                showUserSelectWizard={this.state.showUserSelectWizard}
+                showGroupRemoveModal={this.state.showGroupRemoveModal}
+                showGroupSelectWizard={this.state.showGroupSelectWizard}
+                showRoleRemoveModal={this.state.showRoleRemoveModal}
+                showRoleSelectWizard={this.state.showRoleSelectWizard}
+                canEditOwners={canEditOwners}
+                group={this.state.group}
+                groups={namespace.groups}
+                user={this.state.user}
+                users={namespace.users}
+                name={namespace.name}
+                pulpObjectType='pulp_ansible/namespaces'
+                selectRolesMessage={t`The selected roles will be added to this specific namespace.`}
+                updateProps={(prop) => {
+                  this.setState(prop);
+                }}
+                addUser={(user, roles) => {
+                  const { users, name } = namespace;
+                  const newUser = {
+                    ...user,
+                    object_roles: roles.map(({ name }) => name),
+                  };
+                  const newUsers = [...users, newUser];
 
-                this.updateRoles({
-                  users: newUsers,
-                  alertSuccess: t`User "${user.username}" has been successfully added to "${name}".`,
-                  alertFailure: t`User "${user.username}" could not be added to "${name}".`,
-                  stateUpdate: { showUserSelectWizard: null },
-                });
-              }}
-              removeUser={(user) => {
-                const { name, users } = namespace;
-                const newUsers = users.filter((u) => u !== user);
-                this.updateRoles({
-                  users: newUsers,
-                  alertSuccess: t`User "${user.username}" has been successfully removed from "${name}".`,
-                  alertFailure: t`User "${user.username}" could not be removed from "${name}".`,
-                  stateUpdate: { showUserRemoveModal: null },
-                });
-              }}
-              addGroup={(group, roles) => {
-                const { groups, name } = namespace;
-                const newGroup = {
-                  ...group,
-                  object_roles: roles.map(({ name }) => name),
-                };
-                const newGroups = [...groups, newGroup];
+                  this.updateRoles({
+                    users: newUsers,
+                    alertSuccess: t`User "${user.username}" has been successfully added to "${name}".`,
+                    alertFailure: t`User "${user.username}" could not be added to "${name}".`,
+                    stateUpdate: { showUserSelectWizard: null },
+                  });
+                }}
+                removeUser={(user) => {
+                  const { name, users } = namespace;
+                  const newUsers = users.filter((u) => u !== user);
+                  this.updateRoles({
+                    users: newUsers,
+                    alertSuccess: t`User "${user.username}" has been successfully removed from "${name}".`,
+                    alertFailure: t`User "${user.username}" could not be removed from "${name}".`,
+                    stateUpdate: { showUserRemoveModal: null },
+                  });
+                }}
+                addGroup={(group, roles) => {
+                  const { groups, name } = namespace;
+                  const newGroup = {
+                    ...group,
+                    object_roles: roles.map(({ name }) => name),
+                  };
+                  const newGroups = [...groups, newGroup];
 
-                this.updateRoles({
-                  groups: newGroups,
-                  alertSuccess: t`Group "${group.name}" has been successfully added to "${name}".`,
-                  alertFailure: t`Group "${group.name}" could not be added to "${name}".`,
-                  stateUpdate: { showGroupSelectWizard: null },
-                });
-              }}
-              removeGroup={(group) => {
-                const { name, groups } = namespace;
-                const newGroups = groups.filter((g) => g !== group);
-                this.updateRoles({
-                  groups: newGroups,
-                  alertSuccess: t`Group "${group.name}" has been successfully removed from "${name}".`,
-                  alertFailure: t`Group "${group.name}" could not be removed from "${name}".`,
-                  stateUpdate: { showGroupRemoveModal: null },
-                });
-              }}
-              addUserRole={(user, roles) => {
-                const { name, users } = namespace;
-                const newUser = {
-                  ...user,
-                  object_roles: [
-                    ...user.object_roles,
-                    ...roles.map(({ name }) => name),
-                  ],
-                };
-                const newUsers = users.map((u) => (u === user ? newUser : u));
+                  this.updateRoles({
+                    groups: newGroups,
+                    alertSuccess: t`Group "${group.name}" has been successfully added to "${name}".`,
+                    alertFailure: t`Group "${group.name}" could not be added to "${name}".`,
+                    stateUpdate: { showGroupSelectWizard: null },
+                  });
+                }}
+                removeGroup={(group) => {
+                  const { name, groups } = namespace;
+                  const newGroups = groups.filter((g) => g !== group);
+                  this.updateRoles({
+                    groups: newGroups,
+                    alertSuccess: t`Group "${group.name}" has been successfully removed from "${name}".`,
+                    alertFailure: t`Group "${group.name}" could not be removed from "${name}".`,
+                    stateUpdate: { showGroupRemoveModal: null },
+                  });
+                }}
+                addUserRole={(user, roles) => {
+                  const { name, users } = namespace;
+                  const newUser = {
+                    ...user,
+                    object_roles: [
+                      ...user.object_roles,
+                      ...roles.map(({ name }) => name),
+                    ],
+                  };
+                  const newUsers = users.map((u) => (u === user ? newUser : u));
 
-                this.updateRoles({
-                  users: newUsers,
-                  alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
-                  alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
-                  stateUpdate: { showRoleSelectWizard: null },
-                });
-              }}
-              removeUserRole={(role, user) => {
-                const { name, users } = namespace;
-                const newUser = {
-                  ...user,
-                  object_roles: user.object_roles.filter(
-                    (name) => name !== role,
-                  ),
-                };
-                const newUsers = users.map((u) => (u === user ? newUser : u));
+                  this.updateRoles({
+                    users: newUsers,
+                    alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
+                    alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
+                    stateUpdate: { showRoleSelectWizard: null },
+                  });
+                }}
+                removeUserRole={(role, user) => {
+                  const { name, users } = namespace;
+                  const newUser = {
+                    ...user,
+                    object_roles: user.object_roles.filter(
+                      (name) => name !== role,
+                    ),
+                  };
+                  const newUsers = users.map((u) => (u === user ? newUser : u));
 
-                this.updateRoles({
-                  users: newUsers,
-                  alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
-                  alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
-                  stateUpdate: { showRoleRemoveModal: null },
-                });
-              }}
-              addRole={(group, roles) => {
-                const { name, groups } = namespace;
-                const newGroup = {
-                  ...group,
-                  object_roles: [
-                    ...group.object_roles,
-                    ...roles.map(({ name }) => name),
-                  ],
-                };
-                const newGroups = groups.map((g) =>
-                  g === group ? newGroup : g,
-                );
+                  this.updateRoles({
+                    users: newUsers,
+                    alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
+                    alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
+                    stateUpdate: { showRoleRemoveModal: null },
+                  });
+                }}
+                addRole={(group, roles) => {
+                  const { name, groups } = namespace;
+                  const newGroup = {
+                    ...group,
+                    object_roles: [
+                      ...group.object_roles,
+                      ...roles.map(({ name }) => name),
+                    ],
+                  };
+                  const newGroups = groups.map((g) =>
+                    g === group ? newGroup : g,
+                  );
 
-                this.updateRoles({
-                  groups: newGroups,
-                  alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
-                  alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
-                  stateUpdate: { showRoleSelectWizard: null },
-                });
-              }}
-              removeRole={(role, group) => {
-                const { name, groups } = namespace;
-                const newGroup = {
-                  ...group,
-                  object_roles: group.object_roles.filter(
-                    (name) => name !== role,
-                  ),
-                };
-                const newGroups = groups.map((g) =>
-                  g === group ? newGroup : g,
-                );
+                  this.updateRoles({
+                    groups: newGroups,
+                    alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
+                    alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
+                    stateUpdate: { showRoleSelectWizard: null },
+                  });
+                }}
+                removeRole={(role, group) => {
+                  const { name, groups } = namespace;
+                  const newGroup = {
+                    ...group,
+                    object_roles: group.object_roles.filter(
+                      (name) => name !== role,
+                    ),
+                  };
+                  const newGroups = groups.map((g) =>
+                    g === group ? newGroup : g,
+                  );
 
-                this.updateRoles({
-                  groups: newGroups,
-                  alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
-                  alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
-                  stateUpdate: { showRoleRemoveModal: null },
-                });
-              }}
-              urlPrefix={formatPath(Paths.namespaceDetail, {
-                namespace: namespace.name,
-              })}
-            />
+                  this.updateRoles({
+                    groups: newGroups,
+                    alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
+                    alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
+                    stateUpdate: { showRoleRemoveModal: null },
+                  });
+                }}
+                urlPrefix={formatPath(Paths.namespaceDetail, {
+                  namespace: namespace.name,
+                })}
+              />
+            </section>
           ) : null}
         </Main>
         {canSign && (

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -59,6 +59,11 @@ import {
 } from 'src/utilities';
 import './namespace-detail.scss';
 
+interface UserType {
+  username: string;
+  object_roles: string[];
+}
+
 interface IState {
   alerts: AlertType[];
   canSign: boolean;
@@ -68,6 +73,7 @@ interface IState {
   deleteCollection: CollectionVersionSearch;
   filteredCount: number;
   group: GroupType;
+  user: UserType;
   isDeletionPending: boolean;
   isNamespacePending: boolean;
   isOpenNamespaceModal: boolean;
@@ -75,16 +81,20 @@ interface IState {
   isOpenWisdomModal: boolean;
   namespace: NamespaceType;
   params: {
-    group?: number;
+    group?: string;
     keywords?: string;
     namespace?: string;
     page?: number;
     page_size?: number;
+    repository_name?: string;
     sort?: string;
     tab?: string;
+    user?: string;
   };
   redirect: string;
   showControls: boolean;
+  showUserRemoveModal?: UserType;
+  showUserSelectWizard?: { user?: UserType; roles?: RoleType[] };
   showGroupRemoveModal?: GroupType;
   showGroupSelectWizard?: { group?: GroupType; roles?: RoleType[] };
   showImportModal: boolean;
@@ -96,7 +106,7 @@ interface IState {
 }
 
 export class NamespaceDetail extends React.Component<RouteProps, IState> {
-  nonAPIParams = ['tab', 'group'];
+  nonAPIParams = ['tab', 'group', 'user'];
 
   // namespace is a positional url argument, so don't include it in the
   // query params
@@ -107,11 +117,11 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     const params = ParamHelper.parseParamString(props.location.search, [
       'page',
       'page_size',
-    ]);
+    ]) as IState['params'];
 
-    params['namespace'] = props.routeParams.namespace;
-    if (props.routeParams.repo && !params['repository_name']) {
-      params['repository_name'] = props.routeParams.repo;
+    params.namespace = props.routeParams.namespace;
+    if (props.routeParams.repo && !params.repository_name) {
+      params.repository_name = props.routeParams.repo;
     }
 
     this.state = {
@@ -123,6 +133,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
       deleteCollection: null,
       filteredCount: 0,
       group: null,
+      user: null,
       isDeletionPending: false,
       isNamespacePending: false,
       isOpenNamespaceModal: false,
@@ -154,44 +165,56 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     const params = ParamHelper.parseParamString(this.props.location.search, [
       'page',
       'page_size',
-    ]);
+    ]) as IState['params'];
 
     if (prevProps.location.search !== this.props.location.search) {
-      params['namespace'] = this.props.routeParams.namespace;
+      params.namespace = this.props.routeParams.namespace;
 
       this.setState({
         params,
-        group: this.filterGroup(params['group'], this.state.namespace.groups),
+        group: this.filterGroup(params.group, this.state.namespace.groups),
+        user: this.filterUser(params.user, this.state.namespace.users),
       });
     }
 
     if (
       prevProps.routeParams.repo !== this.props.routeParams.repo &&
       this.props.routeParams.repo &&
-      (!params['repository_name'] ||
-        params['repository_name'] === prevProps.routeParams.repo)
+      (!params.repository_name ||
+        params.repository_name === prevProps.routeParams.repo)
     ) {
-      params['repository_name'] = this.props.routeParams.repo;
+      params.repository_name = this.props.routeParams.repo;
       this.setState({ params });
     }
   }
 
-  filterGroup(groupId, groups) {
-    return groupId ? groups.find(({ id }) => Number(groupId) === id) : null;
+  filterUser(username, users) {
+    return username ? users.find((u) => u.username === username) : null;
   }
 
-  private updateGroups({ groups, alertSuccess, alertFailure, stateUpdate }) {
+  filterGroup(name, groups) {
+    return name ? groups.find((g) => g.name === name) : null;
+  }
+
+  private updateRoles({
+    users = null,
+    groups = null,
+    alertSuccess,
+    alertFailure,
+    stateUpdate,
+  }) {
     const { name } = this.state.namespace;
     MyNamespaceAPI.update(name, {
       ...this.state.namespace,
-      groups,
+      users: users || this.state.namespace.users,
+      groups: groups || this.state.namespace.groups,
     })
       .then(() => {
         this.addAlert({
           title: alertSuccess,
           variant: 'success',
         });
-        this.load(); // ensure reload() sets groups: null to trigger loading spinner
+        this.load(); // ensure reload() sets users/groups: null to trigger loading spinner
       })
       .catch(({ response: { status, statusText } }) => {
         this.addAlert({
@@ -241,7 +264,8 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
       { id: 'access', name: t`Access` },
     ].filter(Boolean);
 
-    const tab = params['tab'] || 'collections';
+    const tab = params.tab || 'collections';
+    const { user, group } = params;
 
     const breadcrumbs = [
       namespaceBreadcrumb(),
@@ -254,23 +278,19 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
               })
             : null,
       },
-      tab === 'access'
+      tab === 'access' && (group || user)
         ? {
+            url: formatPath(
+              Paths.namespaceDetail,
+              { namespace: namespace.name },
+              { tab },
+            ),
             name: t`Access`,
-            url: params.group
-              ? formatPath(
-                  Paths.namespaceDetail,
-                  {
-                    namespace: namespace.name,
-                  },
-                  { tab: 'access' },
-                )
-              : null,
           }
         : null,
-      tab === 'access' && params.group
-        ? { name: t`Group ${params.group}` }
-        : null,
+      tab === 'access' && group ? { name: t`Group ${group}` } : null,
+      tab === 'access' && user ? { name: t`User ${user}` } : null,
+      tab === 'access' && !user && !group ? { name: t`Access` } : null,
     ].filter(Boolean);
 
     const repositoryUrl = getRepoURL('published');
@@ -294,6 +314,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
       'sort',
       'tab',
       'group',
+      'user',
       'view_type',
     ];
 
@@ -304,17 +325,18 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
         'galaxy.change_namespace',
       ) || hasPermission('galaxy.change_namespace');
 
-    // remove ?group (access tab) when switching tabs
+    // remove ?user/group (access tab) when switching tabs
     const tabParams = { ...params };
     delete tabParams.group;
+    delete tabParams.user;
 
-    const repository = params['repository_name'] || null;
+    const repository = params.repository_name || null;
     const deleteFromRepo = this.state.deleteAll
       ? null
       : deleteCollection?.repository?.name;
 
     return (
-      <React.Fragment>
+      <>
         <AlertList alerts={alerts} closeAlert={(i) => this.closeAlert(i)} />
         <ImportModal
           isOpen={showImportModal}
@@ -486,6 +508,8 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
           {tab === 'resources' ? this.renderResources(namespace) : null}
           {tab === 'access' ? (
             <AccessTab
+              showUserRemoveModal={this.state.showUserRemoveModal}
+              showUserSelectWizard={this.state.showUserSelectWizard}
               showGroupRemoveModal={this.state.showGroupRemoveModal}
               showGroupSelectWizard={this.state.showGroupSelectWizard}
               showRoleRemoveModal={this.state.showRoleRemoveModal}
@@ -493,11 +517,38 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
               canEditOwners={canEditOwners}
               group={this.state.group}
               groups={namespace.groups}
+              user={this.state.user}
+              users={namespace.users}
               name={namespace.name}
               pulpObjectType='pulp_ansible/namespaces'
               selectRolesMessage={t`The selected roles will be added to this specific namespace.`}
               updateProps={(prop) => {
                 this.setState(prop);
+              }}
+              addUser={(user, roles) => {
+                const { users, name } = namespace;
+                const newUser = {
+                  ...user,
+                  object_roles: roles.map(({ name }) => name),
+                };
+                const newUsers = [...users, newUser];
+
+                this.updateRoles({
+                  users: newUsers,
+                  alertSuccess: t`User "${user.username}" has been successfully added to "${name}".`,
+                  alertFailure: t`User "${user.username}" could not be added to "${name}".`,
+                  stateUpdate: { showUserSelectWizard: null },
+                });
+              }}
+              removeUser={(user) => {
+                const { name, users } = namespace;
+                const newUsers = users.filter((u) => u !== user);
+                this.updateRoles({
+                  users: newUsers,
+                  alertSuccess: t`User "${user.username}" has been successfully removed from "${name}".`,
+                  alertFailure: t`User "${user.username}" could not be removed from "${name}".`,
+                  stateUpdate: { showUserRemoveModal: null },
+                });
               }}
               addGroup={(group, roles) => {
                 const { groups, name } = namespace;
@@ -507,7 +558,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
                 };
                 const newGroups = [...groups, newGroup];
 
-                this.updateGroups({
+                this.updateRoles({
                   groups: newGroups,
                   alertSuccess: t`Group "${group.name}" has been successfully added to "${name}".`,
                   alertFailure: t`Group "${group.name}" could not be added to "${name}".`,
@@ -517,11 +568,46 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
               removeGroup={(group) => {
                 const { name, groups } = namespace;
                 const newGroups = groups.filter((g) => g !== group);
-                this.updateGroups({
+                this.updateRoles({
                   groups: newGroups,
                   alertSuccess: t`Group "${group.name}" has been successfully removed from "${name}".`,
                   alertFailure: t`Group "${group.name}" could not be removed from "${name}".`,
                   stateUpdate: { showGroupRemoveModal: null },
+                });
+              }}
+              addUserRole={(user, roles) => {
+                const { name, users } = namespace;
+                const newUser = {
+                  ...user,
+                  object_roles: [
+                    ...user.object_roles,
+                    ...roles.map(({ name }) => name),
+                  ],
+                };
+                const newUsers = users.map((u) => (u === user ? newUser : u));
+
+                this.updateRoles({
+                  users: newUsers,
+                  alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
+                  alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
+                  stateUpdate: { showRoleSelectWizard: null },
+                });
+              }}
+              removeUserRole={(role, user) => {
+                const { name, users } = namespace;
+                const newUser = {
+                  ...user,
+                  object_roles: user.object_roles.filter(
+                    (name) => name !== role,
+                  ),
+                };
+                const newUsers = users.map((u) => (u === user ? newUser : u));
+
+                this.updateRoles({
+                  users: newUsers,
+                  alertSuccess: t`User "${user.username}" roles successfully updated in "${name}".`,
+                  alertFailure: t`User "${user.username}" roles could not be update in "${name}".`,
+                  stateUpdate: { showRoleRemoveModal: null },
                 });
               }}
               addRole={(group, roles) => {
@@ -537,7 +623,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
                   g === group ? newGroup : g,
                 );
 
-                this.updateGroups({
+                this.updateRoles({
                   groups: newGroups,
                   alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
                   alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
@@ -556,7 +642,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
                   g === group ? newGroup : g,
                 );
 
-                this.updateGroups({
+                this.updateRoles({
                   groups: newGroups,
                   alertSuccess: t`Group "${group.name}" roles successfully updated in "${name}".`,
                   alertFailure: t`Group "${group.name}" roles could not be update in "${name}".`,
@@ -577,7 +663,7 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
             onCancel={() => this.setState({ isOpenSignModal: false })}
           />
         )}
-      </React.Fragment>
+      </>
     );
   }
 
@@ -753,11 +839,15 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
         ]) => {
           this.setState({
             canSign: canSignNamespace(this.context, myNamespace?.data),
-            group: this.filterGroup(
-              this.state.params['group'],
-              namespace['groups'],
-            ),
-            namespace,
+            group: this.filterGroup(this.state.params.group, namespace.groups),
+            user: this.filterUser(this.state.params.user, namespace.users),
+            namespace: {
+              ...namespace,
+              users: namespace.users.map(({ name, object_roles }) => ({
+                username: name,
+                object_roles,
+              })),
+            },
             showControls: !!myNamespace,
             unfilteredCount,
           });
@@ -777,11 +867,11 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     const { can_upload_signatures } = this.context.featureFlags;
     const { ai_deny_index } = this.context.featureFlags;
     const { hasPermission } = this.context;
-    const repository = this.state.params['repository_name'] || null;
+    const repository = this.state.params.repository_name || null;
 
     const dropdownItems = [
       <DropdownItem
-        key='1'
+        key='edit'
         component={
           <Link
             to={formatPath(Paths.editNamespace, {
@@ -792,31 +882,30 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
           </Link>
         }
       />,
-      hasPermission('galaxy.delete_namespace') && (
-        <React.Fragment key={'2'}>
-          {unfilteredCount === 0 ? (
-            <DropdownItem
-              onClick={() => this.setState({ isOpenNamespaceModal: true })}
-            >{t`Delete namespace`}</DropdownItem>
-          ) : (
-            <Tooltip
-              isVisible={false}
-              content={
-                <Trans>
-                  Cannot delete namespace until <br />
-                  collections&apos; dependencies have <br />
-                  been deleted
-                </Trans>
-              }
-              position='left'
-            >
-              <DropdownItem isDisabled>{t`Delete namespace`}</DropdownItem>
-            </Tooltip>
-          )}
-        </React.Fragment>
-      ),
+      hasPermission('galaxy.delete_namespace') &&
+        (unfilteredCount === 0 ? (
+          <DropdownItem
+            key='delete'
+            onClick={() => this.setState({ isOpenNamespaceModal: true })}
+          >{t`Delete namespace`}</DropdownItem>
+        ) : (
+          <Tooltip
+            key='delete'
+            isVisible={false}
+            content={
+              <Trans>
+                Cannot delete namespace until <br />
+                collections&apos; dependencies have <br />
+                been deleted
+              </Trans>
+            }
+            position='left'
+          >
+            <DropdownItem isDisabled>{t`Delete namespace`}</DropdownItem>
+          </Tooltip>
+        )),
       <DropdownItem
-        key='3'
+        key='imports'
         component={
           <Link
             to={formatPath(

--- a/src/utilities/assign-roles.ts
+++ b/src/utilities/assign-roles.ts
@@ -1,0 +1,34 @@
+import { sortBy } from 'lodash';
+
+export const assignRoles = (roles) => {
+  const userRoles = {};
+  const groupRoles = {};
+
+  roles.forEach(({ users, groups, role }) => {
+    (users || []).forEach((username) => {
+      userRoles[username] ||= [];
+      userRoles[username].push(role);
+    });
+    (groups || []).forEach((name) => {
+      groupRoles[name] ||= [];
+      groupRoles[name].push(role);
+    });
+  });
+
+  return {
+    users: sortBy(
+      Object.entries(userRoles).map(([username, object_roles]) => ({
+        username,
+        object_roles,
+      })),
+      'username',
+    ),
+    groups: sortBy(
+      Object.entries(groupRoles).map(([name, object_roles]) => ({
+        name,
+        object_roles,
+      })),
+      'name',
+    ),
+  };
+};

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,3 +1,4 @@
+export { assignRoles } from './assign-roles';
 export { canSignEE, canSignNamespace } from './can-sign';
 export { chipGroupProps } from './chip-group-props';
 export { convertContentSummaryCounts } from './content-summary';

--- a/test/cypress/e2e/misc/rbac_access.js
+++ b/test/cypress/e2e/misc/rbac_access.js
@@ -124,13 +124,13 @@ function testAccessTab({
     .parent('.pf-c-alert')
     .find('button')
     .click();
-  cy.get('tr[data-cy="AccessTab-row-access_group"]');
+  cy.get('tr[data-cy="AccessTab-row-group-access_group"]');
 
   // group list view, try modal, open group
   cy.get('button').contains('Select a group').click();
   cy.get('.pf-c-wizard__footer-cancel').click();
 
-  cy.get('tr[data-cy="AccessTab-row-access_group"] a').click();
+  cy.get('tr[data-cy="AccessTab-row-group-access_group"] a').click();
 
   // role list view, use modal
   cy.get(`[data-cy="RoleListTable-ExpandableRow-row-${role}"]`);
@@ -179,7 +179,7 @@ function testAccessTab({
 
   // list view, delete, see empty
   cy.get(
-    'tr[data-cy="AccessTab-row-access_group"] [data-cy=kebab-toggle] button',
+    'tr[data-cy="AccessTab-row-group-access_group"] [data-cy=kebab-toggle] button',
   ).click();
   cy.get('.pf-c-dropdown__menu-item').contains('Remove group').click();
   cy.get('.pf-c-modal-box__body b').contains('access_group');


### PR DESCRIPTION
Issue: AAH-2284
Depends on https://github.com/ansible/galaxy_ng/pull/1899 (+ https://github.com/pulp/pulp_ansible/pull/1594 for clients)

Previously, the Access tab (Namespaces, Repositories, Remotes & Execution Environments) only allowed assigning object permissions to groups.

This adds support for users.

![20230925001524](https://github.com/ansible/ansible-hub-ui/assets/289743/ca055e30-a6db-4d4b-9759-61a35f982980)
