### PR TITLE
Import modal - respect display_repositories, hide selector when no choices

### DIFF
--- a/test/cypress/e2e/collections/collection_upload.js
+++ b/test/cypress/e2e/collections/collection_upload.js
@@ -49,7 +49,7 @@ describe('Collection Upload Tests', () => {
     );
     cy.contains('testcollection');
     cy.contains('Upload new version').click();
-    cy.contains('New version of testcollection');
+    cy.contains('New version of testspace.testcollection');
 
     cy.visit(
       `${uiPrefix}collections?page_size=10&view_type=card&keywords=testcollection`,
@@ -57,7 +57,7 @@ describe('Collection Upload Tests', () => {
     cy.contains('testcollection');
     cy.get('button[aria-label="Actions"]').click();
     cy.contains('Upload new version').click();
-    cy.contains('New version of testcollection');
+    cy.contains('New version of testspace.testcollection');
   });
 
   it('should see upload new collection version in collection detail when user does have permissions', () => {
@@ -66,7 +66,7 @@ describe('Collection Upload Tests', () => {
     cy.contains('testcollection');
     cy.get('[data-cy="kebab-toggle"] button[aria-label="Actions"]').click();
     cy.contains('Upload new version').click();
-    cy.contains('New version of testcollection');
+    cy.contains('New version of testspace.testcollection');
   });
 
   it('user should not be able to upload new collection without permissions', () => {


### PR DESCRIPTION
When the `display_repositories` feature flag is disabled, don't show the "Staging Repos"/"All Repos" radios, only allow staging.

When there is only 1 candidate choice within the current list, don't show the whole list, only the preselected repo.

Thus...

`display_repositories == false, staging count == 1`:
![20231031034619](https://github.com/ansible/ansible-hub-ui/assets/289743/3c32e05c-a84f-4304-88dc-05abf25f73e2)

`display_repositories == true, staging count == 1`:
![20231031034653](https://github.com/ansible/ansible-hub-ui/assets/289743/14fa43ba-4d85-4b67-acfe-6cc21f827a4f)

`display_repositories == false, staging count > 1`:
![20231031040227](https://github.com/ansible/ansible-hub-ui/assets/289743/8b791359-9ec8-406e-9dd2-a54bf475c2c5)

`display_repositories == true, staging count > 1`:
![20231031035136](https://github.com/ansible/ansible-hub-ui/assets/289743/6bddab4a-51f2-458a-881b-e380a41cafba)
