### PR TITLE
Fix webpack-dev-server options

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -226,15 +226,8 @@ module.exports = (inputConfigs) => {
   );
 
   // webpack-dev-server 5
-  if (!isBuild && newWebpackConfig.devServer.onBeforeSetupMiddleware) {
-    const orig = newWebpackConfig.devServer.onBeforeSetupMiddleware;
-    delete newWebpackConfig.devServer.onBeforeSetupMiddleware;
+  if (!isBuild && 'https' in newWebpackConfig.devServer) {
     delete newWebpackConfig.devServer.https;
-
-    newWebpackConfig.devServer.setupMiddlewares = (middlewares, app) => {
-      orig(app);
-      return middlewares;
-    };
   }
 
   return {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7134,10 +7134,11 @@
       "dev": true
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
@@ -8571,9 +8572,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8582,7 +8583,7 @@
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",


### PR DESCRIPTION
Bump @redhat-cloud-services/frontend-components-config-utilities from 3.2.2 to 3.2.3 switched from using `onBeforeSetupMiddleware` to `setupMiddlewares` (https://github.com/RedHatInsights/frontend-components/pull/2070)

so we don't need that fix anymore,
but it was also removing devServer.https, which is still used, deleting as before, with fixed condition.

(stable branches are not affected, no frontend-components-config)