### PR TITLE
Repository create - preselect "create a ... distribution" when creating new repo

### DIFF
--- a/src/components/repositories/ansible-repository-form.tsx
+++ b/src/components/repositories/ansible-repository-form.tsx
@@ -125,7 +125,8 @@ export const AnsibleRepositoryForm = ({
   useEffect(() => loadRemotes(), []);
 
   useEffect(() => {
-    if (!repository) {
+    // create
+    if (!repository || !repository.name) {
       onDistributionsLoad(null);
       return;
     }


### PR DESCRIPTION
the logic to preselected "create ... distribution" was there, but didn't expect an `initialRepository` instead of `null`, fixing.

![20231031041720](https://github.com/ansible/ansible-hub-ui/assets/289743/db207ee6-38f7-4250-ab87-f3fe3d3f23a4)
