### PR TITLE
galaxy: hide distributions, distribution links

### DIFF
--- a/src/components/collection-detail/collection-info.tsx
+++ b/src/components/collection-detail/collection-info.tsx
@@ -44,7 +44,7 @@ export const CollectionInfo = ({
   addAlert,
 }: IProps) => {
   const downloadLinkRef = React.useRef<HTMLAnchorElement>(null);
-  const context = useContext();
+  const { user, settings } = useContext();
 
   let installCommand = `ansible-galaxy collection install ${collection_version.namespace}.${collection_version.name}`;
 
@@ -94,9 +94,8 @@ export const CollectionInfo = ({
         <GridItem>
           <Split hasGutter={true}>
             <SplitItem className='install-title'>{t`Download`}</SplitItem>
-            {context.user.is_anonymous &&
-            !context.settings
-              .GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD ? (
+            {user.is_anonymous &&
+            !settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_DOWNLOAD ? (
               <Alert
                 className={'hub-collection-download-alert'}
                 isInline
@@ -110,22 +109,24 @@ export const CollectionInfo = ({
               />
             ) : (
               <SplitItem isFilled>
-                <div>
-                  <Trans>
-                    To download this collection, configure your client to
-                    connect to one of this repositories{' '}
-                    <Link
-                      to={formatPath(Paths.collectionDistributionsByRepo, {
-                        repo: repository.name,
-                        namespace: collection_version.namespace,
-                        collection: collection_version.name,
-                      })}
-                    >
-                      distributions
-                    </Link>
-                    .
-                  </Trans>
-                </div>
+                {!IS_COMMUNITY ? (
+                  <div>
+                    <Trans>
+                      To download this collection, configure your client to
+                      connect to one of the{' '}
+                      <Link
+                        to={formatPath(Paths.collectionDistributionsByRepo, {
+                          repo: repository.name,
+                          namespace: collection_version.namespace,
+                          collection: collection_version.name,
+                        })}
+                      >
+                        distributions
+                      </Link>{' '}
+                      of this repository.
+                    </Trans>
+                  </div>
+                ) : null}
                 <a ref={downloadLinkRef} style={{ display: 'none' }} />
                 <Button
                   className='download-button'

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -697,15 +697,17 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           reduced,
         ),
       },
-      {
-        active: active === 'distributions',
-        title: t`Distributions`,
-        link: formatPath(
-          Paths.collectionDistributionsByRepo,
-          pathParams,
-          reduced,
-        ),
-      },
+      !IS_COMMUNITY
+        ? {
+            active: active === 'distributions',
+            title: t`Distributions`,
+            link: formatPath(
+              Paths.collectionDistributionsByRepo,
+              pathParams,
+              reduced,
+            ),
+          }
+        : null,
     ];
 
     return <LinkTabs tabs={tabs} />;

--- a/src/components/shared/link-tabs.tsx
+++ b/src/components/shared/link-tabs.tsx
@@ -28,6 +28,8 @@ const renderTab = ({ link, title, active = false }) => (
 // We're not using the Tab react component because they don't support links.
 export const LinkTabs = ({ tabs }: IProps) => (
   <div className='pf-c-tabs'>
-    <ul className='pf-c-tabs__list'>{tabs.map((tab) => renderTab(tab))}</ul>
+    <ul className='pf-c-tabs__list'>
+      {tabs.filter(Boolean).map((tab) => renderTab(tab))}
+    </ul>
   </div>
 );


### PR DESCRIPTION
Depends on #4523 (merged)

CollectionInfo - don't link to distribution list in community mode
Collection detail - hide Distributions tab

that list helps users configure their clients to connect to the right PAH,
but on galaxy, there is only one published distribution, and the clients are preconfigured to use it