### PR TITLE
allow mintmaker to update konflux references

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": [
+    "tekton"
+  ],
+  "tekton": {
+    "enabled": true,
+    "automerge": false,
+    "schedule": ["at any time"]
+  }
+}


### PR DESCRIPTION
#### What is this PR doing:
<!-- Describe your changes giving context and all the needed details. -->
* adds a mintmaker config file with only the tekton manager enabled

this allows mintmaker to update the Konflux references, while still blocking all other dependency update branches/PRs

<!-- Add Jira issue link or replace with No-Issue -->
No-Issue
