### PR TITLE
feat(ui): add promotional banner for Hub on Galaxy pages

### DIFF
--- a/src/components/hub-promo-banner.tsx
+++ b/src/components/hub-promo-banner.tsx
@@ -1,0 +1,27 @@
+import { Trans } from '@lingui/react/macro';
+import { Alert } from '@patternfly/react-core';
+import { ExternalLink } from './external-link';
+
+export const HubPromoBanner = () => {
+  if (!IS_COMMUNITY) {
+    return null;
+  }
+
+  return (
+    <Alert
+      isInline
+      variant='info'
+      title={
+        <Trans>
+          Looking for certified and Red Hat supported Ansible content?{' '}
+          <ExternalLink href='https://console.redhat.com/ansible/automation-hub'>
+            Browse Red Hat Automation Hub
+          </ExternalLink>{' '}
+          for enterprise-ready collections that are tested, signed, and backed
+          by Red Hat.
+        </Trans>
+      }
+      style={{ margin: '0 24px 16px 24px' }}
+    />
+  );
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -48,6 +48,7 @@ export { HelpButton } from './help-button';
 export { HubAboutModal } from './hub-about-modal';
 export { HubCopyButton } from './hub-copy-button';
 export { HubListToolbar } from './hub-list-toolbar';
+export { HubPromoBanner } from './hub-promo-banner';
 export { HubPagination } from './hub-pagination';
 export { ImportConsole } from './import-console';
 export { ImportList } from './import-list';

--- a/src/containers/ansible-role/role-detail.tsx
+++ b/src/containers/ansible-role/role-detail.tsx
@@ -32,6 +32,7 @@ import {
   DownloadCount,
   EmptyStateNoData,
   ExternalLink,
+  HubPromoBanner,
   ImportConsole,
   LabelGroup,
   LoadingPage,
@@ -495,6 +496,7 @@ class AnsibleRoleDetail extends Component<RouteProps, RoleState> {
             })
           }
         />
+        <HubPromoBanner />
         <BaseHeader
           breadcrumbs={<Breadcrumbs links={breadcrumbs} />}
           title={`${namespace.name}.${role.name}`}

--- a/src/containers/collection-detail/collection-detail.tsx
+++ b/src/containers/collection-detail/collection-detail.tsx
@@ -4,6 +4,7 @@ import {
   AlertList,
   CollectionHeader,
   CollectionInfo,
+  HubPromoBanner,
   LoadingPage,
   Main,
   closeAlert,
@@ -85,6 +86,7 @@ class CollectionDetail extends Component<RouteProps, IBaseCollectionState> {
             })
           }
         />
+        <HubPromoBanner />
         <CollectionHeader
           activeTab='install'
           actuallyCollection={actuallyCollection}


### PR DESCRIPTION
## Summary
- Adds a reusable `HubPromoBanner` component that renders an info banner on Galaxy (community) pages directing users to Red Hat Automation Hub for certified and Red Hat supported content
- Banner appears on collection detail pages and role detail pages
- Only renders in community mode (`IS_COMMUNITY`) — no-op on Hub/standalone deployments

## Files changed
- `src/components/hub-promo-banner.tsx` — New reusable banner component
- `src/components/index.ts` — Barrel export
- `src/containers/collection-detail/collection-detail.tsx` — Added banner
- `src/containers/ansible-role/role-detail.tsx` — Added banner

Ref: [AAP-53655](https://redhat.atlassian.net/browse/AAP-53655)

## Test plan
- [ ] Verify banner appears on Galaxy collection detail pages with working Hub link
- [ ] Verify banner appears on Galaxy role detail pages with working Hub link
- [ ] Verify banner does NOT appear on Hub/standalone deployments
- [ ] Verify TypeScript compiles without errors (`npm run lint:ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)