### PR TITLE
Repository sync - fix "optimize" description

### DIFF
--- a/CHANGES/2884.bug
+++ b/CHANGES/2884.bug
@@ -1,0 +1,1 @@
+Repository sync - fix "optimize" description

--- a/src/actions/ansible-repository-sync.tsx
+++ b/src/actions/ansible-repository-sync.tsx
@@ -87,14 +87,14 @@ const SyncModal = ({
         label={t`Optimize`}
         labelIcon={
           <HelperText
-            content={t`Only perform the sync if no changes are reported by the remote server. To force a sync to happen, deselect this option.`}
+            content={t`Only perform the sync if changes are reported by the remote server. To force a sync to happen, deselect this option.`}
           />
         }
       >
         <Switch
           isChecked={syncParams.optimize}
           onChange={(optimize) => setSyncParams({ ...syncParams, optimize })}
-          label={t`Only perform the sync if no changes are reported by the remote server.`}
+          label={t`Only perform the sync if changes are reported by the remote server.`}
           labelOff={t`Force a sync to happen.`}
         />
       </FormGroup>


### PR DESCRIPTION
Issue: AAH-2884

When syncing a repository, the "Optimize" option has a misleading description.. fix.

```diff
-"Only perform the sync if no changes are reported..."
+"Only perform the sync if changes are reported..."
```
