### PR TITLE
[stable-4.9] Collection upload/deprecate - fix permission checks (#4015)

### DIFF
--- a/CHANGES/2439.bug
+++ b/CHANGES/2439.bug
@@ -1,0 +1,1 @@
+Collection upload/deprecate - fix permission checks

--- a/CHANGES/2853.bug
+++ b/CHANGES/2853.bug
@@ -1,0 +1,1 @@
+Collection upload/deprecate - fix permission checks

--- a/src/components/collection-detail/collection-dropdown.tsx
+++ b/src/components/collection-detail/collection-dropdown.tsx
@@ -1,0 +1,189 @@
+import { t } from '@lingui/macro';
+import { DropdownItem } from '@patternfly/react-core';
+import React from 'react';
+import { StatefulDropdown } from 'src/components';
+import { useContext } from 'src/loaders/app-context';
+import { DeleteCollectionUtils } from 'src/utilities';
+
+interface IProps {
+  collection;
+  'data-cy'?: string;
+  deletionBlocked?: boolean;
+  namespace?;
+  onCopyVersion?;
+  onDelete?;
+  onDeleteVersion?;
+  onDeprecate?;
+  onRemove?;
+  onRemoveVersion?;
+  onSign?;
+  onSignVersion?;
+  onUploadVersion?;
+  version?: string;
+  wrapper?;
+}
+
+export const CollectionDropdown = ({
+  collection,
+  'data-cy': dataCy,
+  deletionBlocked,
+  namespace,
+  onCopyVersion,
+  onDelete,
+  onDeleteVersion,
+  onDeprecate,
+  onRemove,
+  onRemoveVersion,
+  onSign,
+  onSignVersion,
+  onUploadVersion,
+  version,
+  wrapper,
+}: IProps) => {
+  const {
+    featureFlags: {
+      can_create_signatures,
+      can_upload_signatures,
+      display_repositories,
+    },
+    hasPermission,
+    user: { is_anonymous, is_superuser },
+  } = useContext();
+
+  const hasObjectPermission = (permission) =>
+    namespace?.related_fields?.my_permissions?.includes?.(permission);
+
+  const hasPerm = (permission) =>
+    hasPermission(permission) ||
+    hasObjectPermission(permission) ||
+    is_superuser;
+
+  const canCopy = display_repositories && !is_anonymous;
+  const canDelete =
+    hasPerm('ansible.delete_collection') || hasPerm('galaxy.change_namespace');
+  const canDeprecate = hasPerm('galaxy.change_namespace');
+  const canRemove = canDelete && display_repositories;
+  const canSign =
+    can_create_signatures &&
+    !can_upload_signatures &&
+    hasPerm('galaxy.change_namespace') &&
+    hasPerm('galaxy.upload_to_namespace');
+  const canUpload = hasPerm('galaxy.upload_to_namespace');
+
+  const Wrapper =
+    wrapper || (({ any, children }) => (any ? <>{children}</> : null));
+
+  const DeleteWrapper = ({
+    addAlert,
+    caption,
+    collection,
+    'data-cy': dataCy,
+    openModal,
+    skipCheck,
+  }: {
+    addAlert?;
+    caption: string;
+    collection?;
+    'data-cy'?: string;
+    openModal;
+    skipCheck?;
+  }) =>
+    deletionBlocked ? (
+      <DropdownItem
+        isDisabled
+        description={t`Cannot delete until collections that depend on this collection have been deleted.`}
+      >
+        {caption}
+      </DropdownItem>
+    ) : (
+      <DropdownItem
+        data-cy={dataCy}
+        onClick={() =>
+          skipCheck
+            ? openModal()
+            : DeleteCollectionUtils.countUsedbyDependencies(collection)
+                .then((count) => {
+                  if (count) {
+                    addAlert({
+                      title: t`Cannot delete until collections that depend on this collection have been deleted.`,
+                      variant: 'warning',
+                    });
+                    return;
+                  }
+
+                  openModal();
+                })
+                .catch(addAlert)
+        }
+      >
+        {caption}
+      </DropdownItem>
+    );
+
+  const dropdownItems = [
+    canDelete && onDelete && (
+      <DeleteWrapper
+        caption={t`Delete collection from system`}
+        data-cy='delete-collection'
+        key='delete-collection'
+        {...onDelete}
+      />
+    ),
+    canRemove && onRemove && (
+      <DeleteWrapper
+        caption={t`Remove collection from repository`}
+        key='remove-collection'
+        {...onRemove}
+      />
+    ),
+    canDelete && onDeleteVersion && (
+      <DropdownItem
+        data-cy='delete-collection-version'
+        key='delete-collection-version'
+        onClick={onDeleteVersion}
+      >
+        {t`Delete version ${version} from system`}
+      </DropdownItem>
+    ),
+    canRemove && onRemoveVersion && (
+      <DropdownItem key='remove-collection-version' onClick={onRemoveVersion}>
+        {t`Remove version ${version} from repository`}
+      </DropdownItem>
+    ),
+    canSign && onSign && (
+      <DropdownItem key='sign-collection' onClick={onSign}>
+        {t`Sign collection`}
+      </DropdownItem>
+    ),
+    canSign && onSignVersion && (
+      <DropdownItem key='sign-collection-version' onClick={onSignVersion}>
+        {t`Sign version ${version}`}
+      </DropdownItem>
+    ),
+    canDeprecate && onDeprecate && (
+      <DropdownItem onClick={onDeprecate} key='deprecate-collection'>
+        {collection.is_deprecated ? t`Undeprecate` : t`Deprecate`}
+      </DropdownItem>
+    ),
+    canUpload && onUploadVersion && (
+      <DropdownItem key='upload-collection-version' onClick={onUploadVersion}>
+        {t`Upload new version`}
+      </DropdownItem>
+    ),
+    canCopy && onCopyVersion && (
+      <DropdownItem
+        key='copy-collection-version-to-repository-dropdown'
+        onClick={onCopyVersion}
+        data-cy='copy-collection-version-to-repository-dropdown'
+      >
+        {t`Copy version ${version} to repositories`}
+      </DropdownItem>
+    ),
+  ].filter(Boolean);
+
+  return (
+    <Wrapper any={dropdownItems.length}>
+      <StatefulDropdown data-cy={dataCy} items={dropdownItems} />
+    </Wrapper>
+  );
+};

--- a/src/components/headers/collection-header.tsx
+++ b/src/components/headers/collection-header.tsx
@@ -2,7 +2,6 @@ import { Trans, t } from '@lingui/macro';
 import {
   Alert,
   Button,
-  DropdownItem,
   Flex,
   FlexItem,
   List,
@@ -34,6 +33,7 @@ import {
   BaseHeader,
   BreadcrumbType,
   Breadcrumbs,
+  CollectionDropdown,
   CollectionRatings,
   CopyCollectionToRepositoryModal,
   DeleteCollectionModal,
@@ -46,7 +46,6 @@ import {
   RepoSelector,
   SignAllCertificatesModal,
   SignSingleCertificateModal,
-  StatefulDropdown,
   UploadSingCertificateModal,
   closeAlertMixin,
 } from 'src/components';
@@ -67,47 +66,47 @@ import { DateComponent } from '../date-component/date-component';
 import { SignatureBadge } from '../signing';
 
 interface IProps {
+  activeTab: string;
+  actuallyCollection: CollectionDetailType;
+  breadcrumbs: BreadcrumbType[];
+  className?: string;
+  collection: CollectionVersionSearch;
   collections: CollectionVersionSearch[];
   collectionsCount: number;
-  collection: CollectionVersionSearch;
-  actuallyCollection: CollectionDetailType;
   content: CollectionVersionContentType;
   params: {
     version?: string;
     latestVersion?: string;
   };
-  updateParams: (params) => void;
-  breadcrumbs: BreadcrumbType[];
-  activeTab: string;
-  className?: string;
-  repo?: string;
   reload: () => void;
+  repo?: string;
+  updateParams: (params) => void;
 }
 
 interface IState {
-  isOpenVersionsSelect: boolean;
-  isOpenVersionsModal: boolean;
-  isOpenSignModal: boolean;
+  alerts: AlertType[];
+  collectionVersion: string | null;
+  confirmDelete: boolean;
+  copyCollectionToRepositoryModal: CollectionVersionSearch;
+  deleteAll: boolean;
+  deleteCollection: CollectionVersionSearch;
+  deletionBlocked: boolean;
+  isDeletionPending: boolean;
   isOpenSignAllModal: boolean;
+  isOpenSignModal: boolean;
+  isOpenVersionsModal: boolean;
+  isOpenVersionsSelect: boolean;
   modalCollections: CollectionVersionSearch[];
   modalPagination: {
     page: number;
     page_size: number;
   };
-  deleteCollection: CollectionVersionSearch;
-  collectionVersion: string | null;
-  confirmDelete: boolean;
-  alerts: AlertType[];
+  namespace: NamespaceType;
   redirect: string;
-  noDependencies: boolean;
-  isDeletionPending: boolean;
-  updateCollection: CollectionVersionSearch;
   showImportModal: boolean;
+  updateCollection: CollectionVersionSearch;
   uploadCertificateModalOpen: boolean;
   versionToUploadCertificate: CollectionVersionSearch;
-  namespace: NamespaceType;
-  copyCollectionToRepositoryModal: CollectionVersionSearch;
-  deleteAll: boolean;
 }
 
 export class CollectionHeader extends React.Component<IProps, IState> {
@@ -118,36 +117,36 @@ export class CollectionHeader extends React.Component<IProps, IState> {
     super(props);
 
     this.state = {
-      isOpenVersionsSelect: false,
-      isOpenVersionsModal: false,
-      isOpenSignModal: false,
+      alerts: [],
+      collectionVersion: null,
+      confirmDelete: false,
+      copyCollectionToRepositoryModal: null,
+      deleteAll: false,
+      deleteCollection: null,
+      deletionBlocked: true,
+      isDeletionPending: false,
       isOpenSignAllModal: false,
+      isOpenSignModal: false,
+      isOpenVersionsModal: false,
+      isOpenVersionsSelect: false,
       modalCollections: null,
       modalPagination: {
         page: 1,
         page_size: Constants.DEFAULT_PAGINATION_OPTIONS[0],
       },
-      deleteCollection: null,
-      deleteAll: false,
-      collectionVersion: null,
-      confirmDelete: false,
-      alerts: [],
+      namespace: null,
       redirect: null,
-      noDependencies: false,
-      isDeletionPending: false,
-      updateCollection: null,
       showImportModal: false,
+      updateCollection: null,
       uploadCertificateModalOpen: false,
       versionToUploadCertificate: undefined,
-      namespace: null,
-      copyCollectionToRepositoryModal: null,
     };
   }
 
   componentDidMount() {
     const { collection } = this.props;
-    DeleteCollectionUtils.getUsedbyDependencies(collection)
-      .then((noDependencies) => this.setState({ noDependencies }))
+    DeleteCollectionUtils.countUsedbyDependencies(collection)
+      .then((count) => this.setState({ deletionBlocked: !!count }))
       .catch((alert) => this.addAlert(alert));
 
     NamespaceAPI.get(collection.collection_version.namespace, {
@@ -180,20 +179,30 @@ export class CollectionHeader extends React.Component<IProps, IState> {
     } = this.props;
 
     const {
-      modalCollections,
-      modalPagination,
+      alerts,
+      collectionVersion,
+      confirmDelete,
+      copyCollectionToRepositoryModal,
+      deleteAll,
+      deleteCollection,
+      deletionBlocked,
+      isDeletionPending,
+      isOpenSignAllModal,
+      isOpenSignModal,
       isOpenVersionsModal,
       isOpenVersionsSelect,
+      modalCollections,
+      modalPagination,
+      namespace,
       redirect,
-      noDependencies,
-      collectionVersion,
-      deleteCollection,
-      confirmDelete,
-      isDeletionPending,
       showImportModal,
       updateCollection,
-      copyCollectionToRepositoryModal,
+      uploadCertificateModalOpen,
     } = this.state;
+
+    const {
+      featureFlags: { can_upload_signatures, display_signatures },
+    } = this.context;
 
     const urlKeys = [
       { key: 'documentation', name: t`Docs site` },
@@ -202,14 +211,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       { key: 'origin_repository', name: t`Repo` },
     ];
 
-    const { can_upload_signatures, display_signatures, display_repositories } =
-      this.context.featureFlags;
-
-    const {
-      collection_version,
-      is_signed,
-      namespace_metadata: namespace,
-    } = collection;
+    const { collection_version, is_signed, namespace_metadata } = collection;
 
     const {
       name: collectionName,
@@ -231,7 +233,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         .map((b, i) => (i ? <> {b}</> : b)); // join with spaces
 
     const nsTitle = namespaceTitle(
-      namespace || { name: collection_version.namespace },
+      namespace_metadata || { name: collection_version.namespace },
     );
 
     if (redirect) {
@@ -239,100 +241,16 @@ export class CollectionHeader extends React.Component<IProps, IState> {
     }
 
     const canSign = canSignNamespace(this.context, this.state.namespace);
-    const { hasPermission } = this.context;
 
-    const dropdownItems = [
-      DeleteCollectionUtils.deleteMenuOption({
-        canDeleteCollection: hasPermission('ansible.delete_collection'),
-        noDependencies,
-        onClick: () => this.openDeleteModalWithConfirm(null, true),
-        deleteAll: true,
-        display_repositories: display_repositories,
-      }),
-      DeleteCollectionUtils.deleteMenuOption({
-        canDeleteCollection: hasPermission('ansible.delete_collection'),
-        noDependencies,
-        onClick: () => this.openDeleteModalWithConfirm(null, false),
-        deleteAll: false,
-        display_repositories: display_repositories,
-      }),
-      hasPermission('ansible.delete_collection') && (
-        <DropdownItem
-          data-cy='delete-collection-version'
-          key='delete-collection-version'
-          onClick={() => this.openDeleteModalWithConfirm(version, true)}
-        >
-          {t`Delete version ${version} from system`}
-        </DropdownItem>
-      ),
-      hasPermission('ansible.delete_collection') && display_repositories && (
-        <DropdownItem
-          data-cy='remove-collection-version'
-          key='remove-collection-version'
-          onClick={() => this.openDeleteModalWithConfirm(version, false)}
-        >
-          {t`Delete version ${version} from repository`}
-        </DropdownItem>
-      ),
-      canSign && !can_upload_signatures && (
-        <DropdownItem
-          key='sign-all'
-          data-cy='sign-collection-button'
-          onClick={() => this.setState({ isOpenSignAllModal: true })}
-        >
-          {t`Sign entire collection`}
-        </DropdownItem>
-      ),
-      canSign && (
-        <DropdownItem
-          key='sign-version'
-          onClick={() => {
-            if (can_upload_signatures) {
-              this.setState({
-                uploadCertificateModalOpen: true,
-                versionToUploadCertificate: collection,
-              });
-            } else {
-              this.setState({ isOpenSignModal: true });
-            }
-          }}
-          data-cy='sign-version-button'
-        >
-          {t`Sign version ${version}`}
-        </DropdownItem>
-      ),
-      hasPermission('galaxy.upload_to_namespace') && (
-        <DropdownItem
-          onClick={() => this.deprecate(collection)}
-          key='deprecate'
-        >
-          {collection.is_deprecated ? t`Undeprecate` : t`Deprecate`}
-        </DropdownItem>
-      ),
-      <DropdownItem
-        key='upload-collection-version'
-        onClick={() => this.checkUploadPrivilleges(collection)}
-        data-cy='upload-collection-version-dropdown'
-      >
-        {t`Upload new version`}
-      </DropdownItem>,
-      display_repositories && (
-        <DropdownItem
-          key='copy-collection-version-to-repository-dropdown'
-          onClick={() => this.copyToRepository(collection)}
-          data-cy='copy-collection-version-to-repository-dropdown'
-        >
-          {t`Copy version ${version} to repositories`}
-        </DropdownItem>
-      ),
-    ].filter(Boolean);
+    const deleteFromRepo = deleteAll ? null : collection.repository.name;
 
-    const deleteFromRepo = this.state.deleteAll
-      ? null
-      : collection.repository.name;
+    const deleteFn = (deleteAll) => ({
+      openModal: () => this.openDeleteModalWithConfirm(null, deleteAll),
+      skipCheck: true, // already handled by deletionBlocked
+    });
 
     return (
-      <React.Fragment>
+      <>
         {showImportModal && (
           <ImportModal
             isOpen={showImportModal}
@@ -356,13 +274,13 @@ export class CollectionHeader extends React.Component<IProps, IState> {
         {canSign && (
           <>
             <UploadSingCertificateModal
-              isOpen={this.state.uploadCertificateModalOpen}
+              isOpen={uploadCertificateModalOpen}
               onCancel={() => this.closeUploadCertificateModal()}
               onSubmit={(d) => this.submitCertificate(d)}
             />
             <SignAllCertificatesModal
               name={collectionName}
-              isOpen={this.state.isOpenSignAllModal}
+              isOpen={isOpenSignAllModal}
               onSubmit={this.signCollection}
               onCancel={() => {
                 this.setState({ isOpenSignAllModal: false });
@@ -371,7 +289,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             <SignSingleCertificateModal
               name={collectionName}
               version={version}
-              isOpen={this.state.isOpenSignModal}
+              isOpen={isOpenSignModal}
               onSubmit={this.signVersion}
               onCancel={() => this.setState({ isOpenSignModal: false })}
             />
@@ -464,12 +382,12 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           className={className}
           title={collection_version.name}
           logo={
-            namespace?.avatar_url && (
+            namespace_metadata?.avatar_url && (
               <Logo
                 alt={t`${nsTitle} logo`}
                 className='image'
                 fallbackToDefault
-                image={namespace.avatar_url}
+                image={namespace_metadata.avatar_url}
                 size='40px'
                 unlockWidth
               />
@@ -554,11 +472,38 @@ export class CollectionHeader extends React.Component<IProps, IState> {
           }
           pageControls={
             <Flex>
-              {dropdownItems.length > 0 ? (
-                <FlexItem data-cy='kebab-toggle'>
-                  <StatefulDropdown items={dropdownItems} />
-                </FlexItem>
-              ) : null}
+              <CollectionDropdown
+                collection={collection}
+                data-cy='kebab-toggle'
+                deletionBlocked={deletionBlocked}
+                namespace={namespace}
+                onCopyVersion={() => this.copyToRepository(collection)}
+                onDelete={deleteFn(true)}
+                onDeleteVersion={() =>
+                  this.openDeleteModalWithConfirm(version, true)
+                }
+                onDeprecate={() => this.deprecate(collection)}
+                onRemove={deleteFn(false)}
+                onRemoveVersion={() =>
+                  this.openDeleteModalWithConfirm(version, false)
+                }
+                onSign={() => this.setState({ isOpenSignAllModal: true })}
+                onSignVersion={() => {
+                  if (can_upload_signatures) {
+                    this.setState({
+                      uploadCertificateModalOpen: true,
+                      versionToUploadCertificate: collection,
+                    });
+                  } else {
+                    this.setState({ isOpenSignModal: true });
+                  }
+                }}
+                onUploadVersion={() => this.checkUploadPrivilleges(collection)}
+                version={version}
+                wrapper={({ any, children }) =>
+                  any ? <FlexItem>{children}</FlexItem> : null
+                }
+              />
             </Flex>
           }
         >
@@ -569,10 +514,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
               title={t`This collection has been deprecated.`}
             />
           )}
-          <AlertList
-            alerts={this.state.alerts}
-            closeAlert={(i) => this.closeAlert(i)}
-          />
+          <AlertList alerts={alerts} closeAlert={(i) => this.closeAlert(i)} />
           <div className='hub-tab-link-container'>
             <div className='tabs'>{this.renderTabs(activeTab)}</div>
             <div className='links'>
@@ -591,7 +533,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
             </div>
           </div>
         </BaseHeader>
-      </React.Fragment>
+      </>
     );
   }
 
@@ -1060,7 +1002,7 @@ export class CollectionHeader extends React.Component<IProps, IState> {
       deleteCollection: this.props.collection,
       collectionVersion: version,
       confirmDelete: false,
-      deleteAll: deleteAll,
+      deleteAll,
     });
   }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,6 +10,7 @@ export { NamespaceCard, NamespaceNextPageCard } from './cards/namespace-card';
 export { CollectionDependenciesList } from './collection-dependencies-list/collection-dependencies-list';
 export { CollectionUsedbyDependenciesList } from './collection-dependencies-list/collection-usedby-dependencies-list';
 export { CollectionContentList } from './collection-detail/collection-content-list';
+export { CollectionDropdown } from './collection-detail/collection-dropdown';
 export { CollectionInfo } from './collection-detail/collection-info';
 export { TableOfContents } from './collection-detail/table-of-contents';
 export { collectionFilter } from './collection-list/collection-filter';

--- a/src/components/shared/ratings.tsx
+++ b/src/components/shared/ratings.tsx
@@ -7,30 +7,9 @@ interface IProps {
   name: string;
 }
 
-const cache = { collection: null, role: null };
-
-const loadScore = (type, namespace, name, callback) => () => {
-  const setScores = (data) => {
-    if (namespace && name && callback) {
-      callback(data?.[namespace]?.[name]);
-    }
-  };
-
-  if (!cache[type]) {
-    // not in cache, trigger load
-    cache[type] = fetch(`/static/scores/${type}.json`)
-      .then((response) => response.json())
-      .then((data) => {
-        cache[type] = data;
-        setScores(data);
-      });
-  } else if (typeof cache[type].then === 'function') {
-    // waiting for load
-    cache[type].then(() => setScores(cache[type]));
-  } else {
-    // already loaded
-    setScores(cache[type]);
-  }
+const loadScore = (_type, _namespace, _name, _callback) => () => {
+  // only in community mode
+  return;
 };
 
 export function CollectionRatings({

--- a/src/constants.tsx
+++ b/src/constants.tsx
@@ -26,7 +26,7 @@ export class Constants {
   ];
 
   static TASK_NAMES = {
-    'galaxy_ng.app.tasks.curate_all_synclist_repository': msg`Curate all synclist repository`,
+    'galaxy_ng.app.tasks.curate_all_synclist_repository': msg`Curate all synclist repositories`,
     'galaxy_ng.app.tasks.curate_synclist_repository': msg`Curate synclist repository`,
     'galaxy_ng.app.tasks.import_and_auto_approve': msg`Import and auto approve`,
     'galaxy_ng.app.tasks.import_and_move_to_staging': msg`Import and move to staging`,

--- a/src/utilities/delete-collection.tsx
+++ b/src/utilities/delete-collection.tsx
@@ -1,22 +1,20 @@
 import { Trans, t } from '@lingui/macro';
-import { DropdownItem } from '@patternfly/react-core';
 import React from 'react';
 import {
   CollectionAPI,
   CollectionVersionAPI,
   CollectionVersionSearch,
 } from 'src/api';
-import { Tooltip } from 'src/components';
 import { errorMessage } from './fail-alerts';
 import { parsePulpIDFromURL } from './parse-pulp-id';
 import { repositoryRemoveCollection } from './repository-remove-collection';
 import { waitForTask } from './wait-for-task';
 
 export class DeleteCollectionUtils {
-  public static getUsedbyDependencies(collection: CollectionVersionSearch) {
+  public static countUsedbyDependencies(collection: CollectionVersionSearch) {
     const { name, namespace } = collection.collection_version;
     return CollectionVersionAPI.getUsedDependenciesByCollection(namespace, name)
-      .then(({ data }) => data.data.length === 0)
+      .then(({ data }) => data.data.length)
       .catch((err) => {
         const { status, statusText } = err.response;
         return Promise.reject({
@@ -25,99 +23,6 @@ export class DeleteCollectionUtils {
           description: errorMessage(status, statusText),
         });
       });
-  }
-
-  public static deleteMenuOption({
-    canDeleteCollection,
-    noDependencies,
-    onClick,
-    deleteAll,
-    display_repositories,
-  }) {
-    if (!canDeleteCollection) {
-      return null;
-    }
-
-    if (!display_repositories && !deleteAll) {
-      // cant display delete from repository when repositories are turned off
-      return null;
-    }
-
-    const caption = deleteAll
-      ? t`Delete entire collection from system`
-      : t`Delete collection from repository`;
-
-    const key = deleteAll ? 'delete-collection' : 'remove-collection';
-
-    if (noDependencies === false) {
-      return (
-        <Tooltip
-          key={key}
-          position='left'
-          content={
-            <Trans>
-              Cannot delete until collections <br />
-              that depend on this collection <br />
-              have been deleted.
-            </Trans>
-          }
-        >
-          <DropdownItem isDisabled>{caption}</DropdownItem>
-        </Tooltip>
-      );
-    }
-
-    return (
-      <DropdownItem data-cy={key} key={key} onClick={onClick}>
-        {caption}
-      </DropdownItem>
-    );
-  }
-
-  public static tryOpenDeleteModalWithConfirm({
-    addAlert,
-    setState,
-    collection,
-    deleteAll,
-  }) {
-    DeleteCollectionUtils.getUsedbyDependencies(collection)
-      .then((noDependencies) =>
-        DeleteCollectionUtils.openDeleteModalWithConfirm({
-          addAlert,
-          setState,
-          noDependencies,
-          collection,
-          deleteAll,
-        }),
-      )
-      .catch((alert) => addAlert(alert));
-  }
-
-  private static openDeleteModalWithConfirm({
-    addAlert,
-    setState,
-    noDependencies,
-    collection,
-    deleteAll,
-  }) {
-    if (noDependencies) {
-      setState({
-        deleteCollection: collection,
-        confirmDelete: false,
-        deleteAll: deleteAll,
-      });
-    } else {
-      addAlert({
-        title: (
-          <Trans>
-            Cannot delete until collections <br />
-            that depend on this collection <br />
-            have been deleted.
-          </Trans>
-        ),
-        variant: 'warning',
-      });
-    }
   }
 
   public static deleteCollection({

--- a/test/cypress/e2e/collections/collection.js
+++ b/test/cypress/e2e/collections/collection.js
@@ -22,7 +22,7 @@ describe('collection tests', () => {
 
     cy.visit(`${uiPrefix}repo/published/test_namespace/test_collection`);
 
-    cy.get('[data-cy=kebab-toggle]').click();
+    cy.openHeaderKebab();
     cy.get('[data-cy=delete-collection]').click();
     cy.get('input[id=delete_confirm]').click();
     cy.get('button').contains('Delete').click();
@@ -41,7 +41,7 @@ describe('collection tests', () => {
     cy.get(
       `a[href*="${uiPrefix}repo/published/my_namespace/my_collection"]`,
     ).click();
-    cy.get('[data-cy=kebab-toggle]').click();
+    cy.openHeaderKebab();
     cy.get('[data-cy=delete-collection-version]').click();
     cy.get('input[id=delete_confirm]').click();
     cy.get('button').contains('Delete').click();
@@ -62,7 +62,7 @@ describe('collection tests', () => {
     cy.galaxykit('task wait all');
     cy.visit(`${uiPrefix}repo/published/${namespace}/${collection}`);
 
-    cy.get('[data-cy="kebab-toggle"]').click();
+    cy.openHeaderKebab();
     cy.get(
       '[data-cy="copy-collection-version-to-repository-dropdown"]',
     ).click();
@@ -107,7 +107,7 @@ describe('collection tests', () => {
     cy.get('.collection-container [aria-label="Actions"]:first').click({
       force: true,
     });
-    cy.contains('Delete collection from repository').click();
+    cy.contains('Remove collection from repository').click();
     cy.get('input[id=delete_confirm]').click();
     cy.get('button').contains('Delete').click();
     cy.contains(
@@ -156,8 +156,8 @@ describe('collection tests', () => {
       `${uiPrefix}repo/repo2/test_namespace/test_repo_collection_version2/?version=1.0.0`,
     );
 
-    cy.get('[data-cy="kebab-toggle"] [aria-label="Actions"]:first').click();
-    cy.contains('Delete version 1.0.0 from repository').click();
+    cy.openHeaderKebab();
+    cy.contains('Remove version 1.0.0 from repository').click();
     cy.get('input[id=delete_confirm]').click();
     cy.get('button').contains('Delete').click();
     cy.contains(

--- a/test/cypress/e2e/collections/collection_detail.js
+++ b/test/cypress/e2e/collections/collection_detail.js
@@ -4,13 +4,13 @@ describe('Collection detail', () => {
   const baseURL = `${uiPrefix}repo/published/collection_detail_test_namespace/collection_detail_test_collection`;
 
   function deprecate() {
-    cy.get('[data-cy="kebab-toggle"] [aria-label="Actions"]').click();
+    cy.openHeaderKebab();
     cy.contains('Deprecate').click();
     cy.contains('This collection has been deprecated.', { timeout: 10000 });
   }
 
   function undeprecate() {
-    cy.get('[data-cy="kebab-toggle"] [aria-label="Actions"]').click();
+    cy.openHeaderKebab();
     cy.contains('Undeprecate').click();
     cy.contains('This collection has been deprecated.', {
       timeout: 10000,

--- a/test/cypress/e2e/collections/collection_upload.js
+++ b/test/cypress/e2e/collections/collection_upload.js
@@ -37,9 +37,8 @@ describe('Collection Upload Tests', () => {
     cy.login(userName, userPassword);
     cy.visit(`${uiPrefix}repo/published/testspace/testcollection`);
     cy.contains('testcollection');
-    cy.get('button[aria-label="Actions"]').click();
-    cy.contains('Upload new version').click();
-    cy.contains("You don't have rights to do this operation.");
+    cy.openHeaderKebab();
+    cy.contains('Upload new version').should('not.exist');
   });
 
   it('should see upload new collection version in collection list when user does have permissions', () => {
@@ -64,7 +63,7 @@ describe('Collection Upload Tests', () => {
     cy.login();
     cy.visit(`${uiPrefix}repo/published/testspace/testcollection`);
     cy.contains('testcollection');
-    cy.get('[data-cy="kebab-toggle"] button[aria-label="Actions"]').click();
+    cy.openHeaderKebab();
     cy.contains('Upload new version').click();
     cy.contains('New version of testspace.testcollection');
   });
@@ -121,13 +120,13 @@ describe('Collection Upload Tests', () => {
   it('should deprecate let user deprecate and undeprecate collections', () => {
     cy.login();
     cy.visit(`${uiPrefix}namespaces/testspace`);
-    cy.get('[aria-label=collection-kebab]').first().click();
+    cy.get('[data-cy=collection-kebab]').first().click();
     cy.contains('Deprecate').click();
     cy.visit(`${uiPrefix}namespaces/testspace`);
     cy.contains('DEPRECATED');
 
     cy.visit(`${uiPrefix}namespaces/testspace`);
-    cy.get('[aria-label=collection-kebab]').first().click();
+    cy.get('[data-cy=collection-kebab]').first().click();
     cy.contains('Undeprecate').click();
     cy.visit(`${uiPrefix}namespaces/testspace`);
     cy.contains('DEPRECATED').should('not.exist');

--- a/test/cypress/e2e/collections/collections_list.js
+++ b/test/cypress/e2e/collections/collections_list.js
@@ -21,7 +21,7 @@ describe('Collections list Tests', () => {
   function undeprecate() {
     cy.visit(`${uiPrefix}repo/published/my_namespace/my_collection0`);
     cy.contains('This collection has been deprecated.');
-    cy.get('[data-cy="kebab-toggle"] [aria-label="Actions"]').click();
+    cy.openHeaderKebab();
     cy.contains('Undeprecate').click();
     cy.contains('This collection has been deprecated.', {
       timeout: 10000,
@@ -127,7 +127,7 @@ describe('Collections list Tests', () => {
     cy.get('.hub-list').contains('my_collection0');
 
     cy.get('.collection-container [aria-label="Actions"]').click();
-    cy.contains('Delete entire collection from system').click();
+    cy.contains('Delete collection from system').click();
     cy.get('[data-cy=modal_checkbox] input').click();
     cy.get('[data-cy=delete-button] button').click();
     cy.contains('Collection "my_collection0" has been successfully deleted.', {
@@ -155,7 +155,7 @@ describe('Collections list Tests', () => {
     cy.get('.body').contains('my_collection1');
 
     cy.get('.body [aria-label="Actions"]').click();
-    cy.contains('Delete entire collection from system').click();
+    cy.contains('Delete collection from system').click();
     cy.get('[data-cy=modal_checkbox] input').click();
     cy.get('[data-cy=delete-button] button').click();
 

--- a/test/cypress/e2e/misc/rbac.js
+++ b/test/cypress/e2e/misc/rbac.js
@@ -65,7 +65,7 @@ describe('RBAC test for user without permissions', () => {
     cy.visit(`${uiPrefix}repo/published/testspace/testcollection`);
 
     // cannot Delete collection
-    cy.get('[data-cy=kebab-toggle]').should('not.exist');
+    cy.get('[data-cy="kebab-toggle"]').should('not.exist');
   });
 
   it("shouldn't let view, add, change and delete users when user doesn't have permission", () => {
@@ -287,8 +287,8 @@ describe('RBAC test for user with permissions', () => {
     cy.visit(`${uiPrefix}repo/published/testspace2/testcollection2`);
 
     // can Delete collection
-    cy.get('[data-cy=kebab-toggle]').should('exist').click();
-    cy.contains('Delete entire collection from system');
+    cy.openHeaderKebab();
+    cy.contains('Delete collection from system');
   });
 
   it('should let view, add, change and delete users when user has permissions', () => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -40,6 +40,12 @@ Cypress.Commands.add('assertTitle', {}, (title) => {
   cy.contains('.pf-c-title', title);
 });
 
+Cypress.Commands.add('openHeaderKebab', {}, () => {
+  cy.wait(500); // the collection detaill displays the kebab before all apis are loaded, repaints after.. just wait
+  cy.scrollTo(0, 0, { ensureScrollable: false });
+  cy.get('[data-cy="kebab-toggle"] [aria-label="Actions"]').click();
+});
+
 Cypress.Commands.add(
   'createUser',
   {},


### PR DESCRIPTION
Backports #4015

---

Issue: AAH-2439, AAH-2853

Fixes permission checks for collection upload/deprecate on collection list ,namespace detail & collection detail.

|action|features|model or object permissions|
|-|-|-|
|copy|`display_repositories`|logged in|
|delete|-|`ansible.delete_collection` OR `galaxy.change_namespace`|
|remove|`display_repositories`|`ansible.delete_collection` OR `galaxy.change_namespace`|
|deprecate|-|`galaxy.change_namespace`|
|upload|-|`galaxy.upload_to_namespace`|
|sign|`can_create_signatures` AND NOT `can_upload_signatures`|`galaxy.change_namespace` AND `galaxy.upload_to_namespace`|

* search still won't respect any namespace permissions, ns detail & collection detail will
* search & ns detail don't do versions, collection detail does