### PR TITLE
fix: replace "Github" with "GitHub" on `legacy-role.tsx` and `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ The app will run on http://localhost:8002/preview/ansible/automation-hub (and ht
 
 ## Deploying
 
-We're using Github Actions for deployment.
+We're using GitHub Actions for deployment.
 
 ### How it works
 
-The Github Action invokes the [RedHatInsights/insights-frontend-builder-common//bootstrap.sh](https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh) script, which builds the local branch and pushes the results to [RedHatInsights/ansible-hub-ui-build](https://github.com/RedHatInsights/ansible-hub-ui-build/branches). There, a separate Jenkins process awaits.
+The GitHub Action invokes the [RedHatInsights/insights-frontend-builder-common//bootstrap.sh](https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh) script, which builds the local branch and pushes the results to [RedHatInsights/ansible-hub-ui-build](https://github.com/RedHatInsights/ansible-hub-ui-build/branches). There, a separate Jenkins process awaits.
 
 - any push to the `master` branch will deploy to `ansible-hub-ui-build` `qa-beta` branch
 - any push to the `master` branch will ALSO deploy to `ansible-hub-ui-build` `qa-stable` branch when `.cloud-stage-cron.enabled` exists

--- a/src/containers/legacy-roles/legacy-role.tsx
+++ b/src/containers/legacy-roles/legacy-role.tsx
@@ -307,7 +307,7 @@ class LegacyRole extends React.Component<RouteProps, IProps> {
         {release_name && <div className='hub-entry'>{release_name}</div>}
         <div className='hub-entry'>
           <a href={repository}>
-            Github Repository <ExternalLinkAltIcon />
+            GitHub Repository <ExternalLinkAltIcon />
           </a>
         </div>
         <div className='hub-entry'>


### PR DESCRIPTION
## Changes
Hi, this PR simply adjusts the link label for GitHub repository to ensure the use of the canonical upper case character.

![Screenshot from 2023-10-08 14-27-54](https://github.com/ansible/ansible-hub-ui/assets/1425259/d6eaf5dd-67b1-4c93-8b9a-74f59aec52dd)

## Steps for Testing/QA
1. Open some role page.
2. Check GitHub repository link label.

