### PR TITLE
[stable-4.9] Allow HUB_UI_VERSION to point to a tag name

### DIFF
--- a/src/components/about-modal/about-modal.tsx
+++ b/src/components/about-modal/about-modal.tsx
@@ -158,7 +158,11 @@ export const AboutModalWindow = ({
           <Label>{t`UI Version`}</Label>
           <Value>
             <ExternalLink
-              href={`https://github.com/ansible/ansible-hub-ui/commit/${ui_sha}`}
+              href={
+                ui_sha.includes('.')
+                  ? `https://github.com/ansible/ansible-hub-ui/releases/tag/${ui_sha}`
+                  : `https://github.com/ansible/ansible-hub-ui/commit/${ui_sha}`
+              }
             >
               {ui_sha}
             </ExternalLink>


### PR DESCRIPTION
Issue: AAP-34966
Closes: #5292 

previously the About modal assumed HUB_UI_VERSION would always use the commit sha, when run with a tag name, the link in about modal would lead to the wrong place

this allows for both sha or tag name (as long as the tag name contains a dot)

![20241031120344](https://github.com/user-attachments/assets/1480c5d6-6af9-4b7d-aedc-471feeaecd85)
![20241031120528](https://github.com/user-attachments/assets/7b172227-b880-4dd8-b01f-95d8c4cf640b)
