### PR TITLE
Fix deprecation tests, replace react-router-hash-link, prevent depdenabot from react-router-dom v7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,8 +29,15 @@ updates:
           - 'react-dom'
     ignore:
       - dependency-name: '@patternfly/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: 'eslint'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'react'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'react-dom'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'react-router-dom'
         update-types:
           - 'version-update:semver-major'
       - dependency-name: 'monaco-editor'
@@ -46,9 +53,6 @@ updates:
           - 'version-update:semver-major'
           - 'version-update:semver-minor'
           - 'version-update:semver-patch'
-      - dependency-name: 'typescript-eslint'
-        update-types:
-          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: '/'
@@ -78,19 +82,41 @@ updates:
         patterns:
           - 'react'
           - 'react-dom'
-          - '@types/react'
-          - '@types/react-dom'
     ignore:
       - dependency-name: '@lingui/*'
-        update-types: ['version-update:semver-major']
+        update-types:
+          - 'version-update:semver-major'
       - dependency-name: '@patternfly/*'
-        update-types: ['version-update:semver-major']
-      - dependency-name: '@types/*'
-        update-types: ['version-update:semver-major']
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'eslint'
+        update-types:
+          - 'version-update:semver-major'
       - dependency-name: 'react'
-        update-types: ['version-update:semver-major']
+        update-types:
+          - 'version-update:semver-major'
       - dependency-name: 'react-dom'
-        update-types: ['version-update:semver-major']
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'react-router-dom'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'monaco-editor'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+      - dependency-name: 'react-monaco-editor'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+      - dependency-name: 'sass'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+          - 'version-update:semver-patch'
+      - dependency-name: 'typescript-eslint'
+        update-types:
+          - 'version-update:semver-major'
 
   - package-ecosystem: 'npm'
     directory: '/'
@@ -120,8 +146,6 @@ updates:
         patterns:
           - 'react'
           - 'react-dom'
-          - '@types/react'
-          - '@types/react-dom'
     ignore:
       - dependency-name: '@lingui/*'
         update-types:
@@ -129,7 +153,7 @@ updates:
       - dependency-name: '@patternfly/*'
         update-types:
           - 'version-update:semver-major'
-      - dependency-name: '@types/*'
+      - dependency-name: 'eslint'
         update-types:
           - 'version-update:semver-major'
       - dependency-name: 'react'
@@ -138,11 +162,25 @@ updates:
       - dependency-name: 'react-dom'
         update-types:
           - 'version-update:semver-major'
+      - dependency-name: 'react-router-dom'
+        update-types:
+          - 'version-update:semver-major'
+      - dependency-name: 'monaco-editor'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
+      - dependency-name: 'react-monaco-editor'
+        update-types:
+          - 'version-update:semver-major'
+          - 'version-update:semver-minor'
       - dependency-name: 'sass'
         update-types:
           - 'version-update:semver-major'
           - 'version-update:semver-minor'
           - 'version-update:semver-patch'
+      - dependency-name: 'typescript-eslint'
+        update-types:
+          - 'version-update:semver-major'
 
   # npm in test/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8754,9 +8754,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8779,7 +8779,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -8794,6 +8794,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -13681,9 +13685,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,7 @@
         "react-dom": "^18.3.1",
         "react-markdown": "^9.0.1",
         "react-monaco-editor": "^0.55.0",
-        "react-router-dom": "^6.26.2",
-        "react-router-hash-link": "^2.4.3"
+        "react-router-dom": "^6.26.2"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -14488,17 +14487,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-router-hash-link": {
-      "version": "2.4.3",
-      "license": "MIT",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">=15",
-        "react-router-dom": ">=4"
       }
     },
     "node_modules/read-pkg": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.1",
     "react-monaco-editor": "^0.55.0",
-    "react-router-dom": "^6.26.2",
-    "react-router-hash-link": "^2.4.3"
+    "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -3,7 +3,6 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclam
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import React, { Component, type RefObject, createRef } from 'react';
 import { Link } from 'react-router-dom';
-import { HashLink } from 'react-router-hash-link';
 import { type CollectionVersionSearch } from 'src/api';
 import {
   Alert,
@@ -191,7 +190,7 @@ class CollectionDocs extends Component<RouteProps, IBaseCollectionState> {
                       this.renderDocLink(name, href, collection, params)
                     }
                     renderTableOfContentsLink={(title, section) => (
-                      <HashLink to={'#' + section}>{title}</HashLink>
+                      <a href={'#' + section}>{title}</a>
                     )}
                     renderWarning={(text) => (
                       <Alert isInline variant='warning' title={text} />

--- a/src/containers/execution-environment-detail/execution-environment-detail-activities.tsx
+++ b/src/containers/execution-environment-detail/execution-environment-detail-activities.tsx
@@ -1,7 +1,7 @@
 import { Trans, t } from '@lingui/macro';
 import { Button, Flex, FlexItem } from '@patternfly/react-core';
 import { Table, Tbody, Td, Tr } from '@patternfly/react-table';
-import React, { Component, type ReactFragment } from 'react';
+import React, { Component, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { ActivitiesAPI } from 'src/api';
 import {
@@ -18,7 +18,7 @@ import './execution-environment-detail.scss';
 
 interface IState {
   loading: boolean;
-  activities: { created: string; action: ReactFragment }[];
+  activities: { created: string; action: ReactNode }[];
   redirect: string;
   page: number;
 }

--- a/test/cypress/e2e/collections/collection-upload.js
+++ b/test/cypress/e2e/collections/collection-upload.js
@@ -119,16 +119,15 @@ describe('Collection Upload Tests', () => {
 
   it('should deprecate let user deprecate and undeprecate collections', () => {
     cy.login();
+
     cy.visit(`${uiPrefix}namespaces/testspace`);
     cy.get('[data-cy=collection-kebab]').first().click();
     cy.contains('Deprecate').click();
-    cy.visit(`${uiPrefix}namespaces/testspace`);
     cy.contains('DEPRECATED');
 
     cy.visit(`${uiPrefix}namespaces/testspace`);
     cy.get('[data-cy=collection-kebab]').first().click();
     cy.contains('Undeprecate').click();
-    cy.visit(`${uiPrefix}namespaces/testspace`);
     cy.contains('DEPRECATED').should('not.exist');
   });
 });

--- a/test/cypress/e2e/namespaces/namespace-detail.js
+++ b/test/cypress/e2e/namespaces/namespace-detail.js
@@ -32,9 +32,6 @@ describe('Namespace detail screen', () => {
     ).click();
     cy.contains('.body ul a', 'Deprecate').click();
 
-    // Reload the page
-    cy.visit(`${uiPrefix}namespaces/namespace_detail_test`);
-
     cy.get('[data-cy="CollectionListItem"]:first').contains('DEPRECATED');
   });
 


### PR DESCRIPTION
Closes #5316 

> crc is not yet compatible with react-router v7, is runtime-compatible with react-router-dom v7, but throws a peer dependency error with @redhat-cloud-services/frontend-components@5.0.1.

Pulling out appliable fixes from there.
Updating dependabot config to skip react-router-dom v7.
(and sync the older branches accordingly)
