### PR TITLE
Repository sync - warn about community set to signed_only

### DIFF
--- a/src/actions/ansible-repository-sync.tsx
+++ b/src/actions/ansible-repository-sync.tsx
@@ -134,21 +134,29 @@ export const ansibleRepositorySyncAction = Action({
       return t`Sync task is already queued.`;
     }
 
-    // only available on detail screen; list will have remote: string, so no .url
-    if (
-      remote &&
-      remote.url === 'https://galaxy.ansible.com/api/' &&
-      !remote.requirements_file
-    ) {
+    // Remote checks only available on detail screen; list will have remote: string, so no .url
+    if (remote && remote.url === 'https://galaxy.ansible.com/api/') {
       const name = remote.name;
       const url = formatPath(Paths.ansibleRemoteEdit, { name });
 
-      return (
-        <Trans>
-          YAML requirements are required to sync from Galaxy - you can{' '}
-          <Link to={url}>edit the {name} remote</Link> to add requirements.
-        </Trans>
-      );
+      if (!remote.requirements_file) {
+        return (
+          <Trans>
+            YAML requirements are required to sync from Galaxy. You can{' '}
+            <Link to={url}>edit the {name} remote</Link> to add requirements.
+          </Trans>
+        );
+      }
+
+      if (remote.signed_only) {
+        return (
+          <Trans>
+            Community content will never be synced if the remote is set to only
+            sync signed content. You can{' '}
+            <Link to={url}>edit the {name} remote</Link> to change it.
+          </Trans>
+        );
+      }
     }
 
     return null;


### PR DESCRIPTION
follows #4385, #4392

#4385 adds a warning about missing requirements file when trying to sync from community galaxy,
#4392 adds a warning about missing requirements file & set signed_only when trying to configure the community remote

this adds the signed_only warning to the sync action

---

![20231016171955](https://github.com/ansible/ansible-hub-ui/assets/289743/c9d54f75-ef6b-4252-bbad-6ff8c9abd263)
![20231016171911](https://github.com/ansible/ansible-hub-ui/assets/289743/d4bce62a-1040-4630-9b64-adb39103b2ec)
