### PR TITLE
Community - add trustarc for cookies

### DIFF
--- a/CHANGES/2163.misc
+++ b/CHANGES/2163.misc
@@ -1,0 +1,1 @@
+community - add trustarc

--- a/community/Dockerfile
+++ b/community/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /workspace/
 RUN mkdir -p /workspace/ && \
     apk add --no-cache git
 COPY . /workspace/
+COPY community/index.html /workspace/src/index.html
 RUN npm ci && \
     npm run gettext:extract && \
     npm run gettext:compile && \

--- a/community/index.html
+++ b/community/index.html
@@ -7,9 +7,9 @@
     <script
       id="trustarc"
       type="text/javascript"
-      src="//static.dev.redhat.com/libs/redhat/marketing/latest/trustarc/trustarc.js"
+      src="//static.redhat.com/libs/redhat/marketing/latest/trustarc/trustarc.js"
       defer
-      data-domain="redhat2_test.com"
+      data-domain="redhat2.com"
       data-debug=""
     ></script>
   </head>

--- a/community/index.html
+++ b/community/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en-US">
+  <head>
+    <meta charset="UTF-8" />
+    <title><%= htmlWebpackPlugin.options.applicationName %></title>
+
+    <script
+      id="trustarc"
+      type="text/javascript"
+      src="//static.dev.redhat.com/libs/redhat/marketing/latest/trustarc/trustarc.js"
+      defer
+      data-domain="redhat2_test.com"
+      data-debug=""
+    ></script>
+  </head>
+  <body>
+    <div id="root"></div>
+
+    <footer style="display: none">
+      <span id="teconsent">
+        <!-- trustarc -->
+      </span>
+    </footer>
+  </body>
+</html>

--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -194,6 +194,11 @@ export class LandingPage extends Component<RouteProps, IState> {
                   <ListItem>
                     <ExternalLink href='https://www.redhat.com/en/about/digital-accessibility'>{t`Digital accessibility`}</ExternalLink>
                   </ListItem>
+                  <ListItem>
+                    <a
+                      onClick={this.cookiePreferences}
+                    >{t`Cookie preferences`}</a>
+                  </ListItem>
                 </List>
               }
             />
@@ -207,6 +212,14 @@ export class LandingPage extends Component<RouteProps, IState> {
     this.setState({
       alerts: [...this.state.alerts, alert],
     });
+  }
+
+  private cookiePreferences() {
+    (
+      window.document.querySelector(
+        '#teconsent > a',
+      ) as HTMLAnchorElement | null
+    )?.click();
   }
 }
 


### PR DESCRIPTION
Issue: AAH-2163, AAH-2611, AAP-10043

This *should* add a trustarc script, cookie preferences, and cookie banner; in community mode container only.

![20240315002019](https://github.com/ansible/ansible-hub-ui/assets/289743/8d84fbb2-a160-4aee-876a-0b8981feaa7f)
![20240315002049](https://github.com/ansible/ansible-hub-ui/assets/289743/0a8671d9-7d9a-4b9b-9d25-9be4c97743b9)
![20240315002059](https://github.com/ansible/ansible-hub-ui/assets/289743/7805070f-1724-4bef-aaac-f84f5f76e63b)


~~todo: prod witout .dev and -test~~

EDIT: updated to prod version