### PR TITLE
Update tooling for 4.8 eol

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,33 +39,6 @@ updates:
 
   - package-ecosystem: 'npm'
     directory: '/'
-    target-branch: 'stable-4.8'
-    schedule:
-      interval: 'weekly'
-    commit-message:
-      prefix: '[stable-4.8] '
-    ignore:
-      - dependency-name: '@lingui/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@patternfly/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-dom'
-        update-types: ['version-update:semver-major']
-
-  - package-ecosystem: 'npm'
-    directory: '/test'
-    target-branch: 'stable-4.8'
-    schedule:
-      interval: 'monthly'
-    commit-message:
-      prefix: '[stable-4.8] '
-
-  - package-ecosystem: 'npm'
-    directory: '/'
     target-branch: 'stable-4.7'
     schedule:
       interval: 'monthly'
@@ -123,14 +96,6 @@ updates:
       prefix: '[stable-4.9] '
     schedule:
       interval: "monthly"
-
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    target-branch: 'stable-4.8'
-    commit-message:
-      prefix: '[stable-4.8] '
-    schedule:
-      interval: 'monthly'
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,13 +3,9 @@
 # called by .github/workflows/labeler.yml
 
 backport-4.9:
-- src/**/*
-- test/**/*
-
-backport-4.8:
-- src/**/*
-- test/**/*
+  - src/**/*
+  - test/**/*
 
 backport-4.7:
-- src/**/*
-- test/**/*
+  - src/**/*
+  - test/**/*

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -17,7 +17,6 @@ jobs:
         - 'master'
         - 'stable-4.6'
         - 'stable-4.7'
-        - 'stable-4.8'
         - 'stable-4.9'
 
     steps:

--- a/README.md
+++ b/README.md
@@ -89,9 +89,7 @@ To map between the two:
 |AAP version|AAH version|notes|
 |-|-|-|
 |2.3|4.6||
-|2.4|4.7||
-|2.4|4.8|django 4, still part of 2.4|
-|2.4|4.9||
+|2.4|4.7 and 4.9|
 
 [Table with component versions](https://github.com/ansible/galaxy_ng/wiki/Galaxy-NG-Version-Matrix)
 


### PR DESCRIPTION
Previous #4581

Dropping dependabot config for 4.8,
weekly string extraction,
and updating README.

(also 60314b3d44fe4af0d15a12bc8e191f9090927c71)