### PR TITLE
Bump minimal node version to 18+

### DIFF
--- a/.github/workflows/automerge.js
+++ b/.github/workflows/automerge.js
@@ -30,7 +30,7 @@ if (prTitle.includes('patternfly')) {
 
 if (prTitle.includes('@types/node')) {
   console.log('Checking for @types/node version.');
-  const pattern = /from 16[.]\d+[.]\d+ to 16[.]\d+[.]\d+/;
+  const pattern = /from (\d+)\.\d+\.\d+ to \1\.\d+\.\d+/;
   if (pattern.test(prTitle)) {
     console.log('Version does match the pattern ' + pattern);
   } else {

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,10 +13,10 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v4
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: "Run automerge.js"
       working-directory: ".github/workflows"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -116,10 +116,10 @@ jobs:
       working-directory: 'oci_env'
       run: 'oci-env compose up &'
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: "Cache ~/.npm & ~/.cache/Cypress"
       uses: actions/cache@v3

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -40,10 +40,10 @@ jobs:
         echo "TRAVIS_BUILD_WEB_URL=${TRAVIS_BUILD_WEB_URL}" >> $GITHUB_ENV
         echo -e "TRAVIS_COMMIT_MESSAGE<<EOF\n${TRAVIS_COMMIT_MESSAGE}\nEOF" >> $GITHUB_ENV
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: "Cache ~/.npm"
       uses: actions/cache@v3

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -23,10 +23,10 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v4
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: "Update the dev tag"
       run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -33,10 +33,10 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v4
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
         cache: 'npm'
 
     - name: "Checks"
@@ -108,10 +108,10 @@ jobs:
       with:
         path: 'pr'
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
         cache: 'npm'
         cache-dependency-path: |
           base/package-lock.json

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -28,10 +28,10 @@ jobs:
         RELEASE_TAG=`sed 's/^refs\/tags\///' <<< $GITHUB_REF`
         echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: "Cache ~/.npm"
       uses: actions/cache@v3

--- a/.github/workflows/update-manifest.yml
+++ b/.github/workflows/update-manifest.yml
@@ -28,10 +28,10 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v4
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: "Run update_manifest.sh"
       run: .travis/update_manifest.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # WARNING
 # This Dockerfile is intended for development purposes only. Do not use it for production deployments
 
-FROM node:16-alpine
+FROM node:18-alpine
 WORKDIR /hub/
 
 RUN mkdir -p /hub/app/ && \

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This app can be developed in standalone, community, or insights mode. Insights m
 For every mode, you first need to:
 
 1. Clone the [galaxy_ng](https://github.com/ansible/galaxy_ng) repo and follow the setup instructions
-2. Install node. Node v16+ is known to work. Older versions may work as well.
+2. Install node. Node v18+ is known to work. Older versions may work as well.
 3. `npm install` in the UI
 
 ### Develop in Standalone Mode (default)

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -9,7 +9,7 @@ export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build'
 export APP_ROOT=$(pwd)
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
-export NODE_BUILD_VERSION=16
+export NODE_BUILD_VERSION=18
 export IMAGE="quay.io/cloudservices/ansible-hub-ui"
 
 set -exv

--- a/community/Dockerfile
+++ b/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 WORKDIR /workspace/
 RUN mkdir -p /workspace/ && \
     apk add --no-cache git

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,7 @@ then
   echo 'ANSIBLE_HUB_UI_PATH not supported in insights mode' 1>&2
   echo 1>&2
   echo 'please run' 1>&2
-  echo '  npm run start' 1>&2
+  echo '  npm run start-insights' 1>&2
   echo 'in the UI dir manually' 1>&2
   echo 1>&2
 else

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
                 "@patternfly/react-core": "^4.278.0",
                 "@patternfly/react-table": "^4.113.7",
                 "@redhat-cloud-services/frontend-components": "^3.11.5",
-                "@types/node": "^16.18.61",
+                "@types/node": "^18.18.13",
                 "@types/react": "^17.0.2",
                 "@types/react-dom": "^17.0.2",
                 "antsibull-docs": "^1.0.0",
@@ -75,8 +75,8 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "node": ">=16",
-                "npm": ">=8"
+                "node": ">=18",
+                "npm": ">=9"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -3975,9 +3975,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "16.18.61",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.61.tgz",
-            "integrity": "sha512-k0N7BqGhJoJzdh6MuQg1V1ragJiXTh8VUBAZTWjJ9cUq23SG0F0xavOwZbhiP4J3y20xd6jxKx+xNUhkMAi76Q=="
+            "version": "18.18.13",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.13.tgz",
+            "integrity": "sha512-vXYZGRrSCreZmq1rEjMRLXJhiy8MrIeVasx+PCVlP414N7CJLHnMf+juVvjdprHyH+XRy3zKZLHeNueOpJCn0g==",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
@@ -6635,6 +6638,12 @@
             "engines": {
                 "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
             }
+        },
+        "node_modules/cypress/node_modules/@types/node": {
+            "version": "16.18.65",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.65.tgz",
+            "integrity": "sha512-5E9WgTy95B7i90oISjui9U5Zu7iExUPfU4ygtv4yXEy6zJFE3oQYHCnh5H1jZRPkjphJt2Ml3oQW6M0qtK534A==",
+            "peer": true
         },
         "node_modules/cypress/node_modules/ansi-styles": {
             "version": "4.3.0",
@@ -16000,6 +16009,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "@patternfly/react-core": "^4.278.0",
         "@patternfly/react-table": "^4.113.7",
         "@redhat-cloud-services/frontend-components": "^3.11.5",
-        "@types/node": "^16.18.61",
+        "@types/node": "^18.18.13",
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.2",
         "antsibull-docs": "^1.0.0",
@@ -113,7 +113,7 @@
         }
     },
     "engines": {
-        "node": ">=16",
-        "npm": ">=8"
+        "node": ">=18",
+        "npm": ">=9"
     }
 }

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -8,7 +8,7 @@ export COMPONENT="automation-hub"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
-export NODE_BUILD_VERSION=16
+export NODE_BUILD_VERSION=18
 
 export APP_NAME="automation-hub"  # name of app-sre "application" folder this component lives in
 export COMPONENT_NAME="automation-hub"  # name of app-sre "resourceTemplate" in deploy.yaml for this component


### PR DESCRIPTION
As per https://nodejs.org/en/about/previous-releases
Node 16 is no longer maintained.
Switching the minimum node version to the next LTS - node 18

---

Cc @drodowic , @jctanner , @jerabekjiri  - is there anything we need to update in the build repos?

AFAICT:
* standalone: updated in `packaging!16`, merged
* insights: partly built from `.github/workflows/deploy-cloud.yml`, updated; [partly](https://github.com/RedHatInsights/insights-frontend-builder-common/blob/master/src/releaser.Dockerfile#L9) a fedora 38 container, already installs node 18
* comunity: `galaxy-deploy` reads `community/Dockerfile` from this repo, updated