### PR TITLE
[2005Q2] [stable-4.10] Bump node to v20 (#5107)

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,10 +13,10 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v4
 
-    - name: "Install node 18"
+    - name: "Install node 20"
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
 
     - name: "Check automerge conditions"
       working-directory: ".github/workflows"

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -99,10 +99,10 @@ jobs:
       working-directory: 'oci_env'
       run: 'oci-env compose up &'
 
-    - name: "Install node 18"
+    - name: "Install node 20"
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
 
     - name: "Cache ~/.npm & ~/.cache/Cypress"
       uses: actions/cache@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -13,10 +13,10 @@ jobs:
     - name: "Checkout ansible-hub-ui (${{ github.ref }})"
       uses: actions/checkout@v4
 
-    - name: "Install node 18"
+    - name: "Install node 20"
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
 
     - name: "Checks"
@@ -88,10 +88,10 @@ jobs:
       with:
         path: 'pr'
 
-    - name: "Install node 18"
+    - name: "Install node 20"
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         cache-dependency-path: |
           base/package-lock.json

--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -29,10 +29,10 @@ jobs:
         RELEASE_TAG=`sed 's/^refs\/tags\///' <<< $GITHUB_REF`
         echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
 
-    - name: "Install node 18"
+    - name: "Install node 20"
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
 
     - name: "Cache ~/.npm"
       uses: actions/cache@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # WARNING
 # This Dockerfile is intended for development purposes only. Do not use it for production deployments
 
-FROM node:18-alpine
+FROM node:20-alpine
 WORKDIR /hub/
 
 RUN mkdir -p /hub/app/ && \

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,8 +72,8 @@
         "webpack-dev-server": "^5.1.0"
       },
       "engines": {
-        "node": ">=18",
-        "npm": ">=9"
+        "node": ">=20",
+        "npm": ">=10"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "start-standalone": "NODE_ENV=development webpack serve --host 0.0.0.0 --config config/standalone.dev.webpack.config.js"
   },
   "engines": {
-    "node": ">=18",
-    "npm": ">=9"
+    "node": ">=20",
+    "npm": ">=10"
   }
 }


### PR DESCRIPTION
Merge together with https://github.com/ansible/ansible-hub-ui/pull/5107 and #5125 

---

https://nodejs.org/en/about/previous-releases

Node 18 entered maintentance-only in 2023, and won't receive updates past May 2025.

Update to v20.

(sync with productization before merging, can be done sooner)