### PR TITLE
Update tooling for 4.5 eol

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: '[stable-4.9] '
-    ignore:
+    ignore: &npmIgnore
       - dependency-name: '@lingui/*'
         update-types: ['version-update:semver-major']
       - dependency-name: '@patternfly/*'
@@ -44,17 +44,7 @@ updates:
       interval: 'weekly'
     commit-message:
       prefix: '[stable-4.8] '
-    ignore:
-      - dependency-name: '@lingui/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@patternfly/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-dom'
-        update-types: ['version-update:semver-major']
+    ignore: *npmIgnore
 
   - package-ecosystem: 'npm'
     directory: '/test'
@@ -71,17 +61,7 @@ updates:
       interval: 'monthly'
     commit-message:
       prefix: '[stable-4.7] '
-    ignore:
-      - dependency-name: '@lingui/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@patternfly/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-dom'
-        update-types: ['version-update:semver-major']
+    ignore: *npmIgnore
 
   - package-ecosystem: 'npm'
     directory: '/test'
@@ -98,36 +78,7 @@ updates:
       interval: 'monthly'
     commit-message:
       prefix: '[stable-4.6] '
-    ignore:
-      - dependency-name: '@lingui/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@patternfly/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-dom'
-        update-types: ['version-update:semver-major']
-
-  - package-ecosystem: 'npm'
-    directory: '/'
-    target-branch: 'stable-4.5'
-    schedule:
-      interval: 'monthly'
-    commit-message:
-      prefix: '[stable-4.5] '
-    ignore:
-      - dependency-name: '@lingui/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@patternfly/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-dom'
-        update-types: ['version-update:semver-major']
+    ignore: *npmIgnore
 
   - package-ecosystem: 'github-actions'
     # Workflow files stored in the default location of `.github/workflows`
@@ -141,7 +92,7 @@ updates:
     commit-message:
       prefix: '[stable-4.9] '
     schedule:
-      interval: "weekly"
+      interval: "monthly"
 
   - package-ecosystem: 'github-actions'
     directory: '/'
@@ -164,13 +115,5 @@ updates:
     target-branch: 'stable-4.6'
     commit-message:
       prefix: '[stable-4.6] '
-    schedule:
-      interval: 'monthly'
-
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    target-branch: 'stable-4.5'
-    commit-message:
-      prefix: '[stable-4.5] '
     schedule:
       interval: 'monthly'

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         branch:
         - 'master'
-        - 'stable-4.5'
         - 'stable-4.6'
         - 'stable-4.7'
         - 'stable-4.8'

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ List of all workflows:
 - `cypress`: Run Cypress integration tests; on PRs, pushes and cron
 - `deploy-cloud`: Deploy to c.r.c; when the relevant branch is updated
 - `dev-release`: Build and upload to github releases, update `dev` tag; when master is updated
-- `i18n`: Extract and merge l10n strings for 4.5+; cron
+- `i18n`: Extract and merge l10n strings; cron
 - `pr-checks`: Check for linter errors, obsolete package-lock.json and merge commits; on PRs only
 - `stable-release`: Build and upload to github releases; when a stable release is created
 - `update-manifest`: Update https://github.com/RedHatInsights/manifests ; when master is updated
@@ -79,7 +79,7 @@ List by branches:
 
 - `master`: `backported-labels`, `cypress`, `deploy-cloud`, `dev-release`, `i18n`, `pr-checks`, `stable-release`, `update-manifest`
 - `prod-beta`, `prod-stable`: `deploy-cloud`
-- `stable-4.5`, `stable-4.6`, `stable-4.7`, `stable-4.8`, `stable-4.9`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
+- `stable-*`: `backported-labels`, `cypress`, `pr-checks`, `stable-release` (and `i18n` via cron from master)
 
 ### Version mapping
 
@@ -88,7 +88,6 @@ To map between the two:
 
 |AAP version|AAH version|notes|
 |-|-|-|
-|2.2|4.5||
 |2.3|4.6||
 |2.4|4.7||
 |2.4|4.8|django 4, still part of 2.4|


### PR DESCRIPTION
Previous #4304 , #3805
 
Dropping dependabot config for 4.5,
weekly string extraction,
and updating README.

And use yaml refs to reuse the npm ignore list.
https://stackoverflow.com/questions/8466223/reuse-a-block-of-code-in-yaml

