### PR TITLE
cypress.yml: add DOCKER_DEFAULT_PLATFORM=linux/amd64

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,6 +21,7 @@ jobs:
     env:
       # base of a PR, or pushed-to branch outside PRs, or master
       BRANCH: ${{ github.base_ref || github.ref || 'refs/heads/master' }}
+      DOCKER_DEFAULT_PLATFORM: linux/amd64
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
this should fix the current build failures https://github.com/ansible/ansible-hub-ui/actions/runs/6924200581/job/18833114912#step:9:195

> exec /bin/sh: exec format error

 (not sure if the solution will be needed permanently yet)


TODO:
breaks with `ghcr.io/pulp/pulp-ci-centos:latest@sha256:dfc81fcf64c22f7eed4658706fd8e71526fc6659582e9814440139ed11556265`
works with `ghcr.io/pulp/pulp-ci-centos:latest@sha256:fd5df91b947406b990b0ccf2beab1d0b95d981a3adb9d64bea87dd8012ddeb2d`
(was an image reverted, or other fix pushed?)