### PR TITLE
formatPath: handle optional route components; Role detail: routed tabs

### DIFF
--- a/src/containers/ansible-role/role-detail.tsx
+++ b/src/containers/ansible-role/role-detail.tsx
@@ -223,9 +223,9 @@ class AnsibleRoleDetail extends React.Component<RouteProps, RoleState> {
   constructor(props) {
     super(props);
 
-    const { namespace, name } = props.routeParams;
+    const { namespace, name, tab } = props.routeParams;
     this.state = {
-      activeItem: 'install',
+      activeItem: tab || 'install',
       alerts: [],
       loading: true,
       name,
@@ -303,10 +303,10 @@ class AnsibleRoleDetail extends React.Component<RouteProps, RoleState> {
       release_name = '';
     }
 
-    const table = {
-      install: { title: t`Install` },
-      documentation: { title: t`Documentation` },
-      versions: { title: t`Versions` },
+    const tabs = {
+      install: t`Install`,
+      documentation: t`Documentation`,
+      versions: t`Versions`,
     };
 
     const addAlert = (alert) => this.addAlert(alert);
@@ -363,12 +363,20 @@ class AnsibleRoleDetail extends React.Component<RouteProps, RoleState> {
           name,
         }),
       },
+      { name: tabs[activeItem || 'install'] },
     ];
 
-    const onSelect = (result) =>
-      this.setState({
-        activeItem: result.itemId,
-      });
+    const onTabSelect = ({ itemId: newTab }) => {
+      this.setState({ activeItem: newTab });
+
+      this.props.navigate(
+        formatPath(Paths.standaloneRole, {
+          namespace: namespace.name,
+          name,
+          tab: newTab,
+        }),
+      );
+    };
 
     return (
       <>
@@ -423,17 +431,17 @@ class AnsibleRoleDetail extends React.Component<RouteProps, RoleState> {
         >
           {/* FIXME: replace with LinkTabs */}
           <Panel isScrollable>
-            <Nav theme='light' variant='tertiary' onSelect={onSelect}>
+            <Nav theme='light' variant='tertiary' onSelect={onTabSelect}>
               <NavList>
-                {Object.keys(table).map((key) => {
+                {Object.keys(tabs).map((key) => {
                   return (
                     <NavItem
                       isActive={activeItem === key}
-                      title={table[key].title}
+                      title={tabs[key]}
                       key={key}
                       itemId={key}
                     >
-                      {table[key].title}
+                      {tabs[key]}
                     </NavItem>
                   );
                 })}

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -36,6 +36,8 @@ const menuSection = (name, options = {}, items = []) => ({
   items,
 });
 
+const altPath = (p) => formatPath(p, {}, null, { ignoreMissing: true });
+
 function standaloneMenu() {
   return [
     menuItem(t`Search`, {
@@ -50,14 +52,14 @@ function standaloneMenu() {
         condition: ({ settings, user }) =>
           settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
           !user.is_anonymous,
-        alternativeUrls: [formatPath(Paths.searchByRepo)],
+        alternativeUrls: [altPath(Paths.searchByRepo)],
       }),
       menuItem(t`Namespaces`, {
         url: formatPath(Paths[NAMESPACE_TERM]),
         condition: ({ settings, user }) =>
           settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
           !user.is_anonymous,
-        alternativeUrls: [formatPath(Paths.myNamespaces)],
+        alternativeUrls: [altPath(Paths.myNamespaces)],
       }),
       menuItem(t`Repositories`, {
         condition: canViewAnsibleRepositories,
@@ -100,18 +102,16 @@ function standaloneMenu() {
       [
         menuItem(t`Roles`, {
           url: formatPath(Paths.standaloneRoles),
-          alternativeUrls: [formatPath(Paths.compatLegacyRoles)],
         }),
         menuItem(t`Role Namespaces`, {
           url: formatPath(Paths.standaloneNamespaces),
-          alternativeUrls: [formatPath(Paths.compatLegacyNamespaces)],
         }),
       ],
     ),
     menuItem(t`Task Management`, {
       url: formatPath(Paths.taskList),
       condition: isLoggedIn,
-      alternativeUrls: [formatPath(Paths.taskDetail)],
+      alternativeUrls: [altPath(Paths.taskDetail)],
     }),
     menuItem(t`Signature Keys`, {
       url: formatPath(Paths.signatureKeys),
@@ -148,19 +148,20 @@ function standaloneMenu() {
       menuItem(t`Groups`, {
         condition: (context) => hasPermission(context, 'galaxy.view_group'),
         url: formatPath(Paths.groupList),
-        alternativeUrls: [formatPath(Paths.groupDetail)],
+        alternativeUrls: [altPath(Paths.groupDetail)],
       }),
       menuItem(t`Roles`, {
         condition: (context) => hasPermission(context, 'galaxy.view_group'),
         url: formatPath(Paths.roleList),
-        alternativeUrls: [formatPath(Paths.roleEdit)],
+        alternativeUrls: [altPath(Paths.roleEdit)],
       }),
     ]),
   ];
 }
 
 function activateMenu(items, pathname) {
-  const normalize = (s) => s.replace(/\/$/, '').replace(/\/:[^/:]+$/, '');
+  // ensure no /:var at the end
+  const normalize = (s) => s.replace(/\/$/, '').replace(/(\/:[^/:]+)+$/, '');
   const normalizedPathname = normalize(pathname).replace(
     /\/repo\/[^/]+\//,
     '/repo/:repo/',

--- a/src/loaders/standalone/routes.tsx
+++ b/src/loaders/standalone/routes.tsx
@@ -210,8 +210,6 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
         path: Paths.executionEnvironmentsRegistries,
         isDisabled: isContainerDisabled,
       },
-
-      // roles ...
       {
         component: AnsibleRoleNamespaceDetail,
         path: Paths.standaloneNamespace,
@@ -219,18 +217,6 @@ export class StandaloneRoutes extends React.Component<IRoutesProps> {
       { component: AnsibleRoleNamespaceList, path: Paths.standaloneNamespaces },
       { component: AnsibleRoleDetail, path: Paths.standaloneRole },
       { component: AnsibleRoleList, path: Paths.standaloneRoles },
-      // ... but still support legacy urls
-      {
-        component: AnsibleRoleNamespaceDetail,
-        path: Paths.compatLegacyNamespace,
-      },
-      {
-        component: AnsibleRoleNamespaceList,
-        path: Paths.compatLegacyNamespaces,
-      },
-      { component: AnsibleRoleDetail, path: Paths.compatLegacyRole },
-      { component: AnsibleRoleList, path: Paths.compatLegacyRoles },
-
       {
         component: TaskListView,
         path: Paths.taskList,

--- a/test/cypress/e2e/screenshots/screenshots.js
+++ b/test/cypress/e2e/screenshots/screenshots.js
@@ -44,13 +44,14 @@ describe('screenshots', () => {
     screenshot('/containers');
     screenshot('/registries');
 
-    screenshot('/legacy/roles');
-    screenshot('/legacy/namespaces');
+    screenshot('/standalone/roles');
+    screenshot('/standalone/namespaces');
 
     screenshot('/tasks', { blackout: ['time'] });
     screenshot('/signature-keys', {
       blackout: ['time', '[data-cy=hub-signature-list-fingerprint]'],
     });
+
     screenshot('/users', { blackout: ['time'] });
     screenshot('/group-list');
     screenshot('/roles', { blackout: ['time'] });


### PR DESCRIPTION
Moving out of #4508 to simplify.

Role detail: track current tab in a route param,
make the route param optional,
have formatPath handle that,
add ignoreMissing option to allow ignoring unknown non-optional params,
and update menu route matching to cope with that.

And drop legacy standalone routes as these were never available on galaxy, only beta.