### PR TITLE
fix login redirect url to also include UI_BASE_PATH

### DIFF
--- a/src/utilities/login-url.ts
+++ b/src/utilities/login-url.ts
@@ -1,7 +1,8 @@
 // external login URL, assuming UI_EXETRNAL_LOGIN_URI and featureFlags.external_authentication are set
 export const loginURL = (next, featureFlags) => {
   if (featureFlags.dab_resource_registry && next) {
-    return `/redirect/?next=${encodeURIComponent(next)}`;
+    const fullPath = `${UI_BASE_PATH}/${next}`.replaceAll(/\/+/g, '/');
+    return `/redirect/?next=${encodeURIComponent(fullPath)}`;
   }
 
   return UI_EXTERNAL_LOGIN_URI;


### PR DESCRIPTION
Issue: AAP-23212

Fix login redirect url to include UI_BASE_PATH

Before... `?next=/namespaces/`
After... `?next=/ui/namespaces/`

