### PR TITLE
feat(ui): show certified version link on Galaxy collection pages

### DIFF
--- a/src/components/collection-header.tsx
+++ b/src/components/collection-header.tsx
@@ -493,6 +493,24 @@ export const CollectionHeader = ({
             })
           }
         />
+        {IS_COMMUNITY && (
+          <Alert
+            variant='info'
+            isInline
+            title={
+              <Trans>
+                A Red Hat certified version of this collection may be available
+                on{' '}
+                <ExternalLink
+                  href={`https://console.redhat.com/ansible/automation-hub/repo/published/${collection_version.namespace}/${collection_version.name}`}
+                >
+                  Red Hat Automation Hub
+                </ExternalLink>
+                .
+              </Trans>
+            }
+          />
+        )}
         <div className='hub-tab-link-container'>
           <div className='tabs'>{renderTabs(activeTab)}</div>
           <div className='links'>


### PR DESCRIPTION
## Summary
- Adds an inline info alert on Galaxy collection detail pages linking to the corresponding collection on Red Hat Automation Hub
- Message: "A Red Hat certified version of this collection may be available on Red Hat Automation Hub" with a direct link to `console.redhat.com/ansible/automation-hub/repo/published/{namespace}/{collection}`
- Only renders in community mode (`IS_COMMUNITY`) — no effect on Hub deployments
- Placed inside the collection header, below the deprecation alert and above the tab navigation

## Approach
This is an initial implementation using a direct link approach — the badge appears on all Galaxy collection pages since the frontend doesn't currently have a way to query Hub's certification status. A future enhancement (backend API lookup) could make this conditional on actual certification status.

Ref: [AAP-53672](https://redhat.atlassian.net/browse/AAP-53672)

## Test plan
- [ ] Verify info alert appears on Galaxy collection detail pages with correct Hub link
- [ ] Verify the link URL correctly includes the collection's namespace and name
- [ ] Verify the alert does NOT appear on Hub/standalone deployments
- [ ] Verify TypeScript compiles without errors (`npm run lint:ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)