### PR TITLE
support preview and stable assets in frontend container build

### DIFF
--- a/CHANGES/3039.misc
+++ b/CHANGES/3039.misc
@@ -1,0 +1,1 @@
+support preview and stable assets in frontend container build

--- a/ci.sh
+++ b/ci.sh
@@ -5,7 +5,22 @@ npm ci
 
 npm run gettext:extract
 npm run gettext:compile
-npm run build-insights
+
+if [ "$IS_PR" == true ]; then
+    npm run build-insights
+else
+    export HUB_CLOUD_BETA=false
+    npm run build-insights
+    mv ${DIST_FOLDER} stable
+
+    export HUB_CLOUD_BETA=true
+    npm run build-insights
+    mv ${DIST_FOLDER} preview
+    
+    mkdir -p ${DIST_FOLDER}
+    mv stable ${DIST_FOLDER}/stable
+    mv preview ${DIST_FOLDER}/preview
+fi
 
 # do not use dev dockerfile
 rm "$APP_ROOT"/Dockerfile "$APP_ROOT"/.dockerignore || true

--- a/ci.sh
+++ b/ci.sh
@@ -6,7 +6,7 @@ npm ci
 npm run gettext:extract
 npm run gettext:compile
 
-if [ "$IS_PR" == true ]; then
+if [ "$IS_PR" = true ]; then
     npm run build-insights
 else
     export HUB_CLOUD_BETA=false


### PR DESCRIPTION
Per the Frontend Container Migration Onboarding documentation[1], the build needs to support both the stable and the preview assets in a single image.
Utilizing logic from the default build script[2], this PR updates our ci.sh script to move our build directory to the stable and preview directories as expected by the caddyfile[3]

Issue: AAH-3039

Links [Optional]
----------------

1. Documentation: https://consoledot.pages.redhat.com/docs/dev/containerized-frontends/migration/migration.html#_4_be_ready_for_stable_and_preview_builds
2. Build script: https://gitlab.cee.redhat.com/insights-platform/frontend-build-container/-/blob/main/universal_build.sh
3. Caddyfile: https://gitlab.cee.redhat.com/insights-platform/frontend-build-container/-/blob/main/server_config_gen.sh
