### PR TITLE
Remote form: expose "sync dependencies" switch

### DIFF
--- a/src/api/response-types/ansible-remote.ts
+++ b/src/api/response-types/ansible-remote.ts
@@ -11,6 +11,7 @@ export class AnsibleRemoteType {
   tls_validation: boolean;
   url: string;
   signed_only: boolean;
+  sync_dependencies?: boolean;
 
   // connect_timeout
   // headers
@@ -21,7 +22,6 @@ export class AnsibleRemoteType {
   // pulp_last_updated
   // sock_connect_timeout
   // sock_read_timeout
-  // sync_dependencies
   // total_timeout
 
   hidden_fields: {

--- a/src/api/response-types/remote.ts
+++ b/src/api/response-types/remote.ts
@@ -33,6 +33,7 @@ export class RemoteType {
   client_key?: string;
   client_cert?: string;
   ca_cert?: string;
+  sync_dependencies?: boolean;
 
   write_only_fields: WriteOnlyFieldType[];
 

--- a/src/components/repositories/remote-form.tsx
+++ b/src/components/repositories/remote-form.tsx
@@ -129,6 +129,7 @@ export class RemoteForm extends React.Component<IProps, IState> {
           'token',
           'requirements_file',
           'signed_only',
+          'sync_dependencies',
         ]);
         break;
     }
@@ -276,7 +277,6 @@ export class RemoteForm extends React.Component<IProps, IState> {
         {!disabledFields.includes('signed_only') && collection_signing ? (
           <FormGroup
             fieldId={'signed_only'}
-            name={t`Signed only`}
             label={t`Download only signed collections`}
           >
             {isCommunityRemote && this.props.remote.signed_only ? (
@@ -290,6 +290,21 @@ export class RemoteForm extends React.Component<IProps, IState> {
               id='signed_only'
               isChecked={!!remote.signed_only}
               onChange={(value) => this.updateRemote(value, 'signed_only')}
+            />
+          </FormGroup>
+        ) : null}
+
+        {!disabledFields.includes('sync_dependencies') ? (
+          <FormGroup
+            fieldId={'sync_dependencies'}
+            label={t`Include all dependencies when syncing a collection.`}
+          >
+            <Switch
+              id='sync_dependencies'
+              isChecked={!!remote.sync_dependencies}
+              onChange={(value) =>
+                this.updateRemote(value, 'sync_dependencies')
+              }
             />
           </FormGroup>
         ) : null}


### PR DESCRIPTION
![20231017153241](https://github.com/ansible/ansible-hub-ui/assets/289743/3e8017ba-0d34-4ab7-ad7a-8e5e8f682ced)

Related to https://issues.redhat.com/browse/AAP-15208
