### PR TITLE
Gateway logout - call gateway logout API

### DIFF
--- a/src/api/gateway-logout.ts
+++ b/src/api/gateway-logout.ts
@@ -1,0 +1,9 @@
+import { GatewayAPI } from './gateway';
+
+class API extends GatewayAPI {
+  logout() {
+    return this.http.post('v1/logout/', {});
+  }
+}
+
+export const GatewayLogoutAPI = new API();

--- a/src/api/gateway.ts
+++ b/src/api/gateway.ts
@@ -1,0 +1,9 @@
+import { BaseAPI } from './base';
+
+export class GatewayAPI extends BaseAPI {
+  mapPageToOffset = false; // page & page_size
+
+  constructor() {
+    super('/api/gateway');
+  }
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -15,6 +15,7 @@ export { ExecutionEnvironmentNamespaceAPI } from './execution-environment-namesp
 export { ExecutionEnvironmentRegistryAPI } from './execution-environment-registry';
 export { ExecutionEnvironmentRemoteAPI } from './execution-environment-remote';
 export { FeatureFlagsAPI } from './feature-flags';
+export { GatewayLogoutAPI } from './gateway-logout';
 export { GenericPulpAPI } from './generic-pulp';
 export { GroupAPI } from './group';
 export { GroupRoleAPI } from './group-role';

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -21,6 +21,7 @@ import { Link } from 'react-router-dom';
 import {
   ActiveUserAPI,
   type FeatureFlagsType,
+  GatewayLogoutAPI,
   type SettingsType,
   type UserType,
 } from 'src/api';
@@ -53,6 +54,7 @@ export const StandaloneLayout = ({
   user,
 }: IProps) => {
   const [aboutModalVisible, setAboutModalVisible] = useState<boolean>(false);
+  const isGateway = featureFlags?.dab_resource_registry;
 
   let aboutModal = null;
   let docsDropdownItems = [];
@@ -83,6 +85,7 @@ export const StandaloneLayout = ({
         aria-label={'logout'}
         onClick={() =>
           ActiveUserAPI.logout()
+            .then(isGateway ? () => GatewayLogoutAPI.logout() : () => null)
             .then(() => ActiveUserAPI.getUser().catch(() => null))
             .then((user) => setUser(user))
         }


### PR DESCRIPTION
add api for POSTing {} to /api/gateway/v1/logout/

to log out:

* call galaxy logout
* **call gateway logout (only in gateway mode)**
* call galaxy me
* set user accordingly

:crossed_fingers: 