### PR TITLE
pf5 - update deprecated imports

### DIFF
--- a/src/actions/action.tsx
+++ b/src/actions/action.tsx
@@ -1,6 +1,6 @@
 import { type MessageDescriptor, i18n } from '@lingui/core';
 import { Button } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import React, { type ReactNode } from 'react';
 import { Tooltip } from 'src/components';
 import { type PermissionContextType } from 'src/permissions';

--- a/src/components/access-tab.tsx
+++ b/src/components/access-tab.tsx
@@ -5,7 +5,7 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
 import { sortBy } from 'lodash';
 import React, { Component } from 'react';

--- a/src/components/ansible-repository-form.tsx
+++ b/src/components/ansible-repository-form.tsx
@@ -7,7 +7,7 @@ import {
   FormGroup,
   TextInput,
 } from '@patternfly/react-core';
-import { Select, SelectOption } from '@patternfly/react-core/deprecated';
+import { Select, SelectOption } from '@patternfly/react-core';
 import React, { useEffect, useState } from 'react';
 import { AnsibleRemoteAPI, type AnsibleRepositoryType } from 'src/api';
 import {

--- a/src/components/approval-row.tsx
+++ b/src/components/approval-row.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { Button, ButtonVariant, Label } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import CheckCircleIcon from '@patternfly/react-icons/dist/esm/icons/check-circle-icon';
 import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';

--- a/src/components/collection-dropdown.tsx
+++ b/src/components/collection-dropdown.tsx
@@ -1,5 +1,5 @@
 import { t } from '@lingui/macro';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import React from 'react';
 import { StatefulDropdown } from 'src/components';
 import { useHubContext } from 'src/loaders/app-context';

--- a/src/components/collection-header.tsx
+++ b/src/components/collection-header.tsx
@@ -8,11 +8,7 @@ import {
   Modal,
   Text,
 } from '@patternfly/react-core';
-import {
-  Select,
-  SelectOption,
-  SelectVariant,
-} from '@patternfly/react-core/deprecated';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import React, { Component, Fragment } from 'react';
 import { Navigate } from 'react-router-dom';
 import {

--- a/src/components/compound-filter.tsx
+++ b/src/components/compound-filter.tsx
@@ -12,7 +12,7 @@ import {
   SelectGroup,
   SelectOption,
   SelectVariant,
-} from '@patternfly/react-core/deprecated';
+} from '@patternfly/react-core';
 import FilterIcon from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import SearchIcon from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import React, { Component } from 'react';

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -1,8 +1,5 @@
 import { Trans, t } from '@lingui/macro';
-import {
-  DropdownItem,
-  DropdownSeparator,
-} from '@patternfly/react-core/deprecated';
+import { DropdownItem, DropdownSeparator } from '@patternfly/react-core';
 import React from 'react';
 import { StatefulDropdown } from 'src/components';
 import { availableLanguages, language, languageNames } from 'src/l10n';

--- a/src/components/multiple-repo-selector.tsx
+++ b/src/components/multiple-repo-selector.tsx
@@ -12,7 +12,7 @@ import {
   DropdownItem,
   DropdownToggle,
   DropdownToggleCheckbox,
-} from '@patternfly/react-core/deprecated';
+} from '@patternfly/react-core';
 import { Table, Td } from '@patternfly/react-table';
 import React, { useEffect, useState } from 'react';
 import { AnsibleRepositoryAPI, type AnsibleRepositoryType } from 'src/api';

--- a/src/components/permission-chip-selector.tsx
+++ b/src/components/permission-chip-selector.tsx
@@ -1,10 +1,6 @@
 import { t } from '@lingui/macro';
 import { Label } from '@patternfly/react-core';
-import {
-  Select,
-  SelectOption,
-  SelectVariant,
-} from '@patternfly/react-core/deprecated';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import React, { Component } from 'react';
 import { LabelGroup } from 'src/components';
 import { AppContext, type IAppContextType } from 'src/loaders/app-context';

--- a/src/components/role-namespace-item.tsx
+++ b/src/components/role-namespace-item.tsx
@@ -5,7 +5,7 @@ import {
   DataListItemCells,
   DataListItemRow,
 } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import React from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { type LegacyNamespaceDetailType } from 'src/api';

--- a/src/components/sort.tsx
+++ b/src/components/sort.tsx
@@ -1,9 +1,5 @@
 import { t } from '@lingui/macro';
-import {
-  Select,
-  SelectOption,
-  SelectVariant,
-} from '@patternfly/react-core/deprecated';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import SortAlphaDownIcon from '@patternfly/react-icons/dist/esm/icons/sort-alpha-down-icon';
 import SortAlphaUpIcon from '@patternfly/react-icons/dist/esm/icons/sort-alpha-up-icon';
 import SortAmountDownIcon from '@patternfly/react-icons/dist/esm/icons/sort-amount-down-icon';

--- a/src/components/stateful-dropdown.tsx
+++ b/src/components/stateful-dropdown.tsx
@@ -4,7 +4,7 @@ import {
   DropdownPosition,
   DropdownToggle,
   KebabToggle,
-} from '@patternfly/react-core/deprecated';
+} from '@patternfly/react-core';
 import React, { type ReactNode, useState } from 'react';
 
 interface IProps {

--- a/src/components/typeahead.tsx
+++ b/src/components/typeahead.tsx
@@ -1,9 +1,5 @@
 import { t } from '@lingui/macro';
-import {
-  Select,
-  SelectOption,
-  SelectVariant,
-} from '@patternfly/react-core/deprecated';
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import React, { type CSSProperties, Component, type ReactElement } from 'react';
 
 interface IProps {

--- a/src/containers/ansible-role/namespace-detail.tsx
+++ b/src/containers/ansible-role/namespace-detail.tsx
@@ -1,6 +1,6 @@
 import { t } from '@lingui/macro';
 import { DataList } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import {

--- a/src/containers/execution-environment-detail/base.tsx
+++ b/src/containers/execution-environment-detail/base.tsx
@@ -1,6 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import { Button } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import React, { Component } from 'react';
 import { Navigate } from 'react-router-dom';
 import {

--- a/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
+++ b/src/containers/execution-environment-detail/execution_environment_detail_images.tsx
@@ -8,7 +8,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import AngleDownIcon from '@patternfly/react-icons/dist/esm/icons/angle-down-icon';
 import AngleRightIcon from '@patternfly/react-icons/dist/esm/icons/angle-right-icon';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';

--- a/src/containers/execution-environment-list/execution_environment_list.tsx
+++ b/src/containers/execution-environment-list/execution_environment_list.tsx
@@ -7,7 +7,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -6,7 +6,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
 import React, { Component } from 'react';
 import { ExecutionEnvironmentRegistryAPI, type RemoteType } from 'src/api';

--- a/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
+++ b/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
@@ -6,7 +6,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import { Td } from '@patternfly/react-table';
 import React, { type FunctionComponent, useEffect, useState } from 'react';
 import {

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -7,7 +7,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
 import React, { Component } from 'react';
 import { Link, Navigate } from 'react-router-dom';

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -6,7 +6,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
 import React, { Component } from 'react';
 import { Link, Navigate } from 'react-router-dom';

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -1,6 +1,6 @@
 import { Trans, t } from '@lingui/macro';
 import { Button, Checkbox, Text } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import ArrowRightIcon from '@patternfly/react-icons/dist/esm/icons/arrow-right-icon';
 import React, { Component } from 'react';
 import ReactMarkdown from 'react-markdown';

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -6,7 +6,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import { Td } from '@patternfly/react-table';
 import React, { Component } from 'react';
 import { Link, Navigate } from 'react-router-dom';

--- a/src/containers/signature-keys/list.tsx
+++ b/src/containers/signature-keys/list.tsx
@@ -5,7 +5,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
 import React, { Component } from 'react';
 import { SigningServiceAPI, type SigningServiceType } from 'src/api';

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -7,7 +7,7 @@ import {
   ToolbarGroup,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { DropdownItem } from '@patternfly/react-core/deprecated';
+import { DropdownItem } from '@patternfly/react-core';
 import UserPlusIcon from '@patternfly/react-icons/dist/esm/icons/user-plus-icon';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
 import React, { Component } from 'react';

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -11,10 +11,7 @@ import {
   PageSidebarBody,
   PageToggleButton,
 } from '@patternfly/react-core';
-import {
-  DropdownItem,
-  DropdownSeparator,
-} from '@patternfly/react-core/deprecated';
+import { DropdownItem, DropdownSeparator } from '@patternfly/react-core';
 import BarsIcon from '@patternfly/react-icons/dist/esm/icons/bars-icon';
 import QuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/question-circle-icon';
 import React, { type ReactNode, useState } from 'react';


### PR DESCRIPTION
Follows #4866 

replace `@patternfly/react-core/deprecated` imports:


* [Dropdown](https://www.patternfly.org/components/menus/dropdown)
  * `Dropdown`
  * `DropdownItem`
  * `DropdownPosition`
  * `DropdownSeparator`
  * `DropdownToggle`
  * `DropdownToggleCheckbox`
  * `KebabToggle`

* [Select](https://www.patternfly.org/components/menus/select) => https://github.com/ansible/ansible-hub-ui/pull/4948
  * `Select`
  * `SelectGroup`
  * `SelectOption`
  * `SelectVariant`

* [Wizard](https://www.patternfly.org/components/wizard) => #4947 (merged)
  * `Wizard`
  * `WizardStep`

---

```
TODO Also deal with l10n for any new components.

// @patternfly/react-core/deprecated

Select
  clearSelectionsAriaLabel={t`Clear all`}
  createText={t`Create`}
  favoritesLabel={t`Favorites`}
  noResultsFoundText={t`No results found`}
  removeSelectionAriaLabel={t`Remove`}
  toggleAriaLabel={t`Options menu`}
```

```
(later TODOs?)
test dark mode, https://www.patternfly.org/design-foundations/colors
revisit the whole form/formhelpertext/helpertext thing into a HubFormGroup? or direct to DataForm?
use patternfly component groups instead of custom impls
consistently use PageSection
```