### PR TITLE
Plugin option choices: both 'bool' and 'boolean' are valid types for plugins, and should be treated the same

### DIFF
--- a/CHANGES/5415.bug
+++ b/CHANGES/5415.bug
@@ -1,0 +1,1 @@
+Collection documentation: treat options of type `boolean` the same as options of type `bool`.

--- a/src/components/render-plugin-doc.tsx
+++ b/src/components/render-plugin-doc.tsx
@@ -692,7 +692,7 @@ export class RenderPluginDoc extends Component<IProps, IState> {
       defaultChoice,
       legends = {};
 
-    if (option['type'] === 'bool') {
+    if (option['type'] === 'bool' || option['type'] === 'boolean') {
       choices = ['true', 'false'];
 
       if (option['default'] === true) {


### PR DESCRIPTION
This bug was reported in https://github.com/ansible-collections/community.general/pull/9573#discussion_r1922838554.

Example: https://galaxy.ansible.com/ui/repo/published/community/general/content/inventory/iocage/#parameters option "leading_separator", which is a boolean with type `boolean` with default `false`. "trailing_separator", on the other hand, is a boolean of type `bool` with default `true`.