### PR TITLE
Docs - table to items

### DIFF
--- a/src/components/render-plugin-doc.scss
+++ b/src/components/render-plugin-doc.scss
@@ -1,36 +1,3 @@
-.hub-doc-options-table {
-  td,
-  th {
-    border: 1px solid black;
-    padding: 5px;
-    vertical-align: top;
-  }
-
-  ul {
-    margin-top: 0;
-  }
-
-  small {
-    margin-bottom: 0;
-  }
-
-  // ensures the bottom of the table always has a border even
-  // if there is a spacer at the bottom which might otherwise cause
-  // a gap
-  border-bottom: 1px solid black;
-  width: 100%;
-
-  .spacer {
-    width: 20px;
-    border-top: 0;
-    border-bottom: 0;
-  }
-
-  .parent {
-    border-bottom: 0;
-  }
-}
-
 .hub-doc-blue {
   color: var(--pf-v5-global--info-color--100);
 }

--- a/src/components/render-plugin-doc.tsx
+++ b/src/components/render-plugin-doc.tsx
@@ -111,46 +111,46 @@ export class RenderPluginDoc extends Component<IProps, IState> {
       return this.renderError(plugin);
     }
 
-    // componentDidCatch doesn't seem to be able to catch errors that
-    // are thrown outside of return(), so we'll wrap everything in a
-    // try just in case
-    let content;
+    // componentDidCatch only catches at child component render
     try {
       const doc: PluginDoc = this.parseDocString(plugin);
-      const example: string = this.parseExamples(plugin);
-      const returnVals: ReturnedValue[] = this.parseReturn(plugin);
-      content = {
-        synopsis: this.renderSynopsis(doc),
-        parameters: this.renderParameters(doc.options, plugin.content_type),
-        notes: this.renderNotes(doc),
-        examples: this.renderExample(example),
-        returnValues: this.renderReturnValues(returnVals),
-        shortDescription: this.renderShortDescription(doc),
-        deprecated: this.renderDeprecated(doc, plugin.content_name),
-        requirements: this.renderRequirements(doc),
-      };
+
+      const synopsis = this.renderSynopsis(doc);
+      const parameters = this.renderParameters(
+        doc.options,
+        plugin.content_type,
+      );
+      const notes = this.renderNotes(doc);
+      const examples = this.renderExample(this.parseExamples(plugin));
+      const returnValues = this.renderReturnValues(this.parseReturn(plugin));
+
+      return (
+        <div>
+          <h1>
+            {plugin.content_type} &gt; {plugin.content_name}
+          </h1>
+          <br />
+          {this.renderShortDescription(doc)}
+          {this.renderDeprecated(doc, plugin.content_name)}
+          {this.renderTableOfContents({
+            synopsis,
+            parameters,
+            notes,
+            examples,
+            returnValues,
+          })}
+          {synopsis}
+          {this.renderRequirements(doc)}
+          {parameters}
+          {notes}
+          {examples}
+          {returnValues}
+        </div>
+      );
     } catch (error) {
       console.log('RenderPluginDoc render catch', error);
       return this.renderError(plugin);
     }
-
-    return (
-      <div>
-        <h1>
-          {plugin.content_type} &gt; {plugin.content_name}
-        </h1>
-        <br />
-        {content.shortDescription}
-        {content.deprecated}
-        {this.renderTableOfContents(content)}
-        {content.synopsis}
-        {content.requirements}
-        {content.parameters}
-        {content.notes}
-        {content.examples}
-        {content.returnValues}
-      </div>
-    );
   }
 
   private renderError(plugin) {
@@ -329,9 +329,11 @@ export class RenderPluginDoc extends Component<IProps, IState> {
           {part.name}={part.value}
         </span>
       );
+
     if (!part.plugin) {
       return content;
     }
+
     return this.props.renderPluginLink(
       part.plugin.fqcn,
       part.plugin.type,
@@ -407,6 +409,7 @@ export class RenderPluginDoc extends Component<IProps, IState> {
         fragments.push(this.formatPart(part));
       }
     }
+
     return (
       <span>
         {fragments.map((x, i) => (
@@ -461,28 +464,34 @@ export class RenderPluginDoc extends Component<IProps, IState> {
     );
   }
 
-  private renderTableOfContents(content) {
+  private renderTableOfContents({
+    synopsis,
+    parameters,
+    notes,
+    examples,
+    returnValues,
+  }) {
     return (
       <ul>
-        {content['synopsis'] !== null && (
+        {synopsis !== null && (
           <li>
             {this.props.renderTableOfContentsLink(t`Synopsis`, 'synopsis')}
           </li>
         )}
-        {content['parameters'] !== null && (
+        {parameters !== null && (
           <li>
             {this.props.renderTableOfContentsLink(t`Parameters`, 'parameters')}
           </li>
         )}
-        {content['notes'] !== null && (
+        {notes !== null && (
           <li>{this.props.renderTableOfContentsLink(t`Notes`, 'notes')}</li>
         )}
-        {content['examples'] !== null && (
+        {examples !== null && (
           <li>
             {this.props.renderTableOfContentsLink(t`Examples`, 'examples')}
           </li>
         )}
-        {content['returnValues'] !== null && (
+        {returnValues !== null && (
           <li>
             {this.props.renderTableOfContentsLink(
               t`Return Values`,


### PR DESCRIPTION
continues #5049 

wip: render tables as flexboxes to allow wrapping with small widths ([forum](https://forum.ansible.com/t/lack-of-mobile-friendly-responsive-ui-in-new-galaxy-docs/5759) & jira(TODO find it)) .. TODO better vertical align, more clearly visible recursion relationship, direct nesting

TODO: some of these need to go in ansible-ui too
https://docs.ansible.com/ansible/latest/collections/amazon/aws/backup_plan_module.html#ansible-collections-amazon-aws-backup-plan-module
http://localhost:8002/ui/repo/published/amazon/aws/content/module/backup_plan/

and test if the table is ok if it always has 2 columns, like https://docs.ansible.com/ansible/latest/collections/ansible/builtin/wait_for_module.html#id2