### PR TITLE
feat(ui): update platform headers for clarity

### DIFF
--- a/src/containers/landing/landing-page.tsx
+++ b/src/containers/landing/landing-page.tsx
@@ -58,7 +58,20 @@ export class LandingPage extends Component<RouteProps, IState> {
             })
           }
         />
-        <BaseHeader title={t`Welcome to Galaxy`} />
+        <BaseHeader
+          title={t`Welcome to Ansible Galaxy`}
+          subTitle={
+            <Trans>
+              The community hub for sharing Ansible roles and collections —
+              free, open source, community-maintained content. Looking for Red
+              Hat certified and supported content?{' '}
+              <ExternalLink href='https://console.redhat.com/ansible/automation-hub'>
+                Visit Red Hat Automation Hub
+              </ExternalLink>
+              .
+            </Trans>
+          }
+        />
         <Main>
           <MultiSearchSearch
             updateParams={({ keywords }) =>

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -223,7 +223,15 @@ class Search extends Component<RouteProps, IState> {
               namespace={updateCollection.collection_version.namespace}
             />
           )}
-          <BaseHeader className='hub-header-bordered' title={t`Collections`} />
+          <BaseHeader
+            className='hub-header-bordered'
+            title={t`Collections`}
+            subTitle={
+              !IS_COMMUNITY
+                ? t`Red Hat certified and validated Ansible content — tested, Red Hat supported, and enterprise-ready.`
+                : undefined
+            }
+          />
           {!noData && (
             <HubListToolbar
               count={count}


### PR DESCRIPTION
## Summary
- Updates Galaxy landing page header from "Welcome to Galaxy" to "Welcome to Ansible Galaxy" with a descriptive subtitle and link to Red Hat Automation Hub for certified content
- Adds subtitle to Hub collections page: "Red Hat certified and validated Ansible content — tested, Red Hat supported, and enterprise-ready."
- Subtitle on Hub only renders in non-community mode (`!IS_COMMUNITY`)

## Motivation
Users landing on either platform cannot immediately distinguish between community and enterprise content. This change provides immediate context and cross-links between platforms.

Ref: [AAP-53656](https://redhat.atlassian.net/browse/AAP-53656)

## Test plan
- [ ] Verify Galaxy landing page shows updated header + subtitle with working Hub link
- [ ] Verify Hub collections page shows subtitle in standalone/insights mode
- [ ] Verify Galaxy collections page does NOT show subtitle (`IS_COMMUNITY` guard)
- [ ] Verify TypeScript compiles without errors (`npm run lint:ts`)
- [ ] Verify translations extract correctly (`npm run extract`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)