### PR TITLE
[after branch cut] Bump master to 4.11.0dev, enable 4.10 tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,48 @@ updates:
 
   - package-ecosystem: 'npm'
     directory: '/'
+    target-branch: 'stable-4.10'
+    schedule:
+      interval: 'monthly'
+    commit-message:
+      prefix: '[stable-4.10] '
+    groups:
+      babel:
+        patterns:
+          - '@babel/*'
+          - 'babel-loader'
+      eslint:
+        patterns:
+          - 'eslint'
+          - 'eslint-config-*'
+          - 'eslint-plugin-*'
+          - 'typescript-eslint'
+      lingui:
+        patterns:
+          - '@lingui/*'
+      patternfly:
+        patterns:
+          - '@patternfly/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
+    ignore:
+      - dependency-name: '@lingui/*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@patternfly/*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@types/*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+
+  - package-ecosystem: 'npm'
+    directory: '/'
     target-branch: 'stable-4.9'
     schedule:
       interval: 'monthly'
@@ -109,6 +151,14 @@ updates:
 
   - package-ecosystem: 'npm'
     directory: '/test'
+    target-branch: 'stable-4.10'
+    schedule:
+      interval: 'monthly'
+    commit-message:
+      prefix: '[stable-4.10] '
+
+  - package-ecosystem: 'npm'
+    directory: '/test'
     target-branch: 'stable-4.9'
     schedule:
       interval: 'monthly'
@@ -121,6 +171,14 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    target-branch: 'stable-4.10'
+    commit-message:
+      prefix: '[stable-4.10] '
+    schedule:
+      interval: 'monthly'
 
   - package-ecosystem: 'github-actions'
     directory: '/'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -7,3 +7,9 @@ backport-4.9:
   - any-glob-to-any-file:
     - src/**/*
     - test/**/*
+
+backport-4.10:
+- changed-files:
+  - any-glob-to-any-file:
+    - src/**/*
+    - test/**/*

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -16,6 +16,7 @@ jobs:
         branch:
         - 'master'
         - 'stable-4.9'
+        - 'stable-4.10'
 
     steps:
 

--- a/README.md
+++ b/README.md
@@ -113,5 +113,6 @@ To map between the two:
 |AAP version|AAH version|
 |-|-|
 |2.4|4.9|
+|2.5|4.10|
 
 [Table with component versions](https://github.com/ansible/galaxy_ng/wiki/Galaxy-NG-Version-Matrix)

--- a/ansible-hub-ui/__init__.py
+++ b/ansible-hub-ui/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "4.10.0dev"
+__version__ = "4.11.0dev"


### PR DESCRIPTION
Merge with https://github.com/ansible/ansible-hub-ui/pull/5127 (but different branch)

Enables tooling for stable-4.10, and bumps master version to 4.11.

---

4.6: #2604
4.7: #3469
4.8: #4219 
4.9: #4541
4.10: here