### PR TITLE
fix: use docs_blob.contents for plugin link resolution in docs tab

### DIFF
--- a/src/containers/collection-detail/collection-docs.tsx
+++ b/src/containers/collection-detail/collection-docs.tsx
@@ -183,7 +183,7 @@ class CollectionDocs extends Component<RouteProps, IBaseCollectionState> {
                         text ?? pluginName,
                         collection,
                         params,
-                        content.contents,
+                        content.docs_blob.contents ?? [],
                       )
                     }
                     renderDocLink={(name, href) =>
@@ -255,7 +255,7 @@ class CollectionDocs extends Component<RouteProps, IBaseCollectionState> {
     allContent,
   ) {
     const module = allContent.find(
-      (x) => x.content_type === pluginType && x.name === pluginName,
+      (x) => x.content_type === pluginType && x.content_name === pluginName,
     );
 
     if (module) {


### PR DESCRIPTION
## Summary

Fixes #5586 — plugin/module documentation pages on Galaxy crash with `TypeError: can't access property "find", a is undefined` whenever the doc string contains `M(...)` or `P(...)` markup.

**Root cause**: #5572 changed the Docs tab to fetch collection data with `exclude_fields='files,manifest,contents'`, which excludes the top-level `contents` field from the API response. However, `renderPluginLink` still passes `content.contents` (now `undefined`) to resolve inline module/plugin references, and calls `.find()` on it — causing the crash.

**Fix** (two changes in `collection-docs.tsx`):
- Use `content.docs_blob.contents ?? []` instead of `content.contents` — `docs_blob` is already fetched for the Docs tab and contains the plugin metadata needed to resolve `M(...)` and `P(...)` links
- Update `renderPluginLink` find predicate from `x.name` to `x.content_name` — `ContentSummaryType` (top-level `contents`) uses `name`, but `PluginContentType` (`docs_blob.contents`) uses `content_name`

**Related**:
- #5586 — the issue this fixes
- #5572 — the PR that introduced the regression by excluding `contents` from the Docs tab API response
- #5584 — a prior attempt at fixing the crash (added `?? []` guard and optional chaining) but did not address the `name` vs `content_name` field mismatch

## Test plan

- [x] Navigate to an affected page (e.g. [community.openwrt uci module](https://galaxy.ansible.com/ui/repo/published/community/openwrt/content/module/uci/)) — docs should render without the "Documentation Syntax Error" warning
- [x] Pages without `M(...)` / `P(...)` references continue to render normally
- [x] TypeScript (`tsc`), ESLint, and Prettier all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)