### PR TITLE
option A

### DIFF
--- a/config/standalone.gateway.prod.webpack.config.js
+++ b/config/standalone.gateway.prod.webpack.config.js
@@ -4,9 +4,9 @@ const webpackBase = require('./webpack.base.config');
 module.exports = webpackBase({
   API_HOST: '',
   API_BASE_PATH: '/api/galaxy/',
-  UI_BASE_PATH: '/hub/',
+  UI_BASE_PATH: '/ui/',
   UI_USE_HTTPS: false,
   UI_DEBUG: false,
   UI_EXTERNAL_LOGIN_URI: '/',
-  WEBPACK_PUBLIC_PATH: '/hub/',
+  WEBPACK_PUBLIC_PATH: '/static/galaxy_ng/',
 });


### PR DESCRIPTION
Change gateway build back to serving on `/ui/`, from `/static/galaxy_ng/`

.. except that what we have currently seems to work?
TODO: Is the whole dev-gateway / build-gateway bit obsolete now?