### PR TITLE
API: expand getUIPath, simplify base classes

### DIFF
--- a/src/api/active-user.ts
+++ b/src/api/active-user.ts
@@ -2,7 +2,7 @@ import { HubAPI } from './hub';
 import { UserType } from './response-types/user';
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('me/');
+  apiPath = '_ui/v1/me/';
 
   getUser(): Promise<UserType> {
     return this.http.get(this.apiPath).then((result) => result.data);
@@ -28,13 +28,13 @@ class API extends HubAPI {
   // Note: This does not reset the app's authentication state. That has to be done
   // separately by setting the user state in the app's root component
   logout() {
-    return this.http.post(this.getUIPath('auth/logout/'), {});
+    return this.http.post('_ui/v1/auth/logout/', {});
   }
 
   // Note: This does not reset the app's authentication state. That has to be done
   // separately by setting the user state in the app's root component
   login(username, password) {
-    const loginURL = this.getUIPath('auth/login/');
+    const loginURL = '_ui/v1/auth/login/';
 
     // Make a get request to the login endpoint to set CSRF tokens before making
     // the authentication reqest

--- a/src/api/application-info.ts
+++ b/src/api/application-info.ts
@@ -1,8 +1,6 @@
 import { HubAPI } from './hub';
 
 class API extends HubAPI {
-  apiPath = '';
-
   get() {
     return super.get('');
   }

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -47,6 +47,14 @@ export class BaseAPI {
     return params;
   }
 
+  public mapParams(params) {
+    return {
+      params: this.mapSort(
+        this.mapPageToOffset ? this.mapPageToOffset(params) : params,
+      ),
+    };
+  }
+
   // The api uses sort/ordering/order_by for sort
   // the UI uses sort and maps to whatever the api expects
   // (set sortParam)
@@ -60,11 +68,7 @@ export class BaseAPI {
   }
 
   list(params?: object, apiPath?: string) {
-    return this.http.get(this.getPath(apiPath), {
-      params: this.mapSort(
-        this.mapPageToOffset ? this.mapPageToOffset(params) : params,
-      ),
-    });
+    return this.http.get(this.getPath(apiPath), this.mapParams(params));
   }
 
   get(id: string, apiPath?: string) {

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -9,6 +9,7 @@ export class BaseAPI {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   http: any;
   sortParam: string; // translate ?sort into sortParam in list()
+  mapPageToOffset: boolean;
 
   // a request URL is created from:
   // * API_HOST - optional, for use with different hostname
@@ -26,45 +27,35 @@ export class BaseAPI {
     this.http.interceptors.request.use((request) => this.authHandler(request));
   }
 
-  // The api uses offset/limit OR page/page_size for pagination
-  // the UI uses page/page size and maps to whatever the api expects
-  // (override mapPageToOffset for page)
-  public mapPageToOffset(p) {
-    // Need to copy the object to make sure we aren't accidentally
-    // setting page state
-    const params = { ...p };
-
-    const pageSize =
-      parseInt(params['page_size']) || Constants.DEFAULT_PAGE_SIZE;
-    const page = parseInt(params['page']) || 1;
-
-    delete params['page'];
-    delete params['page_size'];
-
-    params['offset'] = page * pageSize - pageSize;
-    params['limit'] = pageSize;
-
-    return params;
-  }
-
   public mapParams(params) {
-    return {
-      params: this.mapSort(
-        this.mapPageToOffset ? this.mapPageToOffset(params) : params,
-      ),
-    };
-  }
-
-  // The api uses sort/ordering/order_by for sort
-  // the UI uses sort and maps to whatever the api expects
-  // (set sortParam)
-  public mapSort(params) {
     const newParams = { ...params };
-    if (newParams['sort'] && this.sortParam !== 'sort') {
+
+    if (this.mapPageToOffset) {
+      // The api uses offset/limit OR page/page_size for pagination
+      // the UI uses page/page size and maps to whatever the api expects
+
+      const pageSize =
+        parseInt(newParams['page_size'], 10) || Constants.DEFAULT_PAGE_SIZE;
+      const page = parseInt(newParams['page'], 10) || 1;
+
+      delete newParams['page'];
+      delete newParams['page_size'];
+
+      newParams['offset'] = page * pageSize - pageSize;
+      newParams['limit'] = pageSize;
+    }
+
+    if (this.sortParam && newParams['sort'] && this.sortParam !== 'sort') {
+      // The api uses sort/ordering/order_by for sort
+      // the UI uses sort and maps to whatever the api expects
+
       newParams[this.sortParam] = newParams['sort'];
       delete newParams['sort'];
     }
-    return newParams;
+
+    return {
+      params: newParams,
+    };
   }
 
   list(params?: object, apiPath?: string) {

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -4,7 +4,6 @@ import { Constants } from 'src/constants';
 import { ParamHelper } from 'src/utilities';
 
 export class BaseAPI {
-  apiBase: string; // API_BASE_PATH or PULP_API_BASE_PATH
   apiPath: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   http: any;
@@ -13,12 +12,12 @@ export class BaseAPI {
 
   // a request URL is created from:
   // * API_HOST - optional, for use with different hostname
-  // * apiBase - set by HubAPI, LegacyAPI & PulpAPI
+  // * apiBaseUrl - api/pulp prefix, ends in trailing slash
   // * apiPath - set by leaf API classes
   // any extra id or params added by custom methods
-  constructor() {
+  constructor(apiBaseUrl) {
     this.http = axios.create({
-      baseURL: API_HOST + this.apiBase,
+      baseURL: API_HOST + apiBaseUrl,
       paramsSerializer: {
         serialize: (params) => ParamHelper.getQueryString(params),
       },

--- a/src/api/base.ts
+++ b/src/api/base.ts
@@ -4,14 +4,20 @@ import { Constants } from 'src/constants';
 import { ParamHelper } from 'src/utilities';
 
 export class BaseAPI {
+  apiBase: string; // API_BASE_PATH or PULP_API_BASE_PATH
   apiPath: string;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   http: any;
-  sortParam = 'sort'; // translate ?sort into sortParam in list()
+  sortParam: string; // translate ?sort into sortParam in list()
 
-  constructor(apiBaseUrl) {
+  // a request URL is created from:
+  // * API_HOST - optional, for use with different hostname
+  // * apiBase - set by HubAPI, LegacyAPI & PulpAPI
+  // * apiPath - set by leaf API classes
+  // any extra id or params added by custom methods
+  constructor() {
     this.http = axios.create({
-      baseURL: apiBaseUrl,
+      baseURL: API_HOST + this.apiBase,
       paramsSerializer: {
         serialize: (params) => ParamHelper.getQueryString(params),
       },
@@ -55,7 +61,9 @@ export class BaseAPI {
 
   list(params?: object, apiPath?: string) {
     return this.http.get(this.getPath(apiPath), {
-      params: this.mapSort(this.mapPageToOffset(params)),
+      params: this.mapSort(
+        this.mapPageToOffset ? this.mapPageToOffset(params) : params,
+      ),
     });
   }
 
@@ -79,8 +87,8 @@ export class BaseAPI {
     return this.http.patch(this.getPath(apiPath) + id + '/', data);
   }
 
-  getPath(apiPath?: string) {
-    return apiPath || this.apiPath;
+  private getPath(apiPath?: string) {
+    return apiPath || this.apiPath || '';
   }
 
   private async authHandler(request) {

--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -37,7 +37,7 @@ export class API extends HubAPI {
     cancelToken = undefined,
   ) {
     return this.http.get(
-      `${this.apiPath}?dependency=${namespace}.${collection}`,
+      this.apiPath + `?dependency=${namespace}.${collection}`,
       { params: this.mapPageToOffset(params), cancelToken: cancelToken?.token },
     );
   }

--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -30,15 +30,10 @@ export class API extends HubAPI {
     return super.get(id, 'pulp/api/v3/content/ansible/collection_versions/');
   }
 
-  getUsedDependenciesByCollection(
-    namespace,
-    collection,
-    params = {},
-    cancelToken = undefined,
-  ) {
+  getUsedDependenciesByCollection(namespace, collection, params = {}) {
     return this.http.get(
       this.apiPath + `?dependency=${namespace}.${collection}`,
-      { params: this.mapPageToOffset(params), cancelToken: cancelToken?.token },
+      { params: this.mapPageToOffset(params) },
     );
   }
 

--- a/src/api/collection-version.ts
+++ b/src/api/collection-version.ts
@@ -33,7 +33,7 @@ export class API extends HubAPI {
   getUsedDependenciesByCollection(namespace, collection, params = {}) {
     return this.http.get(
       this.apiPath + `?dependency=${namespace}.${collection}`,
-      { params: this.mapPageToOffset(params) },
+      this.mapParams(params),
     );
   }
 

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -147,7 +147,7 @@ export class API extends HubAPI {
   getUsedDependenciesByCollection(namespace, collection, params = {}) {
     return this.http.get(
       `_ui/v1/collection-versions/?dependency=${namespace}.${collection}`,
-      { params: this.mapPageToOffset(params) },
+      this.mapParams(params),
     );
   }
 

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -33,7 +33,7 @@ function filterListItem(item: CollectionListType) {
 }
 
 export class API extends HubAPI {
-  apiPath = this.getUIPath('repo/');
+  apiPath = '_ui/v1/repo/';
   cachedCollection: CollectionDetailType;
 
   list(params?, repo?: string) {
@@ -151,9 +151,7 @@ export class API extends HubAPI {
     cancelToken = undefined,
   ) {
     return this.http.get(
-      this.getUIPath(
-        `collection-versions/?dependency=${namespace}.${collection}`,
-      ),
+      `_ui/v1/collection-versions/?dependency=${namespace}.${collection}`,
       { params: this.mapPageToOffset(params), cancelToken: cancelToken?.token },
     );
   }

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -144,15 +144,10 @@ export class API extends HubAPI {
     );
   }
 
-  getUsedDependenciesByCollection(
-    namespace,
-    collection,
-    params = {},
-    cancelToken = undefined,
-  ) {
+  getUsedDependenciesByCollection(namespace, collection, params = {}) {
     return this.http.get(
       `_ui/v1/collection-versions/?dependency=${namespace}.${collection}`,
-      { params: this.mapPageToOffset(params), cancelToken: cancelToken?.token },
+      { params: this.mapPageToOffset(params) },
     );
   }
 

--- a/src/api/container-tag.ts
+++ b/src/api/container-tag.ts
@@ -4,14 +4,14 @@ class API extends PulpAPI {
   apiPath = 'repositories/container/container-push/';
 
   tag(repositoryID: string, tag: string, digest: string) {
-    return this.http.post(`${this.apiPath}${repositoryID}/tag/`, {
+    return this.http.post(this.apiPath + `${repositoryID}/tag/`, {
       digest: digest,
       tag: tag,
     });
   }
 
   untag(repositoryID: string, tag: string) {
-    return this.http.post(`${this.apiPath}${repositoryID}/untag/`, {
+    return this.http.post(this.apiPath + `${repositoryID}/untag/`, {
       tag: tag,
     });
   }

--- a/src/api/controller.ts
+++ b/src/api/controller.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 export class API extends HubAPI {
-  apiPath = this.getUIPath('controllers/');
+  apiPath = '_ui/v1/controllers/';
 
   // list(params?)
 }

--- a/src/api/execution-environment-registry.ts
+++ b/src/api/execution-environment-registry.ts
@@ -32,7 +32,7 @@ function smartUpdate(remote: RemoteType, unmodifiedRemote: RemoteType) {
 }
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('execution-environments/registries/');
+  apiPath = '_ui/v1/execution-environments/registries/';
 
   // list(params?)
   // create(data)

--- a/src/api/execution-environment-remote.ts
+++ b/src/api/execution-environment-remote.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('execution-environments/remotes/');
+  apiPath = '_ui/v1/execution-environments/remotes/';
 
   // list(params?)
   // create(data)

--- a/src/api/execution-environment.ts
+++ b/src/api/execution-environment.ts
@@ -12,9 +12,10 @@ class API extends HubAPI {
   }
 
   images(name, params) {
-    return this.http.get(this.apiPath + `${name}/_content/images/`, {
-      params: this.mapPageToOffset(params),
-    });
+    return this.http.get(
+      this.apiPath + `${name}/_content/images/`,
+      this.mapParams(params),
+    );
   }
 
   image(name, digest) {
@@ -22,9 +23,10 @@ class API extends HubAPI {
   }
 
   tags(name, params) {
-    return this.http.get(this.apiPath + `${name}/_content/tags/`, {
-      params: this.mapPageToOffset(params),
-    });
+    return this.http.get(
+      this.apiPath + `${name}/_content/tags/`,
+      this.mapParams(params),
+    );
   }
 
   deleteImage(name, manifest) {

--- a/src/api/execution-environment.ts
+++ b/src/api/execution-environment.ts
@@ -2,38 +2,39 @@ import { HubAPI } from './hub';
 
 class API extends HubAPI {
   apiPath = 'v3/plugin/execution-environments/repositories/';
+
   readme(name) {
-    return this.http.get(this.apiPath + name + '/_content/readme/');
+    return this.http.get(this.apiPath + `${name}/_content/readme/`);
   }
 
   saveReadme(name, readme) {
-    return this.http.put(this.apiPath + name + '/_content/readme/', readme);
+    return this.http.put(this.apiPath + `${name}/_content/readme/`, readme);
   }
 
   images(name, params) {
-    return this.http.get(this.apiPath + name + '/_content/images/', {
+    return this.http.get(this.apiPath + `${name}/_content/images/`, {
       params: this.mapPageToOffset(params),
     });
   }
 
   image(name, digest) {
-    return this.http.get(`${this.apiPath}${name}/_content/images/${digest}/`);
+    return this.http.get(this.apiPath + `${name}/_content/images/${digest}/`);
   }
 
   tags(name, params) {
-    return this.http.get(this.apiPath + name + '/_content/tags/', {
+    return this.http.get(this.apiPath + `${name}/_content/tags/`, {
       params: this.mapPageToOffset(params),
     });
   }
 
   deleteImage(name, manifest) {
     return this.http.delete(
-      `${this.apiPath}${name}/_content/images/${manifest}/`,
+      this.apiPath + `${name}/_content/images/${manifest}/`,
     );
   }
 
   deleteExecutionEnvironment(name) {
-    return this.http.delete(`${this.apiPath}${name}/`);
+    return this.http.delete(this.apiPath + `${name}/`);
   }
 }
 

--- a/src/api/feature-flags.ts
+++ b/src/api/feature-flags.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('feature-flags/');
+  apiPath = '_ui/v1/feature-flags/';
 
   get() {
     return this.http.get(this.apiPath);

--- a/src/api/generic-pulp.ts
+++ b/src/api/generic-pulp.ts
@@ -1,10 +1,9 @@
 import { PulpAPI } from './pulp';
 
 export class API extends PulpAPI {
-  apiPath = '';
-
-  get(id: string, apiPath?: string) {
-    return this.http.get(this.getPath(apiPath) + id);
+  // base get adds a trailing slash
+  get(url: string) {
+    return this.http.get(url);
   }
 }
 

--- a/src/api/group-role.ts
+++ b/src/api/group-role.ts
@@ -4,15 +4,15 @@ class API extends PulpAPI {
   apiPath = 'groups/';
 
   listRoles(groupId, params?) {
-    return super.list(params, `${this.apiPath}${groupId}/roles/`);
+    return super.list(params, this.apiPath + `${groupId}/roles/`);
   }
 
   removeRole(groupId, roleId) {
-    return this.http.delete(`${this.apiPath}${groupId}/roles/${roleId}/`);
+    return this.http.delete(this.apiPath + `${groupId}/roles/${roleId}/`);
   }
 
   addRoleToGroup(groupId, role) {
-    return this.http.post(`${this.apiPath}${groupId}/roles/`, {
+    return this.http.post(this.apiPath + `${groupId}/roles/`, {
       role: role.name,
       // required field, can be empty
       content_object: null,

--- a/src/api/group.ts
+++ b/src/api/group.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('groups/');
+  apiPath = '_ui/v1/groups/';
 }
 
 export const GroupAPI = new API();

--- a/src/api/hub.ts
+++ b/src/api/hub.ts
@@ -2,5 +2,6 @@ import { BaseAPI } from './base';
 
 export class HubAPI extends BaseAPI {
   apiBase = API_BASE_PATH;
+  mapPageToOffset = true; // offset & limit
   sortParam = 'sort';
 }

--- a/src/api/hub.ts
+++ b/src/api/hub.ts
@@ -1,15 +1,6 @@
 import { BaseAPI } from './base';
 
 export class HubAPI extends BaseAPI {
-  UI_API_VERSION = 'v1';
-
-  constructor() {
-    super(API_HOST + API_BASE_PATH);
-  }
-
-  // Use this function to get paths in the _ui API. That will ensure the API version
-  // gets updated when it changes
-  getUIPath(url: string) {
-    return `_ui/${this.UI_API_VERSION}/${url}`;
-  }
+  apiBase = API_BASE_PATH;
+  sortParam = 'sort';
 }

--- a/src/api/hub.ts
+++ b/src/api/hub.ts
@@ -1,7 +1,10 @@
 import { BaseAPI } from './base';
 
 export class HubAPI extends BaseAPI {
-  apiBase = API_BASE_PATH;
   mapPageToOffset = true; // offset & limit
   sortParam = 'sort';
+
+  constructor() {
+    super(API_BASE_PATH);
+  }
 }

--- a/src/api/import.ts
+++ b/src/api/import.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 export class API extends HubAPI {
-  apiPath = this.getUIPath('imports/collections/');
+  apiPath = '_ui/v1/imports/collections/';
 
   get(id, path?) {
     // call this to generate more task messages

--- a/src/api/legacy.ts
+++ b/src/api/legacy.ts
@@ -1,7 +1,10 @@
 import { BaseAPI } from './base';
 
 export class LegacyAPI extends BaseAPI {
-  apiBase = API_BASE_PATH;
   mapPageToOffset = false; // page & page_size
   sortParam = 'order_by';
+
+  constructor() {
+    super(API_BASE_PATH);
+  }
 }

--- a/src/api/legacy.ts
+++ b/src/api/legacy.ts
@@ -1,14 +1,7 @@
 import { BaseAPI } from './base';
 
 export class LegacyAPI extends BaseAPI {
+  apiBase = API_BASE_PATH;
+  mapPageToOffset = false; // using page & page_size
   sortParam = 'order_by';
-
-  constructor() {
-    super(API_HOST + API_BASE_PATH);
-  }
-
-  public mapPageToOffset(p) {
-    // override BaseAPI's function to persist page & page_size
-    return p;
-  }
 }

--- a/src/api/legacy.ts
+++ b/src/api/legacy.ts
@@ -2,6 +2,6 @@ import { BaseAPI } from './base';
 
 export class LegacyAPI extends BaseAPI {
   apiBase = API_BASE_PATH;
-  mapPageToOffset = false; // using page & page_size
+  mapPageToOffset = false; // page & page_size
   sortParam = 'order_by';
 }

--- a/src/api/my-distribution.ts
+++ b/src/api/my-distribution.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('my-distributions/');
+  apiPath = '_ui/v1/my-distributions/';
 }
 
 export const MyDistributionAPI = new API();

--- a/src/api/my-namespace.ts
+++ b/src/api/my-namespace.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('my-namespaces/');
+  apiPath = '_ui/v1/my-namespaces/';
 
   get(id: string, params = {}) {
     return this.http.get(this.apiPath + id + '/', { params });

--- a/src/api/my-synclist.ts
+++ b/src/api/my-synclist.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('my-synclists/');
+  apiPath = '_ui/v1/my-synclists/';
 
   curate(id) {
     return this.http.post(this.apiPath + id + '/curate/', {});

--- a/src/api/namespace.ts
+++ b/src/api/namespace.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('namespaces/');
+  apiPath = '_ui/v1/namespaces/';
 
   get(id: string, params = {}) {
     return this.http.get(this.apiPath + id + '/', { params });

--- a/src/api/pulp.ts
+++ b/src/api/pulp.ts
@@ -1,9 +1,6 @@
 import { BaseAPI } from './base';
 
 export class PulpAPI extends BaseAPI {
+  apiBase = PULP_API_BASE_PATH;
   sortParam = 'ordering';
-
-  constructor() {
-    super(API_HOST + PULP_API_BASE_PATH);
-  }
 }

--- a/src/api/pulp.ts
+++ b/src/api/pulp.ts
@@ -1,7 +1,10 @@
 import { BaseAPI } from './base';
 
 export class PulpAPI extends BaseAPI {
-  apiBase = PULP_API_BASE_PATH;
   mapPageToOffset = true; // offset & limit
   sortParam = 'ordering';
+
+  constructor() {
+    super(PULP_API_BASE_PATH);
+  }
 }

--- a/src/api/pulp.ts
+++ b/src/api/pulp.ts
@@ -2,5 +2,6 @@ import { BaseAPI } from './base';
 
 export class PulpAPI extends BaseAPI {
   apiBase = PULP_API_BASE_PATH;
+  mapPageToOffset = true; // offset & limit
   sortParam = 'ordering';
 }

--- a/src/api/settings.ts
+++ b/src/api/settings.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('settings/');
+  apiPath = '_ui/v1/settings/';
 
   get() {
     return this.http.get(this.apiPath);

--- a/src/api/sign-collections.ts
+++ b/src/api/sign-collections.ts
@@ -20,7 +20,7 @@ interface SignCollectionVersion extends SignCollection {
 type SignProps = SignNamespace | SignCollection | SignCollectionVersion;
 
 class API extends HubAPI {
-  apiPath = this.getUIPath('collection_signing/');
+  apiPath = '_ui/v1/collection_signing/';
 
   async sign({ repository, repository_name: name, ...args }: SignProps) {
     const distroBasePath = await repositoryBasePath(

--- a/src/api/tag.ts
+++ b/src/api/tag.ts
@@ -1,14 +1,14 @@
 import { HubAPI } from './hub';
 
 export class API extends HubAPI {
-  apiPath = this.getUIPath('tags/');
+  apiPath = '_ui/v1/tags/';
 
   listCollections(params) {
-    return this.list(params, this.getPath() + 'collections/');
+    return this.list(params, this.apiPath + 'collections/');
   }
 
   listRoles(params) {
-    return this.list(params, this.getPath() + 'roles/');
+    return this.list(params, this.apiPath + 'roles/');
   }
 }
 

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 export class API extends HubAPI {
-  apiPath = this.getUIPath('users/');
+  apiPath = '_ui/v1/users/';
 }
 
 export const UserAPI = new API();

--- a/src/api/wisdom-deny-index.ts
+++ b/src/api/wisdom-deny-index.ts
@@ -1,7 +1,7 @@
 import { HubAPI } from './hub';
 
 export class API extends HubAPI {
-  apiPath = this.getUIPath('ai_deny_index/');
+  apiPath = '_ui/v1/ai_deny_index/';
 
   isInDenyIndex(scope, reference) {
     return this.http

--- a/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
+++ b/src/components/collection-dependencies-list/collection-usedby-dependencies-list.tsx
@@ -1,19 +1,13 @@
 import { t } from '@lingui/macro';
-import {
-  SearchInput,
-  Toolbar,
-  ToolbarGroup,
-  ToolbarItem,
-} from '@patternfly/react-core';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { CollectionUsedByDependencies } from 'src/api';
 import {
   EmptyStateFilter,
   EmptyStateNoData,
+  HubListToolbar,
   LoadingPageSpinner,
   Pagination,
-  Sort,
 } from 'src/components';
 import 'src/containers/collection-detail/collection-dependencies.scss';
 import { Paths, formatPath } from 'src/paths';
@@ -40,8 +34,6 @@ export const CollectionUsedbyDependenciesList = ({
   updateParams,
   usedByDependenciesLoading,
 }: IProps) => {
-  const ignoredParams = ['page_size', 'page', 'sort', 'name__icontains'];
-
   if (!itemCount && !filterIsSet(params, ['name__icontains'])) {
     return (
       <EmptyStateNoData
@@ -51,50 +43,29 @@ export const CollectionUsedbyDependenciesList = ({
     );
   }
 
+  const ignoredParams = ['page_size', 'page', 'sort'];
+
+  const filterConfig = [
+    {
+      id: 'name__icontains',
+      title: t`Name`,
+    },
+  ];
+
+  const sortOptions = [
+    { title: t`Collection`, id: 'collection', type: 'alpha' as const },
+  ];
+
   return (
     <>
-      <div className='hub-toolbar'>
-        <Toolbar>
-          <ToolbarGroup>
-            <ToolbarItem>
-              <SearchInput
-                value={params.name__icontains || ''}
-                onChange={(_e, val) =>
-                  updateParams(
-                    ParamHelper.setParam(params, 'name__icontains', val),
-                  )
-                }
-                onClear={() =>
-                  updateParams(
-                    ParamHelper.setParam(params, 'name__icontains', ''),
-                  )
-                }
-                aria-label='filter-collection-name'
-                placeholder={t`Filter by name`}
-              />
-            </ToolbarItem>
-            <ToolbarItem>
-              <Sort
-                options={[
-                  { title: t`Collection`, id: 'collection', type: 'alpha' },
-                ]}
-                params={params}
-                updateParams={({ sort }) =>
-                  updateParams(ParamHelper.setParam(params, 'sort', sort))
-                }
-              />
-            </ToolbarItem>
-          </ToolbarGroup>
-        </Toolbar>
-        {!!itemCount && (
-          <Pagination
-            params={params}
-            updateParams={(p) => updateParams(p)}
-            count={itemCount}
-            isTop
-          />
-        )}
-      </div>
+      <HubListToolbar
+        count={itemCount}
+        filterConfig={filterConfig}
+        ignoredParams={ignoredParams}
+        params={params}
+        sortOptions={sortOptions}
+        updateParams={updateParams}
+      />
 
       {usedByDependenciesLoading ? (
         <LoadingPageSpinner />
@@ -118,10 +89,10 @@ export const CollectionUsedbyDependenciesList = ({
                                 namespace,
                                 repo: repository_list[0],
                               },
-                              ParamHelper.getReduced(
-                                { version },
-                                ignoredParams,
-                              ),
+                              ParamHelper.getReduced({ version }, [
+                                ...ignoredParams,
+                                'name__icontains',
+                              ]),
                             )}
                           >
                             {namespace + '.' + name} v{version}

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -39,7 +39,6 @@ interface IState extends IBaseCollectionState {
 
 class CollectionDependencies extends React.Component<RouteProps, IState> {
   private ignoredParams = ['page_size', 'page', 'sort', 'name__icontains'];
-  private cancelToken: ReturnType<typeof CollectionAPI.getCancelToken>;
 
   constructor(props) {
     super(props);
@@ -234,21 +233,14 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
 
   private loadUsedByDependencies() {
     this.setState({ usedByDependenciesLoading: true }, () => {
-      if (this.cancelToken) {
-        this.cancelToken.cancel('request-canceled');
-      }
-
-      this.cancelToken = CollectionAPI.getCancelToken();
-
       const { name, namespace } = this.state.collection.collection_version;
 
-      // We have to use CollectionAPI here for used by dependencies
+      // FIXME: We have to use CollectionAPI here for used by dependencies
       // because cross repo collection search doesn't allow `name__icontains` filter
       CollectionAPI.getUsedDependenciesByCollection(
         namespace,
         name,
         ParamHelper.getReduced(this.state.params, ['version']),
-        this.cancelToken,
       )
         .then(({ data }) => {
           this.setState({
@@ -257,24 +249,19 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
             usedByDependenciesLoading: false,
           });
         })
-        .catch(({ response, message }) => {
-          if (message !== 'request-canceled') {
-            const { status, statusText } = response;
-            this.setState({
-              usedByDependenciesLoading: false,
-              alerts: [
-                ...this.state.alerts,
-                {
-                  variant: 'danger',
-                  title: t`Dependent collections could not be displayed.`,
-                  description: errorMessage(status, statusText),
-                },
-              ],
-            });
-          }
-        })
-        .finally(() => {
-          this.cancelToken = undefined;
+        .catch(({ response }) => {
+          const { status, statusText } = response;
+          this.setState({
+            usedByDependenciesLoading: false,
+            alerts: [
+              ...this.state.alerts,
+              {
+                variant: 'danger',
+                title: t`Dependent collections could not be displayed.`,
+                description: errorMessage(status, statusText),
+              },
+            ],
+          });
         });
     });
   }

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -115,7 +115,7 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
     const noDependencies = !Object.keys(version.dependencies).length;
 
     return (
-      <React.Fragment>
+      <>
         <AlertList alerts={alerts} closeAlert={(i) => this.closeAlert(i)} />
         <CollectionHeader
           activeTab='dependencies'
@@ -129,9 +129,7 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
           reload={() => this.loadData(true)}
           repo={repository.name}
           updateParams={(p) => {
-            this.updateParams(this.combineParams(this.state.params, p), () =>
-              this.loadData(true),
-            );
+            this.updateParams(p, () => this.loadData(true));
           }}
         />
         <Main>
@@ -160,15 +158,12 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
               params={dependenciesParams}
               usedByDependenciesLoading={usedByDependenciesLoading}
               updateParams={(p) =>
-                this.updateParams(
-                  this.combineParams(this.state.params, p),
-                  () => this.loadUsedByDependencies(),
-                )
+                this.updateParams(p, () => this.loadUsedByDependencies())
               }
             />
           </section>
         </Main>
-      </React.Fragment>
+      </>
     );
   }
 
@@ -296,10 +291,6 @@ class CollectionDependencies extends React.Component<RouteProps, IState> {
 
   get updateParams() {
     return ParamHelper.updateParamsMixin();
-  }
-
-  private combineParams(...params) {
-    return params.reduce((acc, cur) => ({ ...acc, ...cur }));
   }
 
   get closeAlert() {


### PR DESCRIPTION
Follows #4520 

expand `getUIPath`,
move `API_HOST` to `BaseAPI`,
use `apiPath` directly when applicable, fallback to `''` when undefined,
move `sortParam = 'sort'` to `HubAPI`, not `BaseAPI` .. all direct descendants set it,
change `mapPageToOffset` to boolean,
use `mapParams` (page + sort) instead of `mapPageToOffset` method,
remove cancel token from dependencies api (keep in upload),
use `HubListToolbar` in dependencies tab (to prevent requests when typing)
