### PR TITLE
insights token - update sso link

### DIFF
--- a/CHANGES/2626.misc
+++ b/CHANGES/2626.misc
@@ -1,0 +1,1 @@
+Insights token: update SSO link

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -127,7 +127,7 @@ class TokenInsights extends React.Component<RouteProps, IState> {
             <Trans>
               To revoke a token or see all of your tokens, visit the{' '}
               <a
-                href='https://sso.redhat.com/auth/realms/redhat-external/account'
+                href='https://sso.redhat.com/auth/realms/redhat-external/account/#/applications'
                 target='_blank'
                 rel='noreferrer'
               >


### PR DESCRIPTION
adds a `/#/applications` to the end of the link

Issue: AAH-2626
