### PR TITLE
Fix Documentation tab crash when docs_blob is absent

### DIFF
--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -168,6 +168,7 @@ export class API extends HubAPI {
         namespace,
         name,
         version,
+        exclude_fields: 'files,manifest',
       },
       `pulp/api/v3/content/ansible/collection_versions/`,
     );

--- a/src/components/collection-detail/table-of-contents.tsx
+++ b/src/components/collection-detail/table-of-contents.tsx
@@ -120,7 +120,7 @@ function parseLinks(docs_blob: DocsBlobType, props): Table {
     name: 'readme',
   });
 
-  if (docs_blob.documentation_files) {
+  if (docs_blob?.documentation_files) {
     for (const file of docs_blob.documentation_files) {
       const url = sanitizeDocsUrls(file.name);
       table.documentation.push({
@@ -136,7 +136,7 @@ function parseLinks(docs_blob: DocsBlobType, props): Table {
     }
   }
 
-  if (docs_blob.contents) {
+  if (docs_blob?.contents) {
     for (const content of docs_blob.contents) {
       switch (content.content_type) {
         case 'role':

--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -75,7 +75,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
     const contentName = urlFields['name'] || urlFields['page'] || null;
 
     if (contentType === 'docs' && contentName) {
-      if (content.docs_blob.documentation_files) {
+      if (content.docs_blob?.documentation_files) {
         const file = content.docs_blob.documentation_files.find(
           (x) => sanitizeDocsUrls(x.name) === urlFields['page'],
         );
@@ -85,8 +85,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
         }
       }
     } else if (contentName) {
-      // check if contents exists
-      if (content.docs_blob.contents) {
+      if (content.docs_blob?.contents) {
         const selectedContent = content.docs_blob.contents.find(
           (x) =>
             x.content_type === contentType && x.content_name === contentName,
@@ -101,7 +100,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
         }
       }
     } else {
-      if (content.docs_blob.collection_readme) {
+      if (content.docs_blob?.collection_readme) {
         displayHTML = content.docs_blob.collection_readme.html;
       }
     }
@@ -183,7 +182,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
                         text ?? pluginName,
                         collection,
                         params,
-                        content.contents,
+                        content.contents ?? [],
                       )
                     }
                     renderDocLink={(name, href) =>
@@ -198,7 +197,7 @@ class CollectionDocs extends React.Component<RouteProps, IBaseCollectionState> {
                   />
                 )
               ) : collection.repository.name === 'community' &&
-                !content.docs_blob.contents ? (
+                !content.docs_blob?.contents ? (
                 this.renderCommunityWarningMessage()
               ) : (
                 this.renderNotFound(collection.collection_version.name)


### PR DESCRIPTION
Fix Documentation tab crash when docs_blob is absent

  - Add `exclude_fields=files,manifest` to the collection versions API call so pulp_ansible includes `docs_blob` in the response
  - Add optional chaining (`?.`) on all `docs_blob` accesses in `collection-docs.tsx` and `table-of-contents.tsx` as a defensive guard
  - Guard `content.contents` with `?? []` to prevent a crash in `renderPluginLink`