### PR TITLE
Namespace form: add warning that Logo URL must point to a jpeg/png

### DIFF
--- a/src/components/namespace-form/namespace-form.tsx
+++ b/src/components/namespace-form/namespace-form.tsx
@@ -1,5 +1,12 @@
 import { t } from '@lingui/macro';
-import { Form, FormGroup, TextArea, TextInput } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  HelperText,
+  HelperTextItem,
+  TextArea,
+  TextInput,
+} from '@patternfly/react-core';
 import PlusCircleIcon from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import TrashIcon from '@patternfly/react-icons/dist/esm/icons/trash-icon';
 import React, { Component } from 'react';
@@ -75,6 +82,11 @@ export class NamespaceForm extends Component<IProps> {
             value={namespace.avatar_url}
             onChange={(value, event) => this.updateField(value, event)}
           />
+          <HelperText>
+            <HelperTextItem variant='warning'>
+              {t`Please use jpg or png; svg images are NOT supported.`}
+            </HelperTextItem>
+          </HelperText>
         </FormGroup>
 
         <FormGroup


### PR DESCRIPTION
When SVGs are used, the backends uploads the svg to S3, which treats it as application/octet-stream, which, coming from a different domain, the browser rejects as an invalid request for an `<img>` tag. These would still work when not using S3 (or when telling s3 about the right type on upload), but the users can try at their own risk - adding the warning here.

![20240229220027](https://github.com/ansible/ansible-hub-ui/assets/289743/061e201a-007c-4419-bebd-81f7e2a92d2f)

