### PR TITLE
Language switcher

### DIFF
--- a/CHANGES/2730.misc
+++ b/CHANGES/2730.misc
@@ -1,0 +1,1 @@
+community: add language switcher

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -117,6 +117,7 @@ export { DetailList } from './shared/detail-list';
 export { Details } from './shared/details';
 export { DownloadCount } from './shared/download-count';
 export { ExternalLink } from './shared/external-link';
+export { LanguageSwitcher } from './shared/language-switcher';
 export { LoginLink } from './shared/login-link';
 export { MultiRepoModal } from './shared/multi-repo-modal';
 export { MultiSearchSearch } from './shared/multi-search-search';

--- a/src/components/patternfly-wrappers/stateful-dropdown.tsx
+++ b/src/components/patternfly-wrappers/stateful-dropdown.tsx
@@ -27,6 +27,7 @@ interface IProps {
   isPlain?: boolean;
 
   ariaLabel?: string;
+  'data-cy'?: string;
 }
 
 export const StatefulDropdown = ({
@@ -37,6 +38,7 @@ export const StatefulDropdown = ({
   defaultText,
   isPlain = true,
   ariaLabel,
+  'data-cy': dataCy,
 }: IProps) => {
   const [isOpen, setOpen] = useState<boolean>(false);
   const [selected, setSelected] = useState<string>(undefined);
@@ -54,6 +56,7 @@ export const StatefulDropdown = ({
       position={position || DropdownPosition.right}
       autoFocus={false}
       aria-label={ariaLabel}
+      data-cy={dataCy}
     />
   );
 };

--- a/src/components/shared/language-switcher.tsx
+++ b/src/components/shared/language-switcher.tsx
@@ -10,6 +10,7 @@ export function LanguageSwitcher(_props) {
   return (
     <StatefulDropdown
       ariaLabel={t`Select language`}
+      data-cy='language-dropdown'
       defaultText={currentLanguage}
       toggleType='icon'
       items={[

--- a/src/components/shared/language-switcher.tsx
+++ b/src/components/shared/language-switcher.tsx
@@ -1,0 +1,44 @@
+import { Trans, t } from '@lingui/macro';
+import { DropdownItem, DropdownSeparator } from '@patternfly/react-core';
+import React from 'react';
+import { StatefulDropdown } from 'src/components';
+import { availableLanguages, language, languageNames } from 'src/l10n';
+
+export function LanguageSwitcher(_props) {
+  const currentLanguage = languageNames[language] || language;
+
+  return (
+    <StatefulDropdown
+      ariaLabel={t`Select language`}
+      defaultText={currentLanguage}
+      toggleType='icon'
+      items={[
+        <DropdownItem isDisabled key='current'>
+          {window.localStorage.override_l10n ? (
+            <Trans>{currentLanguage} (current)</Trans>
+          ) : (
+            <Trans>{currentLanguage} (browser default)</Trans>
+          )}
+        </DropdownItem>,
+        <DropdownSeparator key='separator1' />,
+        ...availableLanguages.map((lang) => (
+          <DropdownItem
+            key={lang}
+            href={`?lang=${lang}`}
+            isDisabled={lang === language}
+          >
+            {languageNames[lang] || lang}
+          </DropdownItem>
+        )),
+        <DropdownSeparator key='separator2' />,
+        <DropdownItem
+          key='current'
+          href='?lang='
+          isDisabled={!window.localStorage.override_l10n}
+        >
+          <Trans>Reset to browser defaults</Trans>
+        </DropdownItem>,
+      ]}
+    />
+  );
+}

--- a/src/entry-standalone.tsx
+++ b/src/entry-standalone.tsx
@@ -8,6 +8,7 @@ import App from './loaders/standalone/loader';
 
 // Entrypoint for compiling the app to run in standalone mode
 
+const searchParams = new URLSearchParams(window.location.search);
 if (!window.location.pathname.startsWith(UI_BASE_PATH)) {
   // react-router v6 won't redirect to base path by default
   // also support old-galaxy /namespace/name/ urls
@@ -20,6 +21,16 @@ if (!window.location.pathname.startsWith(UI_BASE_PATH)) {
     : UI_BASE_PATH;
 
   window.history.pushState(null, null, newPath);
+} else if (searchParams.has('lang') || searchParams.has('pseudolocalization')) {
+  // delete lang after src/l10n uses it
+  searchParams.delete('lang');
+  searchParams.delete('pseudolocalization');
+  window.history.pushState(
+    null,
+    null,
+    window.location.pathname +
+      (searchParams.toString() ? '?' + searchParams.toString() : ''),
+  );
 }
 
 ReactDOM.render(

--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -2,7 +2,16 @@ import { i18n } from '@lingui/core';
 import * as moment from 'moment';
 
 // remember to update lingui.config.js as well
-const availableLanguages = ['en', 'es', 'fr', 'ko', 'nl', 'ja', 'zh'];
+export const availableLanguages = ['en', 'es', 'fr', 'ko', 'nl', 'ja', 'zh'];
+export const languageNames = {
+  en: 'English',
+  es: 'Español',
+  fr: 'Français',
+  ko: '한국어',
+  nl: 'Nederlands',
+  ja: '日本語',
+  zh: '中文',
+};
 
 // map missing moment locales (node_modules/moment/src/locale/<locale>.js must exist, except for english)
 const momentLocales = {

--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -62,6 +62,10 @@ if (searchParams.lang === '') {
   delete window.localStorage.override_l10n;
 }
 
+// ?lang and ?pseudolocalization get removed in entry-standalone
+// (removed to prevent the param getting passed to api calls)
+// (in entry-standalone to prevent interaction with pushState)
+
 const overrideLanguage =
   window.localStorage.override_l10n &&
   availableLanguages.includes(window.localStorage.override_l10n) &&

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -129,23 +129,25 @@ export const StandaloneLayout = ({
       headerTools={
         <PageHeaderTools>
           <LanguageSwitcher />
+          {user ? (
+            <StatefulDropdown
+              ariaLabel={t`Docs dropdown`}
+              data-cy='docs-dropdown'
+              defaultText={<QuestionCircleIcon />}
+              items={docsDropdownItems}
+              toggleType='icon'
+            />
+          ) : null}
           {!user || user.is_anonymous ? (
             <LoginLink next={location.pathname} />
           ) : (
-            <div>
-              <StatefulDropdown
-                ariaLabel={'docs-dropdown'}
-                defaultText={<QuestionCircleIcon />}
-                items={docsDropdownItems}
-                toggleType='icon'
-              />
-              <StatefulDropdown
-                ariaLabel={'user-dropdown'}
-                defaultText={userName}
-                items={userDropdownItems}
-                toggleType='dropdown'
-              />
-            </div>
+            <StatefulDropdown
+              ariaLabel={t`User dropdown`}
+              data-cy='user-dropdown'
+              defaultText={userName}
+              items={userDropdownItems}
+              toggleType='dropdown'
+            />
           )}
         </PageHeaderTools>
       }

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -20,6 +20,7 @@ import {
 } from 'src/api';
 import {
   AboutModalWindow,
+  LanguageSwitcher,
   LoginLink,
   SmallLogo,
   StatefulDropdown,
@@ -127,6 +128,7 @@ export const StandaloneLayout = ({
       )}
       headerTools={
         <PageHeaderTools>
+          <LanguageSwitcher />
           {!user || user.is_anonymous ? (
             <LoginLink next={location.pathname} />
           ) : (

--- a/test/cypress/e2e/groups_and_users/login.js
+++ b/test/cypress/e2e/groups_and_users/login.js
@@ -19,7 +19,7 @@ const manualLogin = (username, password) => {
 const manualLogout = () => {
   cy.intercept('GET', `${apiPrefix}_ui/v1/feature-flags/`).as('feature-flags');
 
-  cy.get('[aria-label="user-dropdown"] button').click();
+  cy.get('[data-cy="user-dropdown"] button').click();
   cy.get('[aria-label="logout"]').click();
 
   cy.wait('@feature-flags');

--- a/test/cypress/e2e/misc/docs_menu.js
+++ b/test/cypress/e2e/misc/docs_menu.js
@@ -7,7 +7,7 @@ describe('Documentation dropdown', () => {
   });
 
   it('user can open docs dropdown menu', () => {
-    cy.get('[aria-label="docs-dropdown"]').click();
+    cy.get('[data-cy="docs-dropdown"]').click();
 
     cy.get('.pf-c-dropdown__menu')
       .contains('Customer Support')
@@ -23,7 +23,7 @@ describe('Documentation dropdown', () => {
   });
 
   it('user can toggle about modal', () => {
-    cy.get('[aria-label="docs-dropdown"]').click();
+    cy.get('[data-cy="docs-dropdown"]').click();
     cy.get('.pf-c-dropdown__menu').contains('About').click();
     cy.get('.pf-c-about-modal-box').should('be.visible');
     cy.get('h1').contains('Galaxy NG');

--- a/test/cypress/e2e/misc/profile.js
+++ b/test/cypress/e2e/misc/profile.js
@@ -12,7 +12,7 @@ describe('My Profile Tests', () => {
   beforeEach(() => {
     cy.login();
     // open the dropdown labeled with the username and then...
-    cy.get('[aria-label="user-dropdown"] button').click();
+    cy.get('[data-cy="user-dropdown"] button').click();
     // a little hacky, but basically
     // just click the one link that says 'My profile'.
     cy.get('a').contains('My profile').click();
@@ -44,7 +44,7 @@ describe('My Profile Tests', () => {
   it('user cannot set superusers rights', () => {
     cy.login(username, password);
 
-    cy.get('[aria-label="user-dropdown"] button').click();
+    cy.get('[data-cy="user-dropdown"] button').click();
     cy.get('a').contains('My profile').click();
 
     cy.get('.pf-c-switch__input').should('be.disabled');
@@ -53,7 +53,7 @@ describe('My Profile Tests', () => {
   it('email must be email', () => {
     cy.login(username, password);
 
-    cy.get('[aria-label="user-dropdown"] button').click();
+    cy.get('[data-cy="user-dropdown"] button').click();
     cy.get('a').contains('My profile').click();
     cy.get('button:contains("Edit")').click();
 
@@ -71,7 +71,7 @@ describe('My Profile Tests', () => {
   it('password validations', () => {
     cy.login(username, password);
 
-    cy.get('[aria-label="user-dropdown"] button').click();
+    cy.get('[data-cy="user-dropdown"] button').click();
     cy.get('a').contains('My profile').click();
     cy.get('button:contains("Edit")').click();
 


### PR DESCRIPTION
Issue: AAH-2730; [discord](https://forum.ansible.com/t/how-can-i-change-language-in-new-galaxy-ng-site/1223)

This adds a language switcher to standalone navbar:

closed
![20231003034056](https://github.com/ansible/ansible-hub-ui/assets/289743/53072aa8-3dea-4afc-8087-aad5ea9a4f53)

opened, using browser default language
![20231003033955](https://github.com/ansible/ansible-hub-ui/assets/289743/156478e2-33db-4e02-a567-5763dd5a7c26)

manualy switched
![20231003034013](https://github.com/ansible/ansible-hub-ui/assets/289743/3ac072f9-ad71-400e-9c0e-8158f62a2a3c)

manually switched back
![20231003034039](https://github.com/ansible/ansible-hub-ui/assets/289743/87dd55bb-f514-41a6-9fc2-0d72d4c515f4)

(reset to browser defaults leads back to second screenshot :))

(the `(current)`, `(browser default)` and `Reset to browser defaults` strings would be translated once we have the right strings in the catalog)

This uses the language-switching mechanism introduced in #3225, updating it to not pass ?lang to API calls.