### PR TITLE
fix galaxykit: command not found on CI

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -36,6 +36,12 @@ jobs:
 
     steps:
 
+    # galaxykit needs pip 23+, Ubuntu 22.04's default Python uses pip 22
+    - name: "Install python 3.11"
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
     - name: "Install galaxykit dependency"
       run: |
         # pip install git+https://github.com/ansible/galaxykit.git@branch_name


### PR DESCRIPTION
Problem:

```
$ pip install git+https://github.com/ansible/galaxykit.git
Defaulting to user installation because normal site-packages is not writeable
Collecting git+https://github.com/ansible/galaxykit.git
  Cloning https://github.com/ansible/galaxykit.git to /tmp/pip-req-build-o_4bpppk
  Running command git clone --filter=blob:none --quiet https://github.com/ansible/galaxykit.git /tmp/pip-req-build-o_4bpppk
  Resolved https://github.com/ansible/galaxykit.git to commit 9ecb2cd8203b88ad08aa4f[7](https://github.com/ansible/ansible-hub-ui/actions/runs/8903369393/job/24450997489?pr=5003#step:2:8)bbf3a9a70fc4a2046
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Building wheels for collected packages: UNKNOWN
  Building wheel for UNKNOWN (pyproject.toml): started
  Building wheel for UNKNOWN (pyproject.toml): finished with status 'done'
  Created wheel for UNKNOWN: filename=UNKNOWN-0.0.0-py3-none-any.whl size=1597 sha256=ba930e9b2d061[8](https://github.com/ansible/ansible-hub-ui/actions/runs/8903369393/job/24450997489?pr=5003#step:2:9)d7802427669b6a52[9](https://github.com/ansible/ansible-hub-ui/actions/runs/8903369393/job/24450997489?pr=5003#step:2:10)6e9e06c92cc382b29a311afd4c24f0f6b
  Stored in directory: /tmp/pip-ephem-wheel-cache-8f432z66/wheels/d3/56/16/7c88c31fb035860164d9aae593faa487f6ecbccc9324005f6b
Successfully built UNKNOWN
Installing collected packages: UNKNOWN
Successfully installed UNKNOWN-0.0.0

$ galaxykit
galaxykit: command not found
```

^ this fails on github actions ( https://github.com/ansible/ansible-hub-ui/actions/runs/8903369393/job/24450997489?pr=5003 ), but works locally for me, both with Python 3.11 and Python 3.10.

Likely related to https://github.com/ansible/galaxykit/pull/104

---

Solution:

trying to see if explicitly installing python 3.11 helps

... it does `Successfully installed attrs-23.2.0 certifi-2024.2.2 charset-normalizer-3.3.2 galaxykit-0.14.0 idna-3.7 orionutils-0.1.7 pyyaml-6.0.1 requests-2.31.0 simplejson-3.19.2 urllib3-2.2.1` .. not sure why yet

...Ah...

pre-installed 3.10 uses pip 22 - and breaks
explicitly installed 3.10  uses pip 23 - and works
3.11 uses pip 24 - and works

TODO(me): once this works, backport to 4.9 (or install a specific version from pypi), and update ansible-ui to use the same version (https://github.com/ansible/ansible-ui/pull/1536 set this to my branch, but https://github.com/ansible/galaxykit/pull/99 is merged now)