### PR TITLE
Repository collection versions - fix "Cannot read properties of undefined" after removing cv

### DIFF
--- a/src/actions/ansible-repository-collection-version-add.tsx
+++ b/src/actions/ansible-repository-collection-version-add.tsx
@@ -88,7 +88,8 @@ const AddCollectionVersionModal = ({
     setAlerts([...alerts, alert]);
   };
 
-  const query = ({ params }) => {
+  // @ts-expect-error: TS2525: Initializer provides no value for this binding element and the binding element has no default value.
+  const query = ({ params } = {}) => {
     const newParams = { ...params };
     newParams.ordering = newParams.sort;
     delete newParams.sort;

--- a/src/containers/ansible-repository/tab-collection-versions.tsx
+++ b/src/containers/ansible-repository/tab-collection-versions.tsx
@@ -27,7 +27,8 @@ export const CollectionVersionsTab = ({
   item,
   actionContext: { addAlert, hasPermission },
 }: TabProps) => {
-  const query = ({ params }) => {
+  // @ts-expect-error: TS2525: Initializer provides no value for this binding element and the binding element has no default value.
+  const query = ({ params } = {}) => {
     const newParams = { ...params };
     newParams.ordering = newParams.sort;
     delete newParams.sort;

--- a/src/containers/ansible-repository/tab-repository-versions.tsx
+++ b/src/containers/ansible-repository/tab-repository-versions.tsx
@@ -51,7 +51,8 @@ const VersionContent = ({
   }
 
   const API = AnyAPI(href);
-  const query = ({ params }) => API.list(params);
+  // @ts-expect-error: TS2525: Initializer provides no value for this binding element and the binding element has no default value.
+  const query = ({ params } = {}) => API.list(params);
   const renderTableRow = ({
     manifest: {
       collection_info: { namespace, name, version },


### PR DESCRIPTION
go to a Repository Collection versions tab,
remove a collection version

removal succeeds, but produces an extra error because we're calling the reload query wrong .. fixing

AAP-16936
