### PR TITLE
fix about modal ui repo url

### DIFF
--- a/src/components/about-modal/about-modal.tsx
+++ b/src/components/about-modal/about-modal.tsx
@@ -152,7 +152,7 @@ export const AboutModalWindow = ({
           <Label>{t`UI Version`}</Label>
           <Value>
             <ExternalLink
-              href={`https://github.com/ansible/ansible-hub/ui/commit/${ui_sha}`}
+              href={`https://github.com/ansible/ansible-hub-ui/commit/${ui_sha}`}
               title={ui_sha}
             />
           </Value>


### PR DESCRIPTION
Follows #4381 

typo in the url