### PR TITLE
[stable-4.7] Use a single variable for all access.redhat.com docs URLs (#4391)

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -27,6 +27,12 @@ const defaultConfigs = [
   { name: 'APPLICATION_NAME', default: 'Galaxy NG', scope: 'global' },
   { name: 'UI_EXTERNAL_LOGIN_URI', default: '/login', scope: 'global' },
   { name: 'UI_COMMIT_HASH', default: gitCommit, scope: 'global' },
+  {
+    name: 'UI_DOCS_URL',
+    default:
+      'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4',
+    scope: 'global',
+  },
 
   // Webpack scope means the variable will only be available to webpack at
   // build time

--- a/src/components/execution-environment/publish-to-controller-modal.tsx
+++ b/src/components/execution-environment/publish-to-controller-modal.tsx
@@ -237,9 +237,7 @@ export const PublishToControllerModal = (props: IProps) => {
 
   const { image, isOpen, onClose } = props;
 
-  const docsLink =
-    'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4';
-
+  const docsLink = UI_DOCS_URL;
   const noData =
     controllers?.length === 0 &&
     !filterIsSet(controllerParams, ['host__icontains']);

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -134,12 +134,7 @@ class ExecutionEnvironmentList extends React.Component<RouteProps, IState> {
     const pushImagesButton = (
       <Button
         variant='link'
-        onClick={() =>
-          window.open(
-            'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/managing_containers_in_private_automation_hub/index',
-            '_blank',
-          )
-        }
+        onClick={() => window.open(UI_DOCS_URL, '_blank')}
         data-cy='push-images-button'
       >
         <Trans>Push container images</Trans> <ExternalLinkAltIcon />

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -11,4 +11,5 @@ declare var APPLICATION_NAME;
 declare var PULP_API_BASE_PATH;
 declare var UI_BASE_PATH;
 declare var UI_COMMIT_HASH;
+declare var UI_DOCS_URL;
 declare var UI_EXTERNAL_LOGIN_URI;

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -109,7 +109,7 @@ function standaloneMenu() {
         !user.is_anonymous,
     }),
     menuItem(t`Documentation`, {
-      url: 'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4',
+      url: UI_DOCS_URL,
       external: true,
       condition: ({ settings, user }) =>
         settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||


### PR DESCRIPTION
Backports #4391 - conflicts because the URL ends in /2.4 here

Mostly because https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.4/html-single/managing_containers_in_private_automation_hub/index no longer works

---

EEs were the only one linking further down into the docs, but that link 404s now

No-Issue

(cherry picked from commit b7ecd4f5f9ba0fa16898144a98d8b0ca28f61cfe)
