### PR TITLE
[2024-06-01] Update tooling for 4.6 EOL

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,40 +53,6 @@ updates:
       - dependency-name: 'react-dom'
         update-types: ['version-update:semver-major']
 
-  - package-ecosystem: 'npm'
-    directory: '/'
-    target-branch: 'stable-4.6'
-    schedule:
-      interval: 'monthly'
-    commit-message:
-      prefix: '[stable-4.6] '
-    groups:
-      babel:
-        patterns:
-          - "@babel/*"
-          - "babel-core"
-          - "babel-loader"
-      lingui:
-        patterns:
-          - "@lingui/*"
-      react:
-        patterns:
-          - "react"
-          - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
-    ignore:
-      - dependency-name: '@lingui/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@patternfly/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'react-dom'
-        update-types: ['version-update:semver-major']
-
   # npm in test/
 
   - package-ecosystem: 'npm'
@@ -102,14 +68,6 @@ updates:
     commit-message:
       prefix: '[stable-4.9] '
 
-  - package-ecosystem: 'npm'
-    directory: '/test'
-    target-branch: 'stable-4.6'
-    schedule:
-      interval: 'monthly'
-    commit-message:
-      prefix: '[stable-4.6] '
-
   # github-actions
 
   - package-ecosystem: 'github-actions'
@@ -124,11 +82,3 @@ updates:
       prefix: '[stable-4.9] '
     schedule:
       interval: "monthly"
-
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    target-branch: 'stable-4.6'
-    commit-message:
-      prefix: '[stable-4.6] '
-    schedule:
-      interval: 'monthly'

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -15,7 +15,6 @@ jobs:
       matrix:
         branch:
         - 'master'
-        - 'stable-4.6'
         - 'stable-4.9'
 
     steps:

--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ To map between the two:
 
 |AAP version|AAH version|
 |-|-|
-|2.3|4.6|
 |2.4|4.9|
 
 [Table with component versions](https://github.com/ansible/galaxy_ng/wiki/Galaxy-NG-Version-Matrix)

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -24,7 +24,6 @@ export { LegacyImportAPI } from './legacy-import';
 export { LegacyNamespaceAPI } from './legacy-namespace';
 export { LegacyRoleAPI } from './legacy-role';
 export { LegacySyncAPI } from './legacy-sync';
-export { MyDistributionAPI } from './my-distribution';
 export { MyNamespaceAPI } from './my-namespace';
 export { MySyncListAPI } from './my-synclist';
 export { NamespaceAPI } from './namespace';

--- a/src/api/my-distribution.ts
+++ b/src/api/my-distribution.ts
@@ -1,7 +1,0 @@
-import { HubAPI } from './hub';
-
-class API extends HubAPI {
-  apiPath = '_ui/v1/my-distributions/';
-}
-
-export const MyDistributionAPI = new API();


### PR DESCRIPTION
Same as #4893, but 4.6.

Dropping dependabot config for 4.6,
weekly string extraction,
and updating README.

Also remove 2.3 synclist info from insights.

(TODO also branch commit - https://github.com/himdel/ansible-hub-ui/commit/a69e35878099c7d1c22c002b1a313669cd26f5c7)