### PR TITLE
Docs - render object choices

### DIFF
--- a/src/components/render-plugin-doc/render-plugin-doc.tsx
+++ b/src/components/render-plugin-doc/render-plugin-doc.tsx
@@ -1,5 +1,6 @@
+import { Trans, t } from '@lingui/macro';
 import { dom, parse } from 'antsibull-docs';
-import React from 'react';
+import React, { ReactNode } from 'react';
 import {
   PluginContentType,
   PluginDoc,
@@ -29,6 +30,18 @@ interface IProps {
     section: string,
   ) => React.ReactElement;
   renderWarning: (text: string) => React.ReactElement;
+}
+
+function Choice({ children }: { children: ReactNode }) {
+  return <pre style={{ display: 'inline-block' }}>{children}</pre>;
+}
+
+function Legend({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ display: 'inline-block', verticalAlign: 'top' }}>
+      {children}
+    </div>
+  );
 }
 
 export class RenderPluginDoc extends React.Component<IProps, IState> {
@@ -653,13 +666,17 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
       legend = [legend];
     }
 
-    // TODO look more like in https://docs.ansible.com/ansible/devel/collections/ansible/builtin/config_lookup.html#parameter-on_missing
     return (
       <>
-        {' - '}
-        {legend.map((d) => (
-          <p>{this.applyDocFormatters(d)}</p>
-        ))}
+        {': '}
+        <Legend>
+          {legend.map((d, i) => (
+            <>
+              {i ? <br /> : null}
+              {this.applyDocFormatters(d)}
+            </>
+          ))}
+        </Legend>
       </>
     );
   }
@@ -687,21 +704,22 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
       choices = Object.keys(choices);
     }
 
-    // DEBUG, http://localhost:8002/ui/repo/published/arista/eos/content/module/eos_acl_interfaces/
-    legends = { merged: 'foo', replaced: ['foo', 'bar'] };
-
     return (
       <>
         {choices && Array.isArray(choices) && choices.length !== 0 ? (
           <div>
-            <span className='option-name'>Choices: </span>
+            <span className='option-name'>
+              <Trans>Choices: </Trans>
+            </span>
             <ul>
               {choices.map((c, i) => (
                 <li key={i}>
                   {c === defaultChoice ? (
-                    <span className='blue'>{c} &nbsp;&larr;</span>
+                    <span className='blue' title={t`default`}>
+                      <Choice>{c}</Choice> &nbsp;&larr;
+                    </span>
                   ) : (
-                    c
+                    <Choice>{c}</Choice>
                   )}
                   {this.renderLegend(legends[c])}
                 </li>
@@ -712,7 +730,9 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
 
         {defaultChoice && !choices.includes(defaultChoice) ? (
           <span>
-            <span className='option-name'>Default: </span>
+            <span className='option-name'>
+              <Trans>Default: </Trans>
+            </span>
             <span className='blue'>{defaultChoice}</span>
           </span>
         ) : null}

--- a/src/components/render-plugin-doc/render-plugin-doc.tsx
+++ b/src/components/render-plugin-doc/render-plugin-doc.tsx
@@ -728,7 +728,7 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
           </div>
         ) : null}
 
-        {defaultChoice && !choices.includes(defaultChoice) ? (
+        {defaultChoice !== undefined && !choices.includes(defaultChoice) ? (
           <span>
             <span className='option-name'>
               <Trans>Default: </Trans>

--- a/src/components/render-plugin-doc/render-plugin-doc.tsx
+++ b/src/components/render-plugin-doc/render-plugin-doc.tsx
@@ -653,6 +653,7 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
       legend = [legend];
     }
 
+    // TODO look more like in https://docs.ansible.com/ansible/devel/collections/ansible/builtin/config_lookup.html#parameter-on_missing
     return (
       <>
         {' - '}
@@ -685,6 +686,9 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
       legends = choices;
       choices = Object.keys(choices);
     }
+
+    // DEBUG, http://localhost:8002/ui/repo/published/arista/eos/content/module/eos_acl_interfaces/
+    legends = { merged: 'foo', replaced: ['foo', 'bar'] };
 
     return (
       <>

--- a/src/components/render-plugin-doc/render-plugin-doc.tsx
+++ b/src/components/render-plugin-doc/render-plugin-doc.tsx
@@ -644,47 +644,75 @@ export class RenderPluginDoc extends React.Component<IProps, IState> {
     );
   }
 
-  private renderChoices(option) {
-    let choices, defaul;
+  private renderLegend(legend) {
+    if (!legend) {
+      return null;
+    }
 
-    if (option['type'] === 'bool') {
-      choices = ['true', 'false'];
-      if (option['default'] === true) {
-        defaul = 'true';
-      } else if (option['default'] === false) {
-        defaul = 'false';
-      }
-    } else {
-      choices = option['choices'] || [];
-      defaul = option['default'];
+    if (!Array.isArray(legend)) {
+      legend = [legend];
     }
 
     return (
-      <React.Fragment>
+      <>
+        {' - '}
+        {legend.map((d) => (
+          <p>{this.applyDocFormatters(d)}</p>
+        ))}
+      </>
+    );
+  }
+
+  private renderChoices(option) {
+    let choices,
+      defaultChoice,
+      legends = {};
+
+    if (option['type'] === 'bool') {
+      choices = ['true', 'false'];
+
+      if (option['default'] === true) {
+        defaultChoice = 'true';
+      } else if (option['default'] === false) {
+        defaultChoice = 'false';
+      }
+    } else {
+      choices = option['choices'] || [];
+      defaultChoice = option['default'];
+    }
+
+    if (typeof choices === 'object' && !Array.isArray(choices)) {
+      legends = choices;
+      choices = Object.keys(choices);
+    }
+
+    return (
+      <>
         {choices && Array.isArray(choices) && choices.length !== 0 ? (
           <div>
             <span className='option-name'>Choices: </span>
             <ul>
               {choices.map((c, i) => (
                 <li key={i}>
-                  {c === defaul ? (
+                  {c === defaultChoice ? (
                     <span className='blue'>{c} &nbsp;&larr;</span>
                   ) : (
                     c
                   )}
+                  {this.renderLegend(legends[c])}
                 </li>
               ))}
             </ul>
           </div>
         ) : null}
 
-        {defaul && !choices.includes(defaul) ? (
+        {defaultChoice && !choices.includes(defaultChoice) ? (
           <span>
             <span className='option-name'>Default: </span>
-            <span className='blue'>{defaul}</span>
+            <span className='blue'>{defaultChoice}</span>
           </span>
         ) : null}
-      </React.Fragment>
+      </>
     );
   }
 

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -155,7 +155,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
             />
 
             <div
-              className='body hub-docs-content pf-c-content'
+              className='body hub-docs-content pf-c-content hub-content-alert-fix'
               ref={this.docsRef}
             >
               {displayHTML || pluginData ? (


### PR DESCRIPTION
https://github.com/ansible/ansible/pull/81951#issuecomment-1772123886

In docs renderer, `choices` used to be an array of string values, that's still permissible,
but now we also accept an object of `{ value: description }` instead of the array.

This also changes the rendering of choices to be closer to https://docs.ansible.com/ansible/devel/collections/ansible/builtin/config_lookup.html#parameter-on_missing
=> monospace the choice value, "`value`: description"

Before - Array:

![20231025011837](https://github.com/ansible/ansible-hub-ui/assets/289743/1b6aedd0-030b-45fb-aa0d-f1309a878e7a)

Before - Object:

![20231101021437](https://github.com/ansible/ansible-hub-ui/assets/289743/fb2af1dc-a14c-40d2-ac15-e4dca11dadf6)

Now - Array:

![20231101021542](https://github.com/ansible/ansible-hub-ui/assets/289743/a9964f88-9125-463e-9c8f-91e87f9db1a6)

Now - Object:

![20231101020734](https://github.com/ansible/ansible-hub-ui/assets/289743/cabc04eb-9e6a-462c-84bf-a74795f23828)
![20231101020747](https://github.com/ansible/ansible-hub-ui/assets/289743/5bcabc4e-19a9-4423-8b35-c2167a9d5c12)


(also fixed the error message...

![20231101022139](https://github.com/ansible/ansible-hub-ui/assets/289743/47694764-368b-434e-866d-14f1acf7150b)
)