### PR TITLE
multi-search: fix EE card layout

### DIFF
--- a/src/components/cards/cards.scss
+++ b/src/components/cards/cards.scss
@@ -68,3 +68,13 @@
 .hidden-menu-space {
   margin-right: 8px;
 }
+
+.hub-card-layout {
+  display: flex;
+  flex-wrap: wrap;
+
+  .card-wrapper {
+    margin-right: 24px;
+    margin-bottom: 24px;
+  }
+}

--- a/src/containers/namespace-list/namespace-list.scss
+++ b/src/containers/namespace-list/namespace-list.scss
@@ -8,16 +8,6 @@
     margin-top: 24px;
     margin-left: 24px;
     flex-grow: 1;
-
-    .card-layout {
-      display: flex;
-      flex-wrap: wrap;
-
-      .card-wrapper {
-        margin-right: 24px;
-        margin-bottom: 24px;
-      }
-    }
   }
 
   .footer {

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -321,7 +321,7 @@ export class NamespaceList extends React.Component<IProps, IState> {
     }
 
     return (
-      <section className='card-layout'>
+      <section className='hub-card-layout'>
         {namespaces.map((ns, i) => (
           <div key={i} className='card-wrapper'>
             <NamespaceCard

--- a/src/containers/search/multi-search.tsx
+++ b/src/containers/search/multi-search.tsx
@@ -342,34 +342,40 @@ export const MultiSearch = (props: RouteProps) => {
               >{t`Show more execution environments`}</Link>
             }
           >
-            <DataList aria-label={t`Available matching execution environments`}>
+            <DataList
+              aria-label={t`Available matching execution environments`}
+              className='hub-card-layout'
+              style={{ paddingTop: '8px' }}
+            >
               {containers.map((item, index) => (
-                <section className='card-layout' key={index}>
-                  <div className='card-wrapper'>
-                    <article className='pf-c-card hub-c-card-ns-container'>
-                      <div className='pf-c-card__title'>
-                        <Link
-                          to={formatEEPath(Paths.executionEnvironmentDetail, {
-                            container: item.pulp.distribution.base_path,
-                          })}
-                        >
-                          {item.name}
-                        </Link>
-                      </div>
-                      <div className='pf-c-card__body pf-m-truncate'>
-                        {item.description ? (
-                          <Tooltip content={item.description}>
-                            {item.description}
-                          </Tooltip>
-                        ) : null}
-                      </div>
-                      <div className='pf-c-card__footer'>
-                        <Label>
-                          {item.pulp.repository.remote ? t`Remote` : t`Local`}
-                        </Label>
-                      </div>
-                    </article>
-                  </div>
+                <section
+                  key={index}
+                  className='card-wrapper'
+                  style={{ width: '300px' }}
+                >
+                  <article className='pf-c-card'>
+                    <div className='pf-c-card__title'>
+                      <Link
+                        to={formatEEPath(Paths.executionEnvironmentDetail, {
+                          container: item.pulp.distribution.base_path,
+                        })}
+                      >
+                        {item.name}
+                      </Link>
+                    </div>
+                    <div className='pf-c-card__body pf-m-truncate'>
+                      {item.description ? (
+                        <Tooltip content={item.description}>
+                          {item.description}
+                        </Tooltip>
+                      ) : null}
+                    </div>
+                    <div className='pf-c-card__footer'>
+                      <Label>
+                        {item.pulp.repository.remote ? t`Remote` : t`Local`}
+                      </Label>
+                    </div>
+                  </article>
                 </section>
               ))}
             </DataList>


### PR DESCRIPTION
styling previously only applied in namespaces, move to card css, use in both

![20231111034825](https://github.com/ansible/ansible-hub-ui/assets/289743/c5d97ba7-9610-4640-90b6-1a5be8513839)
