### PR TITLE
Remove duplicate trailing slash on fetching legacy role versions and content

### DIFF
--- a/src/api/legacy-role.ts
+++ b/src/api/legacy-role.ts
@@ -5,11 +5,11 @@ export class API extends LegacyAPI {
   sortParam = 'order_by';
 
   getContent(id) {
-    return super.get(id + '/content/');
+    return super.get(id + '/content');
   }
 
   getVersions(id) {
-    return super.get(id + '/versions/');
+    return super.get(id + '/versions');
   }
 
   // list(params?)


### PR DESCRIPTION
The UX on beta is fetching `/api/v1/roles/{id}/versions//` and `/api/v1/roles/{id}/content//`. On a local devstack the API routing is handling this fine and returning the data, but in the hosted environments it's giving 404's.