### PR TITLE
Remote form: warn about signed_only enabled & missing requirements for Galaxy remote

### DIFF
--- a/CHANGES/2748.bug
+++ b/CHANGES/2748.bug
@@ -1,0 +1,1 @@
+Remote form: warn about signed_only enabled & missing requirements for Galaxy remote


### PR DESCRIPTION
Issue: AAH-2748

also related to #4385 and thus AAH-2360

When editing the community remote (matched by Galaxy URL), warn about `signed_only` enabled and `requirements_yaml` empty.

Previously there were no warnings, these are valid settings that just don't work together with community galaxy.


![20231012212659](https://github.com/ansible/ansible-hub-ui/assets/289743/f577345d-095c-4115-a575-f4f17cfcfafb)
