### PR TITLE
add local nginx conf to community docker image

### DIFF
--- a/community/Dockerfile
+++ b/community/Dockerfile
@@ -10,4 +10,6 @@ RUN npm ci && \
 
 FROM registry.access.redhat.com/ubi8/nginx-120:latest
 COPY --from=0 /workspace/dist ${NGINX_APP_ROOT}/src
+COPY community/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY community/nginx/nginx.d/ /opt/app-root/etc/nginx.d/
 CMD ["nginx", "-g", "daemon off;"]

--- a/community/nginx/nginx.conf
+++ b/community/nginx/nginx.conf
@@ -1,0 +1,28 @@
+worker_processes  1;
+
+error_log  /dev/stderr warn;
+pid        /run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent $request_time "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for" $http_cf_connecting_ip';
+
+    access_log  /dev/stdout  main;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    server_tokens       off;
+    absolute_redirect   off;
+
+    include /opt/app-root/etc/nginx.d/*.conf;
+}

--- a/community/nginx/nginx.d/default.conf
+++ b/community/nginx/nginx.d/default.conf
@@ -1,0 +1,41 @@
+upstream api {
+    server host.docker.internal:5001;
+}
+
+server {
+    listen 8002 default_server;
+    server_name _;
+    root /opt/app-root/src/;
+
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+
+    client_max_body_size 20M;
+    
+    location / {
+        try_files $uri /index.html;
+    }
+
+    location /healthz {
+        access_log off;
+        return 200 "OK\n";
+    }
+
+    location /api/ {
+        proxy_pass http://api;
+    }
+
+    location /login/ {
+        proxy_pass http://api;
+    }
+
+    location /complete/ {
+        proxy_pass http://api;
+    }
+
+    location /static/rest_framework/ {
+        proxy_pass http://api;
+    }
+}


### PR DESCRIPTION
### What

* adds nginx config files for use in local debugging to the community Docker image

### Why
This will allow running the community UI container locally alongside galaxy-ng by running:
```
docker run -p 8002:8002 --add-host host.docker.internal:host-gateway quay.io/ansible/galaxy-ui:latest
```

No-Issue
