### PR TITLE
[stable-4.8] Bump minimal node version to 18+

### DIFF
--- a/.github/workflows/automerge.js
+++ b/.github/workflows/automerge.js
@@ -30,7 +30,7 @@ if (prTitle.includes('patternfly')) {
 
 if (prTitle.includes('@types/node')) {
   console.log('Checking for @types/node version.');
-  const pattern = /from 16[.]\d+[.]\d+ to 16[.]\d+[.]\d+/;
+  const pattern = /from (\d+)\.\d+\.\d+ to \1\.\d+\.\d+/;
   if (pattern.test(prTitle)) {
     console.log('Version does match the pattern ' + pattern);
   } else {

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,10 +13,10 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v4
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: "Run automerge.js"
       working-directory: ".github/workflows"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -97,10 +97,10 @@ jobs:
       working-directory: 'oci_env'
       run: 'oci-env compose up &'
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: "Cache ~/.npm & ~/.cache/Cypress"
       uses: actions/cache@v3

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,10 +13,10 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v4
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
         cache: 'npm'
 
     - name: "Checks"
@@ -88,10 +88,10 @@ jobs:
       with:
         path: 'pr'
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
         cache: 'npm'
         cache-dependency-path: |
           base/package-lock.json

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -28,10 +28,10 @@ jobs:
         RELEASE_TAG=`sed 's/^refs\/tags\///' <<< $GITHUB_REF`
         echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
 
-    - name: "Install node 16"
+    - name: "Install node 18"
       uses: actions/setup-node@v4
       with:
-        node-version: '16'
+        node-version: '18'
 
     - name: "Cache ~/.npm"
       uses: actions/cache@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # WARNING
 # This Dockerfile is intended for development purposes only. Do not use it for production deployments
 
-FROM node:16-alpine
+FROM node:18-alpine
 WORKDIR /hub/
 
 RUN mkdir -p /hub/app/ && \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Standalone mode only requires a running instance of the galaxy API for the UI to
 
 1. Clone the [galaxy_ng](https://github.com/ansible/galaxy_ng) repo and follow the setup instructions
 2. Start the API with `COMPOSE_PROFILE=standalone` (compose) or `COMPOSE_PROFILE=galaxy_ng/base` (oci-env)
-3. Install node. Node v16+ is known to work. Older versions may work as well.
+3. Install node. Node v18+ is known to work. Older versions may work as well.
 4. `npm install` in the UI
 5. `npm run start-standalone`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@patternfly/react-code-editor": "^4.82.121",
                 "@patternfly/react-core": "^4.276.11",
                 "@patternfly/react-table": "^4.113.7",
-                "@types/node": "^16.18.61",
+                "@types/node": "^18.18.13",
                 "@types/react": "^17.0.2",
                 "@types/react-dom": "^17.0.2",
                 "antsibull-docs": "^1.0.0",
@@ -72,8 +72,8 @@
                 "webpack-cli": "^5.1.4"
             },
             "engines": {
-                "node": ">=16",
-                "npm": ">=8"
+                "node": ">=18",
+                "npm": ">=9"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -3570,9 +3570,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "16.18.61",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.61.tgz",
-            "integrity": "sha512-k0N7BqGhJoJzdh6MuQg1V1ragJiXTh8VUBAZTWjJ9cUq23SG0F0xavOwZbhiP4J3y20xd6jxKx+xNUhkMAi76Q=="
+            "version": "18.18.13",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.13.tgz",
+            "integrity": "sha512-vXYZGRrSCreZmq1rEjMRLXJhiy8MrIeVasx+PCVlP414N7CJLHnMf+juVvjdprHyH+XRy3zKZLHeNueOpJCn0g==",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
         },
         "node_modules/@types/normalize-package-data": {
             "version": "2.4.1",
@@ -14106,6 +14109,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "@patternfly/react-code-editor": "^4.82.121",
         "@patternfly/react-core": "^4.276.11",
         "@patternfly/react-table": "^4.113.7",
-        "@types/node": "^16.18.61",
+        "@types/node": "^18.18.13",
         "@types/react": "^17.0.2",
         "@types/react-dom": "^17.0.2",
         "antsibull-docs": "^1.0.0",
@@ -101,7 +101,7 @@
         "appname": "automation-hub"
     },
     "engines": {
-        "node": ">=16",
-        "npm": ">=8"
+        "node": ">=18",
+        "npm": ">=9"
     }
 }


### PR DESCRIPTION
4.8 version of https://github.com/ansible/ansible-hub-ui/pull/4582

As per https://nodejs.org/en/about/previous-releases
Node 16 is no longer maintained.
Switching the minimum node version to the next LTS - node 18