### PR TITLE
dependabot: remove patternfly group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,6 @@ updates:
       lingui:
         patterns:
           - "@lingui/*"
-      patternfly:
-        patterns:
-          - "@patternfly/*"
       react:
         patterns:
           - "react"
@@ -41,9 +38,6 @@ updates:
       lingui:
         patterns:
           - "@lingui/*"
-      patternfly:
-        patterns:
-          - "@patternfly/*"
       react:
         patterns:
           - "react"
@@ -78,9 +72,6 @@ updates:
       lingui:
         patterns:
           - "@lingui/*"
-      patternfly:
-        patterns:
-          - "@patternfly/*"
       react:
         patterns:
           - "react"
@@ -115,9 +106,6 @@ updates:
       lingui:
         patterns:
           - "@lingui/*"
-      patternfly:
-        patterns:
-          - "@patternfly/*"
       react:
         patterns:
           - "react"


### PR DESCRIPTION
Follows #4712 

dependabot seems to ignore major version update constaints on grouped updates giving us #4725 trying to update to pf 5 - removing patternfly from groups.
