### PR TITLE
fix collection docs page by requesting docs_blob field

### DIFF
--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -162,12 +162,18 @@ export class API extends HubAPI {
     );
   }
 
-  getContent(namespace, name, version) {
+  getContent(
+    namespace,
+    name,
+    version,
+    exclude_fields = 'files,manifest,docs_blob,contents',
+  ) {
     return super.list(
       {
         namespace,
         name,
         version,
+        exclude_fields,
       },
       `pulp/api/v3/content/ansible/collection_versions/`,
     );

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -1,3 +1,4 @@
+import { type NavigateFunction } from 'react-router-dom';
 import {
   CollectionAPI,
   type CollectionDetailType,
@@ -26,8 +27,8 @@ export interface IBaseCollectionState {
 
 interface LoadCollectionParams {
   forceReload: boolean;
-  matchParams: any;
-  navigate: any;
+  matchParams: Record<string, string>;
+  navigate: NavigateFunction;
   setCollection: (
     collections: CollectionVersionSearch[],
     collection: CollectionVersionSearch,

--- a/src/containers/collection-detail/base.ts
+++ b/src/containers/collection-detail/base.ts
@@ -24,6 +24,24 @@ export interface IBaseCollectionState {
   };
 }
 
+interface LoadCollectionParams {
+  forceReload: boolean;
+  matchParams: any;
+  navigate: any;
+  setCollection: (
+    collections: CollectionVersionSearch[],
+    collection: CollectionVersionSearch,
+    content: CollectionVersionContentType,
+    collectionsCount: number,
+    actuallyCollection: CollectionDetailType,
+  ) => void;
+  stateParams: {
+    version?: string;
+    showing?: string;
+    keywords?: string;
+  };
+}
+
 // Caches the collection data when matching, prevents redundant fetches between collection detail tabs
 const cache = {
   repository: null,
@@ -44,7 +62,7 @@ export function loadCollection({
   navigate,
   setCollection,
   stateParams,
-}) {
+}: LoadCollectionParams) {
   const { version } = stateParams;
   const { collection: name, namespace, repo } = matchParams;
 

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -1,5 +1,6 @@
 import { t } from '@lingui/core/macro';
 import { Component } from 'react';
+import { CollectionAPI } from 'src/api';
 import {
   CollectionContentList,
   CollectionHeader,
@@ -110,14 +111,23 @@ class CollectionContent extends Component<RouteProps, IBaseCollectionState> {
         content,
         collectionsCount,
         actuallyCollection,
-      ) =>
+      ) => {
         this.setState({
           collections,
           collection,
-          content,
           collectionsCount,
           actuallyCollection,
-        }),
+        });
+
+        CollectionAPI.getContent(
+          collection.collection_version.namespace,
+          collection.collection_version.name,
+          collection.collection_version.version,
+          'files,manifest,docs_blob',
+        ).then(({ data: { results } }) => {
+          this.setState({ content: results[0] });
+        });
+      },
       stateParams: this.state.params,
     });
   }

--- a/src/containers/collection-detail/collection-content.tsx
+++ b/src/containers/collection-detail/collection-content.tsx
@@ -45,7 +45,7 @@ class CollectionContent extends Component<RouteProps, IBaseCollectionState> {
       params,
     } = this.state;
 
-    if (collections.length <= 0) {
+    if (collections.length <= 0 || !content) {
       return <LoadingPage />;
     }
 

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -3,7 +3,7 @@ import ExclamationCircleIcon from '@patternfly/react-icons/dist/esm/icons/exclam
 import ExclamationTriangleIcon from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
 import { Component, type RefObject, createRef } from 'react';
 import { Link } from 'react-router-dom';
-import { type CollectionVersionSearch } from 'src/api';
+import { CollectionAPI, type CollectionVersionSearch } from 'src/api';
 import {
   Alert,
   CollectionHeader,
@@ -312,14 +312,23 @@ class CollectionDocs extends Component<RouteProps, IBaseCollectionState> {
         content,
         collectionsCount,
         actuallyCollection,
-      ) =>
+      ) => {
         this.setState({
           collections,
           collection,
-          content,
           collectionsCount,
           actuallyCollection,
-        }),
+        });
+
+        CollectionAPI.getContent(
+          collection.collection_version.namespace,
+          collection.collection_version.name,
+          collection.collection_version.version,
+          'files,manifest,contents',
+        ).then(({ data: { results } }) => {
+          this.setState({ content: results[0] });
+        });
+      },
       stateParams: this.state.params,
     });
   }


### PR DESCRIPTION
## Summary

pulp_ansible 0.25.5+ strips large fields (`docs_blob`, `contents`, `files`, `manifest`) from collection version API responses by default to prevent OOM. This broke the Docs and Contents tabs which depend on `docs_blob` and `contents` respectively.

## Approach

Uses `exclude_fields` query parameter (same approach as downstream [ansible-ui#3133](https://github.com/ansible/ansible-ui/pull/3133)):

- **Shared cache** (`base.ts` `loadCollection`): requests collection data with `exclude_fields=files,manifest,docs_blob,contents` — all large fields excluded, cache stays consistent across tab navigation
- **Docs tab**: makes a separate API call with `exclude_fields=files,manifest,contents` to fetch `docs_blob`
- **Contents tab**: makes a separate API call with `exclude_fields=files,manifest,docs_blob` to fetch `contents`
- **Other tabs** (Install, Dependencies, Distributions, Import Log): use cached minimal data, no large fields needed

This avoids a cache staleness bug where navigating between tabs served cached data missing required fields (e.g. visiting Install tab first cached content without `docs_blob`, then clicking Docs tab returned stale cache).

## Test plan

- [x] Navigate to collection Install tab, then click Docs tab — docs render without page refresh
- [x] Navigate to Contents tab — content list renders
- [x] Full page refresh on Docs/Contents tabs — still works
- [x] Other tabs (Install, Dependencies, etc.) load without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)