### PR TITLE
feat(ui): restore sort by last updated date

### DIFF
--- a/src/api/response-types/collection.ts
+++ b/src/api/response-types/collection.ts
@@ -71,6 +71,7 @@ export class CollectionVersionSearch {
   is_deprecated: boolean;
   is_highest: boolean;
   is_signed: boolean;
+  updated_at?: string;
   // TODO: ansible namespace metadata doesn't work yet
   // assuming fields from pulp_ansible/NamespaceSummarySerializer
   namespace_metadata?: {

--- a/src/components/collection-filter.ts
+++ b/src/components/collection-filter.ts
@@ -83,6 +83,7 @@ export const collectionFilter = ({
     { title: t`Name`, id: 'name', type: 'alpha' as const },
     { title: t`Namespace`, id: 'namespace', type: 'alpha' as const },
     { title: t`Last modified`, id: 'pulp_created', type: 'numeric' as const },
+    { title: t`Last updated`, id: 'updated_at', type: 'numeric' as const },
     { title: t`Version`, id: 'version', type: 'numeric' as const },
   ];
 

--- a/src/components/collection-list-item.tsx
+++ b/src/components/collection-list-item.tsx
@@ -45,6 +45,7 @@ export const CollectionListItem = ({
     repository,
     is_signed,
     is_deprecated,
+    updated_at,
   },
   displaySignatures,
   dropdownMenu,
@@ -146,7 +147,10 @@ export const CollectionListItem = ({
           <FlexItem>
             <div>
               <Trans>
-                Updated <DateComponent date={collection_version.pulp_created} />
+                Updated{' '}
+                <DateComponent
+                  date={updated_at || collection_version.pulp_created}
+                />
               </Trans>
             </div>
             <div>v{collection_version.version}</div>


### PR DESCRIPTION
## Summary
- Adds "Last updated" (`updated_at`) sort option to the collections search page sort dropdown
- Updates collection list item to prefer `updated_at` over `pulp_created` for the "Updated" date display when available
- Adds optional `updated_at` field to `CollectionVersionSearch` response type

## Backend dependency
The frontend sort option sends `order_by=updated_at` to the `v3/plugin/ansible/search/collection-versions/` API. **The backend (pulp_ansible) must support this parameter** for the sort to work. If `updated_at` is not yet exposed:
- The `pulp_ansible` search endpoint needs to include `updated_at` in the serializer
- The `collections` table should have an index on `updated_at` for performance

Ref: [AAP-67527](https://redhat.atlassian.net/browse/AAP-67527)

## Files changed
- `src/components/collection-filter.ts` — Added "Last updated" sort option
- `src/api/response-types/collection.ts` — Added optional `updated_at` field
- `src/components/collection-list-item.tsx` — Prefer `updated_at` for date display

## Test plan
- [ ] Verify "Last updated" appears in the sort dropdown on collections page
- [ ] Verify sort works when backend supports `order_by=updated_at`
- [ ] Verify graceful fallback — list item shows `pulp_created` when `updated_at` is undefined
- [ ] Verify TypeScript compiles without errors (`npm run lint:ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)