### PR TITLE
The role namespace name is the common identifier, not the github_user.

### DIFF
--- a/src/components/legacy-role-list/legacy-role-item.tsx
+++ b/src/components/legacy-role-list/legacy-role-item.tsx
@@ -37,7 +37,7 @@ export function LegacyRoleListItem({ role, show_thumbnail }: LegacyRoleProps) {
   const latest = versions[0];
 
   const role_url = formatPath(Paths.legacyRole, {
-    username: github_user,
+    username: namespace.name,
     name,
   });
   const release_date = latest?.release_date || modified;


### PR DESCRIPTION
In many cases, the github_user doesn't reflect the role's fully qualified name. For example https://old-galaxy.ansible.com/zyuskin/k8s_registry_credentials aka `zyuskin.k8s_registry_credentials` points to the https://github.com/amaxlab/k8s-registry-credentials repository, but `amaxlab.k8s-registry-credentials` is not the role's FQN.