### PR TITLE
logout: reload user info after logout, instead of assuming null

### DIFF
--- a/CHANGES/2726.misc
+++ b/CHANGES/2726.misc
@@ -1,0 +1,1 @@
+logout: reload user info after logout, instead of assuming null

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -78,7 +78,11 @@ export const StandaloneLayout = ({
       <DropdownItem
         key='logout'
         aria-label={'logout'}
-        onClick={() => ActiveUserAPI.logout().then(() => setUser(null))}
+        onClick={() =>
+          ActiveUserAPI.logout()
+            .then(() => ActiveUserAPI.getUser().catch(() => null))
+            .then((user) => setUser(user))
+        }
       >
         {t`Logout`}
       </DropdownItem>,


### PR DESCRIPTION
Issue: AAH-2726

The UI doesn't really know about the community mode anonymous user, except from the API which pretends it's just another user.

But logout would still set UI user to null, going through the codepath that redirects to /login, which would go to github and log in again instead.
Reloading the user info instead of using null, in community mode, the user gets set to the anonymous user, with no redirects.