### PR TITLE
Documentation link - move from left nav to top nav in standalone mode

### DIFF
--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -137,12 +137,23 @@ export const StandaloneLayout = ({
       ),
       IS_COMMUNITY && (
         <DropdownItem
-          key='communication'
+          key='community'
           component={
             <ExternalLink
               href='https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/community/userguide/'
               variant='menu'
             >{t`Community User Guide`}</ExternalLink>
+          }
+        />
+      ),
+      !IS_COMMUNITY && (
+        <DropdownItem
+          key='documentation'
+          component={
+            <ExternalLink
+              href={UI_DOCS_URL}
+              variant='menu'
+            >{t`Documentation`}</ExternalLink>
           }
         />
       ),

--- a/src/loaders/standalone/layout.tsx
+++ b/src/loaders/standalone/layout.tsx
@@ -95,6 +95,17 @@ export const StandaloneLayout = ({
     ];
 
     docsDropdownItems = [
+      !IS_COMMUNITY && (
+        <DropdownItem
+          key='documentation'
+          component={
+            <ExternalLink
+              href={UI_DOCS_URL}
+              variant='menu'
+            >{t`Documentation`}</ExternalLink>
+          }
+        />
+      ),
       <DropdownItem
         key='customer_support'
         component={
@@ -143,17 +154,6 @@ export const StandaloneLayout = ({
               href='https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/community/userguide/'
               variant='menu'
             >{t`Community User Guide`}</ExternalLink>
-          }
-        />
-      ),
-      !IS_COMMUNITY && (
-        <DropdownItem
-          key='documentation'
-          component={
-            <ExternalLink
-              href={UI_DOCS_URL}
-              variant='menu'
-            >{t`Documentation`}</ExternalLink>
           }
         />
       ),

--- a/src/loaders/standalone/menu.tsx
+++ b/src/loaders/standalone/menu.tsx
@@ -135,14 +135,6 @@ function standaloneMenu() {
       }),
     ]),
     menuItem(t`Documentation`, {
-      url: UI_DOCS_URL,
-      external: true,
-      condition: ({ settings, user }) =>
-        !IS_COMMUNITY &&
-        (settings.GALAXY_ENABLE_UNAUTHENTICATED_COLLECTION_ACCESS ||
-          !user.is_anonymous),
-    }),
-    menuItem(t`Documentation`, {
       url: 'https://ansible.readthedocs.io/projects/galaxy-ng/en/latest/community/userguide/',
       external: true,
       condition: ({ settings, user }) =>

--- a/test/cypress/e2e/community/view-only.js
+++ b/test/cypress/e2e/community/view-only.js
@@ -8,11 +8,9 @@ describe('view-only mode - with download', () => {
   it('has limited menu, nav', () => {
     cy.visit(uiPrefix);
 
-    [
-      'Collections > Collections',
-      'Collections > Namespaces',
-      'Documentation',
-    ].forEach((item) => cy.menuPresent(item));
+    ['Collections > Collections', 'Collections > Namespaces'].forEach((item) =>
+      cy.menuPresent(item),
+    );
 
     [
       'Collections > Repositories',

--- a/test/cypress/e2e/namespaces/docs-menu.js
+++ b/test/cypress/e2e/namespaces/docs-menu.js
@@ -19,6 +19,8 @@ describe('Documentation dropdown', () => {
       .should('have.attr', 'href')
       .and('contain', 'https://www.ansible.com/resources/webinars-training');
 
+    cy.get('.pf-v5-c-dropdown__menu').contains('Documentation');
+
     cy.get('.pf-v5-c-dropdown__menu').contains('About');
   });
 

--- a/test/cypress/e2e/namespaces/menu.js
+++ b/test/cypress/e2e/namespaces/menu.js
@@ -13,7 +13,6 @@ describe('Hub Menu Tests', () => {
     'Execution Environments > Remote Registries',
     'Task Management',
     'Signature Keys',
-    'Documentation',
     'User Access > Users',
     'User Access > Groups',
     'User Access > Roles',
@@ -38,7 +37,6 @@ describe('Hub Menu Tests', () => {
       'Collections > Collections',
       'Collections > Namespaces',
       'Collections > Repositories',
-      'Documentation',
       'Execution Environments > Execution Environments',
       'Execution Environments > Remote Registries',
       'Signature Keys',
@@ -57,16 +55,6 @@ describe('Hub Menu Tests', () => {
 
       visibleMenuItems.forEach((item) => cy.menuPresent(item));
       missingMenuItems.forEach((item) => cy.menuMissing(item));
-    });
-
-    it('has Documentation tab', () => {
-      cy.login(username, password);
-
-      cy.menuPresent('Documentation').should(
-        'have.attr',
-        'href',
-        'https://docs.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/',
-      );
     });
   });
 });


### PR DESCRIPTION
Issue: AAP-25057

Documentation link - move from left nav to top nav in standalone mode
(community Documentation link is still supposed to be the last item in left nav AFAIK - #4991)

![20240610190846](https://github.com/ansible/ansible-hub-ui/assets/289743/d612e3b0-b6b0-45ae-90b0-400820c50cb9)
![20240610190857](https://github.com/ansible/ansible-hub-ui/assets/289743/d734c92e-be6a-4ee7-bfc7-f9967eb2df49)
