### PR TITLE
README.md: update for current dev setups

### DIFF
--- a/config/insights.dev.webpack.config.js
+++ b/config/insights.dev.webpack.config.js
@@ -1,12 +1,12 @@
 const webpackBase = require('./webpack.base.config');
 
 const proxyHost = process.env.API_PROXY_HOST || 'localhost';
-const proxyPort = process.env.API_PROXY_PORT || '5001';
+const proxyPort = process.env.API_PROXY_PORT || '55001';
 
 const cloudBeta = process.env.HUB_CLOUD_BETA; // "true" | "false" | undefined (=default)
 
 module.exports = webpackBase({
-  // The host where the API lives. EX: https://localhost:5001
+  // The host where the API lives. EX: https://localhost:55001
   API_HOST: '',
 
   // Path to the API on the API host. EX: /api/automation-hub

--- a/config/standalone.dev.webpack.config.js
+++ b/config/standalone.dev.webpack.config.js
@@ -5,12 +5,12 @@ const roleRatings = require('../static/scores/role.json');
 
 // Used for getting the correct host when running in a container
 const proxyHost = process.env.API_PROXY_HOST || 'localhost';
-const proxyPort = process.env.API_PROXY_PORT || '5001';
-const apiBasePath = process.env.API_BASE_PATH || '/api/automation-hub/';
+const proxyPort = process.env.API_PROXY_PORT || '55001';
+const apiBasePath = process.env.API_BASE_PATH || '/api/galaxy/';
 const uiExternalLoginURI = process.env.UI_EXTERNAL_LOGIN_URI || '/login';
 
 module.exports = webpackBase({
-  // The host where the API lives. EX: https://localhost:5001
+  // The host where the API lives. EX: https://localhost:55001
   API_HOST: '',
 
   // Path to the API on the API host. EX: /api/automation-hub

--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -175,7 +175,6 @@ module.exports = (inputConfigs) => {
     ).map(([k, v]) => ({
       context: [k],
       target: v,
-      changeOrigin: true,
     }));
   }
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "sort-exports": "perl -i -pe 's/^export/import/' src/**/index.ts ; npm run prettier ; perl -i -pe 's/^import/export/' src/**/index.ts",
     "start-community": "NODE_ENV=development webpack serve --host 0.0.0.0 --config config/community.dev.webpack.config.js",
     "start-insights": "NODE_ENV=development webpack serve --host 0.0.0.0 --config config/insights.dev.webpack.config.js",
-    "start-pulp": "NODE_ENV=development API_PROXY_PORT=8080 API_BASE_PATH='/api/galaxy/' webpack serve --host 0.0.0.0 --config config/standalone.dev.webpack.config.js",
+    "start-pulp": "NODE_ENV=development API_PROXY_PORT=8080 webpack serve --host 0.0.0.0 --config config/standalone.dev.webpack.config.js",
     "start-standalone": "NODE_ENV=development webpack serve --host 0.0.0.0 --config config/standalone.dev.webpack.config.js"
   },
   "insights": {

--- a/test/cypress.env.json.template
+++ b/test/cypress.env.json.template
@@ -1,10 +1,10 @@
 // Standalone
 {
-  "apiPrefix": "/api/automation-hub/",
+  "apiPrefix": "/api/galaxy/",
   "uiPrefix": "/ui/",
   "username": "admin",
   "password": "admin",
-  "containers": "localhost:5001",
+  "containers": "localhost:55001",
   "galaxykit": "galaxykit --ignore-certs"
 }
 


### PR DESCRIPTION
Switch from documenting docker compose & manual oci-env environments to using galaxy\_ng's `make oci/standalone` and similar.

This means `start-standalone` changes from `/api/automation-hub/` to `/api/galaxy/` and port 5001 -> 55001.