### PR TITLE
feat(ui): enable partial matching for collection search

### DIFF
--- a/src/components/collection-filter.ts
+++ b/src/components/collection-filter.ts
@@ -45,7 +45,8 @@ export const collectionFilter = ({
   featureFlags: { display_signatures, display_repositories },
   ignoredParams: i,
 }) => {
-  const displayNamespaces = !i.includes('namespace');
+  const displayNamespaces =
+    !i.includes('namespace') && !i.includes('namespace__icontains');
   const displayRepos = display_repositories && !i.includes('repository_name');
   const displayTags = !i.includes('tags');
 
@@ -54,13 +55,17 @@ export const collectionFilter = ({
       id: 'keywords',
       title: t`Keywords`,
     },
+    {
+      id: 'name__icontains',
+      title: t`Collection name`,
+    },
     displayRepos && {
       id: 'repository_name',
       title: t`Repository`,
       inputType: 'typeahead' as const,
     },
     displayNamespaces && {
-      id: 'namespace',
+      id: 'namespace__icontains',
       title: t`Namespace`,
     },
     displayTags && {

--- a/src/containers/search/search.tsx
+++ b/src/containers/search/search.tsx
@@ -152,10 +152,12 @@ class Search extends Component<RouteProps, IState> {
       collections.length === 0 &&
       !filterIsSet(params, [
         'keywords',
+        'name__icontains',
         'tags',
         'is_signed',
         'repository_name',
         'namespace',
+        'namespace__icontains',
       ]);
 
     const updateParams = (p) =>


### PR DESCRIPTION
## Summary
- Adds a **"Collection name"** filter using `name__icontains` for partial name matching — typing "sap" now returns all SAP-related collections (e.g., `community.sap`, `community.sap_operations`, etc.)
- Changes the **Namespace** filter from exact match (`namespace=X`) to partial match (`namespace__icontains=X`) — typing "cisco" returns all Cisco namespaces
- **Keywords** filter is unchanged — it continues to use the backend's full-text search across name, namespace, description, and tags

## Problem
Previously, the Name and Namespace filters required exact matches. A user searching for "sap" in the name field would only find a collection named exactly "sap", missing collections like `sap_hana`, `sap_operations`, etc. This made content discovery unnecessarily difficult.

## How it works
The Pulp/Django backend supports Django-style field lookups. The frontend now sends:
- `name__icontains=sap` instead of requiring exact name match
- `namespace__icontains=cisco` instead of `namespace=cisco`

These are case-insensitive substring matches handled natively by the backend.

Ref: [AAP-67482](https://redhat.atlassian.net/browse/AAP-67482)

## Test plan
- [ ] Search by "Collection name" filter with partial text (e.g., "sap") — verify partial matches returned
- [ ] Search by "Namespace" filter with partial text (e.g., "cisco") — verify partial matches returned
- [ ] Verify "Keywords" search still works for broad full-text search
- [ ] Verify empty state correctly shows when no filters are set
- [ ] Verify TypeScript compiles without errors (`npm run lint:ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAP-67482]: https://redhat.atlassian.net/browse/AAP-67482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ