### PR TITLE
webpack config - add IS_COMMUNITY & IS_INSIGHTS flags

### DIFF
--- a/config/community.dev.webpack.config.js
+++ b/config/community.dev.webpack.config.js
@@ -26,6 +26,7 @@ module.exports = webpackBase({
   // Determines if the app should be compiled to run on insights or on
   // another platform. Options: insights, standalone
   DEPLOYMENT_MODE: 'standalone',
+  IS_COMMUNITY: true,
 
   NAMESPACE_TERM: 'namespaces',
 

--- a/config/community.prod.webpack.config.js
+++ b/config/community.prod.webpack.config.js
@@ -7,6 +7,7 @@ module.exports = webpackBase({
   API_BASE_PATH: '/api/',
   UI_BASE_PATH: '/ui/',
   DEPLOYMENT_MODE: 'standalone',
+  IS_COMMUNITY: true,
   NAMESPACE_TERM: 'namespaces',
   UI_USE_HTTPS: false,
   UI_DEBUG: false,

--- a/config/insights.dev.webpack.config.js
+++ b/config/insights.dev.webpack.config.js
@@ -27,6 +27,7 @@ module.exports = webpackBase({
   // Determines if the app should be compiled to run on insights or on
   // another platform. Options: insights, standalone
   DEPLOYMENT_MODE: 'insights',
+  IS_INSIGHTS: true,
 
   // Determines the title of the "namespaces" page
   NAMESPACE_TERM: 'partners',

--- a/config/insights.prod.webpack.config.js
+++ b/config/insights.prod.webpack.config.js
@@ -11,6 +11,7 @@ module.exports = webpackBase({
       ? '/preview/ansible/automation-hub/'
       : '/ansible/automation-hub/',
   DEPLOYMENT_MODE: 'insights',
+  IS_INSIGHTS: true,
   NAMESPACE_TERM: 'partners',
   UI_USE_HTTPS: false,
   UI_DEBUG: false,

--- a/config/standalone.dev.webpack.config.js
+++ b/config/standalone.dev.webpack.config.js
@@ -25,6 +25,8 @@ module.exports = webpackBase({
   // Determines if the app should be compiled to run on insights or on
   // another platform. Options: insights, standalone
   DEPLOYMENT_MODE: 'standalone',
+  // dev-mode only, support `IS_COMMUNITY=1 npm run start-standalone` in addition to `npm run start-community`
+  IS_COMMUNITY: !!process.env.IS_COMMUNITY,
 
   NAMESPACE_TERM: 'namespaces',
 

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -22,35 +22,32 @@ const gitCommit =
   process.env.HUB_UI_VERSION ||
   execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
 
+const docsURL =
+  'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/';
+
 // Default user defined settings
 const defaultConfigs = [
   // Global scope means that the variable will be available to the app itself
   // as a constant after it is compiled
-  { name: 'API_HOST', default: '', scope: 'global' },
   { name: 'API_BASE_PATH', default: '', scope: 'global' },
-  { name: 'UI_BASE_PATH', default: '', scope: 'global' },
-  { name: 'DEPLOYMENT_MODE', default: 'standalone', scope: 'global' },
-  { name: 'NAMESPACE_TERM', default: 'namespaces', scope: 'global' },
+  { name: 'API_HOST', default: '', scope: 'global' },
   { name: 'APPLICATION_NAME', default: 'Galaxy NG', scope: 'global' },
-  { name: 'UI_EXTERNAL_LOGIN_URI', default: '/login', scope: 'global' },
-  { name: 'UI_COMMIT_HASH', default: gitCommit, scope: 'global' },
-  {
-    name: 'UI_DOCS_URL',
-    default:
-      'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
-    scope: 'global',
-  },
-  { name: 'IS_INSIGHTS', default: false, scope: 'global' },
   { name: 'IS_COMMUNITY', default: false, scope: 'global' },
+  { name: 'IS_INSIGHTS', default: false, scope: 'global' },
+  { name: 'NAMESPACE_TERM', default: 'namespaces', scope: 'global' },
+  { name: 'UI_BASE_PATH', default: '', scope: 'global' },
+  { name: 'UI_COMMIT_HASH', default: gitCommit, scope: 'global' },
+  { name: 'UI_DOCS_URL', default: docsURL, scope: 'global' },
+  { name: 'UI_EXTERNAL_LOGIN_URI', default: '/login', scope: 'global' },
 
-  // Webpack scope means the variable will only be available to webpack at
-  // build time
-  { name: 'UI_USE_HTTPS', default: false, scope: 'webpack' },
+  // Webpack scope: only available in customConfigs here, not exposed to the UI
+  { name: 'API_PROXY_TARGET', default: undefined, scope: 'webpack' },
+  { name: 'DEPLOYMENT_MODE', default: 'standalone', scope: 'webpack' },
   { name: 'UI_DEBUG', default: false, scope: 'webpack' },
   { name: 'UI_PORT', default: 8002, scope: 'webpack' },
+  { name: 'UI_USE_HTTPS', default: false, scope: 'webpack' },
   { name: 'WEBPACK_PROXY', default: undefined, scope: 'webpack' },
   { name: 'WEBPACK_PUBLIC_PATH', default: undefined, scope: 'webpack' },
-  { name: 'API_PROXY_TARGET', default: undefined, scope: 'webpack' },
 ];
 
 const insightsMockAPIs = ({ app }) => {

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -40,6 +40,8 @@ const defaultConfigs = [
       'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
     scope: 'global',
   },
+  { name: 'IS_INSIGHTS', default: false, scope: 'global' },
+  { name: 'IS_COMMUNITY', default: false, scope: 'global' },
 
   // Webpack scope means the variable will only be available to webpack at
   // build time

--- a/src/api/active-user.ts
+++ b/src/api/active-user.ts
@@ -1,4 +1,3 @@
-import { Constants } from 'src/constants';
 import { HubAPI } from './hub';
 import { UserType } from './response-types/user';
 
@@ -17,7 +16,7 @@ class API extends HubAPI {
   // page to refresh before loading the token that can't be done witha single
   // API request.
   getToken(): Promise<{ data: { token: string } }> {
-    if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
+    if (IS_INSIGHTS) {
       return Promise.reject(
         'Use window.insights.chrome.auth to get tokens for insights deployments',
       );

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -75,10 +75,9 @@ export class BaseAPI {
     // This runs before every API request and ensures that the user is
     // authenticated before the request is executed. On most calls it appears
     // to only add ~10ms of latency.
-    if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
+    if (IS_INSIGHTS) {
       await window.insights.chrome.auth.getUser();
-    }
-    if (DEPLOYMENT_MODE === Constants.STANDALONE_DEPLOYMENT_MODE) {
+    } else {
       request.headers['X-CSRFToken'] = Cookies.get('csrftoken');
     }
     return request;

--- a/src/components/cards/namespace-card.tsx
+++ b/src/components/cards/namespace-card.tsx
@@ -12,7 +12,6 @@ import ArrowRightIcon from '@patternfly/react-icons/dist/esm/icons/arrow-right-i
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Logo, Tooltip } from 'src/components';
-import { Constants } from 'src/constants';
 import { namespaceTitle } from 'src/utilities';
 import './cards.scss';
 
@@ -33,10 +32,7 @@ export const NamespaceNextPageCard = ({ onClick }: { onClick: () => void }) => {
       <div
         style={{
           display: 'flex',
-          height:
-            DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-              ? '216px'
-              : '168px',
+          height: IS_INSIGHTS ? '216px' : '168px',
           justifyContent: 'center',
         }}
       >

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -573,7 +573,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           }
           pageControls={
             <Flex>
-              {DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE ? (
+              {IS_INSIGHTS ? (
                 <FlexItem>
                   <ExternalLink href={issueUrl}>{t`Create issue`}</ExternalLink>
                 </FlexItem>

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -202,12 +202,8 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       { key: 'origin_repository', name: t`Repo` },
     ];
 
-    const {
-      display_signatures,
-      can_upload_signatures,
-      display_repositories,
-      ai_deny_index,
-    } = this.context.featureFlags;
+    const { can_upload_signatures, display_signatures, display_repositories } =
+      this.context.featureFlags;
 
     const {
       collection_version,
@@ -248,7 +244,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       namespace?.related_fields?.my_permissions?.includes?.(permission);
 
     const canDeleteCommunityCollection =
-      ai_deny_index &&
+      IS_COMMUNITY &&
       hasObjectPermission('galaxy.change_namespace', this.state.namespace);
 
     const dropdownItems = [

--- a/src/components/repo-selector/repo-selector.tsx
+++ b/src/components/repo-selector/repo-selector.tsx
@@ -6,7 +6,6 @@ import {
   InputGroupText,
 } from '@patternfly/react-core';
 import React from 'react';
-import { Constants } from 'src/constants';
 import { useContext } from 'src/loaders/app-context';
 
 interface IProps {
@@ -16,7 +15,7 @@ interface IProps {
 export const RepoSelector = ({ selectedRepo }: IProps) => {
   const { featureFlags } = useContext();
 
-  if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
+  if (IS_INSIGHTS) {
     return null;
   }
   if (!featureFlags.display_repositories) {

--- a/src/components/shared/alert-list.tsx
+++ b/src/components/shared/alert-list.tsx
@@ -4,7 +4,6 @@ import {
   AlertProps,
 } from '@patternfly/react-core';
 import React, { ReactNode } from 'react';
-import { Constants } from 'src/constants';
 
 interface IProps {
   /** List of alerts to display */
@@ -26,10 +25,9 @@ export const AlertList = ({ alerts, closeAlert }: IProps) => (
     style={{
       position: 'fixed',
       right: '5px',
-      top:
-        DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-          ? '124px' // 70 + 50 + 4
-          : '80px', // 76 + 4
+      top: IS_INSIGHTS
+        ? '124px' // 70 + 50 + 4
+        : '80px', // 76 + 4
       zIndex: 300,
       display: 'flex',
       flexDirection: 'column',

--- a/src/components/shared/download-count.tsx
+++ b/src/components/shared/download-count.tsx
@@ -2,7 +2,6 @@ import { Trans, t } from '@lingui/macro';
 import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import React from 'react';
 import { Tooltip } from 'src/components';
-import { Constants } from 'src/constants';
 import { language } from 'src/l10n';
 
 interface IProps {
@@ -10,7 +9,7 @@ interface IProps {
 }
 
 export const DownloadCount = ({ item }: IProps) => {
-  if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
+  if (IS_INSIGHTS) {
     return null;
   }
   if (!item?.download_count) {

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -6,13 +6,7 @@ export class Constants {
   static readonly DEFAULT_PAGE_SIZE = 10;
   static readonly DEFAULT_PAGINATION_OPTIONS = [10, 20, 50, 100];
 
-  static readonly INSIGHTS_DEPLOYMENT_MODE = 'insights';
-  static readonly STANDALONE_DEPLOYMENT_MODE = 'standalone';
-
-  static CERTIFIED_REPO =
-    DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-      ? 'published'
-      : 'rh-certified';
+  static CERTIFIED_REPO = IS_INSIGHTS ? 'published' : 'rh-certified';
 
   static USER_GROUP_MGMT_PERMISSIONS = [
     'galaxy.delete_user',

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -12,7 +12,6 @@ import {
   MultiSearchSearch,
   closeAlertMixin,
 } from 'src/components';
-import { AppContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import { RouteProps, withRouter } from 'src/utilities';
 import './landing-page.scss';
@@ -33,8 +32,7 @@ export class LandingPage extends React.Component<RouteProps, IState> {
   }
 
   componentDidMount() {
-    const { ai_deny_index } = this.context.featureFlags;
-    if (!ai_deny_index) {
+    if (!IS_COMMUNITY) {
       this.setState({ redirect: true });
     }
   }
@@ -210,5 +208,3 @@ export class LandingPage extends React.Component<RouteProps, IState> {
 }
 
 export default withRouter(LandingPage);
-
-LandingPage.contextType = AppContext;

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -1013,9 +1013,9 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
     const hasObjectPermission = (permission, namespace) =>
       namespace?.related_fields?.my_permissions?.includes?.(permission);
     const { showControls } = this.state;
-    const { display_repositories, ai_deny_index } = this.context.featureFlags;
+    const { display_repositories } = this.context.featureFlags;
     const canDeleteCommunityCollection =
-      ai_deny_index &&
+      IS_COMMUNITY &&
       hasObjectPermission('galaxy.change_namespace', this.state.namespace);
 
     if (!showControls) {

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -389,9 +389,9 @@ class Search extends React.Component<RouteProps, IState> {
     const { hasPermission } = this.context;
     const hasObjectPermission = (permission, namespace) =>
       namespace?.related_fields?.my_permissions?.includes?.(permission);
-    const { display_repositories, ai_deny_index } = this.context.featureFlags;
+    const { display_repositories } = this.context.featureFlags;
     const canDeleteCommunityCollection =
-      ai_deny_index &&
+      IS_COMMUNITY &&
       hasObjectPermission(
         'galaxy.change_namespace',
         collection.collection_version.namespace,

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -117,7 +117,7 @@ class Search extends React.Component<RouteProps, IState> {
   private load() {
     this.queryCollections();
 
-    if (DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE) {
+    if (IS_INSIGHTS) {
       this.getSynclist();
     }
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,6 +9,8 @@ declare var API_BASE_PATH;
 declare var API_HOST;
 declare var APPLICATION_NAME;
 declare var DEPLOYMENT_MODE;
+declare var IS_COMMUNITY: boolean;
+declare var IS_INSIGHTS: boolean;
 declare var NAMESPACE_TERM;
 declare var PULP_API_BASE_PATH;
 declare var UI_BASE_PATH;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,7 +8,6 @@ declare module '*.svg';
 declare var API_BASE_PATH;
 declare var API_HOST;
 declare var APPLICATION_NAME;
-declare var DEPLOYMENT_MODE;
 declare var IS_COMMUNITY: boolean;
 declare var IS_INSIGHTS: boolean;
 declare var NAMESPACE_TERM;
@@ -18,7 +17,7 @@ declare var UI_COMMIT_HASH;
 declare var UI_DOCS_URL;
 declare var UI_EXTERNAL_LOGIN_URI;
 
-// when DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE only
+// when IS_INSIGHTS only
 interface Window {
   insights: {
     chrome: {

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -168,7 +168,7 @@ export const StandaloneLayout = ({
 
   return (
     <Page isManagedSidebar={true} header={Header} sidebar={Sidebar}>
-      {featureFlags?.ai_deny_index ? (
+      {IS_COMMUNITY ? (
         <Banner>
           <Trans>
             Thanks for trying out the new and improved Galaxy, please share your

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -123,7 +123,7 @@ function standaloneMenu() {
       url: UI_DOCS_URL,
       external: true,
       condition: ({ featureFlags, settings, user }) =>
-        !featureFlags.ai_deny_index &&
+        !IS_COMMUNITY &&
         (settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
           !user.is_anonymous),
     }),
@@ -131,7 +131,7 @@ function standaloneMenu() {
       url: 'https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/community/userguide/',
       external: true,
       condition: ({ featureFlags, settings, user }) =>
-        featureFlags.ai_deny_index &&
+        IS_COMMUNITY &&
         (settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
           !user.is_anonymous),
     }),

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -122,7 +122,7 @@ function standaloneMenu() {
     menuItem(t`Documentation`, {
       url: UI_DOCS_URL,
       external: true,
-      condition: ({ featureFlags, settings, user }) =>
+      condition: ({ settings, user }) =>
         !IS_COMMUNITY &&
         (settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
           !user.is_anonymous),
@@ -130,7 +130,7 @@ function standaloneMenu() {
     menuItem(t`Documentation`, {
       url: 'https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/community/userguide/',
       external: true,
-      condition: ({ featureFlags, settings, user }) =>
+      condition: ({ settings, user }) =>
         IS_COMMUNITY &&
         (settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
           !user.is_anonymous),

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,15 +1,13 @@
 import { t } from '@lingui/macro';
-import { Constants } from 'src/constants';
 import { ParamHelper, ParamType } from 'src/utilities';
 
 export function formatPath(path: Paths, data = {}, params?: ParamType) {
   // insights router has basename="/", "/beta/" or "/preview/", with hub under a nested "ansible/automation-hub" route - our urls are relative to that
-  let url =
-    DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-      ? UI_BASE_PATH.replace('/preview/', '/')
-          .replace('/beta/', '/')
-          .replace(/\/$/, '')
-      : '';
+  let url = IS_INSIGHTS
+    ? UI_BASE_PATH.replace('/preview/', '/')
+        .replace('/beta/', '/')
+        .replace(/\/$/, '')
+    : '';
   url += (path as string) + '/';
   url = url.replaceAll('//', '/');
 

--- a/src/utilities/namespace-title.ts
+++ b/src/utilities/namespace-title.ts
@@ -1,5 +1,3 @@
-import { Constants } from 'src/constants';
-
 export function namespaceTitle({
   name,
   company,
@@ -7,7 +5,5 @@ export function namespaceTitle({
   name: string;
   company?: string;
 }): string {
-  return DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE
-    ? company || name
-    : name;
+  return IS_INSIGHTS ? company || name : name;
 }


### PR DESCRIPTION
Extracted from #4522 

Add `IS_COMMUNITY` & `IS_INSIGHTS` flags, set based on the used webpack profile.

Replace non-lightspeed uses of `featureFlags.ai_deny_index` with a build mode check, these now use `IS_COMMUNITY`:

* banner
* canDeleteCommunityCollection
* landing page
* left nav Documentation link

Replace `DEPLOYMENT_MODE === Constants.INSIGHTS_DEPLOYMENT_MODE` with `IS_INSIGHTS`.

Unshare `DEPLOYMENT_MODE` from ui, remove unused constants, imports.


