### PR TITLE
Community - add consent_blackbar - missing for US cookie notice

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -21,5 +21,10 @@
         <!-- trustarc -->
       </span>
     </footer>
+
+    <div
+      id="consent_blackbar"
+      style="position: fixed; bottom: 0; width: 100%; z-index: 5; padding: 10px"
+    ></div>
   </body>
 </html>


### PR DESCRIPTION
Hopefully the last bit of AAH-2163 :)
![image](https://github.com/user-attachments/assets/3897d898-d242-4c34-8df0-c046cc54e6d0)


Approved by `aschuste` (slack).
Pending api changes to make tests pass again.
