### PR TITLE
Bump node to v20

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,10 +13,10 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v4
 
-    - name: "Install node 18"
+    - name: "Install node 20"
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
 
     - name: "Check automerge conditions"
       working-directory: ".github/workflows"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -117,10 +117,10 @@ jobs:
       working-directory: 'oci_env'
       run: 'oci-env compose up &'
 
-    - name: "Install node 18"
+    - name: "Install node 20"
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
 
     - name: "Cache ~/.npm & ~/.cache/Cypress"
       uses: actions/cache@v4

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -23,10 +23,10 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v4
 
-    - name: "Install node 18"
+    - name: "Install node 20"
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
 
     - name: "Update the dev tag"
       run: |

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,10 +13,10 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v4
 
-    - name: "Install node 18"
+    - name: "Install node 20"
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
 
     - name: "Install python 3.11"
@@ -93,10 +93,10 @@ jobs:
       with:
         path: 'pr'
 
-    - name: "Install node 18"
+    - name: "Install node 20"
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         cache-dependency-path: |
           base/package-lock.json

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -29,10 +29,10 @@ jobs:
         RELEASE_TAG=`sed 's/^refs\/tags\///' <<< $GITHUB_REF`
         echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
 
-    - name: "Install node 18"
+    - name: "Install node 20"
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
 
     - name: "Cache ~/.npm"
       uses: actions/cache@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # WARNING
 # This Dockerfile is intended for development purposes only. Do not use it for production deployments
 
-FROM node:18-alpine
+FROM node:20-alpine
 WORKDIR /hub/
 
 RUN mkdir -p /hub/app/ && \

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -9,7 +9,7 @@ export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build'
 export APP_ROOT=$(pwd)
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
-export NODE_BUILD_VERSION=18
+export NODE_BUILD_VERSION=20
 export IMAGE="quay.io/cloudservices/ansible-hub-ui"
 
 set -exv

--- a/community/Dockerfile
+++ b/community/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 WORKDIR /workspace/
 RUN mkdir -p /workspace/ && \
     apk add --no-cache git

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,8 +75,8 @@
         "webpack-dev-server": "^5.1.0"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=9"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "appname": "automation-hub"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=9"
+    "node": ">=20",
+    "npm": ">=10"
   }
 }

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -8,7 +8,7 @@ export COMPONENT="automation-hub"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
-export NODE_BUILD_VERSION=18
+export NODE_BUILD_VERSION=20
 
 export APP_NAME="automation-hub"  # name of app-sre "application" folder this component lives in
 export COMPONENT_NAME="automation-hub"  # name of app-sre "resourceTemplate" in deploy.yaml for this component


### PR DESCRIPTION
https://nodejs.org/en/about/previous-releases

Node 18 entered maintentance-only in 2023, and won't receive updates past May 2025.

Update to v20.

(must happen before 2025Q2)