### PR TITLE
Drop obsolete babel plugin syntax dynamic import

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,12 +1,11 @@
 {
-    "presets": [
-        "@babel/preset-env",
-        "@babel/preset-react",
-        "@babel/preset-typescript",
-    ],
-    "plugins": [
-        "@babel/plugin-syntax-dynamic-import",
-        "@babel/plugin-transform-runtime",
-        "babel-plugin-macros",
-    ]
+  "presets": [
+    "@babel/preset-env",
+    "@babel/preset-react",
+    "@babel/preset-typescript"
+  ],
+  "plugins": [
+    "@babel/plugin-transform-runtime",
+    "babel-plugin-macros"
+  ]
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
       babel:
         patterns:
           - "@babel/*"
-          - "babel-core"
           - "babel-loader"
       lingui:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,8 +18,6 @@ updates:
         patterns:
           - "react"
           - "react-dom"
-          - "@types/react"
-          - "@types/react-dom"
 
   - package-ecosystem: 'npm'
     directory: '/'

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
       },
       "devDependencies": {
         "@babel/core": "^7.24.6",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-transform-runtime": "^7.24.6",
         "@babel/preset-env": "^7.24.6",
         "@babel/preset-react": "^7.24.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "@redhat-cloud-services/frontend-components-config": "^6.0.13",
         "@redhat-cloud-services/frontend-components-config-utilities": "^3.0.6",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
-        "babel-core": "^7.0.0-bridge.0",
         "babel-loader": "^9.1.3",
         "babel-plugin-macros": "^3.1.0",
         "clean-webpack-plugin": "^4.0.0",
@@ -6145,14 +6144,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
-    },
-    "node_modules/babel-core": {
-      "version": "7.0.0-bridge.0",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
     },
     "node_modules/babel-loader": {
       "version": "9.1.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.24.6",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.24.6",
     "@babel/preset-env": "^7.24.6",
     "@babel/preset-react": "^7.24.6",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@redhat-cloud-services/frontend-components-config": "^6.0.13",
     "@redhat-cloud-services/frontend-components-config-utilities": "^3.0.6",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
-    "babel-core": "^7.0.0-bridge.0",
     "babel-loader": "^9.1.3",
     "babel-plugin-macros": "^3.1.0",
     "clean-webpack-plugin": "^4.0.0",


### PR DESCRIPTION
https://babeljs.io/docs/babel-plugin-syntax-dynamic-import 

> You can safely remove this plugin from your Babel config if using @babel/core 7.8.0 or above.

Same for `babel-core` (but not `@babel/core`)