### PR TITLE
automerge workflow - split and fix

### DIFF
--- a/.github/workflows/automerge-condition.js
+++ b/.github/workflows/automerge-condition.js
@@ -1,0 +1,28 @@
+// get these values from env instead of cli args due to RCE issues
+const actor = process.env.GITHUB_ACTOR;
+const branch = process.env.GITHUB_HEAD_REF;
+const prTitle = process.env.PR_TITLE;
+
+console.log({ actor, branch, prTitle });
+
+if (actor != 'dependabot[bot]') {
+  console.log('Actor incorrect (GITHUB_ACTOR)');
+  process.exit(1);
+}
+
+if (!branch) {
+  console.log('Branch name not set (GITHUB_HEAD_REF)');
+  process.exit(1);
+}
+
+if (!prTitle) {
+  console.log('PR title not set (PR_TITLE)');
+  process.exit(1);
+}
+
+if (prTitle.includes('@types/node') && !prTitle.match(/from (\d+)\.\d+\.\d+ to \1\.\d+\.\d+/)) {
+  console.log('Not automerging major @types/node version bump');
+  process.exit(1);
+}
+
+process.exit(0);

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -18,17 +18,22 @@ jobs:
       with:
         node-version: '18'
 
-    - name: "Run automerge.js"
+    - name: "Check automerge conditions"
+      working-directory: ".github/workflows"
+      env:
+        PR_TITLE: "${{ github.event.pull_request.title }}"
+      run: |
+        node automerge-condition.js
+
+    - name: "Wait for other tests"
       working-directory: ".github/workflows"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PR_TITLE: "${{ github.event.pull_request.title }}"
       run: |
-        node automerge.js
+        node automerge-wait.js
 
     - name: "Automerge the PR"
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        echo "Automerge of PR"
         gh pr merge "${{ github.event.pull_request.number }}" -s --auto


### PR DESCRIPTION
* fix HEAD_REF -> GITHUB_HEAD_REF
  * fails otherwise: https://github.com/ansible/ansible-hub-ui/actions/runs/9008091110/job/24749359855?pr=5026

* split into 2 scripts - check conditions & wait
  * pr title is checked in condition checks only
  * branch & token is only used in wait checks

* stop ignoring patternfly bumps - we have screenshot tests now (not backporting to 4.6)