### PR TITLE
Link legacy to provider namespace

### DIFF
--- a/src/api/response-types/legacy-namespace.ts
+++ b/src/api/response-types/legacy-namespace.ts
@@ -3,6 +3,7 @@ export class LegacyNamespaceListType {
   url: string;
   summary_fields: {
     owners?: { username: string }[];
+    providers?: { id: number, name: string, pulp_href: string}[];
   };
   created: string;
   modified: string;
@@ -17,6 +18,7 @@ export class LegacyNamespaceDetailType {
   url: string;
   summary_fields: {
     owners?: { username: string }[];
+    providers?: { id: number, name: string, pulp_href: string}[];
   };
   created: string;
   modified: string;

--- a/src/components/legacy-namespace-list/legacy-namespace-item.tsx
+++ b/src/components/legacy-namespace-list/legacy-namespace-item.tsx
@@ -13,6 +13,7 @@ import { Logo, StatefulDropdown } from 'src/components';
 import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import './legacy-namespace-item.scss';
+import { getProviderInfo } from 'src/utilities/legacy-namespace';
 
 interface LegacyNamespaceProps {
   namespace: LegacyNamespaceDetailType;
@@ -25,6 +26,9 @@ export class LegacyNamespaceListItem extends React.Component<LegacyNamespaceProp
     const namespace_url = formatPath(Paths.legacyNamespace, {
       namespaceid: namespace.id,
     });
+
+    const provider_details = getProviderInfo(namespace);
+    console.log('components.legacy-namespace-list.legacy-namespace-item.LegacyNamespaceListItem', provider_details);
 
     const cells = [];
 

--- a/src/components/legacy-namespace-list/legacy-namespace-provider.tsx
+++ b/src/components/legacy-namespace-list/legacy-namespace-provider.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import {
+    Text,
+    TextContent,
+    TextVariants
+} from '@patternfly/react-core';
+import { Trans } from '@lingui/macro';
+import { Link } from 'react-router-dom';
+
+
+interface IProps {
+    id: number;
+    name: string;
+    url: string;
+}
+
+export class ProviderLink extends React.Component<IProps> {
+
+    constructor(props) {
+        super(props);
+    }
+
+    render () {
+
+        const {
+            id,
+            name,
+            url,
+        } = this.props;
+
+        return (
+              <TextContent>
+                <Text component={TextVariants.small}>
+                  <Trans>
+                    Provided by <Link to={url}>{name}</Link>
+                  </Trans>
+                </Text>
+              </TextContent>
+        )
+    }
+}

--- a/src/components/legacy-role-list/legacy-role-item.tsx
+++ b/src/components/legacy-role-list/legacy-role-item.tsx
@@ -15,6 +15,8 @@ import { LegacyRoleDetailType } from 'src/api';
 import { DateComponent, DownloadCount, Logo, Tag } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { chipGroupProps } from 'src/utilities';
+import { getProviderInfo } from 'src/utilities/legacy-namespace';
+import { ProviderLink } from 'src/components/legacy-namespace-list/legacy-namespace-provider';
 import './legacy-role-item.scss';
 
 interface LegacyRoleProps {
@@ -56,6 +58,9 @@ export class LegacyRoleListItem extends React.Component<LegacyRoleProps> {
       release_name = '';
     }
 
+    const provider = getProviderInfo(role);
+    console.log('PROVIDER', provider);
+
     const cells = [];
 
     if (show_thumbnail !== false) {
@@ -78,6 +83,7 @@ export class LegacyRoleListItem extends React.Component<LegacyRoleProps> {
           <Link to={role_url}>
             {namespace.name}.{role.name}
           </Link>
+          {/*
           <TextContent>
             <Text component={TextVariants.small}>
               <Trans>
@@ -85,6 +91,8 @@ export class LegacyRoleListItem extends React.Component<LegacyRoleProps> {
               </Trans>
             </Text>
           </TextContent>
+          */}
+          <ProviderLink id={provider.id} name={provider.name} url={provider.url}>{provider.name}</ProviderLink>
         </div>
         <div className='hub-entry'>{role.description}</div>
         <div className='hub-entry'>

--- a/src/containers/legacy-namespaces/legacy-namespace.tsx
+++ b/src/containers/legacy-namespaces/legacy-namespace.tsx
@@ -31,6 +31,8 @@ import {
 import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
+import { getProviderInfo } from 'src/utilities/legacy-namespace';
+import { ProviderLink } from 'src/components/legacy-namespace-list/legacy-namespace-provider';
 import './legacy-namespace.scss';
 
 interface LegacyNamespaceRolesProps {
@@ -187,6 +189,7 @@ interface LegacyNamespaceProps {
   alerts: AlertType[];
 }
 
+
 class LegacyNamespace extends React.Component<
   RouteProps,
   LegacyNamespaceProps
@@ -242,6 +245,9 @@ class LegacyNamespace extends React.Component<
       namespaceid: this.state.namespace.id,
     });
 
+    const provider = getProviderInfo(this.state.namespace);
+    console.log('containers.legacy-namespaces.legacy-namespace.LegacyNamespace', provider);
+
     if (this.state.namespace !== undefined) {
       infocells.push(
         <DataListCell isFilled={false} alignRight={false} key='ns-logo'>
@@ -254,6 +260,7 @@ class LegacyNamespace extends React.Component<
             width='90px'
           />
           <Link to={namespace_url}>{this.state.namespace.name}</Link>
+          <ProviderLink id={provider.id} name={provider.name} url={provider.url}>{provider.name}</ProviderLink>
         </DataListCell>,
       );
 

--- a/src/utilities/legacy-namespace.ts
+++ b/src/utilities/legacy-namespace.ts
@@ -1,0 +1,18 @@
+export function getProviderInfo(legacynamespace) {
+
+    const provider = legacynamespace.summary_fields.provider_namespaces[0];
+
+    if (provider === null || provider === undefined) {  
+        return {
+            'id': null,
+            'name': null,
+            'url': null,
+        }
+    }
+
+    return {
+        'id': provider.id,
+        'name': provider.name,
+        'url': `/namespaces/${provider.name}`
+    }
+}

--- a/src/utilities/legacy-namespace.ts
+++ b/src/utilities/legacy-namespace.ts
@@ -1,6 +1,18 @@
-export function getProviderInfo(legacynamespace) {
+export function getProviderInfo(data) {
 
-    const provider = legacynamespace.summary_fields.provider_namespaces[0];
+    console.log('DATA', data);
+
+    let provider = null;
+
+    if (data.summary_fields.hasOwnProperty('provider_namespace')) {
+        // roll summary
+        provider = data.summary_fields.provider_namespace;
+    } else if (data.summary_fields.hasOwnProperty('provider_namespaces')) {
+        // legacy namespace summary
+        provider = data.summary_fields.provider_namespaces[0];
+    }
+
+    console.log('FINAL PROVIDER', provider);
 
     if (provider === null || provider === undefined) {  
         return {


### PR DESCRIPTION
In the legacy namespace summary and legacy role lists, "Provided by" now links to the v3 namespace where RBAC for the legacynamespace is actually managed. If no v3 namespace is linked, it'll be an empty string ... which is fine because we're not supposed to have that situation and it should be fixed for the user.