### PR TITLE
Update tooling for 4.7 eol

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,40 +58,6 @@ updates:
 
   - package-ecosystem: 'npm'
     directory: '/'
-    target-branch: 'stable-4.7'
-    schedule:
-      interval: 'monthly'
-    commit-message:
-      prefix: '[stable-4.7] '
-    groups:
-      babel:
-        patterns:
-          - "@babel/*"
-          - "babel-core"
-          - "babel-loader"
-      lingui:
-        patterns:
-          - "@lingui/*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-    ignore:
-      - dependency-name: '@lingui/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@patternfly/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-dom'
-        update-types: ['version-update:semver-major']
-
-  - package-ecosystem: 'npm'
-    directory: '/'
     target-branch: 'stable-4.6'
     schedule:
       interval: 'monthly'
@@ -141,14 +107,6 @@ updates:
 
   - package-ecosystem: 'npm'
     directory: '/test'
-    target-branch: 'stable-4.7'
-    schedule:
-      interval: 'monthly'
-    commit-message:
-      prefix: '[stable-4.7] '
-
-  - package-ecosystem: 'npm'
-    directory: '/test'
     target-branch: 'stable-4.6'
     schedule:
       interval: 'monthly'
@@ -169,14 +127,6 @@ updates:
       prefix: '[stable-4.9] '
     schedule:
       interval: "monthly"
-
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    target-branch: 'stable-4.7'
-    commit-message:
-      prefix: '[stable-4.7] '
-    schedule:
-      interval: 'monthly'
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,9 +7,3 @@ backport-4.9:
   - any-glob-to-any-file:
     - src/**/*
     - test/**/*
-
-backport-4.7:
-- changed-files:
-  - any-glob-to-any-file:
-    - src/**/*
-    - test/**/*

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -16,7 +16,6 @@ jobs:
         branch:
         - 'master'
         - 'stable-4.6'
-        - 'stable-4.7'
         - 'stable-4.9'
 
     steps:

--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ List by branches:
 Our branches, backport labels, releases and tags use AAH versions, but Jira uses AAP versions.
 To map between the two:
 
-|AAP version|AAH version|notes|
-|-|-|-|
-|2.3|4.6||
-|2.4|4.7 and 4.9|
+|AAP version|AAH version|
+|-|-|
+|2.3|4.6|
+|2.4|4.9|
 
 [Table with component versions](https://github.com/ansible/galaxy_ng/wiki/Galaxy-NG-Version-Matrix)
 


### PR DESCRIPTION
Same as #4684 , but 4.7
4.9 is *the* 2.4 hub now, there's no need to keep 4.7 alive.

Dropping dependabot config for 4.7,
weekly string extraction,
and updating README.

(also (TODOcommit))