### PR TITLE
[stable-4.9] fix galaxykit: command not found on CI

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -40,7 +40,8 @@ jobs:
     - name: "Install galaxykit dependency"
       run: |
         # pip install git+https://github.com/ansible/galaxykit.git@branch_name
-        pip install git+https://github.com/ansible/galaxykit.git
+        #pip install git+https://github.com/ansible/galaxykit.git
+        pip install galaxykit==0.14.0
 
     - name: "Set env.SHORT_BRANCH"
       run: |


### PR DESCRIPTION
to fix galaxykit: command not found when installing from source with pip<23

this is solving the same issue as #5014,
but trying to do that by installing a released galaxykit from pypi, instead of installing from source

(unless it's too old, then just backport)

---

Aah, no, repo mgmt is not part of galaxykit 0.14