### PR TITLE
feat(ui): add Technology Preview tag for collections

### DIFF
--- a/src/components/collection-header.tsx
+++ b/src/components/collection-header.tsx
@@ -52,6 +52,7 @@ import {
   Spinner,
   UploadSignatureModal,
   closeAlert,
+  isTechnologyPreview,
 } from 'src/components';
 import { useHubContext } from 'src/loaders/app-context';
 import { Paths, formatPath } from 'src/paths';
@@ -482,6 +483,13 @@ export const CollectionHeader = ({
             variant='danger'
             isInline
             title={t`This collection has been deprecated.`}
+          />
+        )}
+        {isTechnologyPreview(collection.collection_version.tags) && (
+          <Alert
+            variant='info'
+            isInline
+            title={t`This collection is a Technology Preview. It may not be feature-complete and is not recommended for production use.`}
           />
         )}
         <AlertList

--- a/src/components/collection-list-item.tsx
+++ b/src/components/collection-list-item.tsx
@@ -24,6 +24,8 @@ import {
   RepositoryBadge,
   SignatureBadge,
   Tag,
+  TechnologyPreviewTag,
+  isTechnologyPreview,
 } from 'src/components';
 import { Paths, formatPath } from 'src/paths';
 import { convertContentSummaryCounts, namespaceTitle } from 'src/utilities';
@@ -89,6 +91,9 @@ export const CollectionListItem = ({
           {collection_version.name}
         </Link>
         {is_deprecated && <DeprecatedTag />}
+        {isTechnologyPreview(collection_version.tags) && (
+          <TechnologyPreviewTag />
+        )}
         {showNamespace ? (
           <TextContent>
             <Text component={TextVariants.small}>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -143,6 +143,10 @@ export { StatefulDropdown } from './stateful-dropdown';
 export { StatusIndicator } from './status-indicator';
 export { TableOfContents } from './table-of-contents';
 export { Tag } from './tag';
+export {
+  TechnologyPreviewTag,
+  isTechnologyPreview,
+} from './technology-preview-tag';
 export { TagLabel } from './tag-label';
 export { TagManifestModal } from './tag-manifest-modal';
 export { Typeahead } from './typeahead';

--- a/src/components/technology-preview-tag.tsx
+++ b/src/components/technology-preview-tag.tsx
@@ -1,0 +1,30 @@
+import { t } from '@lingui/core/macro';
+
+export const TECHNOLOGY_PREVIEW_TAG = 'technology_preview';
+
+export const isTechnologyPreview = (
+  tags: { name: string }[] | string[],
+): boolean =>
+  tags?.some((tag) => {
+    const name = typeof tag === 'string' ? tag : tag.name;
+    return name === TECHNOLOGY_PREVIEW_TAG || name === 'tech-preview';
+  }) ?? false;
+
+export const TechnologyPreviewTag = () => (
+  <div
+    style={{
+      display: 'inline-block',
+      margin: '4px',
+      backgroundColor: '#0066CC',
+      color: 'white',
+      fontSize: '14px',
+      paddingLeft: '5px',
+      paddingRight: '5px',
+      paddingBottom: '2px',
+      paddingTop: '2px',
+      borderRadius: '3px',
+    }}
+  >
+    {t`TECHNOLOGY PREVIEW`}
+  </div>
+);


### PR DESCRIPTION
## Summary
- Adds `TechnologyPreviewTag` component (styled blue badge, modeled after `DeprecatedTag`)
- Adds `isTechnologyPreview()` helper that detects `"technology_preview"` or `"tech-preview"` in collection tags
- Collection list items show a "TECHNOLOGY PREVIEW" badge next to collections with this tag
- Collection detail header shows an info alert: "This collection is a Technology Preview. It may not be feature-complete and is not recommended for production use."

## How it works
Content creators add `technology_preview` to the `tags` list in their `galaxy.yml`:
```yaml
tags:
  - cloud
  - technology_preview
```

No backend changes required — this leverages the existing tag system. Users can already filter for these collections using the existing tag search filter.

Ref: [AAP-55564](https://redhat.atlassian.net/browse/AAP-55564)

## Files changed
- `src/components/technology-preview-tag.tsx` — New component + helper
- `src/components/index.ts` — Barrel export
- `src/components/collection-list-item.tsx` — Badge on list items
- `src/components/collection-header.tsx` — Info alert on detail page

## Test plan
- [ ] Add `technology_preview` tag to a test collection's galaxy.yml and upload
- [ ] Verify blue "TECHNOLOGY PREVIEW" badge appears in collection list view
- [ ] Verify info alert appears on collection detail page
- [ ] Verify badge does NOT appear for collections without the tag
- [ ] Verify `tech-preview` alternate tag name also triggers the badge
- [ ] Verify TypeScript compiles without errors (`npm run lint:ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)