### PR TITLE
Docs links: add Communicating, User Guide, Forum

### DIFF
--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -105,10 +105,43 @@ export const StandaloneLayout = ({
           >{t`Training`}</ExternalLink>
         }
       />,
+      IS_COMMUNITY && (
+        <DropdownItem
+          key='forum'
+          component={
+            <ExternalLink
+              href='https://forum.ansible.com'
+              variant='menu'
+            >{t`Ansible Community Forum`}</ExternalLink>
+          }
+        />
+      ),
+      IS_COMMUNITY && (
+        <DropdownItem
+          key='communication'
+          component={
+            <ExternalLink
+              href='https://docs.ansible.com/ansible/latest/community/communication.html'
+              variant='menu'
+            >{t`Communicating with the Ansible community`}</ExternalLink>
+          }
+        />
+      ),
+      IS_COMMUNITY && (
+        <DropdownItem
+          key='communication'
+          component={
+            <ExternalLink
+              href='https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/community/userguide/'
+              variant='menu'
+            >{t`Community User Guide`}</ExternalLink>
+          }
+        />
+      ),
       <DropdownItem key='about' onClick={() => setAboutModalVisible(true)}>
         {t`About`}
       </DropdownItem>,
-    ];
+    ].filter(Boolean);
 
     aboutModal = (
       <AboutModalWindow


### PR DESCRIPTION
Issue: https://forum.ansible.com/t/issues-creating-an-account/2197/4

![20231118073830](https://github.com/ansible/ansible-hub-ui/assets/289743/c9700015-3b70-4941-9c23-f1ed070c7892)

Adds the following links to the documentation menu:

* Ansible Community Forum - https://forum.ansible.com
* Communicating with the Ansible community - https://docs.ansible.com/ansible/latest/community/communication.html
* Community User Guide - https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/community/userguide/

(along with the existing training & customer support)