### PR TITLE
errorMessage: add login link on 401

### DIFF
--- a/src/components/collection-header.tsx
+++ b/src/components/collection-header.tsx
@@ -58,7 +58,7 @@ import {
   DeleteCollectionUtils,
   ParamHelper,
   canSignNamespace,
-  errorMessage,
+  jsxErrorMessage,
   namespaceTitle,
   parsePulpIDFromURL,
   repositoryRemoveCollection,
@@ -779,7 +779,7 @@ export const CollectionHeader = ({
           title: !collection.is_deprecated
             ? t`Collection "${collection.collection_version.name}" could not be deprecated.`
             : t`Collection "${collection.collection_version.name}" could not be undeprecated.`,
-          description: errorMessage(status, statusText),
+          description: jsxErrorMessage(status, statusText),
         });
       });
   }
@@ -890,7 +890,7 @@ export const CollectionHeader = ({
           addAlert({
             variant: 'danger',
             title: t`Collection "${deleteCollection.collection_version.name} v${collectionVersion}" could not be deleted.`,
-            description: errorMessage(status, statusText),
+            description: jsxErrorMessage(status, statusText),
           });
         }
       });

--- a/src/components/collection-info.tsx
+++ b/src/components/collection-info.tsx
@@ -24,7 +24,7 @@ import {
 } from 'src/components';
 import { useHubContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
-import { errorMessage } from 'src/utilities';
+import { jsxErrorMessage } from 'src/utilities';
 import './collection-info.scss';
 
 interface IProps extends CollectionVersionSearch {
@@ -157,7 +157,7 @@ export const CollectionInfo = ({
             addAlert(
               'danger',
               t`Signatures could not be loaded.`,
-              errorMessage(status, statusText),
+              jsxErrorMessage(status, statusText),
             )
           }
         />
@@ -226,7 +226,7 @@ function download(
       addAlert(
         'danger',
         t`Collection "${name}" could not be downloaded.`,
-        errorMessage(status, statusText),
+        jsxErrorMessage(status, statusText),
       );
     });
 }

--- a/src/components/copy-collection-to-repository-modal.tsx
+++ b/src/components/copy-collection-to-repository-modal.tsx
@@ -7,7 +7,7 @@ import {
 } from 'src/api';
 import { type AlertType, MultiRepoModal } from 'src/components';
 import { useHubContext } from 'src/loaders/app-context';
-import { errorMessage, parsePulpIDFromURL, taskAlert } from 'src/utilities';
+import { jsxErrorMessage, parsePulpIDFromURL, taskAlert } from 'src/utilities';
 
 interface IProps {
   addAlert: (alert: AlertType) => void;
@@ -71,7 +71,7 @@ export const CopyCollectionToRepositoryModal = ({
         addAlert({
           variant: 'danger',
           title: t`Collection ${namespace}.${name} v${version} could not be copied.`,
-          description: errorMessage(e.status, e.statusText),
+          description: jsxErrorMessage(e.status, e.statusText),
         }),
       )
       .finally(() => setLoading(false));

--- a/src/components/delete-execution-environment-modal.tsx
+++ b/src/components/delete-execution-environment-modal.tsx
@@ -3,7 +3,7 @@ import { Checkbox, Text } from '@patternfly/react-core';
 import React, { useState } from 'react';
 import { ExecutionEnvironmentAPI } from 'src/api';
 import { DeleteModal } from 'src/components';
-import { errorMessage, waitForTask } from 'src/utilities';
+import { jsxErrorMessage, waitForTask } from 'src/utilities';
 
 interface IProps {
   closeAction: () => void;
@@ -82,7 +82,7 @@ function deleteContainer(
       addAlert(
         t`Execution environment "${selectedItem}" could not be deleted.`,
         'danger',
-        errorMessage(status, statusText),
+        jsxErrorMessage(status, statusText),
       );
       closeAction();
     });

--- a/src/components/delete-user-modal.tsx
+++ b/src/components/delete-user-modal.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import { UserAPI, type UserType } from 'src/api';
 import { DeleteModal } from 'src/components';
 import { useHubContext } from 'src/loaders/app-context';
-import { errorMessage, mapErrorMessages } from 'src/utilities';
+import { jsxErrorMessage, mapErrorMessages } from 'src/utilities';
 
 interface IProps {
   addAlert: (message, variant, description?) => void;
@@ -80,7 +80,7 @@ export const DeleteUserModal = ({
           addAlert(
             t`User "${user.username}" could not be deleted.`,
             'danger',
-            errorMessage(status, statusText),
+            jsxErrorMessage(status, statusText),
           );
         }
 

--- a/src/components/import-list.tsx
+++ b/src/components/import-list.tsx
@@ -18,7 +18,7 @@ import {
   LoadingSpinner,
   Typeahead,
 } from 'src/components';
-import { ParamHelper, errorMessage, filterIsSet } from 'src/utilities';
+import { ParamHelper, filterIsSet, jsxErrorMessage } from 'src/utilities';
 import './my-imports.scss';
 
 interface IProps {
@@ -219,7 +219,7 @@ export const ImportList = ({
         addAlert({
           variant: 'danger',
           title: t`Namespaces list could not be displayed.`,
-          description: errorMessage(e.status, e.statusText),
+          description: jsxErrorMessage(e.status, e.statusText),
         }),
       );
   }

--- a/src/components/lightspeed-modal.tsx
+++ b/src/components/lightspeed-modal.tsx
@@ -14,7 +14,7 @@ import {
   Spinner,
   closeAlert,
 } from 'src/components';
-import { errorMessage } from 'src/utilities';
+import { jsxErrorMessage } from 'src/utilities';
 
 interface IProps {
   scope: 'namespace' | 'legacy_namespace';
@@ -97,7 +97,7 @@ export const LightspeedModal = (props: IProps) => {
         addAlert({
           title: t`Failed to load Ansible Lightspeed information.`,
           variant: 'danger',
-          description: errorMessage(status, statusText),
+          description: jsxErrorMessage(status, statusText),
         });
       });
   }, [props.scope, props.reference]);
@@ -127,7 +127,7 @@ export const LightspeedModal = (props: IProps) => {
         addAlert({
           title: t`Failed to opt in to Ansible Lightspeed.`,
           variant: 'danger',
-          description: errorMessage(status, statusText),
+          description: jsxErrorMessage(status, statusText),
         });
         setLoading(false);
       });
@@ -143,7 +143,7 @@ export const LightspeedModal = (props: IProps) => {
         addAlert({
           title: t`Failed to opt out of Ansible Lightspeed.`,
           variant: 'danger',
-          description: errorMessage(status, statusText),
+          description: jsxErrorMessage(status, statusText),
         });
         setLoading(false);
       });

--- a/src/components/list-page.tsx
+++ b/src/components/list-page.tsx
@@ -29,8 +29,8 @@ import { type PermissionContextType } from 'src/permissions';
 import {
   ParamHelper,
   type RouteProps,
-  errorMessage,
   filterIsSet,
+  jsxErrorMessage,
   withRouter,
 } from 'src/utilities';
 
@@ -397,7 +397,7 @@ export const ListPage = function <T>({
             this.addAlert({
               title: i18n._(errorTitle),
               variant: 'danger',
-              description: errorMessage(status, statusText),
+              description: jsxErrorMessage(status, statusText),
             });
           });
       });

--- a/src/components/multiple-repo-selector.tsx
+++ b/src/components/multiple-repo-selector.tsx
@@ -27,7 +27,7 @@ import {
   SortTable,
   Spinner,
 } from 'src/components';
-import { errorMessage } from 'src/utilities';
+import { jsxErrorMessage } from 'src/utilities';
 
 interface IProps {
   addAlert: (alert: AlertType) => void;
@@ -74,7 +74,7 @@ export const MultipleRepoSelector = (props: IProps) => {
         props.addAlert({
           title: t`Failed to load repositories.`,
           variant: 'danger',
-          description: errorMessage(status, statusText),
+          description: jsxErrorMessage(status, statusText),
         }),
       )
       .finally(() => setLoading(false));

--- a/src/components/page-with-tabs.tsx
+++ b/src/components/page-with-tabs.tsx
@@ -25,7 +25,7 @@ import { type PermissionContextType } from 'src/permissions';
 import {
   ParamHelper,
   type RouteProps,
-  errorMessage,
+  jsxErrorMessage,
   withRouter,
 } from 'src/utilities';
 
@@ -266,7 +266,7 @@ export const PageWithTabs = function <
             this.addAlert({
               title: i18n._(errorTitle),
               variant: 'danger',
-              description: errorMessage(status, statusText),
+              description: jsxErrorMessage(status, statusText),
             });
           });
       });

--- a/src/components/page.tsx
+++ b/src/components/page.tsx
@@ -19,7 +19,7 @@ import {
 } from 'src/components';
 import { AppContext, type IAppContextType } from 'src/loaders/app-context';
 import { type PermissionContextType } from 'src/permissions';
-import { type RouteProps, errorMessage, withRouter } from 'src/utilities';
+import { type RouteProps, jsxErrorMessage, withRouter } from 'src/utilities';
 
 interface IState<T> {
   alerts: AlertType[];
@@ -212,7 +212,7 @@ export const Page = function <
               this.addAlert({
                 title: i18n._(errorTitle),
                 variant: 'danger',
-                description: errorMessage(status, statusText),
+                description: jsxErrorMessage(status, statusText),
               });
               reject();
             });

--- a/src/components/repository-form.tsx
+++ b/src/components/repository-form.tsx
@@ -30,9 +30,9 @@ import {
 import {
   type ErrorMessagesType,
   alertErrorsWithoutFields,
-  errorMessage,
   isFieldValid,
   isFormValid,
+  jsxErrorMessage,
   mapErrorMessages,
 } from 'src/utilities';
 
@@ -108,7 +108,7 @@ export class RepositoryForm extends Component<IProps, IState> {
           this.addAlert({
             variant: 'danger',
             title: errorTitle,
-            description: errorMessage(status, statusText),
+            description: jsxErrorMessage(status, statusText),
           });
           this.setState({
             formErrors: { ...this.state.formErrors, registries: errorTitle },

--- a/src/components/user-form.tsx
+++ b/src/components/user-form.tsx
@@ -18,7 +18,7 @@ import {
   Typeahead,
 } from 'src/components';
 import { useHubContext } from 'src/loaders/app-context';
-import { type ErrorMessagesType, errorMessage } from 'src/utilities';
+import { type ErrorMessagesType, jsxErrorMessage } from 'src/utilities';
 
 interface IProps {
   errorMessages: ErrorMessagesType;
@@ -279,7 +279,7 @@ export const UserForm = ({
           groups: {
             variant: 'danger',
             title: t`Groups list could not be displayed.`,
-            description: errorMessage(status, statusText),
+            description: jsxErrorMessage(status, statusText),
           },
         });
       });

--- a/src/containers/ansible-remote/tab-access.tsx
+++ b/src/containers/ansible-remote/tab-access.tsx
@@ -11,7 +11,11 @@ import {
 import { AccessTab } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { canEditAnsibleRemoteAccess } from 'src/permissions';
-import { assignRoles, errorMessage, parsePulpIDFromURL } from 'src/utilities';
+import {
+  assignRoles,
+  jsxErrorMessage,
+  parsePulpIDFromURL,
+} from 'src/utilities';
 
 interface UserType {
   username: string;
@@ -112,7 +116,7 @@ export const RemoteAccessTab = ({
         addAlert({
           title: alertFailure,
           variant: 'danger',
-          description: errorMessage(status, statusText),
+          description: jsxErrorMessage(status, statusText),
         });
       })
       .finally(() => {

--- a/src/containers/ansible-repository/tab-access.tsx
+++ b/src/containers/ansible-repository/tab-access.tsx
@@ -11,7 +11,11 @@ import {
 import { AccessTab } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { canEditAnsibleRepositoryAccess } from 'src/permissions';
-import { assignRoles, errorMessage, parsePulpIDFromURL } from 'src/utilities';
+import {
+  assignRoles,
+  jsxErrorMessage,
+  parsePulpIDFromURL,
+} from 'src/utilities';
 
 interface UserType {
   username: string;
@@ -112,7 +116,7 @@ export const RepositoryAccessTab = ({
         addAlert({
           title: alertFailure,
           variant: 'danger',
-          description: errorMessage(status, statusText),
+          description: jsxErrorMessage(status, statusText),
         });
       })
       .finally(() => {

--- a/src/containers/certification-dashboard/certification-dashboard.tsx
+++ b/src/containers/certification-dashboard/certification-dashboard.tsx
@@ -37,8 +37,8 @@ import { AppContext, type IAppContextType } from 'src/loaders/app-context';
 import {
   ParamHelper,
   type RouteProps,
-  errorMessage,
   filterIsSet,
+  jsxErrorMessage,
   parsePulpIDFromURL,
   repositoryBasePath,
   waitForTask,
@@ -428,7 +428,7 @@ class CertificationDashboard extends Component<RouteProps, IState> {
       .catch((error) => {
         const description = !error.response
           ? error
-          : errorMessage(error.response.status, error.response.statusText);
+          : jsxErrorMessage(error.response.status, error.response.statusText);
 
         this.addAlert(
           t`The certificate for "${namespace} ${name} v${version}" could not be saved.`,
@@ -516,7 +516,7 @@ class CertificationDashboard extends Component<RouteProps, IState> {
       .catch((error) => {
         const description = !error.response
           ? error
-          : errorMessage(error.response.status, error.response.statusText);
+          : jsxErrorMessage(error.response.status, error.response.statusText);
 
         this.addAlert(
           t`Changes to certification status for collection "${version.namespace} ${version.name} v${version.version}" could not be saved.`,
@@ -546,7 +546,7 @@ class CertificationDashboard extends Component<RouteProps, IState> {
       .catch((error) => {
         const description = !error.response
           ? error
-          : errorMessage(error.response.status, error.response.statusText);
+          : jsxErrorMessage(error.response.status, error.response.statusText);
 
         this.addAlert(
           t`Changes to certification status for collection "${version.namespace} ${version.name} v${version.version}" could not be saved.`,

--- a/src/containers/collection-detail/collection-dependencies.tsx
+++ b/src/containers/collection-detail/collection-dependencies.tsx
@@ -21,7 +21,7 @@ import { Paths, formatPath, namespaceBreadcrumb } from 'src/paths';
 import {
   ParamHelper,
   type RouteProps,
-  errorMessage,
+  jsxErrorMessage,
   withRouter,
 } from 'src/utilities';
 import { type IBaseCollectionState, loadCollection } from './base';
@@ -266,7 +266,7 @@ class CollectionDependencies extends Component<RouteProps, IState> {
               {
                 variant: 'danger',
                 title: t`Dependent collections could not be displayed.`,
-                description: errorMessage(status, statusText),
+                description: jsxErrorMessage(status, statusText),
               },
             ],
           });

--- a/src/containers/edit-namespace/edit-namespace.tsx
+++ b/src/containers/edit-namespace/edit-namespace.tsx
@@ -27,7 +27,7 @@ import {
   type ErrorMessagesType,
   ParamHelper,
   type RouteProps,
-  errorMessage,
+  jsxErrorMessage,
   mapErrorMessages,
   withRouter,
 } from 'src/utilities';
@@ -283,7 +283,7 @@ class EditNamespace extends Component<RouteProps, IState> {
               alerts: this.state.alerts.concat({
                 variant: 'danger',
                 title: t`Changes to namespace "${this.state.namespace.name}" could not be saved.`,
-                description: errorMessage(result.status, result.statusText),
+                description: jsxErrorMessage(result.status, result.statusText),
               }),
               saving: false,
             });

--- a/src/containers/execution-environment-detail/execution-environment-detail-access.tsx
+++ b/src/containers/execution-environment-detail/execution-environment-detail-access.tsx
@@ -13,7 +13,7 @@ import { Paths, formatEEPath } from 'src/paths';
 import {
   ParamHelper,
   assignRoles,
-  errorMessage,
+  jsxErrorMessage,
   withRouter,
 } from 'src/utilities';
 import { type IDetailSharedProps, withContainerRepo } from './base';
@@ -120,7 +120,7 @@ class ExecutionEnvironmentDetailAccess extends Component<
         addAlert({
           title: alertFailure,
           variant: 'danger',
-          description: errorMessage(status, statusText),
+          description: jsxErrorMessage(status, statusText),
         });
       })
       .finally(() => {

--- a/src/containers/execution-environment-detail/execution-environment-detail-images.tsx
+++ b/src/containers/execution-environment-detail/execution-environment-detail-images.tsx
@@ -39,10 +39,10 @@ import { Paths, formatEEPath } from 'src/paths';
 import {
   ParamHelper,
   controllerURL,
-  errorMessage,
   filterIsSet,
   getContainersURL,
   getHumanSize,
+  jsxErrorMessage,
   waitForTask,
   withRouter,
 } from 'src/utilities';
@@ -601,7 +601,7 @@ class ExecutionEnvironmentDetailImages extends Component<
           this.props.addAlert({
             variant: 'danger',
             title: t`Image "${digest}" could not be deleted.`,
-            description: errorMessage(status, statusText),
+            description: jsxErrorMessage(status, statusText),
           });
         }),
     );

--- a/src/containers/execution-environment/registry-list.tsx
+++ b/src/containers/execution-environment/registry-list.tsx
@@ -36,8 +36,8 @@ import {
   type ErrorMessagesType,
   ParamHelper,
   type RouteProps,
-  errorMessage,
   filterIsSet,
+  jsxErrorMessage,
   lastSyncStatus,
   lastSynced,
   mapErrorMessages,
@@ -484,7 +484,7 @@ class ExecutionEnvironmentRegistryList extends Component<RouteProps, IState> {
         this.addAlert(
           t`Remote registry "${name}" could not be deleted.`,
           'danger',
-          errorMessage(status, statusText),
+          jsxErrorMessage(status, statusText),
         );
       })
       .then(() => {
@@ -506,7 +506,7 @@ class ExecutionEnvironmentRegistryList extends Component<RouteProps, IState> {
         this.addAlert(
           t`Remote registry "${name}" could not be synced.`,
           'danger',
-          errorMessage(status, statusText),
+          jsxErrorMessage(status, statusText),
         );
       });
   }
@@ -527,7 +527,7 @@ class ExecutionEnvironmentRegistryList extends Component<RouteProps, IState> {
         this.addAlert(
           t`Execution environment "${name}" could not be indexed.`,
           'danger',
-          errorMessage(status, statusText),
+          jsxErrorMessage(status, statusText),
         );
       });
   }

--- a/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
+++ b/src/containers/group-management/group-detail-role-management/group-detail-role-management.tsx
@@ -34,8 +34,8 @@ import {
 import {
   ParamHelper,
   type ParamType,
-  errorMessage,
   filterIsSet,
+  jsxErrorMessage,
   parsePulpIDFromURL,
   translateLockedRole,
 } from 'src/utilities';
@@ -96,7 +96,7 @@ const GroupDetailRoleManagement: FunctionComponent<IProps> = ({
         addAlert(
           t`Permissions for group "${group.name}" could not be displayed.`,
           'danger',
-          errorMessage(status, statusText),
+          jsxErrorMessage(status, statusText),
         );
       });
   };
@@ -119,7 +119,7 @@ const GroupDetailRoleManagement: FunctionComponent<IProps> = ({
         addAlert(
           t`Role "${selectedDeleteRole.role}" could not be deleted.`,
           'danger',
-          errorMessage(status, statusText),
+          jsxErrorMessage(status, statusText),
         );
       })
       .finally(() => {
@@ -249,7 +249,7 @@ const GroupDetailRoleManagement: FunctionComponent<IProps> = ({
                   const errMessage =
                     data?.non_field_errors?.length > 0
                       ? data.non_field_errors[0]
-                      : errorMessage(status, statusText);
+                      : jsxErrorMessage(status, statusText);
 
                   addAlert(
                     t`Role ${role.name} could not be assigned to group ${group.name}.`,

--- a/src/containers/group-management/group-detail.tsx
+++ b/src/containers/group-management/group-detail.tsx
@@ -44,8 +44,8 @@ import { Paths, formatPath } from 'src/paths';
 import {
   ParamHelper,
   type RouteProps,
-  errorMessage,
   filterIsSet,
+  jsxErrorMessage,
   withRouter,
 } from 'src/utilities';
 import GroupDetailRoleManagement from './group-detail-role-management/group-detail-role-management';
@@ -353,7 +353,7 @@ class GroupDetail extends Component<RouteProps, IState> {
                 this.addAlert(
                   t`Users list could not be displayed.`,
                   'danger',
-                  errorMessage(status, statusText),
+                  jsxErrorMessage(status, statusText),
                 );
               })
           }
@@ -418,7 +418,7 @@ class GroupDetail extends Component<RouteProps, IState> {
           this.addAlert(
             t`Group "${group}" could not be deleted.`,
             'danger',
-            errorMessage(status, statusText),
+            jsxErrorMessage(status, statusText),
           );
         });
     };
@@ -482,7 +482,7 @@ class GroupDetail extends Component<RouteProps, IState> {
         this.addAlert(
           t`User "${selectedUsers[0].name}" could not be added to group "${this.state.group.name}".`,
           'danger',
-          errorMessage(status, statusText),
+          jsxErrorMessage(status, statusText),
         );
       })
       .then(() => this.queryUsers());
@@ -501,7 +501,7 @@ class GroupDetail extends Component<RouteProps, IState> {
         this.addAlert(
           t`Users list could not be displayed.`,
           'danger',
-          errorMessage(status, statusText),
+          jsxErrorMessage(status, statusText),
         );
       });
   }
@@ -752,7 +752,7 @@ class GroupDetail extends Component<RouteProps, IState> {
         this.addAlert(
           t`Users list could not be displayed.`,
           'danger',
-          errorMessage(status, statusText),
+          jsxErrorMessage(status, statusText),
         );
       });
   }
@@ -770,7 +770,7 @@ class GroupDetail extends Component<RouteProps, IState> {
           this.addAlert(
             t`Group could not be displayed.`,
             'danger',
-            errorMessage(status, statusText),
+            jsxErrorMessage(status, statusText),
           );
         }
       });
@@ -801,7 +801,7 @@ class GroupDetail extends Component<RouteProps, IState> {
         this.addAlert(
           t`User "${user.username}" could not be removed from group "${name}".`,
           'danger',
-          errorMessage(status, statusText),
+          jsxErrorMessage(status, statusText),
         );
       });
   }

--- a/src/containers/group-management/group-list.tsx
+++ b/src/containers/group-management/group-list.tsx
@@ -40,8 +40,8 @@ import {
   type ErrorMessagesType,
   ParamHelper,
   type RouteProps,
-  errorMessage,
   filterIsSet,
+  jsxErrorMessage,
   mapErrorMessages,
   withRouter,
 } from 'src/utilities';
@@ -323,7 +323,7 @@ class GroupList extends Component<RouteProps, IState> {
             {
               variant: 'danger',
               title: t`Users list could not be displayed.`,
-              description: errorMessage(status, statusText),
+              description: jsxErrorMessage(status, statusText),
             },
           ],
         });
@@ -501,7 +501,7 @@ class GroupList extends Component<RouteProps, IState> {
               {
                 variant: 'danger',
                 title: t`Groups list could not be displayed.`,
-                description: errorMessage(status, statusText),
+                description: jsxErrorMessage(status, statusText),
               },
             ],
           });

--- a/src/containers/namespace-detail/namespace-detail.tsx
+++ b/src/containers/namespace-detail/namespace-detail.tsx
@@ -45,9 +45,9 @@ import {
   ParamHelper,
   type RouteProps,
   canSignNamespace,
-  errorMessage,
   filterIsSet,
   getRepoURL,
+  jsxErrorMessage,
   parsePulpIDFromURL,
   waitForTask,
   withRouter,
@@ -214,7 +214,7 @@ export class NamespaceDetail extends Component<RouteProps, IState> {
         this.addAlert({
           title: alertFailure,
           variant: 'danger',
-          description: errorMessage(status, statusText),
+          description: jsxErrorMessage(status, statusText),
         });
       })
       .finally(() => {
@@ -1046,7 +1046,7 @@ export class NamespaceDetail extends Component<RouteProps, IState> {
               this.addAlert({
                 variant: 'danger',
                 title: t`Namespace "${name}" could not be deleted.`,
-                description: errorMessage(status, statusText),
+                description: jsxErrorMessage(status, statusText),
               });
             },
           );

--- a/src/containers/namespace-list/namespace-list.tsx
+++ b/src/containers/namespace-list/namespace-list.tsx
@@ -24,8 +24,8 @@ import { Paths, formatPath } from 'src/paths';
 import {
   ParamHelper,
   type RouteProps,
-  errorMessage,
   filterIsSet,
+  jsxErrorMessage,
 } from 'src/utilities';
 import './namespace-list.scss';
 
@@ -118,7 +118,7 @@ export class NamespaceList extends Component<IProps, IState> {
               this.addAlert({
                 variant: 'danger',
                 title: t`Namespaces list could not be displayed.`,
-                description: errorMessage(status, statusText),
+                description: jsxErrorMessage(status, statusText),
               }),
           );
         });
@@ -323,7 +323,7 @@ export class NamespaceList extends Component<IProps, IState> {
               this.addAlert({
                 variant: 'danger',
                 title: t`Namespaces list could not be displayed.`,
-                description: errorMessage(status, statusText),
+                description: jsxErrorMessage(status, statusText),
               }),
           );
         });

--- a/src/containers/role-management/role-create.tsx
+++ b/src/containers/role-management/role-create.tsx
@@ -13,7 +13,7 @@ import { AppContext, type IAppContextType } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
 import {
   type RouteProps,
-  errorMessage,
+  jsxErrorMessage,
   mapNetworkErrors,
   validateInput,
   withRouter,
@@ -149,7 +149,7 @@ class RoleCreate extends Component<RouteProps, IState> {
               alerts: this.state.alerts.concat({
                 variant: 'danger',
                 title: t`Role "${this.state.name}" could not be created.`,
-                description: errorMessage(status, statusText),
+                description: jsxErrorMessage(status, statusText),
               }),
               saving: false,
             });

--- a/src/containers/role-management/role-edit.tsx
+++ b/src/containers/role-management/role-edit.tsx
@@ -246,7 +246,7 @@ class EditRole extends Component<RouteProps, IState> {
               alerts: this.state.alerts.concat({
                 variant: 'danger',
                 title: t`Changes to role "${name}" could not be saved.`,
-                description: errorMessage(status, statusText),
+                description: jsxErrorMessage(status, statusText),
               }),
               saving: false,
             });

--- a/src/containers/role-management/role-edit.tsx
+++ b/src/containers/role-management/role-edit.tsx
@@ -17,7 +17,7 @@ import { Paths, formatPath } from 'src/paths';
 import {
   type ErrorMessagesType,
   type RouteProps,
-  errorMessage,
+  jsxErrorMessage,
   mapNetworkErrors,
   parsePulpIDFromURL,
   translateLockedRole,
@@ -106,7 +106,7 @@ class EditRole extends Component<RouteProps, IState> {
           this.addAlert(
             t`Role "${this.state.role.name}" could not be displayed.`,
             'danger',
-            errorMessage(status, statusText),
+            jsxErrorMessage(status, statusText),
           );
         });
     }

--- a/src/containers/role-management/role-list.tsx
+++ b/src/containers/role-management/role-list.tsx
@@ -37,8 +37,8 @@ import { Paths, formatPath } from 'src/paths';
 import {
   ParamHelper,
   type RouteProps,
-  errorMessage,
   filterIsSet,
+  jsxErrorMessage,
   parsePulpIDFromURL,
   translateLockedRole,
   withRouter,
@@ -379,7 +379,7 @@ export class RoleList extends Component<RouteProps, IState> {
         this.addAlert(
           t`Role "${name}" could not be deleted.`,
           'danger',
-          errorMessage(status, statusText),
+          jsxErrorMessage(status, statusText),
         );
       })
       .then(() => {
@@ -468,7 +468,7 @@ export class RoleList extends Component<RouteProps, IState> {
           this.addAlert(
             t`Roles list could not be displayed.`,
             'danger',
-            errorMessage(status, statusText),
+            jsxErrorMessage(status, statusText),
           );
         });
     });

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -43,8 +43,8 @@ import {
   DeleteCollectionUtils,
   ParamHelper,
   type RouteProps,
-  errorMessage,
   filterIsSet,
+  jsxErrorMessage,
   parsePulpIDFromURL,
   waitForTask,
   withRouter,
@@ -391,7 +391,7 @@ class Search extends Component<RouteProps, IState> {
               title: !collection.deprecated
                 ? t`Collection "${name}" could not be deprecated.`
                 : t`Collection "${name}" could not be undeprecated.`,
-              description: errorMessage(status, statusText),
+              description: jsxErrorMessage(status, statusText),
             },
           ],
         });

--- a/src/containers/signature-keys/list.tsx
+++ b/src/containers/signature-keys/list.tsx
@@ -31,8 +31,8 @@ import { AppContext, type IAppContextType } from 'src/loaders/app-context';
 import {
   ParamHelper,
   type RouteProps,
-  errorMessage,
   filterIsSet,
+  jsxErrorMessage,
   withRouter,
 } from 'src/utilities';
 
@@ -283,7 +283,7 @@ export class SignatureKeysList extends Component<RouteProps, IState> {
           this.addAlert({
             title: t`Signature keys could not be displayed.`,
             variant: 'danger',
-            description: errorMessage(status, statusText),
+            description: jsxErrorMessage(status, statusText),
           });
         });
     });

--- a/src/containers/task-management/task-detail.tsx
+++ b/src/containers/task-management/task-detail.tsx
@@ -31,7 +31,7 @@ import {
 import { Paths, formatPath } from 'src/paths';
 import {
   type RouteProps,
-  errorMessage,
+  jsxErrorMessage,
   parsePulpIDFromURL,
   translateTask,
   withRouter,
@@ -411,7 +411,7 @@ class TaskDetail extends Component<RouteProps, IState> {
             {
               variant: 'danger',
               title: t`Task "${taskName}" could not be stopped.`,
-              description: errorMessage(status, statusText),
+              description: jsxErrorMessage(status, statusText),
             },
           ],
         });

--- a/src/containers/task-management/task-list-view.tsx
+++ b/src/containers/task-management/task-list-view.tsx
@@ -33,8 +33,8 @@ import { Paths, formatPath } from 'src/paths';
 import {
   ParamHelper,
   type RouteProps,
-  errorMessage,
   filterIsSet,
+  jsxErrorMessage,
   parsePulpIDFromURL,
   translateTask,
   withRouter,
@@ -393,7 +393,7 @@ export class TaskListView extends Component<RouteProps, IState> {
             {
               variant: 'danger',
               title: t`Task "${name}" could not be stopped.`,
-              description: errorMessage(status, statusText),
+              description: jsxErrorMessage(status, statusText),
             },
           ],
         });
@@ -421,7 +421,7 @@ export class TaskListView extends Component<RouteProps, IState> {
               {
                 variant: 'danger',
                 title: t`Tasks list could not be displayed.`,
-                description: errorMessage(status, statusText),
+                description: jsxErrorMessage(status, statusText),
               },
             ],
           });

--- a/src/containers/token/token-insights.tsx
+++ b/src/containers/token/token-insights.tsx
@@ -16,8 +16,8 @@ import {
 import { AppContext } from 'src/loaders/app-context';
 import {
   type RouteProps,
-  errorMessage,
   getRepoURL,
+  jsxErrorMessage,
   withRouter,
 } from 'src/utilities';
 
@@ -86,7 +86,7 @@ class TokenInsights extends Component<RouteProps, IState> {
             {
               variant: 'danger',
               title: t`Server URL could not be displayed.`,
-              description: errorMessage(status, statusText),
+              description: jsxErrorMessage(status, statusText),
             },
           ],
         });

--- a/src/containers/token/token-standalone.tsx
+++ b/src/containers/token/token-standalone.tsx
@@ -14,7 +14,7 @@ import {
   closeAlert,
 } from 'src/components';
 import { AppContext, type IAppContextType } from 'src/loaders/app-context';
-import { type RouteProps, errorMessage, withRouter } from 'src/utilities';
+import { type RouteProps, jsxErrorMessage, withRouter } from 'src/utilities';
 
 interface IState {
   token: string;
@@ -158,7 +158,7 @@ class TokenStandalone extends Component<RouteProps, IState> {
               {
                 variant: 'danger',
                 title: t`Token could not be displayed.`,
-                description: errorMessage(status, statusText),
+                description: jsxErrorMessage(status, statusText),
               },
             ],
             loadingToken: false,

--- a/src/containers/user-management/user-list.tsx
+++ b/src/containers/user-management/user-list.tsx
@@ -38,8 +38,8 @@ import { Paths, formatPath } from 'src/paths';
 import {
   ParamHelper,
   type RouteProps,
-  errorMessage,
   filterIsSet,
+  jsxErrorMessage,
   withRouter,
 } from 'src/utilities';
 
@@ -420,7 +420,7 @@ class UserList extends Component<RouteProps, IState> {
               {
                 variant: 'danger',
                 title: t`Users list could not be displayed.`,
-                description: errorMessage(status, statusText),
+                description: jsxErrorMessage(status, statusText),
               },
             ],
           });

--- a/src/utilities/delete-collection.ts
+++ b/src/utilities/delete-collection.ts
@@ -4,7 +4,7 @@ import {
   CollectionVersionAPI,
   type CollectionVersionSearch,
 } from 'src/api';
-import { errorMessage } from './fail-alerts';
+import { jsxErrorMessage } from './fail-alerts';
 import { parsePulpIDFromURL } from './parse-pulp-id';
 import { repositoryRemoveCollection } from './repository-remove-collection';
 import { waitForTask } from './wait-for-task';
@@ -19,7 +19,7 @@ export class DeleteCollectionUtils {
         return Promise.reject({
           title: t`Dependencies for collection "${name}" could not be displayed.`,
           variant: 'danger',
-          description: errorMessage(status, statusText),
+          description: jsxErrorMessage(status, statusText),
         });
       });
   }
@@ -69,7 +69,7 @@ export class DeleteCollectionUtils {
         addAlert({
           variant: 'danger',
           title: t`Collection "${collection.collection_version.name}" could not be deleted.`,
-          description: errorMessage(status, statusText),
+          description: jsxErrorMessage(status, statusText),
         });
       })
       .finally(() =>

--- a/src/utilities/fail-alerts.tsx
+++ b/src/utilities/fail-alerts.tsx
@@ -1,4 +1,6 @@
 import { t } from '@lingui/macro';
+import React from 'react';
+import { LoginLink } from 'src/components';
 import { mapErrorMessages } from './map-error-messages';
 
 export function errorMessage(
@@ -34,6 +36,16 @@ export const handleHttpError = (title, callback, addAlert) => (e) => {
     description = message
       ? errorMessage(status, statusText, message)
       : errorMessage(status, statusText);
+
+    if (status === 401) {
+      description = (
+        <>
+          {description}
+          <br />
+          <LoginLink />
+        </>
+      );
+    }
   }
 
   addAlert({

--- a/src/utilities/fail-alerts.tsx
+++ b/src/utilities/fail-alerts.tsx
@@ -23,6 +23,22 @@ export function errorMessage(
   return messages[statusCode] || messages.default;
 }
 
+export function jsxErrorMessage(code, text, custom?) {
+  const description = errorMessage(code, text, custom);
+
+  if (code == 401) {
+    return (
+      <>
+        {description}
+        <br />
+        <LoginLink />
+      </>
+    );
+  }
+
+  return description;
+}
+
 export const handleHttpError = (title, callback, addAlert) => (e) => {
   let description = e.toString();
 
@@ -33,19 +49,7 @@ export const handleHttpError = (title, callback, addAlert) => (e) => {
     const err = mapErrorMessages(e);
     const message = Object.values(err).join(' ');
 
-    description = message
-      ? errorMessage(status, statusText, message)
-      : errorMessage(status, statusText);
-
-    if (status === 401) {
-      description = (
-        <>
-          {description}
-          <br />
-          <LoginLink />
-        </>
-      );
-    }
+    description = jsxErrorMessage(status, statusText, message);
   }
 
   addAlert({

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -3,7 +3,7 @@ export { canSignEE, canSignNamespace } from './can-sign';
 export { convertContentSummaryCounts } from './content-summary';
 export { DeleteCollectionUtils } from './delete-collection';
 export { downloadString } from './download-data';
-export { errorMessage, handleHttpError } from './fail-alerts';
+export { errorMessage, handleHttpError, jsxErrorMessage } from './fail-alerts';
 export { filterIsSet } from './filter-is-set';
 export { getHumanSize } from './get-human-size';
 export { controllerURL, getContainersURL, getRepoURL } from './get-repo-url';


### PR DESCRIPTION
![20240514145632](https://github.com/ansible/ansible-hub-ui/assets/289743/86e9f308-370c-4447-8234-61a21356f665)

all uses of `errorMessage` (including `handleHttpError`) are now using a `jsxErrorMessage` wrapper, that adds a Login link with a redirect back to the right place.

(The only remaining bare `errorMessage` uses are lazy distro/remote/repo in inline detail.)
