### PR TITLE
fixup insights build

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -145,7 +145,7 @@ jobs:
               perl -ne 'print unless /^[0-9a-f]{64,64}$/d' |
               grep -v '^Current branch:' |
               grep -v '^Waiting for ' |
-              grep -v '^Root folder:' > ~/webpack-config/"$version"/"$file".json
+              grep -v 'Root folder:' > ~/webpack-config/"$version"/"$file".json
           done
 
           popd

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -202,6 +202,10 @@ module.exports = (inputConfigs) => {
 
   if (customConfigs.IS_INSIGHTS) {
     // insights federated modules
+    const packageLock = require(resolve(__dirname, '../package-lock.json'));
+    const routerVersion =
+      packageLock.packages['node_modules/react-router-dom'].version;
+
     plugins.push(
       require('@redhat-cloud-services/frontend-components-config-utilities/federated-modules')(
         {
@@ -209,6 +213,11 @@ module.exports = (inputConfigs) => {
           exposes: {
             './RootApp': resolve(__dirname, '../src/entry-insights.tsx'),
           },
+          shared: [
+            {
+              'react-router-dom': { singleton: true, version: routerVersion },
+            },
+          ],
         },
       ),
     );

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -202,10 +202,6 @@ module.exports = (inputConfigs) => {
 
   if (customConfigs.IS_INSIGHTS) {
     // insights federated modules
-    const packageLock = require(resolve(__dirname, '../package-lock.json'));
-    const routerVersion =
-      packageLock.packages['node_modules/react-router-dom'].version;
-
     plugins.push(
       require('@redhat-cloud-services/frontend-components-config-utilities/federated-modules')(
         {
@@ -215,7 +211,7 @@ module.exports = (inputConfigs) => {
           },
           shared: [
             {
-              'react-router-dom': { singleton: true, version: routerVersion },
+              'react-router-dom': { singleton: true, version: '*' },
             },
           ],
         },


### PR DESCRIPTION
Follows #4866

looks like removing the singleton setting for react-router-dom was premature (sentry error on console stage), putting back, with the field name updated (`requiredVersion` -> `version`)
