### PR TITLE
Update access.redhat.com links to docs.redhat.com

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -22,7 +22,7 @@ const gitCommit =
   execSync('git rev-parse HEAD', { encoding: 'utf-8' }).trim();
 
 const docsURL =
-  'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/';
+  'https://docs.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/';
 
 // Default user defined settings
 const defaultConfigs = [

--- a/test/cypress/e2e/namespaces/menu.js
+++ b/test/cypress/e2e/namespaces/menu.js
@@ -65,7 +65,7 @@ describe('Hub Menu Tests', () => {
       cy.menuPresent('Documentation').should(
         'have.attr',
         'href',
-        'https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
+        'https://docs.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
       );
     });
   });


### PR DESCRIPTION
looks like docs are moving to the new domain, support cases and security keys are not