### PR TITLE
Ensure community users can delete their collections

### DIFF
--- a/CHANGES/2632.bug
+++ b/CHANGES/2632.bug
@@ -1,0 +1,1 @@
+Ensure beta-galaxy users can delete their collections

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -240,7 +240,9 @@ export class CollectionHeader extends React.Component<IProps, IState> {
     }
 
     const canSign = canSignNamespace(this.context, this.state.namespace);
-    const { hasPermission, hasObjectPermission } = this.context;
+    const { hasPermission } = this.context;
+    const hasObjectPermission = (permission, namespace) =>
+      namespace?.related_fields?.my_permissions?.includes?.(permission);
 
     const canDeleteCommunityCollection =
       ai_deny_index &&

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -953,9 +953,12 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
   }
 
   private renderCollectionControls(collection: CollectionVersionSearch) {
-    const { hasPermission } = this.context;
+    const { hasPermission, hasObjectPermission } = this.context;
     const { showControls } = this.state;
-    const { display_repositories } = this.context.featureFlags;
+    const { display_repositories, ai_deny_index } = this.context.featureFlags;
+    const canDeleteCommunityCollection =
+      ai_deny_index &&
+      hasObjectPermission('galaxy.change_namespace', this.state.namespace);
 
     if (!showControls) {
       return;
@@ -979,7 +982,9 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
         <StatefulDropdown
           items={[
             DeleteCollectionUtils.deleteMenuOption({
-              canDeleteCollection: hasPermission('ansible.delete_collection'),
+              canDeleteCollection:
+                hasPermission('ansible.delete_collection') ||
+                canDeleteCommunityCollection,
               noDependencies: null,
               onClick: () =>
                 DeleteCollectionUtils.tryOpenDeleteModalWithConfirm({
@@ -992,7 +997,9 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
               display_repositories: display_repositories,
             }),
             DeleteCollectionUtils.deleteMenuOption({
-              canDeleteCollection: hasPermission('ansible.delete_collection'),
+              canDeleteCollection:
+                hasPermission('ansible.delete_collection') ||
+                canDeleteCommunityCollection,
               noDependencies: null,
               onClick: () =>
                 DeleteCollectionUtils.tryOpenDeleteModalWithConfirm({

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -953,7 +953,9 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
   }
 
   private renderCollectionControls(collection: CollectionVersionSearch) {
-    const { hasPermission, hasObjectPermission } = this.context;
+    const { hasPermission } = this.context;
+    const hasObjectPermission = (permission, namespace) =>
+      namespace?.related_fields?.my_permissions?.includes?.(permission);
     const { showControls } = this.state;
     const { display_repositories, ai_deny_index } = this.context.featureFlags;
     const canDeleteCommunityCollection =

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -374,8 +374,14 @@ class Search extends React.Component<RouteProps, IState> {
   }
 
   private renderMenu(list, collection) {
-    const { hasPermission } = this.context;
-    const { display_repositories } = this.context.featureFlags;
+    const { hasPermission, hasObjectPermission } = this.context;
+    const { display_repositories, ai_deny_index } = this.context.featureFlags;
+    const canDeleteCommunityCollection =
+      ai_deny_index &&
+      hasObjectPermission(
+        'galaxy.change_namespace',
+        collection.collection_version.namespace,
+      );
 
     const menuItems = [
       DeleteCollectionUtils.deleteMenuOption({

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -374,7 +374,9 @@ class Search extends React.Component<RouteProps, IState> {
   }
 
   private renderMenu(list, collection) {
-    const { hasPermission, hasObjectPermission } = this.context;
+    const { hasPermission } = this.context;
+    const hasObjectPermission = (permission, namespace) =>
+      namespace?.related_fields?.my_permissions?.includes?.(permission);
     const { display_repositories, ai_deny_index } = this.context.featureFlags;
     const canDeleteCommunityCollection =
       ai_deny_index &&

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -385,7 +385,9 @@ class Search extends React.Component<RouteProps, IState> {
 
     const menuItems = [
       DeleteCollectionUtils.deleteMenuOption({
-        canDeleteCollection: hasPermission('ansible.delete_collection'),
+        canDeleteCollection:
+          hasPermission('ansible.delete_collection') ||
+          canDeleteCommunityCollection,
         noDependencies: null,
         onClick: () =>
           DeleteCollectionUtils.tryOpenDeleteModalWithConfirm({
@@ -398,7 +400,9 @@ class Search extends React.Component<RouteProps, IState> {
         display_repositories: display_repositories,
       }),
       DeleteCollectionUtils.deleteMenuOption({
-        canDeleteCollection: hasPermission('ansible.delete_collection'),
+        canDeleteCollection:
+          hasPermission('ansible.delete_collection') ||
+          canDeleteCommunityCollection,
         noDependencies: null,
         onClick: () =>
           DeleteCollectionUtils.tryOpenDeleteModalWithConfirm({


### PR DESCRIPTION
Community users do not have the model permission `ansible.delete_collection`, instead we rely on community users having object permissions on their namespace to determine if they have permissions to delete collections. 

Issue: AAH-2632

Links
----------------
PR (merged) implementing this same change in the api:
https://github.com/ansible/galaxy_ng/pull/1900
