### PR TITLE
cypress.yml: upload-artifact v4 needs a unique name

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -371,7 +371,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       if: failure()
       with:
-        name: screenshots_and_videos
+        name: screenshots_and_videos-${{matrix.test}}
         path: |
           ansible-hub-ui/test/cypress/screenshots
           ansible-hub-ui/test/cypress/videos


### PR DESCRIPTION
otherwise multiple uploads from different matrix wont work

> [cypress (repo)](https://github.com/ansible/ansible-hub-ui/actions/runs/7226695127/job/19692809329#step:22:489)
Process completed with exit code 2.
> [cypress (collections)](https://github.com/ansible/ansible-hub-ui/actions/runs/7226695127/job/19692808297#step:23:20)
> Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
> [cypress (collections)](https://github.com/ansible/ansible-hub-ui/actions/runs/7226695127/job/19692808297#step:22:396)
Process completed with exit code 1.

https://github.com/actions/upload-artifact