### PR TITLE
Show gateway landing page banner linking the other UI

### DIFF
--- a/src/containers/search/search.scss
+++ b/src/containers/search/search.scss
@@ -1,4 +1,4 @@
-.search-page {
+.hub-search-page {
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -1,5 +1,13 @@
-import { t } from '@lingui/macro';
-import { Button, DataList, Switch } from '@patternfly/react-core';
+import { Trans, t } from '@lingui/macro';
+import {
+  Banner,
+  Button,
+  DataList,
+  Flex,
+  FlexItem,
+  Switch,
+} from '@patternfly/react-core';
+import InfoCircleIcon from '@patternfly/react-icons/dist/esm/icons/info-circle-icon';
 import React, { Component, type ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
 import {
@@ -21,6 +29,7 @@ import {
   DeleteCollectionModal,
   EmptyStateFilter,
   EmptyStateNoData,
+  ExternalLink,
   HubListToolbar,
   HubPagination,
   ImportModal,
@@ -168,98 +177,117 @@ class Search extends Component<RouteProps, IState> {
     const ignoredParams = ['page', 'page_size', 'sort', 'view_type'];
 
     return (
-      <div className='search-page'>
-        <AlertList
-          alerts={alerts}
-          closeAlert={(i) =>
-            closeAlert(i, {
-              alerts,
-              setAlerts: (alerts) => this.setState({ alerts }),
-            })
-          }
-        />
-        <DeleteCollectionModal
-          deleteCollection={deleteCollection}
-          collections={collections}
-          isDeletionPending={isDeletionPending}
-          confirmDelete={confirmDelete}
-          setConfirmDelete={(confirmDelete) => this.setState({ confirmDelete })}
-          cancelAction={() => this.setState({ deleteCollection: null })}
-          deleteAction={() =>
-            this.setState({ isDeletionPending: true }, () =>
-              DeleteCollectionUtils.deleteCollection({
-                collection: deleteCollection,
-                setState: (state) => this.setState(state),
-                load: () => this.load(),
-                redirect: false,
-                addAlert: (alert) => this.addAlert(alert),
-                deleteFromRepo,
-              }),
-            )
-          }
-          deleteFromRepo={deleteFromRepo}
-        />
-
-        {showImportModal && (
-          <ImportModal
-            isOpen={showImportModal}
-            onUploadSuccess={() =>
-              this.setState({
-                redirect: formatPath(
-                  Paths.myImports,
-                  {},
-                  {
-                    namespace: updateCollection.collection_version.namespace,
-                  },
-                ),
+      <>
+        {IS_GATEWAY ? (
+          <Banner variant='blue'>
+            <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+              <FlexItem>
+                <InfoCircleIcon />
+              </FlexItem>
+              <FlexItem>
+                <Trans>
+                  A tech preview of the new Automation Hub user interface can be
+                  found <ExternalLink href='/'>here</ExternalLink>.
+                </Trans>
+              </FlexItem>
+            </Flex>
+          </Banner>
+        ) : null}
+        <div className='hub-search-page'>
+          <AlertList
+            alerts={alerts}
+            closeAlert={(i) =>
+              closeAlert(i, {
+                alerts,
+                setAlerts: (alerts) => this.setState({ alerts }),
               })
             }
-            // onCancel
-            setOpen={(isOpen, warn) => this.toggleImportModal(isOpen, warn)}
-            collection={updateCollection.collection_version}
-            namespace={updateCollection.collection_version.namespace}
           />
-        )}
-        <BaseHeader className='hub-header-bordered' title={t`Collections`} />
-        {!noData && (
-          <HubListToolbar
-            count={count}
-            ignoredParams={ignoredParams}
-            params={params}
-            switcher='search_view_type'
-            updateParams={updateParams}
-            {...collectionFilter({
-              featureFlags: (this.context as IAppContextType).featureFlags,
-              ignoredParams,
-            })}
+          <DeleteCollectionModal
+            deleteCollection={deleteCollection}
+            collections={collections}
+            isDeletionPending={isDeletionPending}
+            confirmDelete={confirmDelete}
+            setConfirmDelete={(confirmDelete) =>
+              this.setState({ confirmDelete })
+            }
+            cancelAction={() => this.setState({ deleteCollection: null })}
+            deleteAction={() =>
+              this.setState({ isDeletionPending: true }, () =>
+                DeleteCollectionUtils.deleteCollection({
+                  collection: deleteCollection,
+                  setState: (state) => this.setState(state),
+                  load: () => this.load(),
+                  redirect: false,
+                  addAlert: (alert) => this.addAlert(alert),
+                  deleteFromRepo,
+                }),
+              )
+            }
+            deleteFromRepo={deleteFromRepo}
           />
-        )}
-        {loading ? (
-          <LoadingSpinner />
-        ) : noData ? (
-          <EmptyStateNoData
-            title={t`No collections yet`}
-            description={t`Collections will appear once uploaded`}
-          />
-        ) : (
-          <>
-            <section className='collection-container'>
-              {this.renderCollections(collections, {
-                count,
-                params,
-                updateParams,
+
+          {showImportModal && (
+            <ImportModal
+              isOpen={showImportModal}
+              onUploadSuccess={() =>
+                this.setState({
+                  redirect: formatPath(
+                    Paths.myImports,
+                    {},
+                    {
+                      namespace: updateCollection.collection_version.namespace,
+                    },
+                  ),
+                })
+              }
+              // onCancel
+              setOpen={(isOpen, warn) => this.toggleImportModal(isOpen, warn)}
+              collection={updateCollection.collection_version}
+              namespace={updateCollection.collection_version.namespace}
+            />
+          )}
+          <BaseHeader className='hub-header-bordered' title={t`Collections`} />
+          {!noData && (
+            <HubListToolbar
+              count={count}
+              ignoredParams={ignoredParams}
+              params={params}
+              switcher='search_view_type'
+              updateParams={updateParams}
+              {...collectionFilter({
+                featureFlags: (this.context as IAppContextType).featureFlags,
+                ignoredParams,
               })}
-            </section>
-            <section className='footer'>
-              <HubPagination
-                params={params}
-                updateParams={updateParams}
-                count={count}
-              />
-            </section>
-          </>
-        )}
-      </div>
+            />
+          )}
+          {loading ? (
+            <LoadingSpinner />
+          ) : noData ? (
+            <EmptyStateNoData
+              title={t`No collections yet`}
+              description={t`Collections will appear once uploaded`}
+            />
+          ) : (
+            <>
+              <section className='collection-container'>
+                {this.renderCollections(collections, {
+                  count,
+                  params,
+                  updateParams,
+                })}
+              </section>
+              <section className='footer'>
+                <HubPagination
+                  params={params}
+                  updateParams={updateParams}
+                  count={count}
+                />
+              </section>
+            </>
+          )}
+        </div>
+      </>
     );
   }
 

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -1,6 +1,5 @@
 import { Trans, t } from '@lingui/macro';
 import {
-  Banner,
   Masthead,
   MastheadBrand,
   MastheadContent,
@@ -212,18 +211,6 @@ export const StandaloneLayout = ({
 
   return (
     <Page isManagedSidebar header={Header} sidebar={Sidebar}>
-      {IS_COMMUNITY ? (
-        <Banner>
-          <Trans>
-            Thanks for trying out the new and improved Galaxy, please share your
-            feedback on{' '}
-            <ExternalLink href='https://forum.ansible.com/'>
-              forum.ansible.com
-            </ExternalLink>
-            .
-          </Trans>
-        </Banner>
-      ) : null}
       {children}
       {aboutModalVisible && aboutModal}
     </Page>


### PR DESCRIPTION
Issue: AAP-23475
Design: [figma](https://www.figma.com/proto/8pjK0LL5LxF7mz1gwVh3Pb/Hub-Landing-Page---Banner?page-id=0%3A1&type=design&node-id=2-2568&viewport=381%2C432%2C0.14&t=HYpwT5wDfhcJdUo4-1&scaling=scale-down)

![20240509114627](https://github.com/ansible/ansible-hub-ui/assets/289743/01233929-6ee1-4603-b19d-96caf12bb970)

Only shown on the collections list page. Links to `/`. Only shown in gateway mode.