### PR TITLE
Fix rendering of empty return doctrings

### DIFF
--- a/src/components/render-plugin-doc.tsx
+++ b/src/components/render-plugin-doc.tsx
@@ -223,7 +223,10 @@ export class RenderPluginDoc extends Component<IProps, IState> {
       return null;
     }
 
-    if (!plugin.doc_strings.return) {
+    if (
+      !plugin.doc_strings.return ||
+      !plugin.doc_strings.return[Symbol.iterator]
+    ) {
       return null;
     }
 


### PR DESCRIPTION
The existing code checked whether the return docstring was null but does not check if it is iterable. If a collection with 'RETURN: {}' was set it would fail to render the entire docstring. This ensures that both null and {} can be parsed correctly.