### PR TITLE
Collections: sort by name by default

### DIFF
--- a/CHANGES/850.misc
+++ b/CHANGES/850.misc
@@ -1,0 +1,1 @@
+Collections: sort by name by default

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -115,6 +115,10 @@ export class NamespaceDetail extends React.Component<RouteProps, IState> {
       params.repository_name = props.routeParams.repo;
     }
 
+    if (!params['sort']) {
+      params['sort'] = 'name';
+    }
+
     this.state = {
       alerts: [],
       canSign: false,

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -91,6 +91,10 @@ class Search extends React.Component<RouteProps, IState> {
       );
     }
 
+    if (!params['sort']) {
+      params['sort'] = 'name';
+    }
+
     this.state = {
       collections: [],
       params: params,


### PR DESCRIPTION
Issue: AAH-850

Collections: actually set default sort order to `name`, don't just pretend it's sorted :)