### PR TITLE
dependabot: ignore patternfly 6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,8 @@ updates:
           - 'react'
           - 'react-dom'
     ignore:
+      - dependency-name: '@patternfly/*'
+        update-types: ['version-update:semver-major']
       - dependency-name: 'eslint'
         update-types:
           - 'version-update:semver-major'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ make oci/dab
 The backend can be run in multiple modes - `standalone`, `community`, `insights`, `keycloak`, `ldap` and `dab`.
 Depending on the mode, it will listen on http://localhost:5001 or http://localhost:55001, under `/api/galaxy/`, `/api/` or `/api/automation-hub/`.
 
+Or, use the [simplified compose stack](https://github.com/ansible/galaxy_ng/tree/master/dev/compose#galaxy-simplified-compose-stack).
+
 
 ### Frontend
 


### PR DESCRIPTION
PF6 came out, crc doesn't support it yet,
stopping dependabot from offering that update.

(Also https://github.com/RedHatInsights/ansible-platform-dashboard/pull/159, https://github.com/RedHatInsights/tower-analytics-frontend/pull/1090)