### PR TITLE
Fix tests for downstream usage

### DIFF
--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -104,7 +104,7 @@ Cypress.Commands.add('galaxykit', {}, (operation, ...args) => {
   return cy.exec(cmd, options).then(({ code, stderr, stdout }) => {
     console.log(`RUN ${cmd}`, options, { code, stderr, stdout });
 
-    if (code || stderr) {
+    if (code) {
       cy.log('galaxykit code: ' + code);
       cy.log('galaxykit stderr: ' + stderr);
       return Promise.reject(new Error(`Galaxykit failed: ${stderr}`));

--- a/test/cypress/support/login.js
+++ b/test/cypress/support/login.js
@@ -14,7 +14,10 @@ function apiLogin(username, password, url = '/', title = 'Collections') {
             method: 'POST',
             url: loginUrl,
             body: { username, password },
-            headers: { 'X-CSRFToken': csrftoken.value },
+            headers: {
+              'X-CSRFToken': csrftoken.value,
+              Referer: Cypress.config().baseUrl,
+            },
           });
         });
       });


### PR DESCRIPTION
Added a few minor fixes so we can run UI tests for AAP: 
- Added referer heder to avoid problem with `CSRF Failed: Referer checking failed - no Referer`
- Fixed condition for galaxykit execution against HTTPS baseUrl. In that case galaxykit returns 0 code but prints some warnings to the stderr. 