### PR TITLE
Bump stylelint-config-standard-scss to 11.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
                 "source-map-loader": "^4.0.1",
                 "style-loader": "^3.3.3",
                 "stylelint": "^15.11.0",
-                "stylelint-config-standard-scss": "^11.0.0",
+                "stylelint-config-standard-scss": "^11.1.0",
                 "stylelint-scss": "^5.3.0",
                 "typescript": "^5.2.2",
                 "webpack": "^5.88.2",
@@ -13399,9 +13399,9 @@
             }
         },
         "node_modules/postcss-scss": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.8.tgz",
-            "integrity": "sha512-Cr0X8Eu7xMhE96PJck6ses/uVVXDtE5ghUTKNUYgm8ozgP2TkgV3LWs3WgLV1xaSSLq8ZFiXaUrj0LVgG1fGEA==",
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz",
+            "integrity": "sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==",
             "dev": true,
             "funding": [
                 {
@@ -15484,14 +15484,14 @@
             }
         },
         "node_modules/stylelint-config-recommended-scss": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-13.0.0.tgz",
-            "integrity": "sha512-7AmMIsHTsuwUQm7I+DD5BGeIgCvqYZ4BpeYJJpb1cUXQwrJAKjA+GBotFZgUEGP8lAM+wmd91ovzOi8xfAyWEw==",
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-13.1.0.tgz",
+            "integrity": "sha512-8L5nDfd+YH6AOoBGKmhH8pLWF1dpfY816JtGMePcBqqSsLU+Ysawx44fQSlMOJ2xTfI9yTGpup5JU77c17w1Ww==",
             "dev": true,
             "dependencies": {
-                "postcss-scss": "^4.0.7",
+                "postcss-scss": "^4.0.9",
                 "stylelint-config-recommended": "^13.0.0",
-                "stylelint-scss": "^5.1.0"
+                "stylelint-scss": "^5.3.0"
             },
             "peerDependencies": {
                 "postcss": "^8.3.3",
@@ -15519,12 +15519,12 @@
             }
         },
         "node_modules/stylelint-config-standard-scss": {
-            "version": "11.0.0",
-            "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-11.0.0.tgz",
-            "integrity": "sha512-fGE79NBOLg09a9afqGH/guJulRULCaQWWv4cv1v2bMX92B+fGb0y56WqIguwvFcliPmmUXiAhKrrnXilIeXoHA==",
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-11.1.0.tgz",
+            "integrity": "sha512-5gnBgeNTgRVdchMwiFQPuBOtj9QefYtfXiddrOMJA2pI22zxt6ddI2s+e5Oh7/6QYl7QLJujGnaUR5YyGq72ow==",
             "dev": true,
             "dependencies": {
-                "stylelint-config-recommended-scss": "^13.0.0",
+                "stylelint-config-recommended-scss": "^13.1.0",
                 "stylelint-config-standard": "^34.0.0"
             },
             "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
         "source-map-loader": "^4.0.1",
         "style-loader": "^3.3.3",
         "stylelint": "^15.11.0",
-        "stylelint-config-standard-scss": "^11.0.0",
+        "stylelint-config-standard-scss": "^11.1.0",
         "stylelint-scss": "^5.3.0",
         "typescript": "^5.2.2",
         "webpack": "^5.88.2",


### PR DESCRIPTION
Fixes:

    $ npm run lint:sass
    Deprecation warnings:
    - The "scss/at-import-no-partial-leading-underscore" rule is deprecated.
    - 'at-import-no-partial-leading-underscore' has been deprecated, and will be removed in '6.0'. Use 'load-no-partial-leading-underscore' instead. See: https://github.com/stylelint-scss/stylelint-scss/blob/v5.2.1/src/rules/at-import-no-partial-leading-underscore/README.md
