### PR TITLE
Fix zero width of first spacer columns in case multiple such colums are present

### DIFF
--- a/src/components/render-plugin-doc.scss
+++ b/src/components/render-plugin-doc.scss
@@ -24,6 +24,7 @@
     // The !important is needed here to avoid the value being overridden
     // by table.css injected by some dependencies.
     width: 20px !important;
+
     // In case of multiple indents, it seems that the first indent still
     // has width 0. Adding a min-width seems to fix it on Chrome and Firefox.
     min-width: 20px;

--- a/src/components/render-plugin-doc.scss
+++ b/src/components/render-plugin-doc.scss
@@ -24,6 +24,9 @@
     // The !important is needed here to avoid the value being overridden
     // by table.css injected by some dependencies.
     width: 20px !important;
+    // In case of multiple indents, it seems that the first indent still
+    // has width 0. Adding a min-width seems to fix it on Chrome and Firefox.
+    min-width: 20px;
     border-top: 0;
     border-bottom: 0;
   }


### PR DESCRIPTION
It seems that #5417 was not sufficient in some cases.

1. `default_gateway` in https://galaxy.ansible.com/ui/repo/published/community/vmware/content/module/vmware_vmkernel/?version=5.4.0 is now correctly indented.
2. `authorizations ` in https://galaxy.ansible.com/ui/repo/published/community/crypto/content/module/acme_account_info/#return-values is not correctly indented (but note that its field `identifiers` is indented).

For me, adding an additional `min-width: 20px` to `.spacer` fixed the problem. I've tested this both with current Firefox and Chromium.