### PR TITLE
Role import form: add overrides for namespace/role name

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -117,6 +117,14 @@ jobs:
           base/package-lock.json
           pr/package-lock.json
 
+    - name: 'npm install (base)'
+      working-directory: 'base'
+      run: 'npm install'
+
+    - name: 'npm install (pr)'
+      working-directory: 'pr'
+      run: 'npm install'
+
     - name: "Diff configs"
       run: |
         mkdir ~/webpack-config/
@@ -126,9 +134,7 @@ jobs:
 
         for version in base pr; do
           mkdir ~/webpack-config/$version/
-          cd $version/
-          npm install
-          cd config/
+          pushd $version/config/
 
           for file in *.webpack.config.js; do
             export NODE_ENV=`grep -q '\.prod\.' <<< "$file" && echo production || echo development`
@@ -142,7 +148,7 @@ jobs:
               grep -v '^Root folder:' > ~/webpack-config/"$version"/"$file".json
           done
 
-          cd ../../
+          popd
         done
 
         diff -Naur ~/webpack-config/{base,pr}

--- a/src/components/ansible-role/role-import-form.tsx
+++ b/src/components/ansible-role/role-import-form.tsx
@@ -184,15 +184,18 @@ export const RoleImportForm = ({ addAlert }: IProps) => {
     back?: string;
   };
   const [data, setData] = useState<{
+    alternate_namespace_name?: string;
     alternate_role_name?: string;
     github_reference?: string;
     github_repo?: string;
     github_user?: string;
   }>({
-    github_reference: params.github_branch,
-    github_repo: params.github_repo,
+    alternate_namespace_name: '',
+    alternate_role_name: '',
+    github_reference: params.github_branch || '',
+    github_repo: params.github_repo || '',
     github_user:
-      params.github_user || (user.is_superuser ? null : user.username),
+      params.github_user || (user.is_superuser ? '' : user.username) || '',
   });
   const [errors, setErrors] = useState<ErrorMessagesType>(null);
 
@@ -234,9 +237,14 @@ export const RoleImportForm = ({ addAlert }: IProps) => {
       placeholder: t`Automatic`,
     },
     {
+      id: 'alternate_namespace_name',
+      title: t`Namespace name`,
+      placeholder: t`Overrides any galaxy_info.namespace metadata`,
+    },
+    {
       id: 'alternate_role_name',
       title: t`Role name`,
-      placeholder: t`Only used when a role doesn't have galaxy_info.role_name metadata, and doesn't follow the ansible-role-$name naming convention.`,
+      placeholder: t`Overrides any galaxy_info.role_name metadata`,
     },
   ];
 


### PR DESCRIPTION
Follows #4508 
Depends on ansible/galaxy_ng#2011
Forum: https://forum.ansible.com/t/new-ansible-galaxy-web-portal-where-is-all-the-old-role-admin-functionality/2304

![20231218075425](https://github.com/ansible/ansible-hub-ui/assets/289743/32ed9625-2c6a-4253-a084-5520dd955951)

Add alertnate namespace/role fields,
update placeholder to match,

(And fixup a bug from #4794 - npm install in the wrong place, to make the webpack config check pass)

TODO (later):
update github_user handling to use that new get_or_create logic
link from role import log to previous imports by role_id?