### PR TITLE
Fix zero width of spacer columns indenting suboptions and sub-return values

### DIFF
--- a/CHANGES/5417.bug
+++ b/CHANGES/5417.bug
@@ -1,0 +1,1 @@
+Collection documentation: fix zero width of spacer columns indenting suboptions and sub-return values.

--- a/src/components/render-plugin-doc.scss
+++ b/src/components/render-plugin-doc.scss
@@ -21,7 +21,9 @@
   width: 100%;
 
   .spacer {
-    width: 20px;
+    // The !important is needed here to avoid the value being overridden
+    // by table.css injected by some dependencies.
+    width: 20px !important;
     border-top: 0;
     border-bottom: 0;
   }


### PR DESCRIPTION
The CSS from table.css (coming from some dependency, I guess) overrides `width` with `0` due to the column being `:empty`. This makes the indent almost disappear (you can still see it by noticing that the left border line is a tiny bit thicker).

For example, check out the return values here:

Before:
![image](https://github.com/user-attachments/assets/6f8a4a3f-8a56-44bb-89a1-c70f0c08e5ad)

After:
![image](https://github.com/user-attachments/assets/0fe37594-7bb5-4a50-8621-b05f243a2ef5)
