### PR TITLE
Use a single variable for all access.redhat.com docs URLs

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -34,6 +34,12 @@ const defaultConfigs = [
   { name: 'APPLICATION_NAME', default: 'Galaxy NG', scope: 'global' },
   { name: 'UI_EXTERNAL_LOGIN_URI', default: '/login', scope: 'global' },
   { name: 'UI_COMMIT_HASH', default: gitCommit, scope: 'global' },
+  {
+    name: 'UI_DOCS_URL',
+    default:
+      'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
+    scope: 'global',
+  },
 
   // Webpack scope means the variable will only be available to webpack at
   // build time

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -239,9 +239,7 @@ export const PublishToControllerModal = (props: IProps) => {
   const { image, isOpen, onClose } = props;
 
   // redirects to ./2.x (latest)
-  const docsLink =
-    'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/';
-
+  const docsLink = UI_DOCS_URL;
   const noData =
     controllers?.length === 0 &&
     !filterIsSet(controllerParams, ['host__icontains']);

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -134,12 +134,7 @@ class ExecutionEnvironmentList extends React.Component<RouteProps, IState> {
     const pushImagesButton = (
       <Button
         variant='link'
-        onClick={() =>
-          window.open(
-            'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/managing_containers_in_private_automation_hub/index',
-            '_blank',
-          )
-        }
+        onClick={() => window.open(UI_DOCS_URL, '_blank')}
         data-cy='push-images-button'
       >
         <Trans>Push container images</Trans> <ExternalLinkAltIcon />

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -73,11 +73,7 @@ class TokenInsights extends React.Component<RouteProps, IState> {
               <Trans>
                 Documentation on how to configure the{' '}
                 <code>ansible-galaxy</code> client can be found{' '}
-                <a
-                  href='https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/'
-                  target='_blank'
-                  rel='noreferrer'
-                >
+                <a href={UI_DOCS_URL} target='_blank' rel='noreferrer'>
                   here
                 </a>
                 . Use the following parameters to configure the client.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,6 +14,7 @@ declare var PULP_API_BASE_PATH;
 declare var UI_BASE_PATH;
 declare var UI_COMMIT_HASH;
 declare var UI_EXTERNAL_LOGIN_URI;
+declare var UI_DOCS_URL;
 
 // when DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE only
 interface Window {

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -120,7 +120,7 @@ function standaloneMenu() {
         !user.is_anonymous,
     }),
     menuItem(t`Documentation`, {
-      url: 'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
+      url: UI_DOCS_URL,
       external: true,
       condition: ({ featureFlags, settings, user }) =>
         !featureFlags.ai_deny_index &&


### PR DESCRIPTION
EEs were the only one linking further down into the docs, but that link 404s now (https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/managing_containers_in_private_automation_hub/index)

=> adding a `UI_DOCS_URL` configuration var, set to https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/