### PR TITLE
[stable-4.9] Fixups found during #5127

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -86,7 +86,6 @@ module.exports = (inputConfigs) => {
               ([k, v]) => ({
                 context: [k],
                 target: v,
-                changeOrigin: true,
               }),
             ),
             server: { type: customConfigs.UI_USE_HTTPS ? 'https' : 'http' },

--- a/test/README.md
+++ b/test/README.md
@@ -26,7 +26,7 @@ The tests need to know details about the instance of Automation Hub that it's ru
     }
 
 
-*NOTE*: the likely values for `apiPrefix` are `/api/` (community), `/api/automation-hub/` (insights), or `/api/galaxy/` (standalone).
+*NOTE*: the likely values for `apiPrefix` is `/api/galaxy/` (standalone).
 
 *NOTE*: `containers` is what you would use with `docker push`/`podman push` to add a local container, eg. `localhost:5001`
 


### PR DESCRIPTION
Fixups found during #5127,
applying to 4.9.

`changeOrigin` breaks  the login/logout endpoints,
insights is irrelevant in 4.9.