### PR TITLE
use name property on version

### DIFF
--- a/CHANGES/2807.bug
+++ b/CHANGES/2807.bug
@@ -1,0 +1,1 @@
+Use version property name instead of number.

--- a/src/containers/ansible-role/role-detail.tsx
+++ b/src/containers/ansible-role/role-detail.tsx
@@ -117,9 +117,7 @@ class RoleVersion extends React.Component<RoleVersionProps> {
   render() {
     return (
       <DataListItemRow>
-        <DataListCell alignRight>
-          {this.props.role_version.version}
-        </DataListCell>
+        <DataListCell alignRight>{this.props.role_version.name}</DataListCell>
 
         <DataListCell alignRight>
           <Trans>


### PR DESCRIPTION
Change the version property to display the version name instead of version number. 