### PR TITLE
Fix insights dev mode

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -121,21 +121,17 @@ jobs:
       run: |
         mkdir ~/webpack-config/
 
+        # eliminate differences caused by branch name based logic in f-c-config
+        export BRANCH="${{ github.base_ref }}"
+
         for version in base pr; do
           mkdir ~/webpack-config/$version/
-          pushd $version/config/
+          cd $version/
           npm install
+          cd config/
 
-          for file in *.js; do
-            # FIXME: that's what TARGET_ENVIRONMENT is for
-            NODE_ENV=
-            if grep -q prod <<< "$file"; then
-              NODE_ENV=production
-            fi
-            export NODE_ENV
-
-            # eliminate differences caused by branch name based logic in f-c-config
-            export BRANCH="${{ github.base_ref }}"
+          for file in *.webpack.config.js; do
+            export NODE_ENV=`grep -q '\.prod\.' <<< "$file" && echo production || echo development`
 
             node -e 'console.log(JSON.stringify(require("./'"$file"'"), null, 2))' |
               sed -e 's/\/home\/.*\/\(base\|pr\)\//\/DIR\//g' \
@@ -146,7 +142,7 @@ jobs:
               grep -v '^Root folder:' > ~/webpack-config/"$version"/"$file".json
           done
 
-          popd
+          cd ../../
         done
 
         diff -Naur ~/webpack-config/{base,pr}

--- a/config/community.prod.webpack.config.js
+++ b/config/community.prod.webpack.config.js
@@ -1,4 +1,3 @@
-process.env.NODE_ENV = 'production';
 const webpackBase = require('./webpack.base.config');
 
 // Compile configuration for stnadalone mode

--- a/config/insights.prod.webpack.config.js
+++ b/config/insights.prod.webpack.config.js
@@ -1,4 +1,3 @@
-process.env.NODE_ENV = 'production';
 const webpackBase = require('./webpack.base.config');
 const cloudBeta = process.env.HUB_CLOUD_BETA; // "true" | "false" | undefined (=default)
 

--- a/config/standalone.prod.webpack.config.js
+++ b/config/standalone.prod.webpack.config.js
@@ -1,4 +1,3 @@
-process.env.NODE_ENV = 'production';
 const webpackBase = require('./webpack.base.config');
 
 // Compile configuration for stnadalone mode

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -1,13 +1,12 @@
-const { resolve } = require('path'); // node:path
+const { resolve } = require('node:path');
 const config = require('@redhat-cloud-services/frontend-components-config');
 const {
-  rbac,
-  defaultServices,
-} = require('@redhat-cloud-services/frontend-components-config-utilities/standalone');
+  default: { rbac, defaultServices },
+} = require('@redhat-cloud-services/frontend-components-config-utilities/standalone/services');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
-const { execSync } = require('child_process'); // node:child_process
+const { execSync } = require('node:child_process');
 
 const isBuild = process.env.NODE_ENV === 'production';
 const cloudBeta = process.env.HUB_CLOUD_BETA; // "true" | "false" | undefined (=default)
@@ -50,6 +49,23 @@ const defaultConfigs = [
   { name: 'WEBPACK_PUBLIC_PATH', default: undefined, scope: 'webpack' },
 ];
 
+const mockFedModules = {
+  automationHub: {
+    manifestLocation: '/apps/automation-hub/fed-mods.json',
+    modules: [
+      {
+        id: 'ansible-automation-hub',
+        module: './RootApp',
+        routes: [
+          {
+            pathname: '/ansible/automation-hub',
+          },
+        ],
+      },
+    ],
+  },
+};
+
 const insightsMockAPIs = ({ app }) => {
   // GET
   [
@@ -62,6 +78,14 @@ const insightsMockAPIs = ({ app }) => {
           visitedBundles: {},
         },
       },
+    },
+    {
+      url: '/api/chrome-service/v1/static/stable/stage/modules/fed-modules.json',
+      response: mockFedModules,
+    },
+    {
+      url: '/api/chrome-service/v1/static/beta/stage/modules/fed-modules.json',
+      response: mockFedModules,
     },
     { url: '/api/featureflags/v0', response: { toggles: [] } },
     { url: '/api/quickstarts/v1/progress', response: { data: [] } },
@@ -147,7 +171,7 @@ module.exports = (inputConfigs) => {
 
     // insights deployments from master
     ...(!isStandalone &&
-      cloudBeta && {
+      isBuild && {
         deployment: cloudBeta === 'true' ? 'beta/apps' : 'apps',
       }),
   });


### PR DESCRIPTION
`config/webpack.base.*` - import insights dev services from new location, mock more apis
`config/*.prod.*` - remove unneeded process.env setting, downstream doesn't have it either
`.github/*/pr-checks.yml` - set NODE_ENV to development or production, don't import base directly

this makes insights dev mode *load* again with the version of frontend-components-config we have
it still only loads an empty insights screen, but it's a step in the right direction (hopefully).

(if it redirects to a 404 page .. change the url from `/authrealm/...` to `/auth/realm/...`, log in as admin/admin, it redirects back; no idea how to fix the slash yet)