### PR TITLE
NamespaceListItem - fix url

### DIFF
--- a/src/components/shared/namespace-list-item.tsx
+++ b/src/components/shared/namespace-list-item.tsx
@@ -17,7 +17,7 @@ export function NamespaceListItem({
   namespace: { avatar_url: string; company: string; name: string };
 }) {
   const { avatar_url, name } = namespace;
-  const namespace_url = formatPath(Paths.namespaces, {
+  const namespace_url = formatPath(Paths.namespaceDetail, {
     namespace: name,
   });
   const title = namespaceTitle(namespace);


### PR DESCRIPTION
Follows #4216 

Fixes namespace links on the search screen - go to namespace detail, not namespace list.
Thanks @drodowic :)