### PR TITLE
Fix failing collection, repository tests

### DIFF
--- a/test/cypress/e2e/collections/collection.js
+++ b/test/cypress/e2e/collections/collection.js
@@ -82,8 +82,9 @@ describe('collection tests', () => {
     cy.get('[data-cy="AlertList"]').contains(
       `Started adding ${namespace}.${collection} v1.0.0 from "published" to repository "validated".`,
     );
+    cy.galaxykit('task wait all');
     cy.get('[data-cy="AlertList"]').contains('detail page').click();
-    cy.contains('Completed', { timeout: 15000 });
+    cy.contains('Completed');
   });
 
   it('deletes an collection from repository', () => {

--- a/test/cypress/e2e/collections/collection.js
+++ b/test/cypress/e2e/collections/collection.js
@@ -83,7 +83,7 @@ describe('collection tests', () => {
       `Started adding ${namespace}.${collection} v1.0.0 from "published" to repository "validated".`,
     );
     cy.get('[data-cy="AlertList"]').contains('detail page').click();
-    cy.contains('Completed', { timeout: 10000 });
+    cy.contains('Completed', { timeout: 15000 });
   });
 
   it('deletes an collection from repository', () => {

--- a/test/cypress/e2e/repo/repository.js
+++ b/test/cypress/e2e/repo/repository.js
@@ -141,7 +141,7 @@ function versionCheck(version) {
         'Started adding repo_test_namespace.repo_test_collection v1.0.0 from "published" to repository "repo1Test".',
       );
       cy.contains('a', 'detail page').click();
-      cy.contains('Completed', { timeout: 10000 });
+      cy.contains('Completed', { timeout: 15000 });
     });
 
     it('checks there are 2 versions and collection is here', () => {

--- a/test/cypress/e2e/repo/repository.js
+++ b/test/cypress/e2e/repo/repository.js
@@ -140,8 +140,9 @@ function versionCheck(version) {
       cy.contains(
         'Started adding repo_test_namespace.repo_test_collection v1.0.0 from "published" to repository "repo1Test".',
       );
+      cy.galaxykit('task wait all');
       cy.contains('a', 'detail page').click();
-      cy.contains('Completed', { timeout: 15000 });
+      cy.contains('Completed');
     });
 
     it('checks there are 2 versions and collection is here', () => {


### PR DESCRIPTION
collection: https://github.com/ansible/ansible-hub-ui/actions/runs/6501115433/job/17657814640?pr=4392
repository: https://github.com/ansible/ansible-hub-ui/actions/runs/6501115433/job/17657816163?pr=4392

the screenshot of the failures look like successes so trying to increase timeouts ~~(or maybe we'll need a better selector for the "Completed" badge)~~
timeouts worked, trying to replace with `galaxykit task wait all` so we don't need random wait constants